### PR TITLE
docs(agents): refresh AGENTS.md files with verified project content

### DIFF
--- a/.ddev/AGENTS.md
+++ b/.ddev/AGENTS.md
@@ -1,0 +1,88 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
+
+# AGENTS.md — .ddev
+
+## Overview
+DDEV local development environment for nr-vault. Hosts TYPO3 + MariaDB + OAuth mock for auth-flow tests.
+Invoke skill **`typo3-ddev`** for setup and multi-version testing patterns.
+
+## Key Files
+| File | Purpose |
+|------|---------|
+| `.ddev/config.yaml` | Main DDEV configuration (PHP/Node versions, webserver) |
+| `.ddev/docker-compose.mock-oauth.yaml` | Mock OAuth sidecar for OAuthTokenManager tests |
+| `.ddev/commands/host/` | Host-side custom commands |
+| `.ddev/commands/web/` | Container-side custom commands |
+
+## Golden Samples
+| Pattern | Reference |
+|---------|-----------|
+| Sidecar service override | `.ddev/docker-compose.mock-oauth.yaml` |
+| Standard TYPO3 v14 config | `.ddev/config.yaml` |
+
+## Setup
+| Task | Command |
+|------|---------|
+| Start env | `make up` (runs `ddev start` + TYPO3 install) |
+| Stop env | `make down` |
+| Shell into web container | `make shell` (or `ddev ssh`) |
+| Composer in container | `ddev composer <cmd>` |
+| Describe URLs/credentials | `ddev describe` |
+
+## Build/Tests
+| Task | Command |
+|------|---------|
+| Run unit tests in container | `ddev composer ci:test:php:unit` |
+| Run functional tests in container | `ddev composer ci:test:php:functional` |
+| Run single test | `ddev exec vendor/bin/phpunit -c Build/phpunit.xml <path>` |
+| DB export | `ddev export-db --file=dump.sql.gz` |
+| DB import | `ddev import-db --file=dump.sql.gz` |
+
+## Directory Structure
+```
+.ddev/
+├── config.yaml                        # PHP/node versions, webserver
+├── docker-compose.mock-oauth.yaml     # Mock OAuth server sidecar
+└── commands/
+    ├── host/                          # Host-side commands
+    └── web/                           # In-container commands
+```
+
+## Code Style
+- Keep `config.yaml` minimal; put extras in `docker-compose.*.yaml` overrides.
+- Custom commands start with `## Description: …` header.
+- Mark DDEV-managed files with `#ddev-generated` comment.
+- Pin addon versions for reproducibility.
+
+## Security
+- **Never** commit `.ddev/.env` with secrets — include only sample/placeholder values.
+- Mock OAuth server must return deterministic, obviously-fake tokens — never reuse prod token shapes.
+- Do not expose the DDEV Mailhog/router to public networks; DDEV binds loopback by default — keep it that way.
+
+## Checklist
+- [ ] `ddev start` works after changes
+- [ ] `make up` → `make test-unit` → `make test-functional` all pass
+- [ ] Custom commands carry `## Description:` header
+- [ ] No hardcoded paths or credentials in `config.yaml`
+- [ ] Overrides live in `docker-compose.*.yaml`, not `config.yaml`
+- [ ] Works on macOS, Linux, WSL2
+
+## Examples
+### Enable mock-oauth sidecar
+```bash
+ddev start   # picks up docker-compose.mock-oauth.yaml automatically
+ddev describe mock-oauth   # show URL
+```
+
+### Multi-version PHP testing
+```yaml
+# .ddev/config.override.yaml (developer-local, not committed)
+php_version: "8.3"
+```
+
+## When Stuck
+- `ddev describe` — URLs, credentials, add-on status
+- `ddev logs` — web/db/custom containers
+- DDEV docs: <https://ddev.readthedocs.io>
+- Invoke skill: `typo3-ddev`

--- a/.ddev/CLAUDE.md
+++ b/.ddev/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.ddev/GEMINI.md
+++ b/.ddev/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,0 +1,122 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
+
+# AGENTS.md — .github/workflows
+
+## Overview
+GitHub Actions workflows for nr-vault. CI, releases, auto-merge, and community automation.
+
+## Key Files
+| File | Purpose |
+|------|---------|
+| `ci.yml` | Lint + PHPStan + PHPUnit (unit/functional/fuzz) matrix on PRs & main |
+| `release.yml` | Tag-triggered TER publish + GitHub release assets |
+| `auto-merge-deps.yml` | Auto-merge dependency PRs when CI green (Renovate/Dependabot) |
+| `community.yml` | Community health: labeler, stale bot, welcome |
+| `../labeler.yml` | PR auto-labeling rules |
+| `../CODEOWNERS` | Code ownership |
+| `../renovate.json` | Renovate configuration |
+
+## Golden Samples
+| Pattern | Reference |
+|---------|-----------|
+| TYPO3 extension matrix test | `.github/workflows/ci.yml` |
+| TER release pipeline | `.github/workflows/release.yml` |
+| Auto-merge with CI gate | `.github/workflows/auto-merge-deps.yml` |
+
+## Setup
+- Workflows run on GitHub-hosted runners (`ubuntu-latest`).
+- Local validation: `actionlint` (via pre-commit or `gh act`).
+
+## Build/Tests
+| Task | Command |
+|------|---------|
+| Lint workflows | `actionlint .github/workflows/*.yml` |
+| Local workflow run | `act -j <job>` (requires Docker) |
+| Workflow status | `gh run list --limit 5` |
+| Re-run failed run | `gh run rerun <run-id>` |
+| Inspect annotations | `gh api repos/$REPO/check-runs/$ID/annotations` |
+
+## Directory Structure
+```
+.github/
+├── workflows/
+│   ├── ci.yml
+│   ├── release.yml
+│   ├── auto-merge-deps.yml
+│   └── community.yml
+├── actions/                 # composite actions (if any)
+├── labeler.yml
+├── renovate.json
+├── CODEOWNERS
+└── pull_request_template.md (optional)
+```
+
+## Code Style
+- **Pin every action to a full commit SHA** (not tags). Keep `# vX.Y.Z` comment next to the SHA.
+- **Minimal permissions** on every workflow — declare `permissions: contents: read` by default, widen per-job only where needed.
+- **Reusable workflows** live under `.github/workflows/reusable-*.yml` or are centrally hosted.
+- **Naming**:
+  - Workflow file: `<purpose>.yml`
+  - Workflow name: Title Case (`CI`, `Release`)
+  - Job id: `kebab-case`
+  - Step name: Sentence case
+  - Secret: `SCREAMING_SNAKE`
+- **Caching**: `actions/setup-php` + `actions/cache` for composer, cache by `composer.json`.
+- **Concurrency**: add `concurrency: { group: ${{ github.workflow }}-${{ github.ref }}, cancel-in-progress: true }` on CI.
+
+## Security
+- **Never use `permissions: write-all`** — declare minimal per-job.
+- **Never use `secrets: inherit`** when calling reusable workflows — pass secrets explicitly by name:
+  ```yaml
+  secrets:
+    TER_TOKEN: ${{ secrets.TER_TOKEN }}
+  ```
+- **Pin actions to commit SHAs** (not tags) — mitigates tag-hijack supply-chain attacks.
+- **Mask dynamic values** with `::add-mask::` before logging.
+- **Environment protection** for release/deploy — require reviewers.
+- **OIDC** over long-lived credentials where possible.
+- **Reviewdog / actionlint**: set `fail_level: error` so warnings block merges.
+
+## Checklist
+- [ ] `actionlint` clean
+- [ ] Actions pinned to full SHA with version comment
+- [ ] `permissions:` block explicit and minimal
+- [ ] No `secrets: inherit` — explicit per-secret
+- [ ] Cache key uses lockfile/composer.json hash
+- [ ] Concurrency group set for long-running workflows
+- [ ] CI annotations checked: `gh api repos/OWNER/REPO/check-runs/$ID/annotations`
+
+## Examples
+```yaml
+# Pinned action with comment
+- uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+# Minimal permissions + concurrency
+name: CI
+on: [push, pull_request]
+permissions:
+  contents: read
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+      - uses: shivammathur/setup-php@c541c155eee45413f5b09a52248675b1a2575231 # v2.31.1
+        with:
+          php-version: '8.2'
+          coverage: none
+      - run: composer install --prefer-dist --no-progress
+      - run: composer ci
+```
+
+## When Stuck
+- Actions docs: <https://docs.github.com/en/actions>
+- Workflow syntax: <https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions>
+- Existing workflows in this repo are the best reference.
+- Invoke skill: `github-project` for ruleset / merge-queue / branch protection
+- Invoke skill: `git-workflow` for release orchestration

--- a/.github/workflows/CLAUDE.md
+++ b/.github/workflows/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/.github/workflows/GEMINI.md
+++ b/.github/workflows/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -99,29 +99,50 @@ This extension handles sensitive data. Non-negotiable rules:
 7. **Tamper-evident audit log** — HMAC hash chain; verify on schedule (see `VaultAuditCommand`).
 
 ## Key Interfaces
-```php
-// Core vault operations
-VaultServiceInterface::store(string $identifier, string $secret, array $options): void
-VaultServiceInterface::retrieve(string $identifier): ?string
-VaultServiceInterface::rotate(string $identifier, string $newSecret, ?string $reason): void
-VaultServiceInterface::delete(string $identifier, ?string $reason): void
+> Authoritative source: the `*Interface.php` files. This is a cheat-sheet — read the PHP for full docblocks.
 
-// Encryption
-EncryptionServiceInterface::encrypt(string $plaintext, string $dataKey): string
-EncryptionServiceInterface::decrypt(string $ciphertext, string $dataKey): string
+```php
+// Core vault operations — Classes/Service/VaultServiceInterface.php
+VaultServiceInterface::store(string $identifier, string $secret, array $options = []): void
+VaultServiceInterface::retrieve(string $identifier): ?string
+VaultServiceInterface::exists(string $identifier): bool
+VaultServiceInterface::delete(string $identifier, string $reason = ''): void
+VaultServiceInterface::rotate(string $identifier, string $newSecret, string $reason = ''): void
+VaultServiceInterface::list(?string $pattern = null): array
+VaultServiceInterface::getMetadata(string $identifier): SecretDetails
+VaultServiceInterface::clearCache(): void
+VaultServiceInterface::http(): VaultHttpClientInterface
+
+// Encryption — Classes/Crypto/EncryptionServiceInterface.php
+EncryptionServiceInterface::encrypt(string $plaintext, string $identifier): EncryptedData
+EncryptionServiceInterface::decrypt(
+    string $encryptedValue, string $encryptedDek,
+    string $dekNonce, string $valueNonce, string $identifier
+): string
+EncryptionServiceInterface::generateDek(): string
+EncryptionServiceInterface::calculateChecksum(string $plaintext): string
+
+// Master key — Classes/Crypto/MasterKeyProviderInterface.php
 MasterKeyProviderInterface::getMasterKey(): string
 
-// Audit logging
-AuditLogServiceInterface::log(string $operation, string $identifier, array $context): void
+// Audit logging — Classes/Audit/AuditLogServiceInterface.php
+AuditLogServiceInterface::log(
+    string $secretIdentifier, string $action, bool $success,
+    ?string $errorMessage = null, ?string $reason = null,
+    ?string $hashBefore = null, ?string $hashAfter = null,
+    ?AuditContextInterface $context = null,
+): void
+AuditLogServiceInterface::query(?AuditLogFilter $filter = null, int $limit = 100, int $offset = 0): array
+AuditLogServiceInterface::verifyHashChain(?int $fromUid = null, ?int $toUid = null): HashChainVerificationResult
 ```
 
 ## CLI Commands (TYPO3 `vendor/bin/typo3`)
 ```
-vault:audit              # View / verify audit log entries
-vault:audit:migrate      # Migrate audit log to HMAC hash chain
-vault:migrate-field      # Move DB field values into the vault
-vault:rotate-master-key  # Re-encrypt all DEKs with a new master key
-vault:cleanup-orphans    # Scheduled task wrapper
+vault:audit                # View / verify audit log entries
+vault:audit-migrate-hmac   # Migrate audit log hash chain from SHA-256 to HMAC-SHA256
+vault:migrate-field        # Move DB field values into the vault
+vault:rotate-master-key    # Re-encrypt all DEKs with a new master key
+vault:cleanup-orphans      # Scheduled task wrapper
 ```
 
 ## Boundaries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,174 +1,110 @@
-# AGENTS.md - nr-vault
+<!-- FOR AI AGENTS - Human readability is a side effect, not a goal -->
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
 
-> AI agent guidelines for the nr-vault TYPO3 extension.
+# AGENTS.md — nr-vault
 
-## Precedence
+> Secure secrets management for TYPO3 (envelope encryption, access control, tamper-evident audit log).
 
-1. This file (root)
-2. Directory-specific AGENTS.md files:
-   - `Classes/AGENTS.md` - Source code patterns
-   - `Configuration/AGENTS.md` - TYPO3 configuration
-   - `Documentation/AGENTS.md` - RST documentation
-   - `Resources/AGENTS.md` - Templates, language, assets
-   - `Tests/AGENTS.md` - Testing patterns
-   - `Tests/E2E/AGENTS.md` - E2E testing specifics
-3. TYPO3 coding standards
+**Precedence:** the **closest `AGENTS.md`** to the files you're changing wins. Root holds global defaults only. Explicit user prompts override files.
 
 ## Project Overview
 
-**nr-vault** is a TYPO3 v13.4/v14 extension providing secure secrets management with envelope encryption, access control, and audit logging.
+- **Stack:** PHP 8.2+, TYPO3 ^13.4 || ^14.0, libsodium (XChaCha20-Poly1305 / AES-256-GCM envelope encryption)
+- **Environment:** DDEV for local development
+- **License:** GPL-2.0-or-later
+- **Namespace:** `Netresearch\NrVault\` (PSR-4 from `Classes/`)
+- **Extension key:** `nr_vault`
 
-- **Stack**: PHP 8.2+, TYPO3 v13.4/v14, libsodium (AES-256-GCM)
-- **Environment**: DDEV for local development
-- **License**: GPL-2.0-or-later
+## Commands
+> Source: `Makefile` (primary) and `composer.json` scripts
 
-## Quick Reference
+| Task | Command | Notes |
+|------|---------|-------|
+| Start env | `make up` | DDEV + install TYPO3 v14 |
+| Stop env | `make down` | |
+| Shell | `make shell` | Container shell |
+| Lint (syntax) | `make lint` | `php -l` across sources |
+| CS check | `make cgl` | php-cs-fixer --dry-run |
+| CS fix | `make fix` | alias of `make cgl-fix` |
+| PHPStan | `make phpstan` | Static analysis |
+| Rector (dry-run) | `make rector` | |
+| Unit tests | `make test-unit` | `composer ci:test:php:unit` |
+| Functional tests | `make test-functional` | `composer ci:test:php:functional` |
+| All tests | `make test` | unit + functional |
+| Mutation tests | `make test-mutation` | Infection |
+| All CI | `make ci` | lint+cs+phpstan+rector+tests |
+| Docs render | `make docs` | |
 
-```bash
-# Environment
-make up                    # Start DDEV + install TYPO3 v14
-make down                  # Stop DDEV
-make shell                 # Open container shell
+Direct composer (without make):
+- `composer ci` — unit + fuzz + phpstan + cgl
+- `composer ci:test:php:functional` — functional suite
+- `composer ci:cgl` — fix code style
 
-# Testing
-make test                  # Run all tests (unit + functional)
-make unit                  # Unit tests only
-make functional            # Functional tests only
+## Response Style
+- Answer first, elaborate only if needed. No sycophantic openers.
+- For yes/no or status questions, lead with the answer.
+- Skip preamble. Match response length to task complexity.
 
-# Quality
-make cs                    # Check code style
-make fix                   # Fix code style
-make phpstan               # Static analysis
-make lint                  # PHP syntax check
+## Workflow
+1. **Before coding**: Read nearest `AGENTS.md` + inspect Golden Samples.
+2. **After each change**: Run the smallest relevant check (`make lint` → `make phpstan` → single test).
+3. **Before committing**: `make ci` when changes affect >2 files or touch shared code.
+4. **Before claiming done**: Run verification and **paste output as evidence** — never say "should work now" / "tested" / "all green" without showing output.
 
-# CI
-make ci                    # Run all CI checks locally
-
-# Documentation
-make docs                  # Render documentation
+## File Map
+```
+Classes/         → PHP sources (Adapter, Audit, Command, Controller, Crypto, Domain, Hook, Http, Service, Task, Upgrades, Utility)
+Configuration/   → TYPO3 config (TCA, Backend routes, Services.yaml)
+Documentation/   → reStructuredText docs + ADRs
+Resources/       → Templates (Fluid), JS/CSS, XLIFF language files
+Tests/           → Unit + Functional + E2E (Playwright)
+Build/           → phpunit.xml, FunctionalTests.xml
+.ddev/           → DDEV environment (mock-oauth sidecar, phpunit extras)
+.github/         → workflows, CODEOWNERS, renovate, labeler
 ```
 
-## Code Style
+## Golden Samples
+| For | Reference |
+|-----|-----------|
+| Domain service | `Classes/Service/VaultService.php` |
+| Crypto boundary | `Classes/Crypto/EncryptionService.php` |
+| Controller (backend module) | `Classes/Controller/SecretsController.php` |
+| AJAX controller | `Classes/Controller/AjaxController.php` |
+| TYPO3 hook | `Classes/Hook/FlexFormVaultHook.php` |
+| Audit writer | `Classes/Audit/AuditLogService.php` |
+| Upgrade wizard | `Classes/Upgrades/AuditHmacMigrationWizard.php` |
+| Functional test | `Tests/Functional/Crypto/MasterKeyRotationTest.php` |
 
-- **Standard**: PSR-12 + TYPO3 CGL
-- **Tool**: PHP-CS-Fixer (`.php-cs-fixer.dist.php`)
-- **Run before commit**: `make fix`
-
-Key conventions:
-- `declare(strict_types=1);` in all PHP files
-- `final` classes by default (extend only when necessary)
-- `readonly` properties where possible
-- Constructor property promotion
-- No `@author` tags in docblocks
-- Use dependency injection via constructor
-
-## Architecture
-
-```
-Classes/
-├── Adapter/       # Vault backend adapters (local, external)
-├── Audit/         # Audit logging service
-├── Command/       # CLI commands (vault:init, vault:rotate, etc.)
-├── Configuration/ # Extension configuration
-├── Controller/    # Backend module controllers
-├── Crypto/        # Encryption/decryption services
-├── Domain/        # Domain models (Secret, Repository)
-├── Event/         # PSR-14 events
-├── EventListener/ # Event listeners (TypoScript, SiteConfig)
-├── Exception/     # Custom exceptions
-├── Form/          # FormEngine integration (NodeFactory, elements)
-├── Hook/          # TYPO3 hooks
-├── Http/          # HTTP middleware
-├── Security/      # Access control services
-├── Service/       # Core VaultService
-├── Task/          # Scheduler tasks (TCA-based registration)
-├── TCA/           # TCA field configuration
-└── Utility/       # Helper utilities
-```
+## Heuristics
+| When | Do |
+|------|-----|
+| Adding class | PSR-4 under `Classes/`, namespace `Netresearch\NrVault\*` |
+| New command | `Classes/Command/` + register in `Configuration/Services.yaml` |
+| AJAX route | Add to `Configuration/Backend/AjaxRoutes.php` + controller in `Classes/Controller/` |
+| Touching secrets | Audit log every read/write via `AuditLogServiceInterface::log()` |
+| Running locally | `make up` then `make shell` |
+| Committing | Conventional Commits (feat:/fix:/chore:/docs:/refactor:/test:) |
+| Merging PRs | Merge commit (not squash, not rebase) — preserves GPG signatures |
 
 ## Security Requirements
+This extension handles sensitive data. Non-negotiable rules:
 
-This extension handles sensitive data. Follow these rules:
-
-1. **Never log secrets** - Use `[REDACTED]` placeholders
-2. **Constant-time comparisons** - Use `hash_equals()` for secret comparison
-3. **Memory clearing** - Use `sodium_memzero()` after processing secrets
-4. **No plaintext storage** - All secrets encrypted with envelope encryption
-5. **Audit all access** - Every read/write creates an audit log entry
-6. **Access control** - Respect backend user groups and ownership
-
-## Testing
-
-| Type | Location | Purpose |
-|------|----------|---------|
-| Unit | `Tests/Unit/` | Isolated class testing |
-| Functional | `Tests/Functional/` | TYPO3 integration |
-| E2E | `Tests/E2E/` | Playwright browser tests |
-| Architecture | `Tests/Architecture/` | PHPat dependency rules |
-| Fuzz | `Tests/Fuzz/` | Input fuzzing |
-
-Run tests in container:
-```bash
-ddev exec .Build/bin/phpunit -c Build/phpunit.xml --testsuite Unit
-```
-
-## Pre-Commit Checklist
-
-Before committing:
-
-- [ ] `make fix` - Code style fixed
-- [ ] `make phpstan` - No new errors
-- [ ] `make test` - All tests pass
-- [ ] No secrets in code or tests
-- [ ] Audit logging added for new operations
-
-## Commit Format
-
-Use conventional commits:
-```
-feat: add OAuth token refresh support
-fix: prevent timing attacks in secret comparison
-refactor: extract encryption to dedicated service
-test: add unit tests for OrphanCleanupTask
-docs: update TCA integration examples
-```
-
-## CLI Commands
-
-```bash
-# Initialization
-vault:init                  # Initialize vault with master key
-
-# Secret management
-vault:store                 # Store a new secret
-vault:retrieve              # Retrieve a secret by identifier
-vault:delete                # Delete a secret
-vault:list                  # List all secrets (identifiers only)
-vault:rotate                # Rotate a secret value
-
-# Key management
-vault:rotate-master-key     # Rotate the master encryption key
-
-# Maintenance
-vault:cleanup-orphans       # Remove orphaned secrets
-vault:scan                  # Scan for vault placeholder usage
-vault:migrate-field         # Migrate field values to vault
-vault:audit                 # View audit log entries
-```
+1. **Never log secrets** — use `[REDACTED]` placeholders in logs & exceptions.
+2. **Constant-time comparisons** — `hash_equals()` for secret comparison.
+3. **Memory clearing** — `sodium_memzero()` after processing plaintext secrets.
+4. **No plaintext storage** — all secrets via envelope encryption (master key wraps per-secret DEK).
+5. **Audit every access** — reads/writes/rotations/deletes all create audit log entries.
+6. **Access control** — respect backend user groups & ownership via `AccessControlServiceInterface`.
+7. **Tamper-evident audit log** — HMAC hash chain; verify on schedule (see `VaultAuditCommand`).
 
 ## Key Interfaces
-
 ```php
 // Core vault operations
 VaultServiceInterface::store(string $identifier, string $secret, array $options): void
 VaultServiceInterface::retrieve(string $identifier): ?string
 VaultServiceInterface::rotate(string $identifier, string $newSecret, ?string $reason): void
 VaultServiceInterface::delete(string $identifier, ?string $reason): void
-
-// Access control
-AccessControlServiceInterface::canRead(Secret $secret): bool
-AccessControlServiceInterface::canWrite(Secret $secret): bool
-AccessControlServiceInterface::canCreate(): bool
 
 // Encryption
 EncryptionServiceInterface::encrypt(string $plaintext, string $dataKey): string
@@ -179,20 +115,66 @@ MasterKeyProviderInterface::getMasterKey(): string
 AuditLogServiceInterface::log(string $operation, string $identifier, array $context): void
 ```
 
+## CLI Commands (TYPO3 `vendor/bin/typo3`)
+```
+vault:audit              # View / verify audit log entries
+vault:audit:migrate      # Migrate audit log to HMAC hash chain
+vault:migrate-field      # Move DB field values into the vault
+vault:rotate-master-key  # Re-encrypt all DEKs with a new master key
+vault:cleanup-orphans    # Scheduled task wrapper
+```
+
+## Boundaries
+
+### Always Do
+- Use `declare(strict_types=1);`, `final` classes by default, `readonly` properties, constructor promotion.
+- Dependency injection via `Configuration/Services.yaml` — not `GeneralUtility::makeInstance()`.
+- Run `make fix && make phpstan && make test` before pushing.
+- Use atomic commits (one logical change per commit); preserve GPG signatures.
+- Force-push only with `--force-with-lease`.
+- Follow PSR-12 + TYPO3 CGL.
+
+### Ask First
+- Adding new dependencies (composer / npm).
+- Modifying CI/CD configuration.
+- Changing public API signatures of `*Interface.php`.
+- Rotating / regenerating cryptographic keys in fixtures.
+
+### Never Do
+- Commit secrets, credentials, or real master keys (test fixtures only — allowlisted in `.gitleaks.toml`).
+- Commit `composer.lock` (extension, not application).
+- Push directly to `main` — open a PR.
+- Merge a PR before all review threads are resolved.
+- Squash or rebase-merge (loses GPG signatures — use merge commits).
+- Use `secrets: inherit` in reusable GitHub Actions workflows (pass secrets explicitly).
+- Modify `.Build/`, `vendor/`, `Documentation-GENERATED-temp/`, `.php-cs-fixer.cache`.
+- Use `$GLOBALS['TYPO3_DB']` (deprecated) — use Doctrine QueryBuilder.
+
+## Index of scoped AGENTS.md
+MUST read when working in these directories:
+- `./Classes/AGENTS.md` — PHP sources, crypto, services, hooks
+- `./Configuration/AGENTS.md` — TCA, Services.yaml, routes
+- `./Documentation/AGENTS.md` — RST docs + ADRs
+- `./Resources/AGENTS.md` — Fluid templates, JS/CSS, XLIFF
+- `./Tests/AGENTS.md` — PHPUnit unit + functional + fuzz
+- `./Tests/E2E/AGENTS.md` — Playwright E2E
+- `./.ddev/AGENTS.md` — DDEV environment
+- `./.github/workflows/AGENTS.md` — CI workflows
+
+> **Agents**: When you read or edit files in a listed directory, load its AGENTS.md first.
+
+## Repository Settings
+- **Default branch:** `main`
+- **Merge strategy:** merge commit (required for GPG signature preservation)
+- **Signed commits:** required (GPG/SSH)
+- **DCO:** required (`Signed-off-by:` trailer on every commit)
+
 ## When Stuck
-
-1. Check TYPO3 v14 documentation: https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/
-2. Review existing tests for patterns
+1. TYPO3 v14 docs: <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/>
+2. Review ADRs in `Documentation/Developer/Adr/`
 3. Run `make phpstan` for type hints
-4. Check audit logs for access issues
-
-## Files to Never Modify
-
-- `composer.lock` (auto-generated)
-- `.Build/` (vendor directory)
-- `Documentation-GENERATED-temp/` (rendered docs)
-- `.php-cs-fixer.cache`
+4. Check audit logs (`vault:audit`) for access issues
+5. Root AGENTS.md for project-wide conventions
 
 ---
-
-*[n] Netresearch DTT GmbH*
+*© Netresearch DTT GmbH — GPL-2.0-or-later*

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -1,129 +1,116 @@
-# AGENTS.md - Classes
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
 
-> Source code guidelines for nr-vault.
+# AGENTS.md — Classes
 
-## Architecture Overview
+## Overview
+PHP sources for the nr-vault TYPO3 extension. PSR-4 namespace `Netresearch\NrVault\` rooted here.
+Strict types, final classes, readonly properties, constructor promotion. DI via `Configuration/Services.yaml`.
 
+## Key Files
+| File | Purpose |
+|------|---------|
+| `Classes/Service/VaultService.php` | Core secret CRUD + rotation; binds vault adapters |
+| `Classes/Service/VaultServiceInterface.php` | Public contract for store/retrieve/rotate/delete |
+| `Classes/Crypto/EncryptionService.php` | libsodium envelope-encryption (plaintext ↔ ciphertext) |
+| `Classes/Crypto/FileMasterKeyProvider.php` | Reads master key from filesystem (config-driven) |
+| `Classes/Crypto/EnvironmentMasterKeyProvider.php` | Reads master key from env var |
+| `Classes/Crypto/Typo3MasterKeyProvider.php` | Uses TYPO3 encryptionKey as fallback |
+| `Classes/Audit/AuditLogService.php` | Tamper-evident audit log (HMAC hash chain) |
+| `Classes/Controller/SecretsController.php` | Backend module: list/create/rotate UI |
+| `Classes/Controller/AjaxController.php` | AJAX reveal/copy endpoints |
+| `Classes/Hook/FlexFormVaultHook.php` | Rewrites vault placeholders in FlexForms |
+| `Classes/Hook/DataHandlerHook.php` | DataHandler integration for vault fields |
+| `Classes/Command/VaultMigrateFieldCommand.php` | `vault:migrate-field` CLI |
+| `Classes/Command/VaultRotateMasterKeyCommand.php` | `vault:rotate-master-key` CLI |
+| `Classes/Upgrades/AuditHmacMigrationWizard.php` | Install-tool migration to HMAC chain |
+
+## Golden Samples
+| Pattern | Reference |
+|---------|-----------|
+| Service with DI + interface | `Classes/Service/VaultService.php` |
+| Crypto boundary (libsodium) | `Classes/Crypto/EncryptionService.php` |
+| TYPO3 hook integration | `Classes/Hook/FlexFormVaultHook.php` |
+| AJAX controller | `Classes/Controller/AjaxController.php` |
+| Symfony Console command | `Classes/Command/VaultMigrateFieldCommand.php` |
+| Upgrade wizard | `Classes/Upgrades/AuditHmacMigrationWizard.php` |
+| Interface-first API | `Classes/Service/VaultServiceInterface.php` |
+
+## Setup
+- `make up` — DDEV + TYPO3 v14 install
+- `make shell` — container shell
+- PHP `^8.2`, TYPO3 `^13.4 || ^14.0`
+
+## Directory Structure
 ```
 Classes/
-├── Adapter/        # Vault backend adapters
-├── Audit/          # Audit logging
-├── Command/        # CLI commands (Symfony Console)
-├── Configuration/  # Extension configuration
-├── Controller/     # Backend module controllers (Extbase)
-├── Crypto/         # Encryption services (libsodium)
-├── Domain/         # Models and repositories
-├── Event/          # PSR-14 events
-├── EventListener/  # Event listeners
-├── Exception/      # Custom exceptions
-├── Form/           # FormEngine integration
-├── Hook/           # TYPO3 hooks (DataHandler)
-├── Http/           # HTTP client for external vaults
-├── Security/       # Access control
-├── Service/        # Core business logic
-├── Task/           # Scheduler tasks
-├── TCA/            # TCA field configuration
-└── Utility/        # Helper utilities
+├── Adapter/       # Vault backend adapters (LocalEncryptionAdapter, external)
+├── Audit/         # AuditLogService, HashChainVerificationResult
+├── Command/       # Symfony Console commands (vault:*)
+├── Configuration/ # ExtensionConfiguration wrapper
+├── Controller/    # Backend module + AJAX controllers
+├── Crypto/        # Encryption services + master-key providers
+├── Domain/
+│   ├── Model/      # Secret
+│   └── Repository/ # SecretRepository
+├── EventListener/ # SiteConfigurationVaultListener
+├── Exception/     # OAuthException + domain exceptions
+├── Hook/          # FlexFormVaultHook, DataHandlerHook
+├── Http/          # VaultHttpClient, OAuth token manager
+├── Service/       # VaultService, SecretDetectionService
+├── Task/          # OrphanCleanupTask (scheduler)
+├── Upgrades/      # Install-tool upgrade wizards
+└── Utility/       # IdentifierValidator, VaultFieldResolver
 ```
 
-## Design Principles
+## Build/Tests
+| Task | Command |
+|------|---------|
+| Lint | `make lint` |
+| CS check | `make cgl` |
+| CS fix | `make fix` |
+| PHPStan | `make phpstan` |
+| Rector (dry-run) | `make rector` |
+| Unit tests | `make test-unit` |
+| Functional tests | `make test-functional` |
+| Mutation tests | `make test-mutation` |
+| All CI | `make ci` |
 
-1. **Interface-driven**: All services have interfaces for testability
-2. **Dependency Injection**: Constructor injection via `Services.yaml`
-3. **Final by default**: Classes are `final` unless extension is needed
-4. **Readonly properties**: Use `readonly` for immutable dependencies
-5. **Strict types**: All files use `declare(strict_types=1)`
+## Code Style
+- **PSR-12** + TYPO3 CGL (`.php-cs-fixer.dist.php`)
+- `declare(strict_types=1);` on every file
+- `final` classes by default; extend only where necessary
+- `readonly` properties + constructor promotion
+- No `@author` tags in docblocks
+- DI via `Services.yaml` — avoid `GeneralUtility::makeInstance()`
+- Doctrine QueryBuilder only — never `$GLOBALS['TYPO3_DB']`, never raw SQL
+- Prefer `*Interface.php` seams at public boundaries (services, adapters, providers)
 
-## Encryption Architecture
+## Security
+This directory contains the crypto + audit core. Review bar is high:
+- **libsodium only** — no `openssl_*` fallbacks
+- **Constant-time equality** — `hash_equals()`
+- **Memory scrub** — `sodium_memzero()` once plaintext is consumed
+- **No secrets in logs/exceptions** — pass `[REDACTED]` to context
+- **Audit every access** — `AuditLogServiceInterface::log()` before returning plaintext
+- **Identifier validation** — use `IdentifierValidator` (no path traversal, no control chars)
+- **Access control** — call `AccessControlServiceInterface::canRead/canWrite/canCreate` before mutation
 
-```
-┌─────────────────────────────────────────────────────┐
-│                  Envelope Encryption                │
-├─────────────────────────────────────────────────────┤
-│  Master Key (MEK)                                   │
-│    └── encrypts → Data Encryption Key (DEK)         │
-│                      └── encrypts → Secret Value    │
-└─────────────────────────────────────────────────────┘
-```
+## Checklist
+- [ ] `make ci` passes (lint + cs + phpstan + rector + tests)
+- [ ] New public methods have interfaces + tests
+- [ ] Audit log entry for any new secret operation
+- [ ] TCA changes accompanied by `ext_tables.sql` update
+- [ ] No new `GeneralUtility::makeInstance()` (use DI)
+- [ ] PHPStan level untouched (check `phpstan.neon`)
+- [ ] `ext_emconf.php` version bumped if publishable
 
-- **Algorithm**: AES-256-GCM or XChaCha20-Poly1305 (configurable)
-- **Library**: libsodium (PHP native)
-- **Key storage**: Environment variable or file
+## Examples
+Look at real code — prefer Golden Samples above. No template snippets; copy from existing files.
 
-## Service Layer
-
-| Interface | Implementation | Purpose |
-|-----------|----------------|---------|
-| `VaultServiceInterface` | `VaultService` | Core CRUD operations |
-| `EncryptionServiceInterface` | `EncryptionService` | Encrypt/decrypt |
-| `MasterKeyProviderInterface` | `MasterKeyProvider` | Master key access |
-| `AccessControlServiceInterface` | `AccessControlService` | Permission checks |
-| `AuditLogServiceInterface` | `AuditLogService` | Audit trail |
-| `VaultAdapterInterface` | `LocalEncryptionAdapter` | Storage backend |
-
-## Adding New Features
-
-### New CLI Command
-```php
-#[AsCommand(name: 'vault:example', description: 'Example command')]
-final class VaultExampleCommand extends Command
-{
-    public function __construct(
-        private readonly VaultServiceInterface $vaultService,
-    ) {
-        parent::__construct();
-    }
-
-    protected function execute(InputInterface $input, OutputInterface $output): int
-    {
-        // Implementation
-        return Command::SUCCESS;
-    }
-}
-```
-Register in `Configuration/Services.yaml` with `console.command` tag.
-
-### New Event
-```php
-// Classes/Event/SecretExampleEvent.php
-final readonly class SecretExampleEvent
-{
-    public function __construct(
-        public string $identifier,
-        public array $context = [],
-    ) {}
-}
-
-// Dispatch from service
-$this->eventDispatcher->dispatch(new SecretExampleEvent($identifier));
-```
-
-### New Exception
-```php
-final class CustomVaultException extends \RuntimeException {}
-```
-Exceptions don't need DI registration (excluded in Services.yaml).
-
-## Security Patterns
-
-```php
-// ALWAYS use constant-time comparison for secrets
-if (!hash_equals($expected, $actual)) { ... }
-
-// ALWAYS clear sensitive data from memory
-sodium_memzero($plaintext);
-
-// NEVER log secret values
-$this->logger->info('Secret accessed', ['identifier' => $identifier]);
-// NOT: $this->logger->info('Secret value', ['value' => $secret]);
-```
-
-## Testing Approach
-
-- **Unit tests**: Mock all dependencies, test in isolation
-- **Functional tests**: Test TYPO3 integration with real database
-- Use `#[CoversClass]` attribute for coverage tracking
-
----
-
-*[n] Netresearch DTT GmbH*
+## When Stuck
+- Root AGENTS.md for project-wide rules
+- ADRs: `Documentation/Developer/Adr/ADR-*.rst`
+- TYPO3 v14 docs: <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/>
+- Invoke skill: `typo3-conformance` for extension standards
+- Invoke skill: `php-modernization` for PHP 8.2+ patterns

--- a/Classes/CLAUDE.md
+++ b/Classes/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Classes/GEMINI.md
+++ b/Classes/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Configuration/AGENTS.md
+++ b/Configuration/AGENTS.md
@@ -1,58 +1,84 @@
-# AGENTS.md - Configuration
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
 
-> TYPO3 configuration guidelines for nr-vault.
+# AGENTS.md — Configuration
 
-## Structure
+## Overview
+TYPO3 configuration for nr-vault: TCA, DI (`Services.yaml`), backend modules, AJAX routes, icons, JS modules, site sets.
 
-```
-Configuration/
-├── Backend/
-│   └── Modules.php       # Backend module registration
-├── Sets/
-│   └── NrVault/          # Site set configuration
-├── TCA/
-│   ├── tx_nrvault_secret.php  # Secret table TCA
-│   └── Overrides/             # TCA overrides for core tables
-├── Icons.php             # Icon registration
-├── JavaScriptModules.php # ES6 module registration
-└── Services.yaml         # Dependency injection
-```
+## Key Files
+| File | Purpose |
+|------|---------|
+| `Configuration/Services.yaml` | DI definitions (services, factories, public aliases) |
+| `Configuration/Backend/Modules.php` | Backend module + submodule registration |
+| `Configuration/Backend/AjaxRoutes.php` | AJAX endpoints (reveal, verify-chain, etc.) |
+| `Configuration/Icons.php` | Icon registry (SVG, bitmap) |
+| `Configuration/JavaScriptModules.php` | ES module (`@netresearch/nr-vault/...`) registration |
+| `Configuration/TCA/tx_nrvault_secret.php` | Secret table TCA |
+| `Configuration/TCA/Overrides/*.php` | TCA overrides for core tables |
+| `Configuration/Sets/NrVault/config.yaml` | Site set metadata |
+| `Configuration/Sets/NrVault/settings.yaml` | Default settings |
 
-## Services.yaml Patterns
+## Golden Samples
+| Pattern | Reference |
+|---------|-----------|
+| Interface alias | See `Services.yaml` — `VaultServiceInterface → VaultService` |
+| Factory-provided service | `MasterKeyProviderInterface` factory entry |
+| CLI command registration | `Classes/Command/*` + `console.command` tag in `Services.yaml` |
+| Backend module route | `Configuration/Backend/Modules.php` |
+| AJAX route | `Configuration/Backend/AjaxRoutes.php` |
 
-### Interface Aliasing
+## Setup
+No separate setup — configuration is loaded by TYPO3 at bootstrap. After editing:
+- Flush caches: `ddev exec vendor/bin/typo3 cache:flush`
+- Reload DI container via backend Install Tool or `cache:flush`
+
+## Build/Tests
+| Task | Command |
+|------|---------|
+| Validate YAML | `make lint` covers PHP only — use `ddev exec yq eval Configuration/Services.yaml` |
+| Validate DI wiring | `make test-functional` — DI container boots during kernel setup |
+| PHPStan on TCA/config | `make phpstan` |
+| TCA schema check | `ddev exec vendor/bin/typo3 extension:setup` rebuilds schema |
+
+## Code Style
+- **Services.yaml**: two-space indent; leading underscore for defaults (`_defaults:`); explicit `public: true` only where needed (controllers, commands, listeners).
+- **TCA**: return a single array literal; no side effects; use `LLL:EXT:nr_vault/Resources/Private/Language/locallang_db.xlf:…` for labels.
+- **Backend modules**: short label format `nr_vault.modules.<name>`; POST-only routes declare `methods: ['POST']`.
+- **AJAX routes**: name them `vault_<action>`; controller returns `JsonResponse`.
+- **Do not** use `$GLOBALS['TYPO3_CONF_VARS']` edits inside `Configuration/` — keep them in `ext_localconf.php`.
+
+## Security
+- **No secrets in YAML/PHP config** — master-key material comes from providers (env/file/TYPO3 encryptionKey).
+- **AJAX routes** require backend user context (`'access' => 'admin'` on modules).
+- **TCA**: every column exposing vault data must set `'displayCond'` or guard access via hooks — secrets must not render unredacted in list views.
+- **DI boundary**: avoid making internal classes `public: true`; only controllers, CLI commands, event listeners, and interfaces consumed via DI need it.
+
+## Checklist
+- [ ] `Services.yaml` validates via functional test bootstrap
+- [ ] New service has interface + alias in `Services.yaml`
+- [ ] New CLI command tagged `console.command`
+- [ ] New backend module route paired with controller + template + XLIFF label
+- [ ] New TCA column: matching `ext_tables.sql` + `locallang_db.xlf` entry
+- [ ] `make phpstan` clean
+- [ ] AJAX route registered with appropriate HTTP method
+
+## Examples
+### Interface alias
 ```yaml
 Netresearch\NrVault\Service\VaultServiceInterface:
   alias: Netresearch\NrVault\Service\VaultService
   public: true
 ```
 
-### Factory Pattern
+### Factory-provided service
 ```yaml
 Netresearch\NrVault\Crypto\MasterKeyProviderInterface:
   factory: ['@Netresearch\NrVault\Crypto\MasterKeyProviderFactory', 'create']
   public: true
 ```
 
-### Controller Registration
-```yaml
-Netresearch\NrVault\Controller\SecretsController:
-  public: true
-  tags:
-    - name: backend.controller
-```
-
-### CLI Command Registration
-```yaml
-Netresearch\NrVault\Command\VaultStoreCommand:
-  tags:
-    - name: console.command
-```
-
-## Backend Module Configuration
-
-TYPO3 v14 uses PHP arrays for module registration:
-
+### Backend module route
 ```php
 // Configuration/Backend/Modules.php
 return [
@@ -60,85 +86,28 @@ return [
         'parent' => 'admin',
         'access' => 'admin',
         'path' => '/module/admin/vault',
-        'labels' => 'nr_vault.modules.overview',  // Short format
+        'labels' => 'nr_vault.modules.overview',
         'routes' => [
-            '_default' => [
-                'target' => Controller::class . '::action',
-            ],
+            '_default' => ['target' => Controller::class . '::handleRequest'],
         ],
     ],
 ];
 ```
 
-Key patterns:
-- Use short label format: `ext_key.modules.name`
-- Labels map to `Resources/Private/Language/Modules/{name}.xlf`
-- Submodules use `parent` to nest under parent module
-- POST routes require `'methods' => ['POST']`
-
-## TCA Configuration
-
-### Custom Table
+### AJAX route
 ```php
-// Configuration/TCA/tx_nrvault_secret.php
+// Configuration/Backend/AjaxRoutes.php
 return [
-    'ctrl' => [
-        'title' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_db.xlf:tx_nrvault_secret',
-        'label' => 'identifier',
-        'security' => [
-            'ignorePageTypeRestriction' => true,
-        ],
-    ],
-    'columns' => [ ... ],
-    'types' => [ ... ],
-];
-```
-
-### TCA Overrides
-```php
-// Configuration/TCA/Overrides/tt_content.php
-$GLOBALS['TCA']['tt_content']['columns']['my_field'] = [ ... ];
-```
-
-## Icon Registration
-
-```php
-// Configuration/Icons.php
-return [
-    'module-vault' => [
-        'provider' => SvgIconProvider::class,
-        'source' => 'EXT:nr_vault/Resources/Public/Icons/module-vault.svg',
+    'vault_reveal' => [
+        'path' => '/vault/reveal',
+        'target' => AjaxController::class . '::revealAction',
+        'methods' => ['POST'],
     ],
 ];
 ```
 
-## Site Sets
-
-Site sets provide configurable settings:
-
-```
-Configuration/Sets/NrVault/
-├── config.yaml     # Set metadata
-└── settings.yaml   # Default settings
-```
-
-## Common Tasks
-
-### Add New Backend Module Route
-1. Add route to `Configuration/Backend/Modules.php`
-2. Add controller action in `Classes/Controller/`
-3. Add template in `Resources/Private/Templates/`
-
-### Add New TCA Field
-1. Add column definition in TCA file
-2. Add to `showitem` in types
-3. Add label in `locallang_db.xlf`
-
-### Register New Service
-1. Create interface in `Classes/`
-2. Create implementation in `Classes/`
-3. Add alias in `Configuration/Services.yaml`
-
----
-
-*[n] Netresearch DTT GmbH*
+## When Stuck
+- TYPO3 DI docs: <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/DependencyInjection/>
+- TCA reference: <https://docs.typo3.org/m/typo3/reference-tca/main/en-us/>
+- Backend module howto: <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/BackendRouting/BackendModules/>
+- Invoke skill: `typo3-typoscript-ref` for TypoScript-adjacent patterns

--- a/Configuration/AGENTS.md
+++ b/Configuration/AGENTS.md
@@ -44,7 +44,7 @@ No separate setup — configuration is loaded by TYPO3 at bootstrap. After editi
 ## Code Style
 - **Services.yaml**: two-space indent; leading underscore for defaults (`_defaults:`); explicit `public: true` only where needed (controllers, commands, listeners).
 - **TCA**: return a single array literal; no side effects; use `LLL:EXT:nr_vault/Resources/Private/Language/locallang_db.xlf:…` for labels.
-- **Backend modules**: short label format `nr_vault.modules.<name>`; POST-only routes declare `methods: ['POST']`.
+- **Backend modules**: use `LLL:EXT:nr_vault/Resources/Private/Language/Modules/<name>.xlf` label paths (one XLIFF per module); POST-only routes declare `methods: ['POST']`.
 - **AJAX routes**: name them `vault_<action>`; controller returns `JsonResponse`.
 - **Do not** use `$GLOBALS['TYPO3_CONF_VARS']` edits inside `Configuration/` — keep them in `ext_localconf.php`.
 
@@ -82,13 +82,20 @@ Netresearch\NrVault\Crypto\MasterKeyProviderInterface:
 ```php
 // Configuration/Backend/Modules.php
 return [
-    'admin_vault' => [
-        'parent' => 'admin',
+    'admin_vault_secrets' => [
+        // 'tools' works on v13 natively and is an alias for 'admin' on v14.
+        'parent' => 'tools',
         'access' => 'admin',
-        'path' => '/module/admin/vault',
-        'labels' => 'nr_vault.modules.overview',
+        'workspaces' => 'live',
+        'path' => '/module/admin/vault/secrets',
+        'labels' => 'LLL:EXT:nr_vault/Resources/Private/Language/Modules/secrets.xlf',
+        'iconIdentifier' => 'module-vault-secrets',
         'routes' => [
-            '_default' => ['target' => Controller::class . '::handleRequest'],
+            // Route target is <Controller>::<action>Action — one action per route.
+            // Only Migration flows use a single dispatch method (handleRequest).
+            '_default' => ['target' => SecretsController::class . '::listAction'],
+            'create'   => ['target' => SecretsController::class . '::createAction'],
+            'toggle'   => ['target' => SecretsController::class . '::toggleAction', 'methods' => ['POST']],
         ],
     ],
 ];

--- a/Configuration/CLAUDE.md
+++ b/Configuration/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Configuration/GEMINI.md
+++ b/Configuration/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Documentation/AGENTS.md
+++ b/Documentation/AGENTS.md
@@ -1,160 +1,107 @@
-# AGENTS.md - Documentation
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
 
-> Documentation guidelines for nr-vault using TYPO3 docs standards.
+# AGENTS.md — Documentation
 
-## Critical Requirement: Backend-First Documentation
+## Overview
+RST documentation for <https://docs.typo3.org> + Architecture Decision Records.
+Invoke skill **`typo3-docs`** for deeper guidance (rendering, directives, screenshots).
 
-**nr-vault is fully usable without CLI or file access.** All documentation
-examples MUST show both approaches:
+## Key Files
+| File | Purpose |
+|------|---------|
+| `Documentation/Index.rst` | Main entry point; version table, toctree |
+| `Documentation/guides.xml` | Render metadata (replaces old Settings.cfg) |
+| `Documentation/Introduction/Index.rst` | Product intro |
+| `Documentation/Installation/Index.rst` | Install + environment prep |
+| `Documentation/Usage/ExtensionSettings.rst` | Admin tooling reference |
+| `Documentation/Security/Index.rst` | Threat model + hardening guidance |
+| `Documentation/Troubleshooting/Index.rst` | Common issues + diagnostics |
+| `Documentation/Developer/Index.rst` | Developer toctree |
+| `Documentation/Developer/Commands.rst` | `vault:*` CLI reference |
+| `Documentation/Developer/Adr/Index.rst` | ADR index |
+| `Documentation/Developer/Adr/ADR-006-AuditLogging.rst` | Audit log design |
+| `Documentation/Developer/Adr/ADR-018-FlexFormSecretLifecycle.rst` | FlexForm integration |
+| `Documentation/Developer/Adr/ADR-023-AuditHashChainHmac.rst` | Tamper-evident audit chain |
+| `Documentation/Sitemap.rst` | Page index |
 
-1. **Backend UI** (primary) - For editors and admins without server access
-2. **CLI commands** (secondary) - For developers and automation
+## Golden Samples
+| Pattern | Reference |
+|---------|-----------|
+| Top-level section | `Documentation/Introduction/Index.rst` |
+| ADR structure | `Documentation/Developer/Adr/ADR-023-AuditHashChainHmac.rst` |
+| CLI reference page | `Documentation/Developer/Commands.rst` |
+| Troubleshooting entry | `Documentation/Troubleshooting/Index.rst` |
 
-This is a key feature: secure secret management accessible to non-technical
-users through the TYPO3 backend.
+## Setup
+- Docker required for local rendering.
+- PNG images live in `Documentation/Images/` (subfolders mirror page paths).
 
-### Example Pattern
+## Build/Tests
+| Task | Command |
+|------|---------|
+| Render (Make target) | `make docs` |
+| Render (direct) | `docker run --rm --pull always -v "$(pwd)":/project -t ghcr.io/typo3-documentation/render-guides:latest --config=Documentation` |
+| Preview output | Open `Documentation-GENERATED-temp/Index.html` |
+| Clean output | `rm -rf Documentation-GENERATED-temp/` |
 
+## Code Style
+- RST, not Markdown.
+- Headings: `=` H1, `-` H2, `~` H3, `^` H4.
+- **One sentence per line** — diffs stay readable.
+- Line width ~80 chars where natural.
+- Admonitions: `.. note::`, `.. warning::`, `.. tip::`.
+- Tables: `.. t3-field-list-table::` or grid tables.
+- Cross-reference with `:ref:` and explicit labels.
+- Code blocks: `.. code-block:: php|bash|yaml|rst`.
+
+## Security
+Docs in `Documentation/Security/` are load-bearing — any crypto/access-control claim **must** match source behaviour. When the behaviour changes, update the docs in the same PR.
+
+- Do not publish sample master keys, DEKs, or real audit entries.
+- Redact org-specific paths in examples.
+- Link to ADRs for design decisions, not source comments.
+
+## Checklist
+- [ ] `make docs` renders without warnings
+- [ ] All `:ref:` targets resolve
+- [ ] Screenshots exist for any new UI; `:alt:` present; `:zoom: lightbox`
+- [ ] Images are PNG, viewport ≥ 1440×900
+- [ ] ADRs updated for non-trivial behaviour changes
+- [ ] New CLI commands documented in `Documentation/Developer/Commands.rst`
+
+## Examples
+### Screenshot figure
 ```rst
-**Via backend:**
+.. figure:: /Images/Configuration/ExtensionSettings.png
+   :alt: Vault extension configuration — master key providers
+   :zoom: lightbox
+   :class: with-border with-shadow
 
-1. Go to :guilabel:`Admin Tools > Vault > Secrets`
-2. Click :guilabel:`Create Secret`
-3. Enter identifier ``deepl_api_key`` and paste your API key
-4. Click :guilabel:`Save`
-
-**Via CLI:**
-
-.. code-block:: bash
-   :caption: Alternative: CLI command
-
-   ./vendor/bin/typo3 vault:store deepl_api_key "your-api-key"
+   Configure master-key provider under Admin Tools → Settings.
 ```
 
-Always show backend first, CLI second. Never assume users have CLI access.
-
-## Structure
-
-```
-Documentation/
-├── Index.rst              # Main entry point
-├── Includes.rst.txt       # Common includes
-├── Sitemap.rst            # Auto-generated sitemap
-├── guides.xml             # phpDocumentor configuration
-├── Configuration/         # Extension configuration docs
-├── Developer/             # Developer/API documentation
-├── Installation/          # Installation guide
-├── Introduction/          # Overview and features
-├── Security/              # Security considerations
-└── Usage/                 # User guide
-```
-
-## Rendering Documentation
-
-```bash
-# Render locally
-make docs
-
-# Output in Documentation-GENERATED-temp/
-```
-
-## RST Conventions
-
-### Headings
+### ADR skeleton
 ```rst
+:navigation-title: ADR-NNN Title
+..  include:: /Includes.rst.txt
+
+==============================
+ADR-NNN: Concise decision line
+==============================
+
+Context
 =======
-Level 1
-=======
-
-Level 2
-=======
-
-Level 3
--------
-
-Level 4
-~~~~~~~
+…
+Decision
+========
+…
+Consequences
+============
+…
 ```
 
-### TYPO3-Specific Directives
-
-```rst
-.. confval:: masterKeyPath
-   :type: string
-   :default: /var/secrets/vault.key
-
-   Path to the master encryption key file.
-
-.. versionadded:: 1.2.0
-   Added support for XChaCha20-Poly1305.
-
-.. deprecated:: 1.3.0
-   Use `vault:rotate-master-key` instead.
-```
-
-### Code Blocks
-```rst
-.. code-block:: php
-   :caption: Example usage
-
-   $vault->store('api-key', $secret);
-
-.. code-block:: bash
-
-   ddev exec bin/typo3 vault:init
-```
-
-### Cards (TYPO3 v12+)
-```rst
-.. card-grid::
-   :columns: 2
-
-   .. card:: :ref:`Quick Start <quickstart>`
-
-      Get started in 5 minutes.
-
-   .. card:: :ref:`CLI Reference <cli>`
-
-      Command-line tools.
-```
-
-### Cross-References
-```rst
-See :ref:`installation` for setup instructions.
-
-External: :t3coreapi:`DependencyInjection`
-```
-
-## File Naming
-
-- `Index.rst` - Main file in each directory
-- Use lowercase with hyphens for other files
-- Each major section gets its own directory
-
-## Adding New Documentation
-
-1. Create new `.rst` file in appropriate directory
-2. Add to `toctree` in parent `Index.rst`
-3. Run `make docs` to verify rendering
-4. Check for warnings in build output
-
-## Common Issues
-
-| Issue | Solution |
-|-------|----------|
-| Missing reference | Add `:ref:` label above heading |
-| Broken indentation | RST requires exact spacing (3 spaces) |
-| Image not found | Use relative path from current file |
-| Build warnings | Check `Documentation-GENERATED-temp/` output |
-
-## External References
-
-Inventories defined in `guides.xml`:
-- `t3coreapi` - TYPO3 Core API Reference
-- `t3tca` - TCA Reference
-
-Usage: `:t3coreapi:`SectionName``
-
----
-
-*[n] Netresearch DTT GmbH*
+## When Stuck
+- Invoke skill: `typo3-docs`
+- RST reference: <https://docs.typo3.org/m/typo3/docs-how-to-document/main/en-us/>
+- Render output log: `Documentation-GENERATED-temp/`

--- a/Documentation/CLAUDE.md
+++ b/Documentation/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Documentation/GEMINI.md
+++ b/Documentation/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/GEMINI.md
+++ b/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Resources/AGENTS.md
+++ b/Resources/AGENTS.md
@@ -1,161 +1,122 @@
-# AGENTS.md - Resources
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
 
-> Frontend resources guidelines for nr-vault.
+# AGENTS.md — Resources
 
-## Structure
+## Overview
+Fluid templates, backend JS/CSS, and XLIFF translation files for the nr-vault TYPO3 extension.
 
+## Key Files
+| File | Purpose |
+|------|---------|
+| `Resources/Private/Templates/Overview/Index.html` | Module landing page (status, shortcuts) |
+| `Resources/Private/Templates/Overview/Help.html` | Docheader help tab |
+| `Resources/Private/Templates/Secrets/List.html` | Secrets list + reveal/copy UI |
+| `Resources/Private/Templates/Audit/List.html` | Audit log listing |
+| `Resources/Private/Templates/Audit/VerifyChain.html` | HMAC chain verification view |
+| `Resources/Private/Templates/Migration/*.html` | Migration wizard steps |
+| `Resources/Private/Language/locallang_mod.xlf` | Main translation catalogue |
+| `Resources/Public/JavaScript/SecretReveal.js` | AJAX reveal + clipboard copy |
+| `Resources/Public/JavaScript/SecretsList.js` | List filtering/interaction |
+| `Resources/Public/JavaScript/vault-secret-input.js` | TCA field widget |
+| `Resources/Public/Css/backend.css` | Backend module styles |
+
+## Golden Samples
+| Pattern | Reference |
+|---------|-----------|
+| Fluid template with docheader | `Resources/Private/Templates/Overview/Index.html` |
+| List/detail view | `Resources/Private/Templates/Secrets/List.html` |
+| AJAX-driven JS module | `Resources/Public/JavaScript/SecretReveal.js` |
+| TCA input widget | `Resources/Public/JavaScript/vault-secret-input.js` |
+| XLIFF structure | `Resources/Private/Language/locallang_mod.xlf` |
+
+## Setup
+- Templates consumed by `Classes/Controller/*Controller.php`
+- JS loaded via `ext_localconf.php` / backend module registration
+- XLIFF keys referenced in PHP as `LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:<key>`
+
+## Build/Tests
+| Task | Command |
+|------|---------|
+| Render templates (integration) | `make test-functional` |
+| E2E through UI | See `Tests/E2E/AGENTS.md` |
+| CS for JS (none yet) | `make lint` (PHP only) |
+
+## Directory Structure
 ```
 Resources/
 ├── Private/
-│   ├── Language/
-│   │   ├── Modules/              # Module-specific labels
-│   │   │   ├── overview.xlf
-│   │   │   ├── secrets.xlf
-│   │   │   ├── audit.xlf
-│   │   │   └── migration.xlf
-│   │   ├── locallang.xlf         # General labels
-│   │   ├── locallang_mod.xlf     # Module labels (legacy)
-│   │   └── locallang_tca.xlf     # TCA field labels
-│   ├── Partials/                 # Reusable Fluid partials
-│   └── Templates/                # Fluid templates
-│       ├── Overview/
-│       ├── Secrets/
+│   ├── Language/        # XLIFF translations (locallang_mod.xlf + locales)
+│   ├── Layouts/         # Fluid layouts
+│   ├── Partials/        # Fluid partials
+│   └── Templates/
 │       ├── Audit/
-│       └── Migration/
+│       ├── Migration/
+│       ├── Overview/
+│       └── Secrets/
 └── Public/
-    ├── Icons/                    # SVG icons
-    ├── Css/                      # Stylesheets
-    └── JavaScript/               # ES6 modules
+    ├── Css/
+    ├── Icons/
+    └── JavaScript/
 ```
 
-## Language Files (XLIFF)
+## Code Style
+- **Fluid**:
+  - Prefer `{variable -> f:format.htmlspecialchars()}` where raw rendering is needed; `{variable}` is auto-escaped.
+  - Use `<f:be.pageRenderer>` for backend modules; `<f:be.container>` for docheader.
+  - Keep logic in controllers — templates stay declarative.
+- **JavaScript**:
+  - ES modules (`import`/`export`), no jQuery.
+  - Use TYPO3 backend APIs: `@typo3/backend/modal.js`, `@typo3/backend/notification.js`, `@typo3/core/ajax/ajax-request.js`.
+  - CSP-compliant: no inline handlers, no `eval`.
+- **CSS**: scope to `.module-body` / module-specific classes; no global resets.
+- **XLIFF**: one `<trans-unit id="..."><source>...</source></trans-unit>` per string; keep IDs stable.
 
-### File Naming Convention
-- `locallang.xlf` - General extension labels
-- `locallang_tca.xlf` - TCA/database field labels
-- `Modules/{name}.xlf` - Module-specific labels
+## Security
+- **Auto-escape** — never `<f:format.raw>` on user-controlled values (secrets, identifiers, audit context).
+- **CSP** — inline `<script>` forbidden; load JS via `<f:be.pageRenderer includeJsModules="...">`.
+- **No secrets in templates** — secret values arrive via AJAX at reveal time, rendered to a short-lived container, then cleared.
+- **Clipboard** — use `navigator.clipboard.writeText`; show toast then wipe local variable.
+- **AJAX** — routes declared in `Configuration/Backend/AjaxRoutes.php`; CSRF protected by `@typo3/core/ajax/ajax-request.js`.
 
-### XLIFF Format
-```xml
-<?xml version="1.0" encoding="UTF-8"?>
-<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="messages">
-        <body>
-            <trans-unit id="title">
-                <source>Secret Management</source>
-            </trans-unit>
-            <trans-unit id="button.save">
-                <source>Save Secret</source>
-            </trans-unit>
-        </body>
-    </file>
-</xliff>
-```
+## Checklist
+- [ ] New XLIFF keys added to base `locallang_mod.xlf` and referenced from PHP/Fluid
+- [ ] Fluid output escaping verified (no `format.raw` on secret/user data)
+- [ ] JS modules use `@typo3/backend/*` imports — no direct DOM globals
+- [ ] No inline event handlers (CSP)
+- [ ] Images optimized; stored under `Resources/Public/Icons/`
+- [ ] Functional test exercising the controller → template render path
 
-### Usage in Fluid
+## Examples
 ```html
-<f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang.xlf:title" />
-```
-
-### Short Format (TYPO3 v12+)
-```php
-// In Modules.php
-'labels' => 'nr_vault.modules.secrets',
-// Maps to: EXT:nr_vault/Resources/Private/Language/Modules/secrets.xlf
-```
-
-## Fluid Templates
-
-### Controller → Template Mapping
-```
-Controller: SecretsController::listAction()
-Template:   Resources/Private/Templates/Secrets/List.html
-```
-
-### Template Structure
-```html
+<!-- Backend module layout -->
 <html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
-      xmlns:be="http://typo3.org/ns/TYPO3/CMS/Backend/ViewHelpers"
-      xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
       data-namespace-typo3-fluid="true">
-
-<f:layout name="Module" />
-
-<f:section name="Content">
-    <!-- Template content -->
-</f:section>
-
+  <f:layout name="Module"/>
+  <f:section name="Content">
+    <h1>{f:translate(key:'title.secrets')}</h1>
+    <f:render partial="Secrets/ListTable" arguments="{secrets: secrets}"/>
+  </f:section>
 </html>
 ```
 
-### Partials
-Reusable components in `Partials/`:
-```html
-<f:render partial="SecretRow" arguments="{secret: secret}" />
+```js
+// Backend JS module entry point
+import Notification from '@typo3/backend/notification.js';
+import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
+
+class SecretReveal {
+  async reveal(id) {
+    const resp = await new AjaxRequest(TYPO3.settings.ajaxUrls['vault_reveal'])
+      .post({ id });
+    const body = await resp.resolve();
+    // render then clear
+  }
+}
 ```
 
-## JavaScript (ES6 Modules)
-
-### Registration
-```php
-// Configuration/JavaScriptModules.php
-return [
-    'imports' => [
-        '@netresearch/nr-vault/' => 'EXT:nr_vault/Resources/Public/JavaScript/',
-    ],
-];
-```
-
-### Usage in Templates
-```html
-<script type="module">
-    import VaultModule from '@netresearch/nr-vault/vault-module.js';
-</script>
-```
-
-## Icons
-
-### SVG Requirements
-- Viewbox: `0 0 16 16` or `0 0 24 24`
-- Single color (uses `currentColor`)
-- No embedded styles
-
-### Registration
-```php
-// Configuration/Icons.php
-return [
-    'vault-secret' => [
-        'provider' => SvgIconProvider::class,
-        'source' => 'EXT:nr_vault/Resources/Public/Icons/secret.svg',
-    ],
-];
-```
-
-## CSS
-
-### TYPO3 Backend Styles
-Follow TYPO3 backend styling patterns:
-- Use CSS custom properties where possible
-- Prefix custom classes with `vault-`
-- Use TYPO3 utility classes when available
-
-## Common Tasks
-
-### Add New Translation
-1. Add `<trans-unit>` to appropriate `.xlf` file
-2. Use `<f:translate>` in template
-3. Test in both frontend and backend contexts
-
-### Add New Template
-1. Create `.html` file matching controller action
-2. Use `<f:layout name="Module" />` for backend
-3. Define `<f:section name="Content">`
-
-### Add New Icon
-1. Add SVG to `Resources/Public/Icons/`
-2. Register in `Configuration/Icons.php`
-3. Use with `<core:icon identifier="..." />`
-
----
-
-*[n] Netresearch DTT GmbH*
+## When Stuck
+- Check `Classes/Controller/` for the assigned variables
+- XLIFF reference: <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/Internationalization/>
+- Fluid ViewHelpers: <https://docs.typo3.org/other/typo3/view-helper-reference/main/en-us/>
+- Backend JS modules: <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/ApiOverview/JavaScript/>

--- a/Resources/CLAUDE.md
+++ b/Resources/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Resources/GEMINI.md
+++ b/Resources/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -67,14 +67,14 @@ Tests/
 ## Code Style
 - Unit tests extend `\TYPO3\TestingFramework\Core\Unit\UnitTestCase`.
 - Functional tests extend `\TYPO3\TestingFramework\Core\Functional\FunctionalTestCase`.
-- Test class name: `<SourceClass>Test`; methods use `@Test` attribute or `test` prefix.
+- Test class name: `<SourceClass>Test`; methods use the `#[Test]` PHPUnit attribute (`PHPUnit\Framework\Attributes\Test`) or a `test` prefix — never the legacy `@test` docblock annotation.
 - Use `#[DataProvider]` (native PHPUnit 10 attribute) for parameterized cases.
 - One assertion concept per test; split by behaviour, not by line count.
 - No real HTTP / filesystem calls — mock adapters (`VaultAdapterInterface`).
 - Functional fixtures: `Tests/.../Fixtures/*.csv`, loaded via `$this->importCSVDataSet()`.
 
 ## Security
-- **Never commit real secrets** — fixtures use clearly synthetic values. `.gitleaks.toml` allowlists `Tests/` and `Documentation/` paths for known test strings.
+- **Never commit real secrets** — fixtures use clearly synthetic values. `.gitleaks.toml` allowlists only a narrow set of specific paths (see the `[allowlist] paths` list) for known synthetic tokens; new files are scanned by default.
 - **Master keys in tests** are generated per-test (`sodium_crypto_secretbox_keygen()`), never hard-coded.
 - **Do not** test against production vault backends.
 - **Audit logs** in tests must still verify HMAC chain integrity when the code path produces entries.

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -1,171 +1,118 @@
-# AGENTS.md - Tests
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
 
-> Testing guidelines for nr-vault.
+# AGENTS.md — Tests
 
-**See also**: `Tests/E2E/AGENTS.md` for E2E-specific patterns.
+## Overview
+Unit, Functional, Fuzz, and Architecture tests for nr-vault.
+Invoke skill **`typo3-testing`** for deeper guidance on fixtures, mocking, and CI setup.
 
-## Test Structure
+## Setup
+- Local: `make up` to start DDEV, then `make test-unit` / `make test-functional`.
+- CI-only config at `Build/phpunit.xml` (unit + fuzz) and `Build/FunctionalTests.xml` (functional).
+- Functional tests need DB — run inside DDEV (`ddev exec ...`).
 
+## Key Files
+| File | Purpose |
+|------|---------|
+| `Tests/Unit/Service/VaultServiceTest.php` | Core vault service unit tests |
+| `Tests/Unit/Crypto/FileMasterKeyProviderTest.php` | Master-key provider (file) |
+| `Tests/Unit/Crypto/EnvironmentMasterKeyProviderTest.php` | Master-key provider (env) |
+| `Tests/Unit/Audit/AuditLogServiceTest.php` | Audit log writer + HMAC chain |
+| `Tests/Unit/Hook/FlexFormVaultHookTest.php` | FlexForm hook behavior |
+| `Tests/Unit/Utility/IdentifierValidatorTest.php` | Identifier validation edge cases |
+| `Tests/Functional/Crypto/MasterKeyRotationTest.php` | Full rotation end-to-end |
+| `Tests/Functional/Controller/AjaxControllerTest.php` | AJAX reveal flow |
+| `Tests/Functional/Controller/Fixtures/be_users.csv` | Test BE users |
+| `Tests/Fuzz/` | Fuzz suite — identifiers, payloads |
+| `Tests/Architecture/` | PHPat dependency rules |
+| `Tests/E2E/` | Playwright browser tests (own scoped AGENTS.md) |
+
+## Golden Samples
+| Pattern | Reference |
+|---------|-----------|
+| Unit test with dataProvider | `Tests/Unit/Utility/IdentifierValidatorTest.php` |
+| Unit test of crypto | `Tests/Unit/Crypto/FileMasterKeyProviderTest.php` |
+| Functional with DB fixtures | `Tests/Functional/Controller/AjaxControllerTest.php` |
+| Functional crypto integration | `Tests/Functional/Crypto/MasterKeyRotationTest.php` |
+| Hook test with DataHandler | `Tests/Unit/Hook/FlexFormVaultHookTest.php` |
+
+## Build/Tests
+| Type | Command |
+|------|---------|
+| Unit only | `make test-unit` (or `composer ci:test:php:unit`) |
+| Functional only | `make test-functional` (or `composer ci:test:php:functional`) |
+| Fuzz | `composer ci:test:php:fuzz` |
+| All CI (unit+fuzz+phpstan+cgl) | `composer ci` |
+| Mutation (Infection) | `make test-mutation` |
+| Single file | `ddev exec vendor/bin/phpunit -c Build/phpunit.xml Tests/Unit/Path/ToTest.php` |
+| Coverage | `ddev exec vendor/bin/phpunit -c Build/phpunit.xml --coverage-html .Build/coverage` |
+
+## Directory Structure
 ```
 Tests/
-├── Unit/           # Fast, isolated tests (mocked dependencies)
-├── Functional/     # TYPO3 integration tests (real database)
-├── E2E/            # Playwright browser tests (full stack)
-├── Architecture/   # PHPat dependency rules
-├── Fuzz/           # Input fuzzing tests
-└── Build/          # PHPUnit configuration
+├── Architecture/      # PHPat boundary rules
+├── E2E/               # Playwright (see E2E/AGENTS.md)
+├── Functional/        # DB-backed integration
+│   ├── Controller/
+│   │   └── Fixtures/  # CSV fixtures
+│   └── Crypto/
+├── Fuzz/              # Property / input fuzzing
+└── Unit/              # Fast isolated tests (100+ files)
+    ├── Adapter/  Audit/  Command/  Configuration/  Controller/
+    ├── Crypto/  Domain/  EventListener/  Hook/  Http/
+    ├── Service/  Task/  Upgrades/  Utility/
 ```
 
-## Running Tests
+## Code Style
+- Unit tests extend `\TYPO3\TestingFramework\Core\Unit\UnitTestCase`.
+- Functional tests extend `\TYPO3\TestingFramework\Core\Functional\FunctionalTestCase`.
+- Test class name: `<SourceClass>Test`; methods use `@Test` attribute or `test` prefix.
+- Use `#[DataProvider]` (native PHPUnit 10 attribute) for parameterized cases.
+- One assertion concept per test; split by behaviour, not by line count.
+- No real HTTP / filesystem calls — mock adapters (`VaultAdapterInterface`).
+- Functional fixtures: `Tests/.../Fixtures/*.csv`, loaded via `$this->importCSVDataSet()`.
 
-```bash
-# All tests
-make test
+## Security
+- **Never commit real secrets** — fixtures use clearly synthetic values. `.gitleaks.toml` allowlists `Tests/` and `Documentation/` paths for known test strings.
+- **Master keys in tests** are generated per-test (`sodium_crypto_secretbox_keygen()`), never hard-coded.
+- **Do not** test against production vault backends.
+- **Audit logs** in tests must still verify HMAC chain integrity when the code path produces entries.
 
-# Specific suites
-make unit                    # Unit only
-make functional              # Functional only
+## Checklist
+- [ ] `composer ci` passes (unit + fuzz + phpstan + cs)
+- [ ] `make test-functional` passes
+- [ ] New src file has a matching `Tests/Unit/...Test.php`
+- [ ] Public API change has a functional test exercising it
+- [ ] No hardcoded secrets — generate at runtime or use placeholders
+- [ ] Fixtures are minimal (smallest CSV that reproduces the case)
+- [ ] Mutation score not regressed on touched files (spot-check with `make test-mutation`)
 
-# In container with options
-ddev exec .Build/bin/phpunit -c Build/phpunit.xml --testsuite Unit --filter "OrphanCleanup"
-
-# E2E tests (requires running TYPO3)
-cd Tests/E2E && npx playwright test
-```
-
-## Unit Test Conventions
-
+## Examples
 ```php
-#[CoversClass(MyService::class)]
-final class MyServiceTest extends UnitTestCase
+// Unit test with DataProvider attribute
+use PHPUnit\Framework\Attributes\DataProvider;
+use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
+
+final class IdentifierValidatorTest extends UnitTestCase
 {
-    protected bool $resetSingletonInstances = true;
-
-    private MyService $subject;
-
-    #[Override]
-    protected function setUp(): void
+    #[DataProvider('invalidIdentifierProvider')]
+    public function testRejectsInvalidIdentifier(string $input, string $reason): void
     {
-        parent::setUp();
-        $this->subject = new MyService(/* mocked dependencies */);
+        $this->expectExceptionMessage($reason);
+        (new IdentifierValidator())->validate($input);
     }
 
-    #[Test]
-    public function methodNameDescribesExpectedBehavior(): void
+    public static function invalidIdentifierProvider(): iterable
     {
-        // Arrange
-        $input = 'test';
-
-        // Act
-        $result = $this->subject->process($input);
-
-        // Assert
-        self::assertSame('expected', $result);
+        yield 'path-traversal' => ['../etc/passwd', 'control'];
+        yield 'null-byte' => ["a\0b", 'control'];
     }
 }
 ```
 
-Key rules:
-- One test class per production class
-- Use `#[Test]` attribute (not `@test` annotation)
-- Use `#[CoversClass]` for coverage tracking
-- Method names describe behavior, not implementation
-- Mock all external dependencies
-- Use `self::assert*` (not `$this->assert*`)
-
-## Functional Test Conventions
-
-```php
-#[CoversClass(VaultService::class)]
-final class VaultServiceTest extends FunctionalTestCase
-{
-    protected array $testExtensionsToLoad = [
-        'netresearch/nr-vault',
-    ];
-
-    protected array $coreExtensionsToLoad = [
-        'scheduler',
-    ];
-
-    #[Test]
-    public function storesAndRetrievesSecret(): void
-    {
-        $this->importCSVDataSet(__DIR__ . '/Fixtures/be_users.csv');
-        // ... test with real database
-    }
-}
-```
-
-Key rules:
-- Use CSV fixtures for test data
-- Clean database state between tests
-- Test real TYPO3 integration points
-
-## E2E Test Conventions
-
-```typescript
-test.describe('Secret Management', () => {
-  test('can create and delete secret', async ({ authenticatedPage: page }) => {
-    await page.goto('/typo3/module/admin/vault/secrets/create');
-    await waitForModuleContent(page);
-
-    const frame = getModuleFrame(page);
-    // ... interact with TYPO3 backend
-  });
-});
-```
-
-Key rules:
-- Use `authenticatedPage` fixture for admin access
-- Use `getModuleFrame()` for TYPO3 v14 iframe structure
-- Use `waitForModuleContent()` before assertions
-- Generate unique test identifiers for isolation
-
-## Mocking Patterns
-
-### Mock VaultService
-```php
-$vaultService = $this->createMock(VaultServiceInterface::class);
-$vaultService->method('retrieve')->willReturn('secret-value');
-$vaultService->expects($this->once())->method('store');
-```
-
-### Mock Backend User
-```php
-$GLOBALS['BE_USER'] = $this->createMock(BackendUserAuthentication::class);
-$GLOBALS['BE_USER']->method('isAdmin')->willReturn(true);
-$GLOBALS['BE_USER']->user = ['uid' => 1, 'username' => 'admin'];
-```
-
-### Mock ConnectionPool
-```php
-$connectionPool = $this->createMock(ConnectionPool::class);
-$queryBuilder = $this->createMock(QueryBuilder::class);
-$connectionPool->method('getQueryBuilderForTable')->willReturn($queryBuilder);
-```
-
-## Security Testing
-
-1. **Never use real secrets** - Use generated test values
-2. **Test access control** - Verify permissions are enforced
-3. **Test audit logging** - Verify operations are logged
-4. **Test edge cases** - Empty strings, null, special chars
-
-## Coverage Requirements
-
-- New code: Minimum 80% line coverage
-- Security-critical code: 100% coverage required
-- Run with coverage: `ddev exec .Build/bin/phpunit -c Build/phpunit.xml --testsuite Unit --coverage-text`
-
-## Common Issues
-
-| Issue | Solution |
-|-------|----------|
-| `GeneralUtility::makeInstance` fails | Use `GeneralUtility::addInstance()` in setUp |
-| Singleton not reset | Set `$resetSingletonInstances = true` |
-| E2E iframe not found | Use `getModuleFrame(page)` helper |
-| Functional test DB error | Check `$testExtensionsToLoad` |
-
----
-
-*[n] Netresearch DTT GmbH*
+## When Stuck
+- Invoke skill: `typo3-testing`
+- TYPO3 TestingFramework docs: <https://docs.typo3.org/other/typo3/testing-framework/main/en-us/>
+- Check existing tests in the same directory for patterns
+- Root AGENTS.md for project-wide conventions

--- a/Tests/CLAUDE.md
+++ b/Tests/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Tests/E2E/AGENTS.md
+++ b/Tests/E2E/AGENTS.md
@@ -32,7 +32,11 @@ Playwright browser E2E tests for the nr-vault TYPO3 backend module. Targets the 
 # 1. Start the TYPO3 instance
 make up
 
-# 2. (First run) install Playwright browsers
+# 2. Install Node dependencies declared in package.json
+#    (@playwright/test, @axe-core/playwright, etc.)
+npm install
+
+# 3. (First run) install Playwright browsers + system deps
 npx playwright install --with-deps
 ```
 
@@ -63,8 +67,8 @@ Tests/E2E/
 
 ## Code Style
 - TypeScript, ES modules.
-- Each test fully isolated — generate unique identifiers per run:
-  `const uniqueId = \`test-${Date.now()}-${Math.random().toString(36).slice(2,8)}\``
+- Each test fully isolated — generate unique identifiers per run. Vault identifiers must start with a letter and contain only letters/digits/underscores (see `Classes/Utility/IdentifierValidator.php`), so use **underscores, not hyphens**:
+  `const uniqueId = \`e2e_test_${Date.now()}_${crypto.randomUUID().slice(0, 8)}\`;`
 - Always await inside tests; never mix fire-and-forget promises.
 - Prefer role/label locators over CSS selectors.
 - No `page.waitForTimeout(ms)` — use `waitForModuleContent` or explicit `waitFor`.
@@ -74,7 +78,7 @@ Tests/E2E/
 - **Test credentials** (`admin` / DDEV default) are for local DDEV only — never commit production credentials.
 - **Never** point E2E tests at a production instance.
 - **Clipboard access** — tests that read clipboard require browser permissions in `playwright.config.ts`.
-- **Fixtures** — no real secrets; use placeholders like `fixture-secret-<uniqueId>`.
+- **Fixtures** — no real secrets; use identifier-safe placeholders like `fixture_secret_<uniqueId>` (letters/digits/underscores only — see `IdentifierValidator`).
 
 ## Checklist
 - [ ] Test uses `getModuleFrame(page)` for any assertion inside the module iframe

--- a/Tests/E2E/AGENTS.md
+++ b/Tests/E2E/AGENTS.md
@@ -1,107 +1,120 @@
-# AGENTS.md - E2E Tests
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
 
-> End-to-end testing guidelines for nr-vault using Playwright.
+# AGENTS.md — Tests/E2E
 
-## Structure
+## Overview
+Playwright browser E2E tests for the nr-vault TYPO3 backend module. Targets the running DDEV instance.
 
+## Key Files
+| File | Purpose |
+|------|---------|
+| `Tests/E2E/vault-module.spec.ts` | Basic module loading |
+| `Tests/E2E/fixtures/auth.ts` | Auth fixture + `getModuleFrame`, `waitForModuleContent` helpers |
+| `Tests/E2E/user-pathways/secrets.spec.ts` | Secret CRUD + reveal journey |
+| `Tests/E2E/user-pathways/audit.spec.ts` | Audit log workflows |
+| `Tests/E2E/user-pathways/migration.spec.ts` | Migration wizard |
+| `Tests/E2E/user-pathways/overview.spec.ts` | Dashboard |
+| `Tests/E2E/user-pathways/cross-module.spec.ts` | Multi-module interactions |
+| `Tests/E2E/accessibility/` | axe-core accessibility assertions |
+| `Tests/E2E/USER_PATHWAYS.md` | Journey catalogue |
+| `playwright.config.ts` | Project + reporter config (repo root) |
+
+## Golden Samples
+| Pattern | Reference |
+|---------|-----------|
+| Iframe-aware test | `Tests/E2E/user-pathways/secrets.spec.ts` |
+| Auth fixture usage | `Tests/E2E/fixtures/auth.ts` |
+| Accessibility assertion | `Tests/E2E/accessibility/*.spec.ts` |
+
+## Setup
+```bash
+# 1. Start the TYPO3 instance
+make up
+
+# 2. (First run) install Playwright browsers
+npx playwright install --with-deps
+```
+
+## Build/Tests
+| Task | Command |
+|------|---------|
+| All E2E | `npx playwright test` (from repo root) |
+| Single file | `npx playwright test user-pathways/secrets.spec.ts` |
+| Headed UI | `npx playwright test --ui` |
+| Debug | `npx playwright test --debug` |
+| Report | `npx playwright show-report` |
+
+## Directory Structure
 ```
 Tests/E2E/
 ├── fixtures/
-│   └── auth.ts           # Authentication fixture + TYPO3 helpers
-├── user-pathways/        # User journey tests (87 tests)
-│   ├── audit.spec.ts     # Audit log workflows
-│   ├── cross-module.spec.ts  # Multi-module interactions
-│   ├── migration.spec.ts     # Migration scenarios
-│   ├── overview.spec.ts      # Dashboard workflows
-│   └── secrets.spec.ts       # Secret management
-├── accessibility/        # Accessibility tests
-└── vault-module.spec.ts  # Basic module loading tests
+│   └── auth.ts
+├── user-pathways/
+│   ├── audit.spec.ts
+│   ├── cross-module.spec.ts
+│   ├── migration.spec.ts
+│   ├── overview.spec.ts
+│   └── secrets.spec.ts
+├── accessibility/
+├── tca/
+└── vault-module.spec.ts
 ```
 
-## Running E2E Tests
+## Code Style
+- TypeScript, ES modules.
+- Each test fully isolated — generate unique identifiers per run:
+  `const uniqueId = \`test-${Date.now()}-${Math.random().toString(36).slice(2,8)}\``
+- Always await inside tests; never mix fire-and-forget promises.
+- Prefer role/label locators over CSS selectors.
+- No `page.waitForTimeout(ms)` — use `waitForModuleContent` or explicit `waitFor`.
+- Group pathways by domain (secrets, audit, migration) rather than by page.
 
-```bash
-# Requires running TYPO3 instance
-make up
+## Security
+- **Test credentials** (`admin` / DDEV default) are for local DDEV only — never commit production credentials.
+- **Never** point E2E tests at a production instance.
+- **Clipboard access** — tests that read clipboard require browser permissions in `playwright.config.ts`.
+- **Fixtures** — no real secrets; use placeholders like `fixture-secret-<uniqueId>`.
 
-# Run all E2E tests
-cd Tests/E2E && npx playwright test
+## Checklist
+- [ ] Test uses `getModuleFrame(page)` for any assertion inside the module iframe
+- [ ] `waitForModuleContent(page)` called after navigation
+- [ ] No TYPO3 error page shown: assert absence of "Oops, an error occurred" / "503"
+- [ ] Unique identifiers for isolation (no shared state across tests)
+- [ ] No `waitForTimeout` — use explicit `waitFor`
+- [ ] Accessibility added when a new UI surface is introduced
+- [ ] Cleanup: tests delete the records they create
 
-# Run specific file
-npx playwright test user-pathways/secrets.spec.ts
-
-# Run with UI
-npx playwright test --ui
-
-# Debug mode
-npx playwright test --debug
-```
-
-## TYPO3 v14 Iframe Architecture
-
-TYPO3 v14 renders module content inside an iframe. **Always use the helpers**:
-
+## Examples
+### TYPO3 v14 iframe-aware test
 ```typescript
-import { test, expect, getModuleFrame, waitForModuleContent } from './fixtures/auth';
+import { test, expect, getModuleFrame, waitForModuleContent } from '../fixtures/auth';
 
-test('example', async ({ authenticatedPage: page }) => {
+test('Secrets list renders', async ({ authenticatedPage: page }) => {
   await page.goto('/typo3/module/admin/vault/secrets');
   await waitForModuleContent(page);
 
   const frame = getModuleFrame(page);
   await expect(frame.locator('h1')).toContainText('Secrets');
+  await expect(page.locator('text=Oops, an error occurred')).not.toBeVisible();
 });
 ```
 
-## Key Patterns
-
-### Test Isolation
-```typescript
-// Generate unique identifiers per test
-const uniqueId = `test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
-```
-
-### Error Detection
-```typescript
-// Always check for TYPO3 error pages
-await expect(page.locator('text=Oops, an error occurred')).not.toBeVisible();
-await expect(page.locator('text=503')).not.toBeVisible();
-```
-
-### Conditional Actions
-```typescript
-// Handle elements that may or may not exist
-const button = page.locator('button[data-action="delete"]').first();
-if (await button.isVisible()) {
-  await button.click();
-}
-```
-
-## Module URLs
-
+### Module URLs
 | Module | URL |
 |--------|-----|
 | Overview | `/typo3/module/admin/vault` |
-| Secrets List | `/typo3/module/admin/vault/secrets` |
-| Create Secret | `/typo3/module/admin/vault/secrets/create` |
-| Audit Log | `/typo3/module/admin/vault/audit` |
+| Secrets list | `/typo3/module/admin/vault/secrets` |
+| Create secret | `/typo3/module/admin/vault/secrets/create` |
+| Audit log | `/typo3/module/admin/vault/audit` |
 
-## Test Credentials
+## When Stuck
+| Issue | Resolution |
+|-------|------------|
+| Element not found | Content lives in iframe — use `getModuleFrame(page)` |
+| Timeout waiting | Call `waitForModuleContent(page)` after `goto` |
+| Flaky tests | Generate unique identifiers; replace `waitForTimeout` with `waitFor` |
+| Auth failures | `make up` to ensure DDEV is running |
 
-- **Username**: `admin`
-- **Password**: `Joh316!!`
-
-(DDEV defaults - never use in production)
-
-## Common Issues
-
-| Issue | Solution |
-|-------|----------|
-| Element not found | Use `getModuleFrame(page)` - content is in iframe |
-| Timeout waiting | Use `waitForModuleContent(page)` before assertions |
-| Flaky tests | Add unique identifiers, use `waitFor` explicitly |
-| Auth failures | Check DDEV is running (`make up`) |
-
----
-
-*[n] Netresearch DTT GmbH*
+- Playwright docs: <https://playwright.dev/docs/intro>
+- Invoke skill: `typo3-testing` for PHP-side integration tips

--- a/Tests/E2E/CLAUDE.md
+++ b/Tests/E2E/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Tests/E2E/GEMINI.md
+++ b/Tests/E2E/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/Tests/GEMINI.md
+++ b/Tests/GEMINI.md
@@ -1,0 +1,1 @@
+AGENTS.md


### PR DESCRIPTION
## Summary
- Run `agent-rules` skill — validator reported 15 structural errors + stale/inaccurate content across all AGENTS.md files.
- Regenerated the scaffold, then rewrote each file using verified project data (Makefile targets, composer scripts, real namespace, actual Key Files).
- Added `CLAUDE.md` / `GEMINI.md` symlinks for every AGENTS.md so Claude Code, Gemini CLI, and other agents discover the same rules.
- Created missing scoped files for `Tests/E2E/` and updated `Configuration/`.
- All 9 files now pass `validate-structure.sh`, `verify-content.sh`, and `check-freshness.sh`.

## Files touched
- Root `AGENTS.md` — fixed commands table, restored security requirements + key interfaces, added scope index, project overview
- `Classes/AGENTS.md` — real namespace `Netresearch\NrVault\`, accurate Key Files (VaultService, EncryptionService, AuditLogService, etc.), TYPO3-specific golden samples
- `Configuration/AGENTS.md` — Services.yaml / TCA / Backend routes patterns + AJAX routes example
- `Documentation/AGENTS.md` — real ADR list, `guides.xml` render command, ADR skeleton
- `Resources/AGENTS.md` — Fluid + ES module + XLIFF specifics, CSP guidance, clipboard/AJAX safety notes
- `Tests/AGENTS.md` — real test files as golden samples, PHPUnit 10 `#[DataProvider]` attributes, fuzz/architecture mention
- `Tests/E2E/AGENTS.md` — iframe-aware helpers, test credential scope (DDEV only), accessibility suite
- `.ddev/AGENTS.md` — mock-oauth sidecar, `make` shortcuts, multi-version override pattern
- `.github/workflows/AGENTS.md` — SHA pinning requirement, "never `secrets: inherit`", actionlint, annotations check
- New `CLAUDE.md` / `GEMINI.md` symlinks → `AGENTS.md` in all 8 locations

## Rationale
The auto-generated scaffold contained generic content (wrong Makefile targets, placeholder "Key Files" purposes copied from copyright headers, generic `Vendor\ExtKey\` namespace). Agents reading these would run the wrong commands and produce confusing output. Replacing generated noise with verified project-specific content restores trust in the documentation.

## Test plan
- [x] `scripts/validate-structure.sh .` — all structure checks pass
- [x] `scripts/verify-content.sh .` — all verification checks pass
- [x] `scripts/check-freshness.sh .` — 9 files up to date
- [x] Symlinks verified (`ls -la CLAUDE.md GEMINI.md`) in all 8 dirs