### PR TITLE
fix(phpstan): include curated typo3-ci-workflows ergebnis ruleset

### DIFF
--- a/Build/phpstan.no-plugins.neon
+++ b/Build/phpstan.no-plugins.neon
@@ -4,20 +4,22 @@
 # git-worktree + captainhook/hook-installer, see
 # netresearch/typo3-ci-workflows README), phpstan/extension-installer
 # does NOT auto-register its extensions. This config manually includes
-# every extension the meta-package pulls at its v1.2.0 release so that
-# local PHPStan runs match CI behaviour exactly.
+# every extension the meta-package pulls so that local PHPStan runs
+# match CI behaviour exactly.
 #
 # Usage:
 #   .Build/bin/phpstan analyse --configuration=Build/phpstan.no-plugins.neon
 #
 # Do NOT use this config on CI — extension-installer runs there and
 # double-includes would trigger a warning that fails the run.
+#
+# IMPORTANT: the ergebnis/phpstan-rules package ships rules.neon with
+# `ergebnis.allRules: true`. The shared typo3-ci-workflows curated config
+# (loaded via ../phpstan.neon) sets `ergebnis.allRules: false`. To make
+# the curated value win, the curated include MUST come AFTER the explicit
+# rules.neon includes — hence the order below: explicit-includes first,
+# then project phpstan.neon (which transitively loads the curated config).
 
 includes:
+    - ../.Build/vendor/netresearch/typo3-ci-workflows/config/phpstan/includes-no-extension-installer.neon
     - ../phpstan.neon
-    - ../.Build/vendor/phpstan/phpstan-phpunit/extension.neon
-    - ../.Build/vendor/phpstan/phpstan-phpunit/rules.neon
-    - ../.Build/vendor/phpstan/phpstan-strict-rules/rules.neon
-    - ../.Build/vendor/phpstan/phpstan-deprecation-rules/rules.neon
-    - ../.Build/vendor/saschaegerer/phpstan-typo3/extension.neon
-    - ../.Build/vendor/phpat/phpat/extension.neon

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,12 +1,18 @@
 includes:
     - .Build/vendor/phpstan/phpstan/conf/bleedingEdge.neon
+    - .Build/vendor/netresearch/typo3-ci-workflows/config/phpstan/phpstan.neon
     - Build/phpstan-baseline.neon
     - phpat.neon
     # PHPStan extensions (phpstan-phpunit, phpstan-strict-rules,
-    # phpstan-deprecation-rules, saschaegerer/phpstan-typo3, phpat) are
-    # auto-registered on CI by phpstan/extension-installer (pulled via
-    # netresearch/typo3-ci-workflows). Do NOT list their .neon files
-    # here — double-load triggers a PHPStan warning that fails the run.
+    # phpstan-deprecation-rules, saschaegerer/phpstan-typo3, phpat,
+    # ergebnis/phpstan-rules) are auto-registered on CI by
+    # phpstan/extension-installer (pulled via netresearch/typo3-ci-workflows).
+    # Do NOT list their .neon files here - double-load triggers a PHPStan
+    # warning that fails the run.
+    #
+    # The shared typo3-ci-workflows config above curates the ergebnis ruleset
+    # to a TYPO3-compatible subset (allRules: false + opt-ins). See
+    # netresearch/typo3-ci-workflows PR #74 for the rationale.
     #
     # For the local `composer install --no-plugins` workflow (documented
     # in typo3-ci-workflows README for git worktrees), override this


### PR DESCRIPTION
## Summary

PHPStan turned red across the full matrix (PHP 8.2/8.3/8.4/8.5 x TYPO3 ^13.4/^14.0) with ~700 strict class-design errors after `phpstan/extension-installer` (pulled transitively via `netresearch/typo3-ci-workflows`) began auto-registering `ergebnis/phpstan-rules` with its default `allRules: true`. The package's defaults forbid patterns that are fundamental to TYPO3 extensions (extending Symfony Command, nullable types on lookup APIs, named arguments on framework calls, `isset()`, etc.).

`netresearch/typo3-ci-workflows` PR #74 (v1.3.1) shipped a curated ergebnis config for TYPO3 compatibility but this extension's `phpstan.neon` was not yet wired to it. This PR adds the include.

## Changes

- `phpstan.neon`: include `.Build/vendor/netresearch/typo3-ci-workflows/config/phpstan/phpstan.neon` so the curated `ergebnis.allRules: false` + opt-ins applies. Project-specific config (level 10, paths, type aliases, `ignoreErrors` for TYPO3 v13/v14 cross-version compat) continues to live in this file and merges after the shared config.
- `Build/phpstan.no-plugins.neon`: delegate extension includes to the meta-package's `includes-no-extension-installer.neon` (keeps the variant in sync with what `extension-installer` registers on CI). Include ordering matters: the shipped `rules.neon` defaults `ergebnis.allRules: true`, so the curated config (transitively loaded via `../phpstan.neon`) must come AFTER the explicit includes to win the merge. Inline comment explains the constraint.

No code under `Classes/` was modified; the existing `Build/phpstan-baseline.neon` remains valid (entries cover the long-standing `phpstan-strict-rules` / `phpat` deprecations that pre-date this regression).

## Failing run

[CI run 25655306293](https://github.com/netresearch/t3x-nr-vault/actions/runs/25655306293) on `main` (2026-05-11 schedule) showed ~700 errors per matrix cell. All from `ergebnis/phpstan-rules` defaults:

- `Method ... has a nullable return type declaration` (30x)
- `Method ... has parameter ... with a nullable type declaration` (83x)
- `Method ... has parameter ... with null as default value` (71x)
- `Constructor in ... has parameter ... with default value` (49x)
- `Constructor of self is invoked with named argument` (195x)
- `Class ... is not allowed to extend Symfony\Console\Command\Command` and similar
- `Language construct isset() should not be used` (47x)
- `Errors reported by phpstan/phpstan should not be ignored via @phpstan-ignore` (67x — clashed with v13/v14 compat ignores already in the project)

The curated typo3-ci-workflows config disables every one of these rule families and opts back in only to the universally-safe ones (`declareStrictTypes`, `noCompact`, `noErrorSuppression`, `noEval`, `noReturnByReference`, `testCaseWithSuffix`).

## Verification

Local PHPStan against the project's `phpstan.neon` (matching CI invocation):

- TYPO3 ^13.4 (v13.4.28): `[OK] No errors`
- TYPO3 ^14.0 (v14.3.0): `[OK] No errors`

## Test plan

- [ ] CI matrix turns green: PHPStan (8.2/8.3/8.4/8.5) x (^13.4/^14.0) = 8 cells
- [ ] Existing unit / functional / fuzz / rector jobs unaffected (config-only change, no code under `Classes/` touched)
- [ ] `Build/phpstan.no-plugins.neon` still runs cleanly for the worktree workflow