### PR TITLE
fix(ci): drop slsa-provenance job referencing removed reusable workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,12 +26,3 @@ jobs:
       TYPO3_EXTENSION_KEY: ${{ secrets.TYPO3_EXTENSION_KEY }}
       TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}
 
-  slsa-provenance:
-    needs: release
-    uses: netresearch/typo3-ci-workflows/.github/workflows/slsa-provenance.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main-2026-04-20
-    permissions:
-      actions: read
-      contents: write
-      id-token: write
-    with:
-      version: ${{ github.ref_name }}


### PR DESCRIPTION
The Release run for tag **v0.5.0** failed with *"workflow file not found"* because
`netresearch/typo3-ci-workflows/.github/workflows/slsa-provenance.yml` no longer
exists at the pinned SHA `f7a51aa0` — the workflow was consolidated into
`release.yml` upstream.

The meta-package's `release.yml` already handles SLSA build provenance
internally via `actions/attest-build-provenance@v4.1.0` (verified in the
pinned SHA's source). The separate `slsa-provenance` job was therefore both
duplicate and broken.

### What this fixes

- Unblocks the `v0.5.0` release workflow on re-run (tag already pushed,
  re-running the workflow after this merges should publish successfully)
- Aligns our release pipeline with the current meta-package structure

### Verified

- `curl https://raw.githubusercontent.com/netresearch/typo3-ci-workflows/f7a51aa0e97ba843f583cd18907de87285386b8b/.github/workflows/release.yml | grep attest` → confirms native attestation step is present

### Post-merge action

Re-run the Release workflow for tag v0.5.0:
```
gh api repos/netresearch/t3x-nr-vault/actions/runs/24751231121/rerun -X POST
```