### PR TITLE
fix(rector): exclude ext_emconf.php from SafeDeclareStrictTypesRector

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -1,11 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /*
  * Copyright (c) 2025-2026 Netresearch DTT GmbH
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
+
 $EM_CONF[$_EXTKEY] = [
     'title' => 'Vault - Secure Secrets Management',
     'description' => 'Centralized, secure storage for API keys, credentials, and other secrets with envelope encryption, access control, audit logging, and a secure HTTP client.',

--- a/rector.php
+++ b/rector.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\SetList;
+use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 use Rector\ValueObject\PhpVersion;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 use Ssch\TYPO3Rector\Set\Typo3SetList;
@@ -41,5 +42,10 @@ return RectorConfig::configure()
         __DIR__ . '/Classes/Task/OrphanCleanupTask.php',
         // Factory is called via GeneralUtility::makeInstance without constructor args
         __DIR__ . '/Classes/Http/SecureHttpClientFactory.php',
+        // TER cannot parse ext_emconf.php with declare(strict_types=1); the repo
+        // lint check (.github/workflows) forbids it, so Rector must defer here.
+        SafeDeclareStrictTypesRector::class => [
+            __DIR__ . '/ext_emconf.php',
+        ],
     ])
     ->withImportNames(removeUnusedImports: true);


### PR DESCRIPTION
## Summary

Fixes the `ci / Lint (8.2)` failure on `main` introduced by #104 (run [24207591664](https://github.com/netresearch/t3x-nr-vault/actions/runs/24207591664)):

```
ext_emconf.php must NOT contain declare(strict_types=1) — TER cannot parse it with strict_types enabled. Remove the declaration from this file.
```

## Root cause

- The shared CI workflow ([netresearch/typo3-ci-workflows](https://github.com/netresearch/typo3-ci-workflows/blob/main/.github/workflows/ci.yml)) has an explicit lint step that greps `ext_emconf.php` for `declare(strict_types=1)` and fails the Lint job when present, because the TYPO3 Extension Repository (TER) cannot parse PHP with `strict_types` enabled.
- Rector's `SafeDeclareStrictTypesRector` had previously flagged `ext_emconf.php` as missing the declaration, and #104 applied Rector's suggestion. This put Rector and the TER lint in direct conflict.
- The TER constraint wins because it is a publishing requirement.

## Changes

- Revert `ext_emconf.php` to its pre-#104, byte-identical state (remove `declare(strict_types=1);`, restore blank line before `$EM_CONF[$_EXTKEY]`).
- Add a targeted `withSkip()` entry in `rector.php` for `SafeDeclareStrictTypesRector` on `ext_emconf.php`, so Rector cannot re-add the declaration even if the rule becomes active via a future rule-set upgrade.

## Verification (local)

- `composer ci:test:php:rector` (== `rector process --dry-run`) with `--clear-cache`: `[OK] Rector is done!`, exit 0, 213/213 files clean.
- `php -l ext_emconf.php`: `No syntax errors detected`.
- Exact CI TER regex: `grep -Eq '^[[:space:]]*declare[[:space:]]*\([[:space:]]*strict_types[[:space:]]*=[[:space:]]*1[[:space:]]*\)[[:space:]]*;?' ext_emconf.php` → no match (PASS).
- `ext_emconf.php` is byte-identical to the pre-#104 file at `f952ab0`.

## Test plan

- [ ] `ci / Lint (8.2)` passes on this PR
- [ ] `ci / Rector` passes on this PR
- [ ] Other CI jobs remain green