### PR TITLE
fix(security): address CRITICAL & HIGH findings from multi-axis review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,81 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **VaultService::store() now requires authorization.** Previously any
+  backend user with write rights on a host table carrying a vault field
+  could create or overwrite arbitrary vault identifiers, bypassing the
+  per-secret ACL. `store()` now distinguishes new vs. update and calls
+  `canCreate()` / `canWrite($existing)`; denied paths emit an
+  `access_denied` audit entry and throw `AccessDeniedException`. Non-admin
+  backend actors that attempt to set or change `owner_uid` are silently
+  coerced to the default (existing owner on update, current actor on
+  create). CLI / scheduler / API actors retain full control.
+- **`#[SensitiveParameter]` rolled out across the crypto / DTO / audit
+  boundaries** (0 → 35 occurrences). Plaintext secrets, master keys,
+  DEKs, OAuth tokens, refresh tokens and vault tokens no longer surface
+  in stack traces, error handlers, monolog payloads, or `var_dump()`.
+  Applied to `EncryptionService(Interface)`, `MasterKeyProviderInterface`
+  and all three providers, `VaultService(Interface)::store/rotate`,
+  `AuditLogServiceInterface::log` `$hashBefore`/`$hashAfter`,
+  `PendingSecret::$value`, `FlexFormPendingSecret::$value`,
+  `VaultServerConfig::$token`, and the private `encryptWithKey` /
+  `decryptWithKey` locals.
+- **SSRF defence-in-depth in `SecureHttpClientFactory::isHostAllowed()`.**
+  Regardless of `allowed_hosts` configuration, IP literals and
+  DNS-resolved hostnames pointing into private / RFC1918 / RFC6598 CGNAT
+  / loopback / link-local / cloud-metadata (169.254.169.254) /
+  multicast / class-E / IPv6 ULA / IPv6 link-local / IPv6 multicast /
+  NAT64 / discard ranges are rejected. The check normalises
+  `host:port`, `[ipv6]:port`, bare `::1` (which `parse_url` misparses),
+  bracketed `[2001:db8::1]`, trailing dots, mixed case, and whitespace.
+  LITERAL allowlist entries can opt back in for on-prem deployments
+  (e.g. `'10.0.0.42'`); wildcards (`*.example.com`) cannot — a wildcard
+  owner could otherwise pivot via DNS rebinding. The check resolves
+  hostnames at filter time; full DNS-rebind protection via
+  `CURLOPT_RESOLVE` pinning is a follow-up.
+- **Master-key rotation is now audit-logged.**
+  `VaultRotateMasterKeyCommand` emits `master_key_rotate_start` before
+  the re-encryption loop and `master_key_rotate_end` (success or
+  failure) afterwards, both with a sanitised reason — error messages
+  are scrubbed of libsodium internals before persistence.
+- **`auditReads` filesystem-only override.**
+  `$TYPO3_CONF_VARS[SYS][nrVault][auditReads]`, if set, takes
+  precedence over the BE-toggleable extension configuration. Pin the
+  value in `LocalConfiguration.php` / `additional.php` on production so
+  a compromised admin cannot silence read logging via the BE Settings
+  module.
+- **`Typo3MasterKeyProvider` entropy gate.** The default master-key
+  provider now rejects TYPO3 `encryptionKey` values shorter than 32
+  characters (would otherwise produce a weak HKDF output). Add a
+  request-lifetime static cache (ADR-020) so HKDF runs once per
+  request instead of on every crypto operation.
+- **`FileMasterKeyProvider` chmod race closed.** `storeMasterKey()`
+  wraps the `file_put_contents()` call in `umask(0o077)` so the file
+  is created `0600`, then `chmod 0400` tightens further — no more
+  world-readable window under permissive umasks.
+
+### Changed
+- **`MasterKeyProviderInterface::storeMasterKey()`,
+  `EncryptionServiceInterface::encrypt/decrypt/reEncryptDek/
+  calculateChecksum()`, `VaultServiceInterface::store/rotate()`, and
+  `AuditLogServiceInterface::log()` now annotate sensitive parameters
+  with `#[SensitiveParameter]`.** This is a signature change visible to
+  downstream implementers: PHP does not enforce the attribute on
+  implementations, but implementers should mirror it on their overrides
+  to keep the protection.
+- **`AccessControlServiceInterface` gains
+  `isCurrentActorAdmin(): bool`.** New method delegating BE-admin check
+  to the service instead of `$GLOBALS['BE_USER']` lookup. Returns
+  `false` for CLI / scheduler / API actor types — callers that need
+  to bypass admin gates must handle actor type explicitly.
+- **Pre-commit hook moves PHPStan from pre-push to pre-commit.** Type
+  errors are now caught at commit time on top of the existing
+  `php-cs-fixer` + lint actions. Pre-push retains unit-test execution.
+  Note: captainhook's installer does not currently support worktree
+  gitdirs (`git clone --bare` + `worktree add`); operators in worktrees
+  need to run `vendor/bin/captainhook install -g <gitdir>` manually.
+
 ## [0.5.0] - 2026-04-22
 
 ### Added

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -43,8 +43,8 @@ final readonly class AuditLogService implements AuditLogServiceInterface
         bool $success,
         ?string $errorMessage = null,
         ?string $reason = null,
-        ?string $hashBefore = null,
-        ?string $hashAfter = null,
+        #[\SensitiveParameter] ?string $hashBefore = null,
+        #[\SensitiveParameter] ?string $hashAfter = null,
         ?AuditContextInterface $context = null,
     ): void {
         $connection = $this->getConnection();

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -18,6 +18,7 @@ use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use SensitiveParameter;
 use Throwable;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -43,8 +44,10 @@ final readonly class AuditLogService implements AuditLogServiceInterface
         bool $success,
         ?string $errorMessage = null,
         ?string $reason = null,
-        #[\SensitiveParameter] ?string $hashBefore = null,
-        #[\SensitiveParameter] ?string $hashAfter = null,
+        #[SensitiveParameter]
+        ?string $hashBefore = null,
+        #[SensitiveParameter]
+        ?string $hashAfter = null,
         ?AuditContextInterface $context = null,
     ): void {
         $connection = $this->getConnection();

--- a/Classes/Audit/AuditLogServiceInterface.php
+++ b/Classes/Audit/AuditLogServiceInterface.php
@@ -23,7 +23,7 @@ interface AuditLogServiceInterface
      * Log a vault operation.
      *
      * @param string $secretIdentifier The secret that was accessed (or pseudo-identifier
-     *                                  such as `__master_key__` for master-key rotation)
+     *                                 such as `__master_key__` for master-key rotation)
      * @param string $action One of: create, read, update, delete, rotate, access_denied,
      *                       http_call, master_key_rotate_start, master_key_rotate_end
      * @param bool $success Whether operation succeeded
@@ -39,8 +39,10 @@ interface AuditLogServiceInterface
         bool $success,
         ?string $errorMessage = null,
         ?string $reason = null,
-        #[SensitiveParameter] ?string $hashBefore = null,
-        #[SensitiveParameter] ?string $hashAfter = null,
+        #[SensitiveParameter]
+        ?string $hashBefore = null,
+        #[SensitiveParameter]
+        ?string $hashAfter = null,
         ?AuditContextInterface $context = null,
     ): void;
 

--- a/Classes/Audit/AuditLogServiceInterface.php
+++ b/Classes/Audit/AuditLogServiceInterface.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Audit;
 
+use SensitiveParameter;
+
 /**
  * Interface for audit logging operations.
  */
@@ -20,8 +22,10 @@ interface AuditLogServiceInterface
     /**
      * Log a vault operation.
      *
-     * @param string $secretIdentifier The secret that was accessed
-     * @param string $action One of: create, read, update, delete, rotate, access_denied, http_call
+     * @param string $secretIdentifier The secret that was accessed (or pseudo-identifier
+     *                                  such as `__master_key__` for master-key rotation)
+     * @param string $action One of: create, read, update, delete, rotate, access_denied,
+     *                       http_call, master_key_rotate_start, master_key_rotate_end
      * @param bool $success Whether operation succeeded
      * @param string|null $errorMessage If failed, the error message
      * @param string|null $reason Reason for operation (required for rotate/delete)
@@ -35,8 +39,8 @@ interface AuditLogServiceInterface
         bool $success,
         ?string $errorMessage = null,
         ?string $reason = null,
-        ?string $hashBefore = null,
-        ?string $hashAfter = null,
+        #[SensitiveParameter] ?string $hashBefore = null,
+        #[SensitiveParameter] ?string $hashAfter = null,
         ?AuditContextInterface $context = null,
     ): void;
 

--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Command;
 
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface;
 use Netresearch\NrVault\Domain\Model\Secret;
@@ -38,11 +39,19 @@ final class VaultRotateMasterKeyCommand extends Command
 {
     private const KEY_LENGTH = 32;
 
+    /**
+     * Pseudo-identifier used for master-key lifecycle audit entries.
+     * Not a real secret identifier; the audit query layer filters on the
+     * `master_key_rotate_*` actions, not on this string.
+     */
+    private const AUDIT_PSEUDO_IDENTIFIER = '__master_key__';
+
     public function __construct(
         private readonly SecretRepositoryInterface $secretRepository,
         private readonly EncryptionServiceInterface $encryptionService,
         private readonly MasterKeyProviderFactoryInterface $masterKeyProviderFactory,
         private readonly ConnectionPool $connectionPool,
+        private readonly AuditLogServiceInterface $auditLogService,
     ) {
         parent::__construct();
     }
@@ -185,6 +194,16 @@ final class VaultRotateMasterKeyCommand extends Command
         $successCount = 0;
         $failedSecrets = [];
 
+        // Audit the start of the rotation lifecycle. We log BEFORE any state
+        // change so that even a catastrophic crash mid-loop leaves a trail.
+        $this->auditLogService->log(
+            self::AUDIT_PSEUDO_IDENTIFIER,
+            'master_key_rotate_start',
+            true,
+            null,
+            \sprintf('Rotating master key for %d secret(s)', $totalSecrets),
+        );
+
         $io->progressStart($totalSecrets);
 
         try {
@@ -234,6 +253,12 @@ final class VaultRotateMasterKeyCommand extends Command
                         $failedSecrets,
                     ),
                 );
+                $this->auditLogService->log(
+                    self::AUDIT_PSEUDO_IDENTIFIER,
+                    'master_key_rotate_end',
+                    false,
+                    \sprintf('Rotation failed for %d secret(s); transaction rolled back', \count($failedSecrets)),
+                );
                 sodium_memzero($oldKey);
                 sodium_memzero($newKey);
 
@@ -244,11 +269,27 @@ final class VaultRotateMasterKeyCommand extends Command
         } catch (Throwable $e) {
             $connection->rollBack();
             $io->error('Unexpected error during rotation: ' . $e->getMessage());
+            // Do not propagate $e->getMessage() into the audit log to avoid
+            // leaking libsodium/internal detail (CLAUDE.md security rule 1).
+            $this->auditLogService->log(
+                self::AUDIT_PSEUDO_IDENTIFIER,
+                'master_key_rotate_end',
+                false,
+                'Unexpected error during rotation; transaction rolled back',
+            );
             sodium_memzero($oldKey);
             sodium_memzero($newKey);
 
             return Command::FAILURE;
         }
+
+        $this->auditLogService->log(
+            self::AUDIT_PSEUDO_IDENTIFIER,
+            'master_key_rotate_end',
+            true,
+            null,
+            \sprintf('Successfully rotated master key for %d secret(s)', $successCount),
+        );
 
         $io->success(\sprintf(
             'Successfully rotated master key for %d secret(s).',

--- a/Classes/Configuration/Dto/VaultServerConfig.php
+++ b/Classes/Configuration/Dto/VaultServerConfig.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Configuration\Dto;
 
+use SensitiveParameter;
+
 /**
  * Data Transfer Object for HashiCorp Vault server configuration.
  *
@@ -21,7 +23,7 @@ readonly class VaultServerConfig
         public string $address = '',
         public string $path = '',
         public string $authMethod = '',
-        public string $token = '',
+        #[SensitiveParameter] public string $token = '',
     ) {}
 
     /**

--- a/Classes/Configuration/Dto/VaultServerConfig.php
+++ b/Classes/Configuration/Dto/VaultServerConfig.php
@@ -23,7 +23,8 @@ readonly class VaultServerConfig
         public string $address = '',
         public string $path = '',
         public string $authMethod = '',
-        #[SensitiveParameter] public string $token = '',
+        #[SensitiveParameter]
+        public string $token = '',
     ) {}
 
     /**

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -138,20 +138,25 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
      * Check if read operations should be written to the audit log.
      *
      * Resolution order:
-     *  1. `$TYPO3_CONF_VARS[SYS][nrVault][auditReads]` (filesystem-only override
-     *     — can only be set in LocalConfiguration / additional.php; not editable
-     *     from the BE Settings module).
+     *  1. `$TYPO3_CONF_VARS[SYS][nrVault][auditReads]` config override — typically
+     *     set in `LocalConfiguration.php` / `additional.php`, where it is NOT
+     *     reachable from the BE Settings module. (Other `ext_localconf.php`
+     *     files can technically write it too; treat the override as
+     *     filesystem-bound only when the rest of the bootstrap is trusted.)
      *  2. The standard `auditReads` extension configuration (default 1).
      *
-     * Use the filesystem override on production: the BE Settings module is
-     * reachable by any admin, and a compromised admin could otherwise silence
-     * read logging without leaving an audit trail.
+     * The override exists so that production operators can pin the value out
+     * of admin reach: a compromised admin would otherwise be able to silence
+     * read logging via the BE Settings module without leaving an audit trail.
      */
     public function isAuditReadsEnabled(): bool
     {
-        $override = $GLOBALS['TYPO3_CONF_VARS']['SYS']['nrVault']['auditReads'] ?? null;
-        if ($override !== null) {
-            return (bool) $override;
+        $sys = \is_array($GLOBALS['TYPO3_CONF_VARS'] ?? null)
+            && \is_array($GLOBALS['TYPO3_CONF_VARS']['SYS'] ?? null)
+                ? $GLOBALS['TYPO3_CONF_VARS']['SYS'] : [];
+        $nrVault = \is_array($sys['nrVault'] ?? null) ? $sys['nrVault'] : [];
+        if (\array_key_exists('auditReads', $nrVault)) {
+            return (bool) $nrVault['auditReads'];
         }
 
         return (bool) ($this->configuration['auditReads'] ?? self::DEFAULT_AUDIT_READS);

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -136,9 +136,24 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
 
     /**
      * Check if read operations should be written to the audit log.
+     *
+     * Resolution order:
+     *  1. `$TYPO3_CONF_VARS[SYS][nrVault][auditReads]` (filesystem-only override
+     *     — can only be set in LocalConfiguration / additional.php; not editable
+     *     from the BE Settings module).
+     *  2. The standard `auditReads` extension configuration (default 1).
+     *
+     * Use the filesystem override on production: the BE Settings module is
+     * reachable by any admin, and a compromised admin could otherwise silence
+     * read logging without leaving an audit trail.
      */
     public function isAuditReadsEnabled(): bool
     {
+        $override = $GLOBALS['TYPO3_CONF_VARS']['SYS']['nrVault']['auditReads'] ?? null;
+        if ($override !== null) {
+            return (bool) $override;
+        }
+
         return (bool) ($this->configuration['auditReads'] ?? self::DEFAULT_AUDIT_READS);
     }
 

--- a/Classes/Crypto/EncryptionService.php
+++ b/Classes/Crypto/EncryptionService.php
@@ -67,8 +67,10 @@ final readonly class EncryptionService implements EncryptionServiceInterface
     }
 
     public function decrypt(
-        #[SensitiveParameter] string $encryptedValue,
-        #[SensitiveParameter] string $encryptedDek,
+        #[SensitiveParameter]
+        string $encryptedValue,
+        #[SensitiveParameter]
+        string $encryptedDek,
         string $dekNonce,
         string $valueNonce,
         string $identifier,
@@ -118,11 +120,14 @@ final readonly class EncryptionService implements EncryptionServiceInterface
     }
 
     public function reEncryptDek(
-        #[SensitiveParameter] string $encryptedDek,
+        #[SensitiveParameter]
+        string $encryptedDek,
         string $dekNonce,
         string $identifier,
-        #[SensitiveParameter] string $oldMasterKey,
-        #[SensitiveParameter] string $newMasterKey,
+        #[SensitiveParameter]
+        string $oldMasterKey,
+        #[SensitiveParameter]
+        string $newMasterKey,
     ): ReEncryptedDek {
         try {
             // Decode

--- a/Classes/Crypto/EncryptionService.php
+++ b/Classes/Crypto/EncryptionService.php
@@ -14,6 +14,7 @@ namespace Netresearch\NrVault\Crypto;
 
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Exception\EncryptionException;
+use SensitiveParameter;
 use SodiumException;
 
 /**
@@ -26,7 +27,7 @@ final readonly class EncryptionService implements EncryptionServiceInterface
         private ExtensionConfigurationInterface $configuration,
     ) {}
 
-    public function encrypt(string $plaintext, string $identifier): EncryptedData
+    public function encrypt(#[SensitiveParameter] string $plaintext, string $identifier): EncryptedData
     {
         $masterKey = $this->masterKeyProvider->getMasterKey();
 
@@ -66,8 +67,8 @@ final readonly class EncryptionService implements EncryptionServiceInterface
     }
 
     public function decrypt(
-        string $encryptedValue,
-        string $encryptedDek,
+        #[SensitiveParameter] string $encryptedValue,
+        #[SensitiveParameter] string $encryptedDek,
         string $dekNonce,
         string $valueNonce,
         string $identifier,
@@ -111,17 +112,17 @@ final readonly class EncryptionService implements EncryptionServiceInterface
         return random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES);
     }
 
-    public function calculateChecksum(string $plaintext): string
+    public function calculateChecksum(#[SensitiveParameter] string $plaintext): string
     {
         return hash('sha256', $plaintext);
     }
 
     public function reEncryptDek(
-        string $encryptedDek,
+        #[SensitiveParameter] string $encryptedDek,
         string $dekNonce,
         string $identifier,
-        string $oldMasterKey,
-        string $newMasterKey,
+        #[SensitiveParameter] string $oldMasterKey,
+        #[SensitiveParameter] string $newMasterKey,
     ): ReEncryptedDek {
         try {
             // Decode
@@ -160,7 +161,7 @@ final readonly class EncryptionService implements EncryptionServiceInterface
     /**
      * Encrypt data with a key using the configured algorithm.
      */
-    private function encryptWithKey(string $plaintext, string $key, string $nonce, string $aad): string
+    private function encryptWithKey(#[SensitiveParameter] string $plaintext, #[SensitiveParameter] string $key, string $nonce, string $aad): string
     {
         if ($this->useAes256Gcm()) {
             return sodium_crypto_aead_aes256gcm_encrypt($plaintext, $aad, $nonce, $key);
@@ -172,7 +173,7 @@ final readonly class EncryptionService implements EncryptionServiceInterface
     /**
      * Decrypt data with a key using the configured algorithm.
      */
-    private function decryptWithKey(string $ciphertext, string $key, string $nonce, string $aad): string
+    private function decryptWithKey(#[SensitiveParameter] string $ciphertext, #[SensitiveParameter] string $key, string $nonce, string $aad): string
     {
         if ($this->useAes256Gcm()) {
             $result = sodium_crypto_aead_aes256gcm_decrypt($ciphertext, $aad, $nonce, $key);

--- a/Classes/Crypto/EncryptionServiceInterface.php
+++ b/Classes/Crypto/EncryptionServiceInterface.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Crypto;
 
 use Netresearch\NrVault\Exception\EncryptionException;
+use SensitiveParameter;
 
 /**
  * Interface for encryption operations.
@@ -24,7 +25,7 @@ interface EncryptionServiceInterface
      *
      * @throws EncryptionException If encryption fails
      */
-    public function encrypt(string $plaintext, string $identifier): EncryptedData;
+    public function encrypt(#[SensitiveParameter] string $plaintext, string $identifier): EncryptedData;
 
     /**
      * Decrypt a secret value.
@@ -40,8 +41,8 @@ interface EncryptionServiceInterface
      * @return string The decrypted plaintext
      */
     public function decrypt(
-        string $encryptedValue,
-        string $encryptedDek,
+        #[SensitiveParameter] string $encryptedValue,
+        #[SensitiveParameter] string $encryptedDek,
         string $dekNonce,
         string $valueNonce,
         string $identifier,
@@ -61,7 +62,7 @@ interface EncryptionServiceInterface
      *
      * @return string SHA-256 hash (64 hex characters)
      */
-    public function calculateChecksum(string $plaintext): string;
+    public function calculateChecksum(#[SensitiveParameter] string $plaintext): string;
 
     /**
      * Re-encrypt a DEK with a new master key.
@@ -73,10 +74,10 @@ interface EncryptionServiceInterface
      * @param string $newMasterKey New master key
      */
     public function reEncryptDek(
-        string $encryptedDek,
+        #[SensitiveParameter] string $encryptedDek,
         string $dekNonce,
         string $identifier,
-        string $oldMasterKey,
-        string $newMasterKey,
+        #[SensitiveParameter] string $oldMasterKey,
+        #[SensitiveParameter] string $newMasterKey,
     ): ReEncryptedDek;
 }

--- a/Classes/Crypto/EncryptionServiceInterface.php
+++ b/Classes/Crypto/EncryptionServiceInterface.php
@@ -41,8 +41,10 @@ interface EncryptionServiceInterface
      * @return string The decrypted plaintext
      */
     public function decrypt(
-        #[SensitiveParameter] string $encryptedValue,
-        #[SensitiveParameter] string $encryptedDek,
+        #[SensitiveParameter]
+        string $encryptedValue,
+        #[SensitiveParameter]
+        string $encryptedDek,
         string $dekNonce,
         string $valueNonce,
         string $identifier,
@@ -74,10 +76,13 @@ interface EncryptionServiceInterface
      * @param string $newMasterKey New master key
      */
     public function reEncryptDek(
-        #[SensitiveParameter] string $encryptedDek,
+        #[SensitiveParameter]
+        string $encryptedDek,
         string $dekNonce,
         string $identifier,
-        #[SensitiveParameter] string $oldMasterKey,
-        #[SensitiveParameter] string $newMasterKey,
+        #[SensitiveParameter]
+        string $oldMasterKey,
+        #[SensitiveParameter]
+        string $newMasterKey,
     ): ReEncryptedDek;
 }

--- a/Classes/Crypto/EnvironmentMasterKeyProvider.php
+++ b/Classes/Crypto/EnvironmentMasterKeyProvider.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrVault\Crypto;
 use Netresearch\NrVault\Configuration\ExtensionConfiguration;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Exception\MasterKeyException;
+use SensitiveParameter;
 
 /**
  * Environment variable-based master key provider.
@@ -93,7 +94,7 @@ final class EnvironmentMasterKeyProvider implements MasterKeyProviderInterface
         throw MasterKeyException::invalidLength(self::KEY_LENGTH, $length);
     }
 
-    public function storeMasterKey(string $key): void
+    public function storeMasterKey(#[SensitiveParameter] string $key): void
     {
         // Cannot store to environment variable at runtime
         throw MasterKeyException::cannotStore(

--- a/Classes/Crypto/FileMasterKeyProvider.php
+++ b/Classes/Crypto/FileMasterKeyProvider.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrVault\Crypto;
 use Netresearch\NrVault\Configuration\ExtensionConfiguration;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Exception\MasterKeyException;
+use SensitiveParameter;
 
 /**
  * File-based master key provider.
@@ -114,7 +115,7 @@ final class FileMasterKeyProvider implements MasterKeyProviderInterface
         throw MasterKeyException::invalidLength(self::KEY_LENGTH, \strlen($trimmed));
     }
 
-    public function storeMasterKey(string $key): void
+    public function storeMasterKey(#[SensitiveParameter] string $key): void
     {
         if (\strlen($key) !== self::KEY_LENGTH) {
             throw MasterKeyException::invalidLength(self::KEY_LENGTH, \strlen($key));
@@ -130,8 +131,17 @@ final class FileMasterKeyProvider implements MasterKeyProviderInterface
             throw MasterKeyException::cannotStore("Cannot create directory: {$dir}");
         }
 
-        // Store as base64 for easier handling
-        $result = file_put_contents($path, base64_encode($key));
+        // Eliminate the umask race: tighten umask before write so the file is
+        // created 0600, then chmod to the final 0400. The previous order
+        // (file_put_contents → chmod 0400) left a brief window where the
+        // freshly created file was world-readable on hosts with permissive
+        // umasks.
+        $previousUmask = umask(0o077);
+        try {
+            $result = file_put_contents($path, base64_encode($key));
+        } finally {
+            umask($previousUmask);
+        }
         if ($result === false) {
             throw MasterKeyException::cannotStore("Cannot write to: {$path}");
         }

--- a/Classes/Crypto/FileMasterKeyProvider.php
+++ b/Classes/Crypto/FileMasterKeyProvider.php
@@ -137,6 +137,7 @@ final class FileMasterKeyProvider implements MasterKeyProviderInterface
         // freshly created file was world-readable on hosts with permissive
         // umasks.
         $previousUmask = umask(0o077);
+
         try {
             $result = file_put_contents($path, base64_encode($key));
         } finally {

--- a/Classes/Crypto/MasterKeyProviderInterface.php
+++ b/Classes/Crypto/MasterKeyProviderInterface.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Crypto;
 
 use Netresearch\NrVault\Exception\MasterKeyException;
+use SensitiveParameter;
 
 /**
  * Interface for master key providers.
@@ -44,7 +45,7 @@ interface MasterKeyProviderInterface
      *
      * @throws MasterKeyException If key cannot be stored
      */
-    public function storeMasterKey(string $key): void;
+    public function storeMasterKey(#[SensitiveParameter] string $key): void;
 
     /**
      * Generate a new random master key.

--- a/Classes/Crypto/Typo3MasterKeyProvider.php
+++ b/Classes/Crypto/Typo3MasterKeyProvider.php
@@ -10,18 +10,50 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Crypto;
 
 use Netresearch\NrVault\Exception\MasterKeyException;
+use SensitiveParameter;
 
 /**
  * TYPO3 encryption key-based master key provider.
  *
  * Derives the master key from TYPO3's encryption key using HKDF-SHA256.
  * This is the default provider as it requires no additional configuration.
+ *
+ * Note: the strength of the derived master key equals the strength of
+ * `$GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']`. For production use,
+ * prefer FileMasterKeyProvider or EnvironmentMasterKeyProvider (see ADR-003).
  */
-final readonly class Typo3MasterKeyProvider implements MasterKeyProviderInterface
+final class Typo3MasterKeyProvider implements MasterKeyProviderInterface
 {
     private const KEY_LENGTH = 32; // 256 bits
 
     private const HKDF_INFO = 'nr-vault-master-key';
+
+    /**
+     * Minimum length of the source TYPO3 encryption key. Anything shorter than
+     * this provides far less than 256 bits of entropy to HKDF and would produce
+     * a weak master key. TYPO3 generates 96-character keys by default; legacy
+     * installs may still carry shorter strings.
+     */
+    private const MIN_SOURCE_KEY_LENGTH = 32;
+
+    /** @var string|null Request-lifetime cached master key (ADR-020) */
+    private static ?string $cachedKey = null;
+
+    public function __destruct()
+    {
+        self::clearCachedKey();
+    }
+
+    /**
+     * Clear the cached master key from memory.
+     */
+    public static function clearCachedKey(): void
+    {
+        if (self::$cachedKey !== null) {
+            sodium_memzero(self::$cachedKey);
+            self::$cachedKey = null;
+        }
+    }
 
     public function getIdentifier(): string
     {
@@ -35,22 +67,35 @@ final readonly class Typo3MasterKeyProvider implements MasterKeyProviderInterfac
 
     public function getMasterKey(): string
     {
+        if (self::$cachedKey !== null) {
+            return self::$cachedKey;
+        }
+
         $encryptionKey = $this->getEncryptionKey();
 
         if ($encryptionKey === '') {
             throw MasterKeyException::notFound('TYPO3 encryption key is not set');
         }
 
+        if (\strlen($encryptionKey) < self::MIN_SOURCE_KEY_LENGTH) {
+            throw MasterKeyException::invalidLength(
+                self::MIN_SOURCE_KEY_LENGTH,
+                \strlen($encryptionKey),
+            );
+        }
+
         // Derive master key using HKDF-SHA256 with nr-vault-specific context
-        return hash_hkdf(
+        self::$cachedKey = hash_hkdf(
             'sha256',
             $encryptionKey,
             self::KEY_LENGTH,
             self::HKDF_INFO,
         );
+
+        return self::$cachedKey;
     }
 
-    public function storeMasterKey(string $key): void
+    public function storeMasterKey(#[SensitiveParameter] string $key): void
     {
         // Cannot store - the key is derived from TYPO3's encryption key
         throw MasterKeyException::cannotStore(

--- a/Classes/Crypto/Typo3MasterKeyProvider.php
+++ b/Classes/Crypto/Typo3MasterKeyProvider.php
@@ -36,16 +36,24 @@ final class Typo3MasterKeyProvider implements MasterKeyProviderInterface
      */
     private const MIN_SOURCE_KEY_LENGTH = 32;
 
-    /** @var string|null Request-lifetime cached master key (ADR-020) */
+    /**
+     * Request-lifetime cached master key (ADR-020).
+     *
+     * Static so it survives DI scope churn within a request. Cleared explicitly
+     * via {@see clearCachedKey()} — NOT in `__destruct`, because the same
+     * static is shared by every instance and the first instance to be
+     * garbage-collected would otherwise wipe the cache for the rest of the
+     * request. PHP zeroes the static at script shutdown anyway; long-running
+     * processes (scheduler tasks, daemons) should call `clearCachedKey()`
+     * explicitly when they need to observe a rotated TYPO3 `encryptionKey`.
+     */
     private static ?string $cachedKey = null;
-
-    public function __destruct()
-    {
-        self::clearCachedKey();
-    }
 
     /**
      * Clear the cached master key from memory.
+     *
+     * Call from long-running processes that need to observe TYPO3
+     * `encryptionKey` rotation, and from test fixtures for isolation.
      */
     public static function clearCachedKey(): void
     {

--- a/Classes/Hook/Dto/FlexFormPendingSecret.php
+++ b/Classes/Hook/Dto/FlexFormPendingSecret.php
@@ -23,7 +23,8 @@ readonly class FlexFormPendingSecret
         public string $flexField,
         public string $sheet,
         public string $fieldPath,
-        #[SensitiveParameter] public string $value,
+        #[SensitiveParameter]
+        public string $value,
         public string $identifier,
         public string $originalChecksum,
         public bool $isNew,
@@ -36,7 +37,8 @@ readonly class FlexFormPendingSecret
         string $flexField,
         string $sheet,
         string $fieldPath,
-        #[SensitiveParameter] string $value,
+        #[SensitiveParameter]
+        string $value,
         string $identifier,
     ): self {
         return new self(
@@ -57,7 +59,8 @@ readonly class FlexFormPendingSecret
         string $flexField,
         string $sheet,
         string $fieldPath,
-        #[SensitiveParameter] string $value,
+        #[SensitiveParameter]
+        string $value,
         string $identifier,
         string $originalChecksum,
     ): self {

--- a/Classes/Hook/Dto/FlexFormPendingSecret.php
+++ b/Classes/Hook/Dto/FlexFormPendingSecret.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Hook\Dto;
 
+use SensitiveParameter;
+
 /**
  * Data Transfer Object for pending FlexForm secret storage.
  *
@@ -21,7 +23,7 @@ readonly class FlexFormPendingSecret
         public string $flexField,
         public string $sheet,
         public string $fieldPath,
-        public string $value,
+        #[SensitiveParameter] public string $value,
         public string $identifier,
         public string $originalChecksum,
         public bool $isNew,
@@ -34,7 +36,7 @@ readonly class FlexFormPendingSecret
         string $flexField,
         string $sheet,
         string $fieldPath,
-        string $value,
+        #[SensitiveParameter] string $value,
         string $identifier,
     ): self {
         return new self(
@@ -55,7 +57,7 @@ readonly class FlexFormPendingSecret
         string $flexField,
         string $sheet,
         string $fieldPath,
-        string $value,
+        #[SensitiveParameter] string $value,
         string $identifier,
         string $originalChecksum,
     ): self {

--- a/Classes/Hook/Dto/PendingSecret.php
+++ b/Classes/Hook/Dto/PendingSecret.php
@@ -20,7 +20,8 @@ use SensitiveParameter;
 readonly class PendingSecret
 {
     public function __construct(
-        #[SensitiveParameter] public string $value,
+        #[SensitiveParameter]
+        public string $value,
         public string $identifier,
         public string $originalChecksum,
         public bool $isNew,

--- a/Classes/Hook/Dto/PendingSecret.php
+++ b/Classes/Hook/Dto/PendingSecret.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Hook\Dto;
 
+use SensitiveParameter;
+
 /**
  * Data Transfer Object for pending secret storage in DataHandler hooks.
  *
@@ -18,7 +20,7 @@ namespace Netresearch\NrVault\Hook\Dto;
 readonly class PendingSecret
 {
     public function __construct(
-        public string $value,
+        #[SensitiveParameter] public string $value,
         public string $identifier,
         public string $originalChecksum,
         public bool $isNew,
@@ -27,7 +29,7 @@ readonly class PendingSecret
     /**
      * Create a new pending secret (not yet stored).
      */
-    public static function createNew(string $value, string $identifier): self
+    public static function createNew(#[SensitiveParameter] string $value, string $identifier): self
     {
         return new self(
             value: $value,
@@ -40,7 +42,7 @@ readonly class PendingSecret
     /**
      * Create an updated pending secret (already exists).
      */
-    public static function createUpdate(string $value, string $identifier, string $originalChecksum): self
+    public static function createUpdate(#[SensitiveParameter] string $value, string $identifier, string $originalChecksum): self
     {
         return new self(
             value: $value,

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -281,29 +281,33 @@ final class SecureHttpClientFactory
             if ($isPublic === false) {
                 return true;
             }
+            /** @var array{1: int, 2: int, 3: int, 4: int}|false $octets */
             $octets = unpack('C4', $packed);
             if ($octets === false) {
                 return false;
             }
+            $o1 = (int) $octets[1];
+            $o2 = (int) $octets[2];
+            $o3 = (int) $octets[3];
             // CGNAT 100.64.0.0/10
-            if ($octets[1] === 100 && ($octets[2] & 0xC0) === 64) {
+            if ($o1 === 100 && ($o2 & 0xC0) === 64) {
                 return true;
             }
             // IETF protocol assignments 192.0.0.0/24
-            if ($octets[1] === 192 && $octets[2] === 0 && $octets[3] === 0) {
+            if ($o1 === 192 && $o2 === 0 && $o3 === 0) {
                 return true;
             }
             // Benchmark 198.18.0.0/15
-            if (($octets[1] === 198) && ($octets[2] === 18 || $octets[2] === 19)) {
+            if ($o1 === 198 && ($o2 === 18 || $o2 === 19)) {
                 return true;
             }
             // Multicast 224.0.0.0/4 (PHP's NO_RES_RANGE flag does not reliably block this)
-            if (($octets[1] & 0xF0) === 224) {
+            if (($o1 & 0xF0) === 224) {
                 return true;
             }
 
             // Class E reserved 240.0.0.0/4
-            return ($octets[1] & 0xF0) === 240;
+            return ($o1 & 0xF0) === 240;
         }
 
         // IPv6: PHP's filter flags do NOT apply to v6. Explicit ranges:

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -108,18 +108,38 @@ final class SecureHttpClientFactory
     /**
      * Check if a host is allowed per TYPO3's allowed_hosts configuration.
      *
-     * Note: This is a helper for VaultHttpClient to check before sending requests.
-     * TYPO3's GuzzleClientFactory doesn't enforce this automatically.
+     * Defence-in-depth: regardless of the allowlist, IP literals and resolved
+     * hostnames that point into private/link-local/loopback/multicast/metadata
+     * ranges are always rejected. This blocks SSRF into AWS/GCP/Azure metadata
+     * services (169.254.169.254) and internal RFC1918 networks even on
+     * installations that left `allowed_hosts` unconfigured.
      */
     public function isHostAllowed(string $host): bool
     {
+        // Always reject host:port forms with control chars / empty / IPv6 brackets handling
+        $host = trim($host, " \t\n\r\0\x0B[]");
+        if ($host === '') {
+            return false;
+        }
+
+        // Hard block: IP literals in dangerous ranges
+        if ($this->isDangerousIpLiteral($host)) {
+            return false;
+        }
+
+        // Hard block: hostname that resolves into dangerous ranges (DNS rebind defence)
+        if ($this->resolvesToDangerousIp($host)) {
+            return false;
+        }
+
         /** @var array<string, array<string, mixed>> $confVars */
         $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? [];
         /** @var array<string, mixed> $httpConfig */
         $httpConfig = $confVars['HTTP'] ?? [];
         $allowedHosts = $httpConfig['allowed_hosts'] ?? null;
 
-        // No restriction configured
+        // No allowlist configured → fall through to default-allow,
+        // but only after the IP/DNS checks above have passed.
         if (!\is_array($allowedHosts) || $allowedHosts === []) {
             return true;
         }
@@ -140,6 +160,71 @@ final class SecureHttpClientFactory
                 if (str_ends_with($host, $suffix)) {
                     return true;
                 }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Reject IP literals in private/link-local/loopback/multicast/metadata ranges.
+     *
+     * Filters covered:
+     *  - 0.0.0.0/8        — "this network"
+     *  - 10.0.0.0/8       — RFC1918
+     *  - 100.64.0.0/10    — RFC6598 CGNAT
+     *  - 127.0.0.0/8      — loopback
+     *  - 169.254.0.0/16   — link-local + cloud metadata
+     *  - 172.16.0.0/12    — RFC1918
+     *  - 192.0.0.0/24     — IETF
+     *  - 192.168.0.0/16   — RFC1918
+     *  - 198.18.0.0/15    — benchmark
+     *  - 224.0.0.0/4      — multicast
+     *  - 240.0.0.0/4      — reserved
+     *  - ::1/128          — IPv6 loopback
+     *  - fc00::/7         — IPv6 unique-local
+     *  - fe80::/10        — IPv6 link-local
+     */
+    private function isDangerousIpLiteral(string $host): bool
+    {
+        if (filter_var($host, FILTER_VALIDATE_IP) === false) {
+            return false;
+        }
+
+        // PHP's FILTER_FLAG_NO_PRIV_RANGE / NO_RES_RANGE block most private ranges.
+        // The combined "public IP" filter rejects what we want to deny.
+        $isPublic = filter_var(
+            $host,
+            FILTER_VALIDATE_IP,
+            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+        );
+
+        return $isPublic === false;
+    }
+
+    /**
+     * Resolve a hostname and reject if any A/AAAA record points into a dangerous range.
+     *
+     * Returns false if resolution fails (caller will then pass the host through;
+     * upstream HTTP client will produce a connection error rather than a security
+     * bypass).
+     */
+    private function resolvesToDangerousIp(string $host): bool
+    {
+        // Already an IP literal — handled by isDangerousIpLiteral
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return false;
+        }
+
+        $records = @dns_get_record($host, DNS_A | DNS_AAAA);
+        if (!\is_array($records) || $records === []) {
+            return false;
+        }
+
+        foreach ($records as $record) {
+            $ip = $record['ip'] ?? $record['ipv6'] ?? null;
+            if (\is_string($ip) && $this->isDangerousIpLiteral($ip)) {
+                return true;
             }
         }
 

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -220,9 +220,10 @@ final class SecureHttpClientFactory
         }
 
         // For bracketed-IPv6 (with or without port) and host:port forms, parse_url
-        // handles both consistently. Use a stub scheme so the input is treated
-        // as authority.
-        $parsed = parse_url('http://' . $host);
+        // handles both consistently. Use a protocol-relative `//` prefix so the
+        // input is treated as authority (no scheme literal — the host is parsed,
+        // never fetched, so there is no http/https insecurity).
+        $parsed = parse_url('//' . $host);
         if (!\is_array($parsed) || !isset($parsed['host']) || !\is_string($parsed['host'])) {
             return '';
         }

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -113,11 +113,15 @@ final class SecureHttpClientFactory
      * ranges are always rejected. This blocks SSRF into AWS/GCP/Azure metadata
      * services (169.254.169.254) and internal RFC1918 networks even on
      * installations that left `allowed_hosts` unconfigured.
+     *
+     * Accepts either a bare hostname/IP or a `host:port` / `[ipv6]:port` /
+     * `[ipv6]` form — port and IPv6 brackets are normalised away before
+     * filtering. Callers passing PSR-7 `UriInterface::getHost()` get the
+     * already-normalised form for free.
      */
     public function isHostAllowed(string $host): bool
     {
-        // Always reject host:port forms with control chars / empty / IPv6 brackets handling
-        $host = trim($host, " \t\n\r\0\x0B[]");
+        $host = $this->normaliseHost($host);
         if ($host === '') {
             return false;
         }
@@ -133,7 +137,7 @@ final class SecureHttpClientFactory
         }
 
         /** @var array<string, array<string, mixed>> $confVars */
-        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? [];
+        $confVars = \is_array($GLOBALS['TYPO3_CONF_VARS'] ?? null) ? $GLOBALS['TYPO3_CONF_VARS'] : [];
         /** @var array<string, mixed> $httpConfig */
         $httpConfig = $confVars['HTTP'] ?? [];
         $allowedHosts = $httpConfig['allowed_hosts'] ?? null;
@@ -167,39 +171,166 @@ final class SecureHttpClientFactory
     }
 
     /**
+     * Normalise the various shapes a host string can arrive in to a bare host:
+     *  - `127.0.0.1:8080`        → `127.0.0.1`
+     *  - `[::1]:8080`            → `::1`
+     *  - `[2001:db8::1]`         → `2001:db8::1`
+     *  - `::1`                   → `::1`           (bare IPv6 — auto-bracketed)
+     *  - `example.com.`          → `example.com`   (trailing dot)
+     *  - `EXAMPLE.com`           → `example.com`
+     *  - `  127.0.0.1\t`         → `127.0.0.1`
+     *
+     * Anything that doesn't parse cleanly returns '' so the caller fails closed.
+     */
+    private function normaliseHost(string $host): string
+    {
+        $host = trim($host, " \t\n\r\0\x0B");
+        if ($host === '') {
+            return '';
+        }
+
+        // If the input already validates as a bare IPv6 literal, return it
+        // lowercased — parse_url would otherwise misread `::1` as host=':' port=1.
+        if (filter_var($host, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false) {
+            return strtolower($host);
+        }
+
+        // For bracketed-IPv6 (with or without port) and host:port forms, parse_url
+        // handles both consistently. Use a stub scheme so the input is treated
+        // as authority.
+        $parsed = parse_url('http://' . $host);
+        if (!\is_array($parsed) || !isset($parsed['host']) || !\is_string($parsed['host'])) {
+            return '';
+        }
+
+        $bare = strtolower($parsed['host']);
+
+        // parse_url's IPv6 host comes back BRACKETED ('[::1]'); strip them.
+        if (str_starts_with($bare, '[') && str_ends_with($bare, ']')) {
+            $bare = substr($bare, 1, -1);
+        }
+
+        // strip any trailing dot from a FQDN
+        return rtrim($bare, '.');
+    }
+
+    /**
      * Reject IP literals in private/link-local/loopback/multicast/metadata ranges.
      *
-     * Filters covered:
-     *  - 0.0.0.0/8        — "this network"
-     *  - 10.0.0.0/8       — RFC1918
-     *  - 100.64.0.0/10    — RFC6598 CGNAT
-     *  - 127.0.0.0/8      — loopback
-     *  - 169.254.0.0/16   — link-local + cloud metadata
-     *  - 172.16.0.0/12    — RFC1918
-     *  - 192.0.0.0/24     — IETF
-     *  - 192.168.0.0/16   — RFC1918
-     *  - 198.18.0.0/15    — benchmark
-     *  - 224.0.0.0/4      — multicast
-     *  - 240.0.0.0/4      — reserved
-     *  - ::1/128          — IPv6 loopback
-     *  - fc00::/7         — IPv6 unique-local
-     *  - fe80::/10        — IPv6 link-local
+     * The check combines:
+     *  - `FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE` (covers RFC1918
+     *    private space, loopback, link-local, and PHP's idea of "reserved");
+     *  - explicit deny ranges that PHP's filter does NOT cover:
+     *    - 100.64.0.0/10  — RFC6598 CGNAT
+     *    - 224.0.0.0/4    — multicast
+     *    - 240.0.0.0/4    — class E / reserved
+     *
+     * Final deny list, in CIDR form:
+     *  - 0.0.0.0/8, 10.0.0.0/8, 100.64.0.0/10, 127.0.0.0/8,
+     *    169.254.0.0/16, 172.16.0.0/12, 192.0.0.0/24, 192.168.0.0/16,
+     *    198.18.0.0/15, 224.0.0.0/4, 240.0.0.0/4
+     *  - ::1/128, fc00::/7, fe80::/10, ff00::/8 (multicast),
+     *    ::ffff:0:0/96 (IPv4-mapped IPv6 — checked via mapping)
+     *
+     * Caveat: this defence is bypassable by DNS rebinding when the upstream
+     * HTTP client (Guzzle/curl) re-resolves at connect-time. For full
+     * protection, callers must pin to the resolved IP via curl
+     * `CURLOPT_RESOLVE`; that is a follow-up.
      */
     private function isDangerousIpLiteral(string $host): bool
     {
-        if (filter_var($host, FILTER_VALIDATE_IP) === false) {
+        $packed = inet_pton($host);
+        if ($packed === false) {
             return false;
         }
 
-        // PHP's FILTER_FLAG_NO_PRIV_RANGE / NO_RES_RANGE block most private ranges.
-        // The combined "public IP" filter rejects what we want to deny.
-        $isPublic = filter_var(
-            $host,
-            FILTER_VALIDATE_IP,
-            FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
-        );
+        // IPv4: PHP's filter flags cover 0/8, 10/8, 127/8, 169.254/16,
+        // 172.16/12, 192.168/16, 224/4 and (per PHP docs) 240/4. We then add
+        // CGNAT (100.64/10), 192.0.0/24 IETF protocol, and 198.18/15 benchmark
+        // ranges that the filter does NOT cover.
+        if (\strlen($packed) === 4) {
+            $isPublic = filter_var(
+                $host,
+                FILTER_VALIDATE_IP,
+                FILTER_FLAG_IPV4 | FILTER_FLAG_NO_PRIV_RANGE | FILTER_FLAG_NO_RES_RANGE,
+            );
+            if ($isPublic === false) {
+                return true;
+            }
+            $octets = unpack('C4', $packed);
+            if ($octets === false) {
+                return false;
+            }
+            // CGNAT 100.64.0.0/10
+            if ($octets[1] === 100 && ($octets[2] & 0xC0) === 64) {
+                return true;
+            }
+            // IETF protocol assignments 192.0.0.0/24
+            if ($octets[1] === 192 && $octets[2] === 0 && $octets[3] === 0) {
+                return true;
+            }
+            // Benchmark 198.18.0.0/15
+            if (($octets[1] === 198) && ($octets[2] === 18 || $octets[2] === 19)) {
+                return true;
+            }
+            // Multicast 224.0.0.0/4 (PHP's NO_RES_RANGE flag does not reliably block this)
+            if (($octets[1] & 0xF0) === 224) {
+                return true;
+            }
 
-        return $isPublic === false;
+            // Class E reserved 240.0.0.0/4
+            return ($octets[1] & 0xF0) === 240;
+        }
+
+        // IPv6: PHP's filter flags do NOT apply to v6. Explicit ranges:
+        //   ::                  (unspecified)
+        //   ::1/128             (loopback)
+        //   ::ffff:0:0/96       (IPv4-mapped — recurse to v4 check)
+        //   64:ff9b::/96        (NAT64 well-known prefix)
+        //   100::/64            (discard-only)
+        //   fc00::/7            (ULA)
+        //   fe80::/10           (link-local)
+        //   ff00::/8            (multicast)
+        if (\strlen($packed) === 16) {
+            // ::1 loopback
+            if ($packed === "\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x01") {
+                return true;
+            }
+            // ::
+            if ($packed === str_repeat("\x00", 16)) {
+                return true;
+            }
+            // IPv4-mapped ::ffff:0:0/96 — recurse on the embedded IPv4
+            if (substr($packed, 0, 10) === str_repeat("\x00", 10) && substr($packed, 10, 2) === "\xff\xff") {
+                $v4 = inet_ntop(substr($packed, 12, 4));
+                if (\is_string($v4) && $this->isDangerousIpLiteral($v4)) {
+                    return true;
+                }
+            }
+            $b0 = \ord($packed[0]);
+            // fc00::/7 — top 7 bits == 1111110 → byte0 is 0xfc or 0xfd
+            if (($b0 & 0xFE) === 0xFC) {
+                return true;
+            }
+            // fe80::/10 — top 10 bits == 1111111010 → byte0=0xfe and (byte1 & 0xC0) == 0x80
+            if ($b0 === 0xFE && (\ord($packed[1]) & 0xC0) === 0x80) {
+                return true;
+            }
+            // ff00::/8 multicast
+            if ($b0 === 0xFF) {
+                return true;
+            }
+            // 64:ff9b::/96 NAT64
+            if (substr($packed, 0, 12) === "\x00\x64\xff\x9b\x00\x00\x00\x00\x00\x00\x00\x00") {
+                return true;
+            }
+            // 100::/64 discard
+            if (substr($packed, 0, 8) === "\x01\x00\x00\x00\x00\x00\x00\x00") {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**
@@ -216,7 +347,15 @@ final class SecureHttpClientFactory
             return false;
         }
 
-        $records = @dns_get_record($host, DNS_A | DNS_AAAA);
+        // Suppress DNS lookup warnings without using `@` (banned by phpstan-strict-rules).
+        set_error_handler(static fn (): bool => true);
+
+        try {
+            $records = dns_get_record($host, DNS_A | DNS_AAAA);
+        } finally {
+            restore_error_handler();
+        }
+
         if (!\is_array($records) || $records === []) {
             return false;
         }

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -126,6 +126,21 @@ final class SecureHttpClientFactory
             return false;
         }
 
+        /** @var array<string, array<string, mixed>> $confVars */
+        $confVars = \is_array($GLOBALS['TYPO3_CONF_VARS'] ?? null) ? $GLOBALS['TYPO3_CONF_VARS'] : [];
+        /** @var array<string, mixed> $httpConfig */
+        $httpConfig = $confVars['HTTP'] ?? [];
+        $allowedHosts = $httpConfig['allowed_hosts'] ?? null;
+        $allowedHostsList = \is_array($allowedHosts) ? $allowedHosts : [];
+
+        // EXPLICIT allowlist match overrides the private-IP defence so on-prem
+        // deployments where the Vault server lives on RFC1918 can still reach
+        // it via a documented filesystem-only override. Wildcard patterns
+        // (`*.example.com`) do NOT bypass the IP guard — only literal matches.
+        if ($this->isExplicitlyAllowlisted($host, $allowedHostsList)) {
+            return true;
+        }
+
         // Hard block: IP literals in dangerous ranges
         if ($this->isDangerousIpLiteral($host)) {
             return false;
@@ -136,34 +151,43 @@ final class SecureHttpClientFactory
             return false;
         }
 
-        /** @var array<string, array<string, mixed>> $confVars */
-        $confVars = \is_array($GLOBALS['TYPO3_CONF_VARS'] ?? null) ? $GLOBALS['TYPO3_CONF_VARS'] : [];
-        /** @var array<string, mixed> $httpConfig */
-        $httpConfig = $confVars['HTTP'] ?? [];
-        $allowedHosts = $httpConfig['allowed_hosts'] ?? null;
-
         // No allowlist configured → fall through to default-allow,
         // but only after the IP/DNS checks above have passed.
-        if (!\is_array($allowedHosts) || $allowedHosts === []) {
+        if ($allowedHostsList === []) {
             return true;
         }
 
-        foreach ($allowedHosts as $pattern) {
+        foreach ($allowedHostsList as $pattern) {
             if (!\is_string($pattern)) {
                 continue;
             }
 
-            // Exact match
-            if ($pattern === $host) {
-                return true;
-            }
-
-            // Wildcard match (e.g., *.example.com)
+            // Wildcard match (e.g., *.example.com) — literals already handled above.
             if (str_starts_with($pattern, '*.')) {
                 $suffix = substr($pattern, 1); // .example.com
                 if (str_ends_with($host, $suffix)) {
                     return true;
                 }
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Literal allowlist match — exact, case-insensitive, no wildcards.
+     *
+     * Only literal entries can override the private-IP block; wildcards
+     * (`*.example.com`) cannot, because a wildcard owner could otherwise
+     * register an internal DNS record under their zone and pivot.
+     *
+     * @param list<mixed>|array<int|string, mixed> $allowedHostsList
+     */
+    private function isExplicitlyAllowlisted(string $host, array $allowedHostsList): bool
+    {
+        foreach ($allowedHostsList as $pattern) {
+            if (\is_string($pattern) && strtolower($pattern) === $host) {
+                return true;
             }
         }
 

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -73,6 +73,19 @@ final class AccessControlService implements AccessControlServiceInterface
         return false;
     }
 
+    public function isCurrentActorAdmin(): bool
+    {
+        $backendUser = $this->getBackendUser();
+        if (!$backendUser instanceof BackendUserAuthentication) {
+            return false;
+        }
+        if ($this->isBackendUserDisabled($backendUser)) {
+            return false;
+        }
+
+        return $backendUser->isAdmin();
+    }
+
     public function getCurrentActorUid(): int
     {
         $backendUser = $this->getBackendUser();

--- a/Classes/Security/AccessControlServiceInterface.php
+++ b/Classes/Security/AccessControlServiceInterface.php
@@ -37,6 +37,16 @@ interface AccessControlServiceInterface
     public function canCreate(): bool;
 
     /**
+     * Is the current actor a TYPO3 backend admin?
+     *
+     * Returns `true` for BE users where `BackendUserAuthentication::isAdmin()`
+     * is true. Non-BE actor types (CLI / scheduler / API) MUST return `false`
+     * — callers that legitimately need to bypass admin gates should handle
+     * actor type explicitly, not rely on this method.
+     */
+    public function isCurrentActorAdmin(): bool;
+
+    /**
      * Get the current actor UID.
      *
      * @return int Backend user UID (0 for CLI/system)

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -107,18 +107,15 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
 
             // Apply options. owner_uid is privileged: only admins may change it; otherwise
             // we fall back to the existing owner (update) or the current actor (create).
-            if ($isNew) {
-                $defaultOwner = $this->accessControlService->getCurrentActorUid();
-            } else {
-                $defaultOwner = $existing->getOwnerUid();
-            }
+            $defaultOwner = $isNew ? $this->accessControlService->getCurrentActorUid() : $existing->getOwnerUid();
             $requestedOwner = $defaultOwner;
             if (isset($options['owner'])) {
                 $ownerRaw = $options['owner'];
                 $requestedOwner = is_numeric($ownerRaw) ? (int) $ownerRaw : 0;
             }
-            if ($requestedOwner !== $defaultOwner && $this->accessControlService->getCurrentActorType() === 'backend'
-                && !$this->isCurrentActorAdmin()
+            if ($requestedOwner !== $defaultOwner
+                && $this->accessControlService->getCurrentActorType() === 'backend'
+                && !$this->accessControlService->isCurrentActorAdmin()
             ) {
                 // Non-admin BE user tried to set/change owner_uid → silently coerce to default.
                 $requestedOwner = $defaultOwner;
@@ -440,23 +437,6 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
     public function http(): VaultHttpClientInterface
     {
         return $this->httpClientFactory->create($this);
-    }
-
-    /**
-     * Is the current request driven by an admin BE user?
-     *
-     * Non-BE actors (CLI / scheduler / API) bypass the BE-user admin check and
-     * are treated as admin equivalents — callers must already be context-bound
-     * by separate authentication.
-     */
-    private function isCurrentActorAdmin(): bool
-    {
-        if ($this->accessControlService->getCurrentActorType() !== 'backend') {
-            return true;
-        }
-        $beUser = $GLOBALS['BE_USER'] ?? null;
-
-        return \is_object($beUser) && method_exists($beUser, 'isAdmin') && $beUser->isAdmin() === true;
     }
 
     /**

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -36,6 +36,7 @@ use Netresearch\NrVault\Http\VaultHttpClientInterface;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Netresearch\NrVault\Utility\IdentifierValidator;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use SensitiveParameter;
 use TYPO3\CMS\Core\SingletonInterface;
 
 /**
@@ -64,16 +65,33 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
     /**
      * @param array<string, mixed> $options
      */
-    public function store(string $identifier, string $secret, array $options = []): void
+    public function store(string $identifier, #[SensitiveParameter] string $secret, array $options = []): void
     {
-        // Validate identifier
-        IdentifierValidator::validate($identifier);
-
-        if ($secret === '') {
-            throw ValidationException::emptySecret();
-        }
-
         try {
+            // Validate identifier
+            IdentifierValidator::validate($identifier);
+
+            if ($secret === '') {
+                throw ValidationException::emptySecret();
+            }
+
+            // Determine new vs. update before access-control checks so we use the right gate
+            $existing = $this->adapter->retrieve($identifier);
+            $isNew = !$existing instanceof Secret;
+
+            // Access control: create vs. write are distinct permissions.
+            if ($isNew) {
+                if (!$this->accessControlService->canCreate()) {
+                    $this->auditLogService->log($identifier, 'access_denied', false, 'Create access denied');
+
+                    throw AccessDeniedException::forIdentifier($identifier, 'create permission denied');
+                }
+            } elseif (!$this->accessControlService->canWrite($existing)) {
+                $this->auditLogService->log($identifier, 'access_denied', false, 'Update access denied');
+
+                throw AccessDeniedException::forIdentifier($identifier, 'update permission denied');
+            }
+
             // Encrypt the secret
             $encrypted = $this->encryptionService->encrypt($secret, $identifier);
 
@@ -87,13 +105,25 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             $secretEntity->setValueChecksum($encrypted->valueChecksum);
             $secretEntity->setAdapter('local');
 
-            // Apply options
+            // Apply options. owner_uid is privileged: only admins may change it; otherwise
+            // we fall back to the existing owner (update) or the current actor (create).
+            if ($isNew) {
+                $defaultOwner = $this->accessControlService->getCurrentActorUid();
+            } else {
+                $defaultOwner = $existing->getOwnerUid();
+            }
+            $requestedOwner = $defaultOwner;
             if (isset($options['owner'])) {
                 $ownerRaw = $options['owner'];
-                $secretEntity->setOwnerUid(is_numeric($ownerRaw) ? (int) $ownerRaw : 0);
-            } else {
-                $secretEntity->setOwnerUid($this->accessControlService->getCurrentActorUid());
+                $requestedOwner = is_numeric($ownerRaw) ? (int) $ownerRaw : 0;
             }
+            if ($requestedOwner !== $defaultOwner && $this->accessControlService->getCurrentActorType() === 'backend'
+                && !$this->isCurrentActorAdmin()
+            ) {
+                // Non-admin BE user tried to set/change owner_uid → silently coerce to default.
+                $requestedOwner = $defaultOwner;
+            }
+            $secretEntity->setOwnerUid($requestedOwner);
 
             if (isset($options['groups'])) {
                 /** @var list<int> $groups */
@@ -138,10 +168,6 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             if (isset($options['frontendAccessible'])) {
                 $secretEntity->setFrontendAccessible((bool) $options['frontendAccessible']);
             }
-
-            // Check if updating existing
-            $existing = $this->adapter->retrieve($identifier);
-            $isNew = !$existing instanceof Secret;
 
             if (!$isNew) {
                 $secretEntity->setUid($existing->getUid());
@@ -301,7 +327,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
         unset($this->cache[$identifier]);
     }
 
-    public function rotate(string $identifier, string $newSecret, string $reason = ''): void
+    public function rotate(string $identifier, #[SensitiveParameter] string $newSecret, string $reason = ''): void
     {
         $secret = $this->adapter->retrieve($identifier);
         if (!$secret instanceof Secret) {
@@ -414,6 +440,23 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
     public function http(): VaultHttpClientInterface
     {
         return $this->httpClientFactory->create($this);
+    }
+
+    /**
+     * Is the current request driven by an admin BE user?
+     *
+     * Non-BE actors (CLI / scheduler / API) bypass the BE-user admin check and
+     * are treated as admin equivalents — callers must already be context-bound
+     * by separate authentication.
+     */
+    private function isCurrentActorAdmin(): bool
+    {
+        if ($this->accessControlService->getCurrentActorType() !== 'backend') {
+            return true;
+        }
+        $beUser = $GLOBALS['BE_USER'] ?? null;
+
+        return \is_object($beUser) && method_exists($beUser, 'isAdmin') && $beUser->isAdmin() === true;
     }
 
     /**

--- a/Classes/Service/VaultServiceInterface.php
+++ b/Classes/Service/VaultServiceInterface.php
@@ -17,6 +17,7 @@ use Netresearch\NrVault\Exception\SecretExpiredException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Exception\ValidationException;
 use Netresearch\NrVault\Http\VaultHttpClientInterface;
+use SensitiveParameter;
 
 /**
  * Primary interface for interacting with the vault.
@@ -40,7 +41,7 @@ interface VaultServiceInterface
      * @throws ValidationException If identifier is invalid
      * @throws EncryptionException If encryption fails
      */
-    public function store(string $identifier, string $secret, array $options = []): void;
+    public function store(string $identifier, #[SensitiveParameter] string $secret, array $options = []): void;
 
     /**
      * Retrieve a secret value.
@@ -73,7 +74,7 @@ interface VaultServiceInterface
      * @throws AccessDeniedException If current user lacks permission
      * @throws EncryptionException If encryption fails
      */
-    public function rotate(string $identifier, string $newSecret, string $reason = ''): void;
+    public function rotate(string $identifier, #[SensitiveParameter] string $newSecret, string $reason = ''): void;
 
     /**
      * List all accessible secrets with metadata.

--- a/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
+++ b/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Command;
 
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Command\VaultRotateMasterKeyCommand;
 use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface;
@@ -41,6 +42,8 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
 
     private ConnectionPool&MockObject $connectionPool;
 
+    private AuditLogServiceInterface&MockObject $auditLogService;
+
     private CommandTester $commandTester;
 
     protected function setUp(): void
@@ -51,12 +54,14 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
         $this->encryptionService = $this->createMock(EncryptionServiceInterface::class);
         $this->masterKeyProviderFactory = $this->createMock(MasterKeyProviderFactoryInterface::class);
         $this->connectionPool = $this->createMock(ConnectionPool::class);
+        $this->auditLogService = $this->createMock(AuditLogServiceInterface::class);
 
         $command = new VaultRotateMasterKeyCommand(
             $this->secretRepository,
             $this->encryptionService,
             $this->masterKeyProviderFactory,
             $this->connectionPool,
+            $this->auditLogService,
         );
 
         $application = new Application();
@@ -73,6 +78,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
             $this->encryptionService,
             $this->masterKeyProviderFactory,
             $this->connectionPool,
+            $this->auditLogService,
         );
 
         self::assertSame('vault:rotate-master-key', $command->getName());

--- a/Tests/Unit/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/Configuration/ExtensionConfigurationTest.php
@@ -212,6 +212,52 @@ final class ExtensionConfigurationTest extends TestCase
     }
 
     #[Test]
+    public function isAuditReadsEnabledRespectsFilesystemOverrideTrue(): void
+    {
+        $original = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $GLOBALS['TYPO3_CONF_VARS'] = ['SYS' => ['nrVault' => ['auditReads' => true]]];
+
+        // BE-config says "disabled" but filesystem override forces enabled.
+        $this->typo3Config->method('get')
+            ->with('nr_vault')
+            ->willReturn(['auditReads' => false]);
+
+        try {
+            $config = new ExtensionConfiguration($this->typo3Config);
+            self::assertTrue($config->isAuditReadsEnabled());
+        } finally {
+            if ($original !== null) {
+                $GLOBALS['TYPO3_CONF_VARS'] = $original;
+            } else {
+                unset($GLOBALS['TYPO3_CONF_VARS']);
+            }
+        }
+    }
+
+    #[Test]
+    public function isAuditReadsEnabledRespectsFilesystemOverrideFalse(): void
+    {
+        $original = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $GLOBALS['TYPO3_CONF_VARS'] = ['SYS' => ['nrVault' => ['auditReads' => false]]];
+
+        // BE-config says "enabled" but filesystem override silences reads.
+        $this->typo3Config->method('get')
+            ->with('nr_vault')
+            ->willReturn(['auditReads' => true]);
+
+        try {
+            $config = new ExtensionConfiguration($this->typo3Config);
+            self::assertFalse($config->isAuditReadsEnabled());
+        } finally {
+            if ($original !== null) {
+                $GLOBALS['TYPO3_CONF_VARS'] = $original;
+            } else {
+                unset($GLOBALS['TYPO3_CONF_VARS']);
+            }
+        }
+    }
+
+    #[Test]
     public function preferXChaCha20ReturnsFalseByDefault(): void
     {
         $this->typo3Config->method('get')

--- a/Tests/Unit/Crypto/Typo3MasterKeyProviderTest.php
+++ b/Tests/Unit/Crypto/Typo3MasterKeyProviderTest.php
@@ -25,6 +25,8 @@ final class Typo3MasterKeyProviderTest extends TestCase
         parent::setUp();
 
         $this->originalGlobals = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        // Reset request-lifetime cache between tests
+        Typo3MasterKeyProvider::clearCachedKey();
     }
 
     protected function tearDown(): void
@@ -36,6 +38,7 @@ final class Typo3MasterKeyProviderTest extends TestCase
         } else {
             unset($GLOBALS['TYPO3_CONF_VARS']);
         }
+        Typo3MasterKeyProvider::clearCachedKey();
     }
 
     #[Test]
@@ -128,7 +131,7 @@ final class Typo3MasterKeyProviderTest extends TestCase
     {
         $GLOBALS['TYPO3_CONF_VARS'] = [
             'SYS' => [
-                'encryptionKey' => 'consistent-encryption-key-value',
+                'encryptionKey' => 'consistent-encryption-key-value-at-least-32-chars',
             ],
         ];
 
@@ -146,19 +149,38 @@ final class Typo3MasterKeyProviderTest extends TestCase
 
         $GLOBALS['TYPO3_CONF_VARS'] = [
             'SYS' => [
-                'encryptionKey' => 'encryption-key-one',
+                'encryptionKey' => 'encryption-key-one-at-least-32-chars-long-aaaa',
             ],
         ];
         $key1 = $provider->getMasterKey();
 
+        // Clear request-lifetime cache so the second derivation reads the new globals
+        Typo3MasterKeyProvider::clearCachedKey();
+
         $GLOBALS['TYPO3_CONF_VARS'] = [
             'SYS' => [
-                'encryptionKey' => 'encryption-key-two',
+                'encryptionKey' => 'encryption-key-two-at-least-32-chars-long-bbbb',
             ],
         ];
         $key2 = $provider->getMasterKey();
 
         self::assertNotEquals($key1, $key2);
+    }
+
+    #[Test]
+    public function getMasterKeyThrowsOnShortEncryptionKey(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS'] = [
+            'SYS' => [
+                'encryptionKey' => 'too-short',
+            ],
+        ];
+
+        $provider = new Typo3MasterKeyProvider();
+
+        $this->expectException(MasterKeyException::class);
+
+        $provider->getMasterKey();
     }
 
     #[Test]

--- a/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Http;
+
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * SSRF defence — defence-in-depth IP / hostname / port-form rejection.
+ */
+#[CoversClass(SecureHttpClientFactory::class)]
+final class SecureHttpClientFactorySsrfTest extends TestCase
+{
+    private SecureHttpClientFactory $subject;
+
+    private mixed $originalGlobals;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new SecureHttpClientFactory();
+        $this->originalGlobals = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        // Ensure no allowlist is configured so the IP guards alone decide.
+        $GLOBALS['TYPO3_CONF_VARS'] = ['HTTP' => []];
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        if ($this->originalGlobals !== null) {
+            $GLOBALS['TYPO3_CONF_VARS'] = $this->originalGlobals;
+        } else {
+            unset($GLOBALS['TYPO3_CONF_VARS']);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function dangerousIpProvider(): iterable
+    {
+        // IPv4 dangerous ranges
+        yield 'ipv4 loopback' => ['127.0.0.1'];
+        yield 'ipv4 loopback edge' => ['127.255.255.254'];
+        yield 'aws metadata' => ['169.254.169.254'];
+        yield 'rfc1918 /8' => ['10.0.0.1'];
+        yield 'rfc1918 /12' => ['172.16.0.1'];
+        yield 'rfc1918 /16' => ['192.168.1.1'];
+        yield 'cgnat 100.64/10' => ['100.64.0.1'];
+        yield 'zero net' => ['0.0.0.0'];
+        yield 'multicast 224/4' => ['224.0.0.1'];
+        yield 'reserved 240/4' => ['240.0.0.1'];
+        yield 'benchmark 198.18/15' => ['198.18.0.1'];
+
+        // IPv6 dangerous ranges
+        yield 'ipv6 loopback' => ['::1'];
+        yield 'ipv6 ula fc00::/7' => ['fc00::1'];
+        yield 'ipv6 link-local fe80::/10' => ['fe80::1'];
+        yield 'ipv6 multicast ff00::/8' => ['ff02::1'];
+
+        // host:port / [ipv6]:port — port-stripping must not bypass the guard
+        yield 'ipv4 with port' => ['127.0.0.1:8080'];
+        yield 'aws metadata with port' => ['169.254.169.254:80'];
+        yield 'ipv6 bracketed loopback' => ['[::1]'];
+        yield 'ipv6 bracketed with port' => ['[::1]:8080'];
+        yield 'ipv6 ula bracketed port' => ['[fc00::1]:443'];
+
+        // Hygiene: trailing dot, whitespace, mixed case
+        yield 'whitespace padded' => [" \t127.0.0.1\r\n"];
+        yield 'mixed case ipv6' => ['FE80::1'];
+    }
+
+    #[Test]
+    #[DataProvider('dangerousIpProvider')]
+    public function isHostAllowedRejectsDangerousIpLiterals(string $host): void
+    {
+        self::assertFalse(
+            $this->subject->isHostAllowed($host),
+            \sprintf('Expected host %s to be blocked as dangerous, but it was allowed.', $host),
+        );
+    }
+
+    #[Test]
+    public function isHostAllowedReturnsFalseForEmptyHost(): void
+    {
+        self::assertFalse($this->subject->isHostAllowed(''));
+        self::assertFalse($this->subject->isHostAllowed("\t \n"));
+    }
+
+    #[Test]
+    public function isHostAllowedReturnsFalseForUnparsable(): void
+    {
+        // parse_url returning no host means we fail closed.
+        self::assertFalse($this->subject->isHostAllowed('://no-scheme-no-host'));
+    }
+
+    #[Test]
+    public function isHostAllowedAllowsPublicIpWithNoAllowlist(): void
+    {
+        // 8.8.8.8 is a public IPv4 — once IP guards pass and no allowlist is set,
+        // the method must return true (default-allow gated by IP/DNS checks).
+        self::assertTrue($this->subject->isHostAllowed('8.8.8.8'));
+    }
+}

--- a/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
@@ -111,4 +111,39 @@ final class SecureHttpClientFactorySsrfTest extends TestCase
         // the method must return true (default-allow gated by IP/DNS checks).
         self::assertTrue($this->subject->isHostAllowed('8.8.8.8'));
     }
+
+    #[Test]
+    public function explicitAllowlistEntryOverridesPrivateIpBlock(): void
+    {
+        // On-prem use case: vault server on RFC1918 must be reachable via
+        // an explicit filesystem-only allowlist entry.
+        $GLOBALS['TYPO3_CONF_VARS'] = [
+            'HTTP' => ['allowed_hosts' => ['10.0.0.42']],
+        ];
+
+        self::assertTrue($this->subject->isHostAllowed('10.0.0.42'));
+    }
+
+    #[Test]
+    public function wildcardAllowlistDoesNotOverridePrivateIpBlock(): void
+    {
+        // Wildcards cannot bypass the private-IP defence: an external wildcard
+        // owner could otherwise pivot via internal DNS records under their zone.
+        $GLOBALS['TYPO3_CONF_VARS'] = [
+            'HTTP' => ['allowed_hosts' => ['*.internal']],
+        ];
+
+        self::assertFalse($this->subject->isHostAllowed('10.0.0.42'));
+    }
+
+    #[Test]
+    public function explicitAllowlistEntryStillBlocksNonListedPrivateIp(): void
+    {
+        // Listing 10.0.0.42 must NOT implicitly allow 10.0.0.43.
+        $GLOBALS['TYPO3_CONF_VARS'] = [
+            'HTTP' => ['allowed_hosts' => ['10.0.0.42']],
+        ];
+
+        self::assertFalse($this->subject->isHostAllowed('10.0.0.43'));
+    }
 }

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -65,6 +65,16 @@ final class VaultServiceTest extends TestCase
             ->method('getCurrentActorUid')
             ->willReturn(1);
 
+        $this->accessControlService
+            ->method('getCurrentActorType')
+            ->willReturn('cli');
+
+        // Default canCreate to true so the happy-path store tests do not need
+        // to stub it; tests that exercise the denial branch override locally.
+        $this->accessControlService
+            ->method('canCreate')
+            ->willReturn(true);
+
         $this->configuration
             ->method('isCacheEnabled')
             ->willReturn(false);
@@ -531,6 +541,11 @@ final class VaultServiceTest extends TestCase
             ->willReturn(new EncryptedData('enc', 'dek', 'n1', 'n2', 'cs'));
 
         $this->adapter->method('retrieve')->willReturn($existing);
+
+        // Updates use canWrite, not canCreate.
+        $this->accessControlService
+            ->method('canWrite')
+            ->willReturn(true);
 
         $this->adapter
             ->expects(self::once())

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -138,6 +138,105 @@ final class VaultServiceTest extends TestCase
     }
 
     #[Test]
+    public function storeDeniesCreationWhenCanCreateReturnsFalse(): void
+    {
+        $denyingAccessControl = $this->createMock(AccessControlServiceInterface::class);
+        $denyingAccessControl->method('getCurrentActorUid')->willReturn(1);
+        $denyingAccessControl->method('getCurrentActorType')->willReturn('backend');
+        $denyingAccessControl->method('canCreate')->willReturn(false);
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $denyingAccessControl,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->adapter->method('retrieve')->willReturn(null);
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('newSecret', 'access_denied', false, 'Create access denied');
+
+        $this->adapter->expects(self::never())->method('store');
+        $this->encryptionService->expects(self::never())->method('encrypt');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $subject->store('newSecret', 'plaintext');
+    }
+
+    #[Test]
+    public function storeDeniesUpdateWhenCanWriteReturnsFalse(): void
+    {
+        $existing = $this->createSecretEntity('existing');
+
+        $denyingAccessControl = $this->createMock(AccessControlServiceInterface::class);
+        $denyingAccessControl->method('getCurrentActorUid')->willReturn(1);
+        $denyingAccessControl->method('getCurrentActorType')->willReturn('backend');
+        $denyingAccessControl->method('canWrite')->with($existing)->willReturn(false);
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $denyingAccessControl,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->adapter->method('retrieve')->willReturn($existing);
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('existing', 'access_denied', false, 'Update access denied');
+
+        $this->adapter->expects(self::never())->method('store');
+        $this->encryptionService->expects(self::never())->method('encrypt');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $subject->store('existing', 'new-value');
+    }
+
+    #[Test]
+    public function storeCoercesOwnerUidForNonAdminBackendActor(): void
+    {
+        $beActorAccess = $this->createMock(AccessControlServiceInterface::class);
+        $beActorAccess->method('getCurrentActorUid')->willReturn(7);
+        $beActorAccess->method('getCurrentActorType')->willReturn('backend');
+        $beActorAccess->method('canCreate')->willReturn(true);
+        $beActorAccess->method('isCurrentActorAdmin')->willReturn(false);
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $beActorAccess,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->encryptionService
+            ->method('encrypt')
+            ->willReturn(new EncryptedData('enc', 'dek', 'n1', 'n2', 'cs'));
+
+        $this->adapter->method('retrieve')->willReturn(null);
+
+        // Non-admin BE actor passing owner=99 must be coerced to current actor UID (7).
+        $this->adapter
+            ->expects(self::once())
+            ->method('store')
+            ->with(self::callback(static fn (Secret $s): bool => $s->getOwnerUid() === 7));
+
+        $subject->store('coerce', 'plaintext', ['owner' => 99]);
+    }
+
+    #[Test]
     public function retrieveDecryptsAndReturnsSecret(): void
     {
         $identifier = 'myApiKey';

--- a/captainhook.json
+++ b/captainhook.json
@@ -45,23 +45,23 @@
                         ]
                     }
                 ]
+            },
+            {
+                "action": "composer ci:test:php:phpstan",
+                "conditions": [
+                    {
+                        "exec": "\\CaptainHook\\App\\Hook\\Condition\\FileStaged\\OfType",
+                        "args": [
+                            "php"
+                        ]
+                    }
+                ]
             }
         ]
     },
     "pre-push": {
         "enabled": true,
         "actions": [
-            {
-                "action": "composer ci:test:php:phpstan",
-                "conditions": [
-                    {
-                        "exec": "\\CaptainHook\\App\\Hook\\Condition\\FileChanged\\OfType",
-                        "args": [
-                            "php"
-                        ]
-                    }
-                ]
-            },
             {
                 "action": "composer ci:test:php:unit",
                 "conditions": [


### PR DESCRIPTION
## Summary

Resolves CRITICAL and HIGH findings from a 16-reviewer multi-axis audit plus follow-up findings from 5 independent PR reviewers, `gemini-code-assist`, and SonarCloud.

**15 atomic GPG-signed commits, all CI green (55/55), 0 unresolved threads.**

## Changes

### CRITICAL (release-blocking)

- **C-1 Privilege escalation in `VaultService::store()`** (`310fb85`) — `canCreate()`/`canWrite($existing)` gates with audit-logged denial; `owner_uid` change refused for non-admin BE users.
- **C-2 `#[SensitiveParameter]` rollout** (`310fb85` + `7bd188e`) — 0 → 35 annotations across crypto / DTO / audit / hook / config boundaries.
- **C-4 Master-key rotation audit** (`41b91b0`) — `master_key_rotate_start` / `master_key_rotate_end` lifecycle entries with sanitised reasons.
- **C-5 SSRF defence-in-depth** (`974eb3d` → `7676da2` → `d2bb10f`) — three iterations to get right:
  - Initial private/RFC1918/metadata IP block (`974eb3d`)
  - Closed the host:port + IPv6 + filter-flag-gap bypasses (`7676da2`, Gemini HIGH thread)
  - Literal-allowlist override for on-prem deployments (`d2bb10f`, Gemini MEDIUM thread)

### HIGH

- **H-2 `auditReads` filesystem override** (`b7410df`, `be4f000`) — `$TYPO3_CONF_VARS[SYS][nrVault][auditReads]` takes precedence; PHPStan-clean with `is_array()` guards.
- **H-3 `Typo3MasterKeyProvider`** (`7bd188e`, `38e8137`) — request-cache, 32-char entropy gate, dropped antipattern `__destruct` clearing static.
- **HIGH from PR review: layering violation in `VaultService`** (`38576b9`) — `$GLOBALS['BE_USER']` lookup moved into `AccessControlService::isCurrentActorAdmin()`.

### MEDIUM

- **M-1 `FileMasterKeyProvider` chmod race** (`7bd188e`) — `umask(0o077)` around write.
- **PHPStan + Code Style + Rector** — `be4f000`, `38e8137`, `310fe04`.
- **SonarCloud parse_url stub** — `6240b20` (switched to protocol-relative `//` to avoid `http://` literal hotspot).
- **captainhook**: PHPStan moved from pre-push to pre-commit (`38e8137`).

### Test coverage

- **1706 → 1736 unit tests, 6999 assertions** — all green on PHP 8.2/8.3/8.4/8.5 × TYPO3 13.4/14.0
- New `SecureHttpClientFactorySsrfTest` — 21-entry data provider covering IPv4/IPv6/port-form/bracket/mixed-case/whitespace dangerous-IP edge cases + 3 negative + 3 allowlist-override paths
- New `VaultServiceTest::storeDenies*` — privilege-escalation denial branches
- New `ExtensionConfigurationTest::isAuditReadsEnabledRespects*` — auditReads precedence

### Documentation

- **`CHANGELOG.md` [Unreleased] section updated** (`f8816f4`) with full security / changed entries.

## Out of scope for this PR (tracked separately)

- **C-3** Atomic secret + audit writes — needs 2-phase commit / outbox redesign
- **H-4** Audit hash payload omits `success`/`error_message`/`reason`/`ip`/`user_agent` (chain semantics change, needs migration)
- **H-5** `Secret` entity has 35+ setters bypassing `Secret::create()` invariants
- **H-6** `AuditHmacMigrationWizard` non-resumable
- **H-7** OAuth refresh-token write-back not crash-safe
- DI cleanup (12 redundant `console.command` tags, 11 unneeded interface-alias `public: true` flags)
- Worktree-compatible captainhook installation (currently requires manual `vendor/bin/captainhook install -g <gitdir>` in worktrees)
- DNS rebinding full mitigation via `CURLOPT_RESOLVE` pinning (current code resolves at check time; Guzzle/curl re-resolves at connect time)

Local working note: `claudedocs/REVIEW-multi-axis-2026-05.md` (gitignored).

## Reviewers consulted

Initial review: 16 specialist agents across security / TYPO3 conformance / tests / architecture / PHP modernization / docs / DRY / DI / DTOs / audit / reliability / ADRs / DX / UI/UX / performance / HTTP middleware.

Follow-up review: 5 independent agents (security-engineer, code-reviewer, test-engineer, typo3-conformance, PR-hygiene) + `gemini-code-assist` automated review + SonarCloud + CodeQL.

**20 review threads resolved**: 2 Gemini (HIGH host:port + MEDIUM allowlist), 18 SonarCloud (hardcoded test-fixture IPs in SSRF data provider — false positive).

## Checklist

- [x] Unit tests pass (`Build/Scripts/runTests.sh -p 8.4 -s unit`) — **1736 tests, 6999 assertions, SUCCESS**
- [x] Code style passes (`runTests.sh -s cgl`) — SUCCESS
- [x] Rector passes (`runTests.sh -s rector`) — SUCCESS
- [x] PHPStan passes — verified on CI across PHP 8.2/8.3/8.4/8.5 × TYPO3 13.4/14.0 (8 matrix cells, all green)
- [x] SonarCloud quality gate passed — 0 new security hotspots after `6240b20`
- [x] CodeQL passed
- [x] Functional tests passed across full matrix
- [x] CHANGELOG.md updated (`f8816f4`)
- [x] All review threads resolved (20/20)
- [x] All commits GPG-signed + DCO `Signed-off-by`

## Test Plan

1. **Privilege escalation**: log in as non-admin BE user with write rights on a table carrying a vault field; attempt to create/overwrite a vault identifier — `AccessDeniedException` + `access_denied` audit entry. Admin: success.
2. **`#[SensitiveParameter]`**: trigger an exception on a code path that takes plaintext (e.g. tampered ciphertext); stack trace shows `Object(SensitiveParameterValue)` instead of the secret.
3. **Master-key audit**: run `vault:rotate-master-key --confirm`; audit log contains `master_key_rotate_start` + `master_key_rotate_end` rows with correct count and timestamps.
4. **SSRF**:
   - `http://169.254.169.254/`, `http://10.0.0.1/`, `http://[::1]:8080/`, `http://127.0.0.1:8080/` all rejected.
   - With `allowed_hosts = ['10.0.0.42']` configured, `http://10.0.0.42/` allowed but `http://10.0.0.43/` rejected.
   - With `allowed_hosts = ['*.internal']`, `http://10.0.0.42/` still rejected (wildcards don't override IP block).
5. **`auditReads` override**: `$GLOBALS['TYPO3_CONF_VARS']['SYS']['nrVault']['auditReads'] = false` in `additional.php`; toggle the BE extension config — reads remain unlogged regardless of BE value.