### PR TITLE
fix(rector): add declare(strict_types=1) to ext_emconf.php

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /*
  * Copyright (c) 2025-2026 Netresearch DTT GmbH
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
-
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Vault - Secure Secrets Management',
     'description' => 'Centralized, secure storage for API keys, credentials, and other secrets with envelope encryption, access control, audit logging, and a secure HTTP client.',


### PR DESCRIPTION
## Summary

Fixes the failing `ci / Rector` job on main (run [24105838945](https://github.com/netresearch/t3x-nr-vault/actions/runs/24105838945)).

Rector's `SafeDeclareStrictTypesRector` flagged `ext_emconf.php` as missing a `declare(strict_types=1);` declaration. This applies exactly the change Rector suggested in its dry-run diff.

## Rule

- `SafeDeclareStrictTypesRector`
- File: `ext_emconf.php`

## Test plan

- [ ] `ci / Rector` job passes
- [ ] Other CI jobs remain green