### PR TITLE
ci: silence SAST false positives (Fluid templates, test teardown unlink)

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,16 @@
+# semgrepignore / opengrepignore — paths excluded from SAST scanning.
+# gitignore-style syntax; opengrep reads this file (fork of semgrep).
+
+# Fluid templates. TYPO3 Fluid is HTML-ish but NOT Django/Jinja — the auto
+# ruleset incorrectly loads Python/Django rules for .html files, producing
+# false positives (e.g. django-no-csrf-token on <form> tags that are CSRF-
+# protected by TYPO3's FormProtectionFactory, not Django middleware).
+# There are no semgrep rules that understand Fluid, so excluding .html
+# templates removes noise without losing real coverage.
+Resources/Private/Templates/
+
+# Build cache (never be in repo, belt-and-braces)
+.Build/
+Documentation-GENERATED-temp/
+node_modules/
+vendor/

--- a/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/Tests/Functional/Controller/AjaxControllerTest.php
@@ -63,6 +63,7 @@ final class AjaxControllerTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }
 

--- a/Tests/Functional/Controller/AuditControllerTest.php
+++ b/Tests/Functional/Controller/AuditControllerTest.php
@@ -64,6 +64,7 @@ final class AuditControllerTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }
 

--- a/Tests/Functional/Controller/MigrationControllerTest.php
+++ b/Tests/Functional/Controller/MigrationControllerTest.php
@@ -64,6 +64,7 @@ final class MigrationControllerTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }
 

--- a/Tests/Functional/Controller/SecretsControllerTest.php
+++ b/Tests/Functional/Controller/SecretsControllerTest.php
@@ -66,6 +66,7 @@ final class SecretsControllerTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }
 

--- a/Tests/Functional/Crypto/MasterKeyRotationTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationTest.php
@@ -79,6 +79,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }
 
@@ -148,6 +149,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
             $vaultService->delete($identifier, 'Test cleanup');
         }
         if (file_exists($newKeyPath)) {
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($newKeyPath);
         }
     }
@@ -203,6 +205,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         $vaultService->delete($identifier1, 'Test cleanup');
         $vaultService->delete($identifier2, 'Test cleanup');
         if (file_exists($newKeyPath)) {
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($newKeyPath);
         }
     }
@@ -283,6 +286,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
             $vaultService->delete($identifier, 'Test cleanup');
         }
         if (file_exists($newKeyPath)) {
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($newKeyPath);
         }
     }

--- a/Tests/Functional/Hook/SecretTcaHookTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookTest.php
@@ -67,6 +67,7 @@ final class SecretTcaHookTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }
 

--- a/Tests/Functional/Hook/TcaIntegrationTest.php
+++ b/Tests/Functional/Hook/TcaIntegrationTest.php
@@ -86,6 +86,7 @@ final class TcaIntegrationTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }
 

--- a/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
+++ b/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
@@ -100,6 +100,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }
 

--- a/Tests/Functional/Service/VaultServiceTest.php
+++ b/Tests/Functional/Service/VaultServiceTest.php
@@ -77,6 +77,7 @@ final class VaultServiceTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }
 


### PR DESCRIPTION
## Summary
The SAST (Opengrep) check has been failing on `main` since the scheduled scan at 2026-04-20 06:37 UTC, after the default ruleset picked up 13 new findings. All 13 are false positives; this PR silences them at their source.

## Findings & fixes

### 1. `python.django.security.django-no-csrf-token` on a Fluid template (1×)
**Where:** `Resources/Private/Templates/Secrets/List.html:160`

**Why it's a false positive:** The template is TYPO3 Fluid, not Django. Form CSRF protection is provided by `\TYPO3\CMS\Core\FormProtection\FormProtectionFactory`, not Django middleware. No semgrep/opengrep rules actually understand Fluid, so auto-scanning `.html` files in that directory only produces Python/Django noise.

**Fix:** Add a `.semgrepignore` (Opengrep honours this file) that excludes `Resources/Private/Templates/` plus standard build-cache paths.

### 2. `php.lang.security.unlink-use.unlink-use` on 12 test teardown sites
**Where:**
- `Tests/Functional/Crypto/MasterKeyRotationTest.php` (×4)
- `Tests/Functional/Controller/{Ajax,Audit,Migration,Secrets}ControllerTest.php`
- `Tests/Functional/Service/VaultServiceTest.php`
- `Tests/Functional/Hook/{SecretTca,TcaIntegration}Test.php`
- `Tests/Functional/Http/OAuth/OAuthIntegrationTest.php`

Each is `unlink($this->masterKeyPath)` (or a local `$newKeyPath`) in a `tearDown()` method. The path is constructed by the test itself from `tempnam()` + `sodium_crypto_secretbox_keygen()`. There is no user input anywhere in the call chain. The rule is designed for request handlers, not test fixtures.

**Fix:** Inline `// nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path` comments. No rule-wide disable, so real user-controlled `unlink()` in src code still fails CI.

## Non-changes
- `opengrep-config` severity gate stays at `WARNING`. New real warnings still block CI; only the 13 known false-positive shapes above are silenced.
- No `.opengrep.yml` custom config — kept the zero-config `--config auto` approach.

## Verification
- PHP syntax check passes on all 9 modified test files (`php -l`).
- The `.semgrepignore` uses gitignore syntax documented by opengrep/semgrep.

## Test plan
- [ ] CI: `security / SAST (Opengrep)` job turns green.
- [ ] `Ran N rules on X files: 0 findings.` in the job log (down from 13).
- [ ] Functional tests still pass (the `// nosemgrep:` comments are just PHP line comments, zero runtime impact).