### PR TITLE
fix(rector): skip ext_emconf.php entirely instead of one rule

### DIFF
--- a/rector.php
+++ b/rector.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
 use Rector\Set\ValueObject\SetList;
-use Rector\TypeDeclaration\Rector\StmtsAwareInterface\SafeDeclareStrictTypesRector;
 use Rector\ValueObject\PhpVersion;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 use Ssch\TYPO3Rector\Set\Typo3SetList;
@@ -42,10 +41,11 @@ return RectorConfig::configure()
         __DIR__ . '/Classes/Task/OrphanCleanupTask.php',
         // Factory is called via GeneralUtility::makeInstance without constructor args
         __DIR__ . '/Classes/Http/SecureHttpClientFactory.php',
-        // TER cannot parse ext_emconf.php with declare(strict_types=1); the repo
-        // lint check (.github/workflows) forbids it, so Rector must defer here.
-        SafeDeclareStrictTypesRector::class => [
-            __DIR__ . '/ext_emconf.php',
-        ],
+        // ext_emconf.php is parsed by the TYPO3 Extension Repository (TER), whose
+        // parser is fragile and rejects many modern PHP constructs (declare(strict_types),
+        // namespaced types, etc.). The repo's CI lint check forbids strict_types in this
+        // file, so we exclude it from Rector entirely to be robust against any future
+        // rule that might also break the TER parser.
+        __DIR__ . '/ext_emconf.php',
     ])
     ->withImportNames(removeUnusedImports: true);


### PR DESCRIPTION
## Summary
Addresses [@gemini-code-assist's review on #105](https://github.com/netresearch/t3x-nr-vault/pull/105#discussion_r3060030189): the previous skip only excluded `SafeDeclareStrictTypesRector` from `ext_emconf.php`. Broaden it to skip the file entirely so any future Rector rule that emits constructs the TER parser cannot handle is also covered.

Also drops the no-longer-needed `SafeDeclareStrictTypesRector` import.

## Test plan
- [x] `rector process --dry-run --clear-cache` clean (212/212 files, ext_emconf.php no longer scanned)