### PR TITLE
fix(ci): don't SHA-pin reusable workflows from our own org

### DIFF
--- a/.github/workflows/auto-merge-deps.yml
+++ b/.github/workflows/auto-merge-deps.yml
@@ -10,7 +10,7 @@ jobs:
     # Only run for bot-raised dependency PRs. Prevents non-dependency PRs
     # from triggering auto-merge logic.
     if: github.actor == 'dependabot[bot]' || github.actor == 'renovate[bot]'
-    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@171d4bb5288a8bf6dce09bc295b69f53e86eaa38 # main
+    uses: netresearch/.github/.github/workflows/auto-merge-deps.yml@main
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   ci:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@35a3322e1fbedf79ca3c9f08908e0751d2e37ffc # main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
     permissions:
       contents: read
     with:
@@ -39,13 +39,13 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   security:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@35a3322e1fbedf79ca3c9f08908e0751d2e37ffc # main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
     permissions:
       contents: read
       security-events: write
 
   fuzz:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@35a3322e1fbedf79ca3c9f08908e0751d2e37ffc # main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
     permissions:
       contents: read
     with:
@@ -63,12 +63,12 @@ jobs:
       # but full HTML/JSON reports are only available locally today.
 
   license-check:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@35a3322e1fbedf79ca3c9f08908e0751d2e37ffc # main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
     permissions:
       contents: read
 
   codeql:
-    uses: netresearch/.github/.github/workflows/codeql.yml@171d4bb5288a8bf6dce09bc295b69f53e86eaa38 # main
+    uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
       contents: read
       security-events: write
@@ -76,7 +76,7 @@ jobs:
 
   scorecard:
     if: github.event_name == 'schedule' || (github.event_name == 'push' && github.ref_name == github.event.repository.default_branch)
-    uses: netresearch/.github/.github/workflows/scorecard.yml@171d4bb5288a8bf6dce09bc295b69f53e86eaa38 # main
+    uses: netresearch/.github/.github/workflows/scorecard.yml@main
     permissions:
       contents: read
       security-events: write
@@ -85,21 +85,21 @@ jobs:
 
   dependency-review:
     if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/dependency-review.yml@171d4bb5288a8bf6dce09bc295b69f53e86eaa38 # main
+    uses: netresearch/.github/.github/workflows/dependency-review.yml@main
     permissions:
       contents: read
       pull-requests: write
 
   pr-quality:
     if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/pr-quality.yml@171d4bb5288a8bf6dce09bc295b69f53e86eaa38 # main
+    uses: netresearch/.github/.github/workflows/pr-quality.yml@main
     permissions:
       contents: read
       pull-requests: write
 
   labeler:
     if: github.event_name == 'pull_request'
-    uses: netresearch/.github/.github/workflows/labeler.yml@171d4bb5288a8bf6dce09bc295b69f53e86eaa38 # main
+    uses: netresearch/.github/.github/workflows/labeler.yml@main
     permissions:
       contents: read
       pull-requests: write

--- a/.github/workflows/community.yml
+++ b/.github/workflows/community.yml
@@ -14,21 +14,21 @@ permissions: {}
 jobs:
   stale:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: netresearch/.github/.github/workflows/stale.yml@171d4bb5288a8bf6dce09bc295b69f53e86eaa38 # main
+    uses: netresearch/.github/.github/workflows/stale.yml@main
     permissions:
       issues: write
       pull-requests: write
 
   lock:
     if: github.event_name == 'schedule' || github.event_name == 'workflow_dispatch'
-    uses: netresearch/.github/.github/workflows/lock.yml@171d4bb5288a8bf6dce09bc295b69f53e86eaa38 # main
+    uses: netresearch/.github/.github/workflows/lock.yml@main
     permissions:
       issues: write
       pull-requests: write
 
   greetings:
     if: github.event_name == 'issues' || github.event_name == 'pull_request_target'
-    uses: netresearch/.github/.github/workflows/greetings.yml@171d4bb5288a8bf6dce09bc295b69f53e86eaa38 # main
+    uses: netresearch/.github/.github/workflows/greetings.yml@main
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions: {}
 
 jobs:
   release:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/release.yml@35a3322e1fbedf79ca3c9f08908e0751d2e37ffc # main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/release.yml@main
     permissions:
       contents: write
       id-token: write
@@ -19,7 +19,7 @@ jobs:
       package-name: netresearch/nr-vault
 
   publish-to-ter:
-    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@35a3322e1fbedf79ca3c9f08908e0751d2e37ffc # main
+    uses: netresearch/typo3-ci-workflows/.github/workflows/publish-to-ter.yml@main
     permissions:
       contents: read
     secrets:

--- a/renovate.json
+++ b/renovate.json
@@ -21,8 +21,7 @@
       "matchDepNames": [
         "/^netresearch\\//"
       ],
-      "pinDigests": false,
-      "enabled": false
+      "pinDigests": false
     }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,15 @@
         "digest"
       ],
       "automerge": true
+    },
+    {
+      "description": "Do not SHA-pin reusable workflows from our own org — track the branch/tag ref directly",
+      "matchManagers": ["github-actions"],
+      "matchDepNames": [
+        "/^netresearch\\//"
+      ],
+      "pinDigests": false,
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Reusable workflows from `netresearch/*` now use `@main` directly instead of `@SHA # main` pins.

## Rationale

SHA pinning is a supply-chain hardening practice for **third-party** actions. For our **own** org-owned reusable workflows (`netresearch/typo3-ci-workflows`, `netresearch/.github`) we trust the branch ref, and SHA pins only add maintenance churn (constant Renovate digest PRs) while obscuring which branch/tag is actually in use.

## Changes

- `.github/workflows/*.yml` — replaced all `@<40-hex> # main` refs for `netresearch/*` with `@main`
- `renovate.json` — added a package rule that disables `pinDigests` for any `netresearch/*` github-actions dep so the change sticks

Third-party actions (`actions/checkout`, etc.) retain SHA pins — this PR targets only org-owned reusable workflows.

## Supersedes

This supersedes the approach in #118 (which only fixed the comment without addressing the underlying pin).

## Test Plan

- [x] CI green (behavior identical — same reusable workflow code paths, just referenced by branch rather than SHA)
- [ ] Next Renovate run no longer opens digest-update PRs for `netresearch/*` refs