### PR TITLE
chore(ci): fix Renovate digest lookups for reusable workflow pins

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -10,7 +10,7 @@ jobs:
     # Only run for bot-raised dependency PRs. Prevents non-dependency PRs
     # from triggering auto-merge logic.
     if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main-2026-04-21
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main-2026-04-20
+    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main
     permissions:
       contents: read
     with:
@@ -39,13 +39,13 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   security:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main-2026-04-20
+    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main
     permissions:
       contents: read
       security-events: write
 
   fuzz:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main-2026-04-20
+    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main
     permissions:
       contents: read
     with:
@@ -63,12 +63,12 @@ jobs:
       # but full HTML/JSON reports are only available locally today.
 
   license-check:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main-2026-04-20
+    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main
     permissions:
       contents: read
 
   codeql:
-    uses: netresearch/.github/.github/workflows/codeql.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main-2026-04-21
+    uses: netresearch/.github/.github/workflows/codeql.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main
     permissions:
       contents: read
       security-events: write
@@ -76,7 +76,7 @@ jobs:
 
   scorecard:
     if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
-    uses: netresearch/.github/.github/workflows/scorecard.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main-2026-04-21
+    uses: netresearch/.github/.github/workflows/scorecard.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main
     permissions:
       contents: read
       security-events: write
@@ -85,21 +85,21 @@ jobs:
 
   dependency-review:
     if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/dependency-review.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main-2026-04-21
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main
     permissions:
       contents: read
       pull-requests: write
 
   pr-quality:
     if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main-2026-04-21
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main
     permissions:
       contents: read
       pull-requests: write
 
   labeler:
     if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/labeler.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main-2026-04-21
+    uses: netresearch/.github/.github/workflows/labeler.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -14,21 +14,21 @@ permissions: {}
 jobs:
   stale:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: netresearch/.github/.github/workflows/stale.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main-2026-04-21
+    uses: netresearch/.github/.github/workflows/stale.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main
     permissions:
       issues: write
       pull-requests: write
 
   lock:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: netresearch/.github/.github/workflows/lock.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main-2026-04-21
+    uses: netresearch/.github/.github/workflows/lock.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main
     permissions:
       issues: write
       pull-requests: write
 
   greetings:
     if: github.event_name == 'issues' || github.event_name == 'pull_request_target'
-    uses: netresearch/.github/.github/workflows/greetings.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main-2026-04-21
+    uses: netresearch/.github/.github/workflows/greetings.yml@5c3de827bedce35fc76b51857f8a4431f2488738 # main
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/release.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main-2026-04-20
+    uses: netresearch/typo3-ci-workflows/.github/workflows/release.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main
     permissions:
       contents: write
       id-token: write
@@ -19,7 +19,7 @@ jobs:
       package-name: netresearch/nr-vault
 
   publish-to-ter:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main-2026-04-20
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@f7a51aa0e97ba843f583cd18907de87285386b8b # main
     permissions:
       contents: read
     secrets:


### PR DESCRIPTION
## Summary

Renovate was failing to resolve new digests for the `netresearch/typo3-ci-workflows` and `netresearch/.github` reusable workflow references:

> Could not determine new digest for update (github-digest package netresearch/.github), Could not determine new digest for update (github-digest package netresearch/typo3-ci-workflows).
> Files affected: `.github/workflows/auto-merge-deps.yml`, `.github/workflows/ci.yml`, `.github/workflows/community.yml`, `.github/workflows/release.yml`

## Root Cause

The SHA-pinned `uses:` lines had comments like `# main-2026-04-20` which Renovate interprets as a literal ref name. Since no ref with that name exists on upstream, digest lookup fails.

## Fix

Replace `# main-YYYY-MM-DD` with plain `# main` so Renovate tracks the upstream `main` branch and proposes digest updates when it advances. The SHA pins themselves are unchanged.

## Files Changed

- `.github/workflows/auto-merge-deps.yml` — 1 occurrence
- `.github/workflows/ci.yml` — 10 occurrences
- `.github/workflows/community.yml` — 3 occurrences
- `.github/workflows/release.yml` — 2 occurrences

## Test Plan

- [x] CI green (reusable workflow behavior unchanged — only comment text changed)
- [ ] Next Renovate run no longer surfaces the digest lookup warning on the Dependency Dashboard (#7)