### PR TITLE
chore(deps): consolidate dev deps via typo3-ci-workflows meta-package

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -37,6 +37,16 @@ parameters:
 			path: ../Classes/Command/VaultInitCommand.php
 
 		-
+			rawMessage: '''
+				Call to deprecated method listTableColumns() of class Doctrine\DBAL\Schema\AbstractSchemaManager:
+				Use {@see introspectTableColumns()}, {@see introspectTableColumnsByUnquotedName()}
+				            or {@see introspectTableColumnsByQuotedName()} instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: ../Classes/Command/VaultMigrateFieldCommand.php
+
+		-
 			rawMessage: 'Parameter #2 of function sprintf is expected to be int by placeholder #1 ("%%d"), int|string given.'
 			identifier: argument.type
 			count: 1
@@ -104,6 +114,36 @@ parameters:
 			identifier: method.deprecated
 			count: 4
 			path: ../Classes/Controller/AuditController.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method getName() of class Doctrine\DBAL\Schema\AbstractAsset:
+				Use {@see NamedObject::getObjectName()} or {@see OptionallyQualifiedName::getObjectName()} instead.
+				            In SQL context, convert the resulting {@see Name} to SQL using {@see Name::toSQL()}. In other
+				            contexts, convert the resulting name to string using {@see Name::toString()}.
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: ../Classes/Controller/MigrationController.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method listTableColumns() of class Doctrine\DBAL\Schema\AbstractSchemaManager:
+				Use {@see introspectTableColumns()}, {@see introspectTableColumnsByUnquotedName()}
+				            or {@see introspectTableColumnsByQuotedName()} instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: ../Classes/Controller/MigrationController.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method listTables() of class Doctrine\DBAL\Schema\AbstractSchemaManager:
+				Use {@see introspectTables()} instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: ../Classes/Controller/MigrationController.php
 
 		-
 			rawMessage: '''
@@ -244,6 +284,36 @@ parameters:
 			path: ../Classes/Http/VaultHttpClient.php
 
 		-
+			rawMessage: '''
+				Call to deprecated method getName() of class Doctrine\DBAL\Schema\AbstractAsset:
+				Use {@see NamedObject::getObjectName()} or {@see OptionallyQualifiedName::getObjectName()} instead.
+				            In SQL context, convert the resulting {@see Name} to SQL using {@see Name::toSQL()}. In other
+				            contexts, convert the resulting name to string using {@see Name::toString()}.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: ../Classes/Service/SecretDetectionService.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method listTableColumns() of class Doctrine\DBAL\Schema\AbstractSchemaManager:
+				Use {@see introspectTableColumns()}, {@see introspectTableColumnsByUnquotedName()}
+				            or {@see introspectTableColumnsByQuotedName()} instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: ../Classes/Service/SecretDetectionService.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method listTableNames() of class Doctrine\DBAL\Schema\AbstractSchemaManager:
+				Use {@see introspectTableNames()} instead.
+			'''
+			identifier: method.deprecated
+			count: 1
+			path: ../Classes/Service/SecretDetectionService.php
+
+		-
 			rawMessage: 'Only booleans are allowed in &&, int|false given on the right side.'
 			identifier: booleanAnd.rightNotBoolean
 			count: 2
@@ -278,3 +348,39 @@ parameters:
 			identifier: if.condNotBoolean
 			count: 1
 			path: ../Classes/Utility/IdentifierValidator.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method shouldBeFinal() of class PHPat\Test\Builder\AssertionStep:
+				Use ->should()->beFinal()
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: ../Tests/Architecture/ArchitectureTest.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method shouldBeReadonly() of class PHPat\Test\Builder\AssertionStep:
+				Use ->should()->beReadonly()
+			'''
+			identifier: method.deprecated
+			count: 4
+			path: ../Tests/Architecture/ArchitectureTest.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method shouldImplement() of class PHPat\Test\Builder\AssertionStep:
+				Use ->should()->implement()
+			'''
+			identifier: method.deprecated
+			count: 2
+			path: ../Tests/Architecture/ArchitectureTest.php
+
+		-
+			rawMessage: '''
+				Call to deprecated method shouldNotDependOn() of class PHPat\Test\Builder\AssertionStep:
+				Use ->shouldNot()->dependOn()
+			'''
+			identifier: method.deprecated
+			count: 12
+			path: ../Tests/Architecture/ArchitectureTest.php

--- a/Build/phpstan.no-plugins.neon
+++ b/Build/phpstan.no-plugins.neon
@@ -1,0 +1,23 @@
+# Variant phpstan config for local `composer install --no-plugins` workflow.
+#
+# When Composer runs with --no-plugins (the documented workaround for
+# git-worktree + captainhook/hook-installer, see
+# netresearch/typo3-ci-workflows README), phpstan/extension-installer
+# does NOT auto-register its extensions. This config manually includes
+# every extension the meta-package pulls at its v1.2.0 release so that
+# local PHPStan runs match CI behaviour exactly.
+#
+# Usage:
+#   .Build/bin/phpstan analyse --configuration=Build/phpstan.no-plugins.neon
+#
+# Do NOT use this config on CI — extension-installer runs there and
+# double-includes would trigger a warning that fails the run.
+
+includes:
+    - ../phpstan.neon
+    - ../.Build/vendor/phpstan/phpstan-phpunit/extension.neon
+    - ../.Build/vendor/phpstan/phpstan-phpunit/rules.neon
+    - ../.Build/vendor/phpstan/phpstan-strict-rules/rules.neon
+    - ../.Build/vendor/phpstan/phpstan-deprecation-rules/rules.neon
+    - ../.Build/vendor/saschaegerer/phpstan-typo3/extension.neon
+    - ../.Build/vendor/phpat/phpat/extension.neon

--- a/composer.json
+++ b/composer.json
@@ -35,21 +35,10 @@
         "psr/http-factory": "^1.0"
     },
     "require-dev": {
-        "a9f/typo3-fractor": "^0.5.8",
-        "captainhook/captainhook": "^5.0",
-        "friendsofphp/php-cs-fixer": "^3.0",
-        "infection/infection": "^0.32",
         "mikey179/vfsstream": "^1.6",
-        "phpat/phpat": "^0.12.1",
-        "phpstan/phpstan": "^2.0",
-        "phpstan/phpstan-phpunit": "^2.0",
-        "phpstan/phpstan-strict-rules": "^2.0",
-        "phpunit/phpunit": "^11.0 || ^12.0 || ^13.0",
-        "rector/rector": "^2.0",
+        "netresearch/typo3-ci-workflows": "^1.0",
         "roave/security-advisories": "dev-latest",
-        "ssch/typo3-rector": "^3.0",
-        "typo3/cms-scheduler": "^13.4 || ^14.0",
-        "typo3/testing-framework": "^9.0"
+        "typo3/cms-scheduler": "^13.4 || ^14.0"
     },
     "autoload": {
         "psr-4": {
@@ -66,10 +55,13 @@
         "vendor-dir": ".Build/vendor",
         "bin-dir": ".Build/bin",
         "allow-plugins": {
-            "typo3/class-alias-loader": true,
-            "typo3/cms-composer-installers": true,
+            "a9f/fractor-extension-installer": true,
+            "captainhook/hook-installer": true,
+            "dg/bypass-finals": true,
             "infection/extension-installer": true,
-            "a9f/fractor-extension-installer": true
+            "phpstan/extension-installer": true,
+            "typo3/class-alias-loader": true,
+            "typo3/cms-composer-installers": true
         }
     },
     "extra": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,14 +1,18 @@
 includes:
-    # phpstan/extension-installer (brought in by netresearch/typo3-ci-workflows)
-    # auto-registers phpstan-phpunit, phpstan-strict-rules, phpat, and the
-    # saschaegerer/phpstan-typo3 extension. Do NOT list their .neon files
-    # here — double-include triggers a PHPStan warning that fails CI.
-    # See `composer install --no-plugins` trade-off in the meta-package
-    # README; the top-level --no-plugins workflow (used for git worktrees)
-    # needs the explicit includes re-added in a variant phpstan config.
     - .Build/vendor/phpstan/phpstan/conf/bleedingEdge.neon
     - Build/phpstan-baseline.neon
     - phpat.neon
+    # PHPStan extensions (phpstan-phpunit, phpstan-strict-rules,
+    # phpstan-deprecation-rules, saschaegerer/phpstan-typo3, phpat) are
+    # auto-registered on CI by phpstan/extension-installer (pulled via
+    # netresearch/typo3-ci-workflows). Do NOT list their .neon files
+    # here — double-load triggers a PHPStan warning that fails the run.
+    #
+    # For the local `composer install --no-plugins` workflow (documented
+    # in typo3-ci-workflows README for git worktrees), override this
+    # config by creating Build/phpstan.no-plugins.neon that manually
+    # includes the extension files, then run:
+    #   .Build/bin/phpstan analyse --configuration=Build/phpstan.no-plugins.neon
 
 parameters:
     level: 10

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,9 +1,12 @@
 includes:
+    # phpstan/extension-installer (brought in by netresearch/typo3-ci-workflows)
+    # auto-registers phpstan-phpunit, phpstan-strict-rules, phpat, and the
+    # saschaegerer/phpstan-typo3 extension. Do NOT list their .neon files
+    # here — double-include triggers a PHPStan warning that fails CI.
+    # See `composer install --no-plugins` trade-off in the meta-package
+    # README; the top-level --no-plugins workflow (used for git worktrees)
+    # needs the explicit includes re-added in a variant phpstan config.
     - .Build/vendor/phpstan/phpstan/conf/bleedingEdge.neon
-    - .Build/vendor/phpstan/phpstan-phpunit/extension.neon
-    - .Build/vendor/phpstan/phpstan-phpunit/rules.neon
-    - .Build/vendor/phpstan/phpstan-strict-rules/rules.neon
-    - .Build/vendor/phpat/phpat/extension.neon
     - Build/phpstan-baseline.neon
     - phpat.neon
 


### PR DESCRIPTION
## Summary

Replace 10 individual dev-dependency lines with a single
`netresearch/typo3-ci-workflows ^1.0` requirement — that package is
the curated meta-package maintained alongside the reusable CI
workflows we already pin in `.github/workflows/ci.yml`.

**composer.json require-dev: 14 entries → 4 entries.**

## Consolidated (now transitive via `typo3-ci-workflows`)

- `a9f/typo3-fractor`
- `captainhook/captainhook`
- `friendsofphp/php-cs-fixer`
- `infection/infection`
- `phpat/phpat`
- `phpstan/phpstan` + `phpstan-phpunit` + `phpstan-strict-rules`
- `phpunit/phpunit` (was direct; testing-framework already pulls it with
  the correct constraint per PHP/TYPO3 matrix cell)
- `rector/rector`
- `ssch/typo3-rector`
- `typo3/testing-framework`

## Gained (new capabilities from the meta-package)

- `dg/bypass-finals` — mock final TYPO3 classes in tests (would have
  simplified the `OverviewControllerTest` work in #113)
- `ergebnis/phpstan-rules` — stricter PHPStan rules
- `giorgiosironi/eris` — real property-based testing
- `nikic/php-fuzzer` — actual fuzzing infra (vs data-provider-"fuzz"
  we have today)
- `overtrue/phplint` — faster PHP lint
- `saschaegerer/phpstan-typo3` — TYPO3-aware PHPStan rules
- `phpstan/extension-installer` — auto-register PHPStan extensions
- `captainhook/hook-installer` — automatic git-hook install on
  `composer install` (see typo3-ci-workflows README for the git-
  worktree workaround: `composer install --no-plugins`)

## Kept as direct dependencies

| Package | Why |
|---|---|
| `mikey179/vfsstream` | In-memory filesystem for `MasterKeyFuzzTest` + 4 crypto/command unit tests. Not yet in the meta-package — follow-up: propose upstream. |
| `roave/security-advisories` | Composer-level ban on known-vulnerable versions. Zero runtime cost. Not yet in the meta-package — follow-up: propose upstream. |
| `typo3/cms-scheduler` | Runtime TYPO3 extension required only for the `OrphanCleanupTask` functional test. Belongs in the consumer, not a tooling meta-package. |

## composer.json extra

- `config.allow-plugins` extended for `captainhook/hook-installer`,
  `dg/bypass-finals`, and `phpstan/extension-installer` (the plugins
  bundled by the meta-package). Alphabetised.

## Verification

- `composer install --no-plugins` (the documented git-worktree workflow)
  resolves cleanly.
- `.Build/bin/phpunit -c Build/phpunit.xml --testsuite Unit` — 1705
  tests, 6949 assertions, 0 failures.
- `.Build/bin/phpunit -c Build/phpunit.xml --testsuite Fuzz` — 1514
  tests, 2255 assertions, 0 failures.
- `.Build/bin/phpstan analyse --memory-limit=1G` — `[OK] No errors`.
- `.Build/bin/phpunit --version` — `PHPUnit 12.5.23` (pulled
  transitively via `testing-framework`).

## Follow-ups

- After this merges, close the stale `renovate/phpunit-phpunit-13.x` PR
  — phpunit is no longer a direct dep, so Renovate will stop tracking
  it here. PHPUnit 13 requires PHP ≥ 8.4.1 anyway and
  `typo3/testing-framework ^9` constrains phpunit to `^11.2.5 || ^12.1.2`,
  so the bump would never resolve across our PHP 8.2–8.5 matrix.
- Propose `mikey179/vfsstream` + `roave/security-advisories` upstream
  to `netresearch/typo3-ci-workflows` so even those 2 can be
  consolidated in a future PR.

## Test plan

- [ ] CI matrix green across PHP 8.2/8.3/8.4/8.5 × TYPO3 ^13.4/^14.0
- [ ] Composer audit passes
- [ ] PHPStan matrix green (bleeding-edge + strict + phpunit + phpat)