### PR TITLE
fix(security): make OAuth refresh-token write-back crash-safe (H-7)

### DIFF
--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -328,24 +328,7 @@ final class OAuthTokenManager
                         'source' => 'oauth_refresh',
                     ]);
                 } catch (Throwable $storeException) {
-                    $this->logger?->error(
-                        'OAuth refresh_token rotation: vault store failed — returning access_token but '
-                        . 'subsequent refresh will fail until vault is writeable (auto-recovers via '
-                        . 'fetchTokenWithFallback()).',
-                        [
-                            'token_endpoint' => $config->tokenEndpoint,
-                            'refresh_token_secret' => $config->refreshTokenSecret,
-                            'error' => $storeException->getMessage(),
-                        ],
-                    );
-
-                    $this->auditLogService?->log(
-                        $config->refreshTokenSecret,
-                        'oauth_refresh_store_failed',
-                        false,
-                        'vault store of new refresh_token failed; access_token returned to caller, '
-                        . 'next refresh will fall back to client_credentials',
-                    );
+                    $this->handleRefreshTokenStorageFailure($config, $storeException);
                 }
             }
 
@@ -375,6 +358,57 @@ final class OAuthTokenManager
             throw OAuthException::requestFailed($e->getMessage(), $e);
         } catch (JsonException $e) {
             throw OAuthException::invalidJsonResponse($e);
+        }
+    }
+
+    /**
+     * Best-effort reporting of a refresh-token storage failure.
+     *
+     * Crash-safe by design: both the PSR-3 logger and the audit-log writer
+     * are wrapped in their own `try/catch` because they likely share the
+     * same DB as the failing vault — propagating either would still cost
+     * the caller the access_token they just obtained. Final fallback is
+     * `error_log()`, which writes via PHP's own error handler and does
+     * not depend on the DB.
+     *
+     * The vault identifier (`refreshTokenSecret`) is hashed before
+     * logging — the path itself reveals which secrets exist in the vault
+     * and is useful enough to attackers that we treat it as semi-secret.
+     */
+    private function handleRefreshTokenStorageFailure(OAuthConfig $config, Throwable $storeException): void
+    {
+        $secretIdHash = $config->refreshTokenSecret !== null
+            ? substr(hash('sha256', $config->refreshTokenSecret), 0, 16)
+            : null;
+
+        $message = 'OAuth refresh_token rotation: vault store failed — returning access_token but '
+            . 'subsequent refresh will fail until vault is writeable (auto-recovers via '
+            . 'fetchTokenWithFallback()).';
+        $context = [
+            'token_endpoint' => $config->tokenEndpoint,
+            'refresh_token_secret_hash' => $secretIdHash,
+            'error' => $storeException->getMessage(),
+        ];
+
+        try {
+            $this->logger?->error($message, $context);
+        } catch (Throwable) {
+            // Last-resort: PHP's own error log is independent of DB / logger backend.
+            error_log('nr-vault: ' . $message . ' [' . $storeException->getMessage() . ']');
+        }
+
+        try {
+            $this->auditLogService?->log(
+                $config->refreshTokenSecret ?? '',
+                'oauth_refresh_store_failed',
+                false,
+                'vault store of new refresh_token failed; access_token returned to caller, '
+                . 'next refresh will fall back to client_credentials',
+            );
+        } catch (Throwable) {
+            // Audit log likely uses the same DB as the vault — propagating
+            // here would still cost the caller the access_token. The
+            // logger->error above already captured the failure.
         }
     }
 

--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -25,6 +25,7 @@ use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
+use Throwable;
 
 /**
  * Manages OAuth 2.0 token acquisition and refresh.
@@ -309,11 +310,43 @@ final class OAuthTokenManager
             $expiresIn = \is_int($body['expires_in'] ?? null) ? $body['expires_in'] : 3600;
             $expiresAt = new DateTimeImmutable('+' . $expiresIn . ' seconds');
 
-            // Store new refresh token if provided
+            // Store new refresh token if provided.
+            //
+            // Crash safety: the OAuth server has already issued the new tokens
+            // and (per RFC 6749 §6) will typically have invalidated the old
+            // refresh token. If `vaultService->store()` throws here we must
+            // NOT propagate — the caller would lose the access_token we just
+            // obtained, and the vault would still hold the now-invalidated
+            // old refresh_token. Instead: log loudly, return the access_token
+            // so the caller's current request succeeds. The next refresh
+            // attempt will fetch the stale refresh_token from the vault, the
+            // OAuth server will reject it, and `fetchTokenWithFallback()`
+            // will auto-recover via the `client_credentials` flow.
             if (isset($body['refresh_token']) && \is_string($body['refresh_token']) && $config->refreshTokenSecret !== null) {
-                $this->vaultService->store($config->refreshTokenSecret, $body['refresh_token'], [
-                    'source' => 'oauth_refresh',
-                ]);
+                try {
+                    $this->vaultService->store($config->refreshTokenSecret, $body['refresh_token'], [
+                        'source' => 'oauth_refresh',
+                    ]);
+                } catch (Throwable $storeException) {
+                    $this->logger?->error(
+                        'OAuth refresh_token rotation: vault store failed — returning access_token but '
+                        . 'subsequent refresh will fail until vault is writeable (auto-recovers via '
+                        . 'fetchTokenWithFallback()).',
+                        [
+                            'token_endpoint' => $config->tokenEndpoint,
+                            'refresh_token_secret' => $config->refreshTokenSecret,
+                            'error' => $storeException->getMessage(),
+                        ],
+                    );
+
+                    $this->auditLogService?->log(
+                        $config->refreshTokenSecret,
+                        'oauth_refresh_store_failed',
+                        false,
+                        'vault store of new refresh_token failed; access_token returned to caller, '
+                        . 'next refresh will fall back to client_credentials',
+                    );
+                }
             }
 
             $this->logger?->info('OAuth token obtained successfully', [

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Http\OAuth;
 
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Exception\OAuthException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Http\OAuth\OAuthConfig;
@@ -863,6 +864,119 @@ final class OAuthTokenManagerTest extends TestCase
         $token = $this->subject->getAccessToken($config);
 
         self::assertSame('new-access-token', $token, 'Access token must reach the caller even when vault store fails');
+    }
+
+    #[Test]
+    public function getAccessTokenSurvivesAuditLogFailureDuringStorageFailure(): void
+    {
+        // Both `vaultService->store()` AND `auditLogService->log()` throw —
+        // mimicking a full DB outage. The caller must still receive the
+        // just-obtained access_token; neither secondary failure may
+        // propagate.
+        $auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->willThrowException(new RuntimeException('audit log also down'));
+
+        $subject = new OAuthTokenManager(
+            $this->vaultService,
+            $this->logger,
+            $this->httpClient,
+            $this->requestFactory,
+            $this->streamFactory,
+            $auditLogService,
+        );
+
+        $config = OAuthConfig::refreshToken(
+            tokenEndpoint: 'https://auth.example.com/token',
+            clientIdSecret: 'oauth/client-id',
+            clientSecretSecret: 'oauth/client-secret',
+            refreshTokenSecret: 'oauth/refresh-token',
+        );
+
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(fn (string $id): ?string => match ($id) {
+                'oauth/client-id' => 'my-client-id',
+                'oauth/client-secret' => 'my-client-secret',
+                'oauth/refresh-token' => 'old-refresh-token',
+                default => null,
+            });
+        $this->vaultService
+            ->expects(self::once())
+            ->method('store')
+            ->willThrowException(new RuntimeException('vault write failed'));
+
+        $this->httpClient
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createSuccessfulTokenResponse([
+                'access_token' => 'new-access-token',
+                'token_type' => 'Bearer',
+                'expires_in' => 3600,
+                'refresh_token' => 'new-refresh-token',
+            ]));
+
+        // No exception should reach the test — caller must get access_token.
+        $token = $subject->getAccessToken($config);
+
+        self::assertSame('new-access-token', $token);
+    }
+
+    #[Test]
+    public function getAccessTokenHashesVaultIdentifierInLogContext(): void
+    {
+        // The refresh-token secret PATH (vault identifier) is semi-sensitive —
+        // it reveals which secrets the system uses. Log it as a short hash, not
+        // the raw path.
+        $config = OAuthConfig::refreshToken(
+            tokenEndpoint: 'https://auth.example.com/token',
+            clientIdSecret: 'oauth/client-id',
+            clientSecretSecret: 'oauth/client-secret',
+            refreshTokenSecret: 'oauth/refresh-token-sensitive-path',
+        );
+
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(fn (string $id): ?string => match ($id) {
+                'oauth/client-id' => 'my-client-id',
+                'oauth/client-secret' => 'my-client-secret',
+                'oauth/refresh-token-sensitive-path' => 'old-refresh-token',
+                default => null,
+            });
+        $this->vaultService
+            ->expects(self::once())
+            ->method('store')
+            ->willThrowException(new RuntimeException('vault write failed'));
+
+        $this->httpClient
+            ->method('sendRequest')
+            ->willReturn($this->createSuccessfulTokenResponse([
+                'access_token' => 'new-access-token',
+                'token_type' => 'Bearer',
+                'expires_in' => 3600,
+                'refresh_token' => 'new-refresh-token',
+            ]));
+
+        $loggedContext = null;
+        $this->logger
+            ->expects(self::atLeastOnce())
+            ->method('error')
+            ->willReturnCallback(function (string $message, array $context = []) use (&$loggedContext): void {
+                $loggedContext = $context;
+            });
+
+        $this->subject->getAccessToken($config);
+
+        self::assertIsArray($loggedContext);
+        self::assertArrayHasKey('refresh_token_secret_hash', $loggedContext);
+        self::assertArrayNotHasKey('refresh_token_secret', $loggedContext);
+        // The hash must be 16 hex chars (16-char prefix of sha256).
+        self::assertMatchesRegularExpression('/^[0-9a-f]{16}$/', (string) $loggedContext['refresh_token_secret_hash']);
+        // The full path must NOT appear anywhere in the context.
+        $contextString = var_export($loggedContext, true);
+        self::assertStringNotContainsString('sensitive-path', $contextString);
     }
 
     #[Test]

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -839,7 +839,7 @@ final class OAuthTokenManagerTest extends TestCase
         $this->vaultService
             ->expects(self::once())
             ->method('store')
-            ->willThrowException(new \RuntimeException('vault write failed mid-OAuth-refresh'));
+            ->willThrowException(new RuntimeException('vault write failed mid-OAuth-refresh'));
 
         $response = $this->createSuccessfulTokenResponse([
             'access_token' => 'new-access-token',

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -811,6 +811,61 @@ final class OAuthTokenManagerTest extends TestCase
     }
 
     #[Test]
+    public function getAccessTokenReturnsAccessTokenEvenWhenRefreshTokenStorageFails(): void
+    {
+        // If the OAuth response includes a new refresh_token but `vaultService
+        // ->store()` throws (DB down, audit lock failed, etc.), the manager
+        // must NOT propagate. The OAuth server has already issued the new
+        // tokens and (per RFC 6749 §6) typically invalidated the old refresh
+        // token — propagating the throw would also lose the access_token we
+        // just obtained. The caller's current request succeeds; the next
+        // refresh attempt will fall back to client_credentials.
+        $config = OAuthConfig::refreshToken(
+            tokenEndpoint: 'https://auth.example.com/token',
+            clientIdSecret: 'oauth/client-id',
+            clientSecretSecret: 'oauth/client-secret',
+            refreshTokenSecret: 'oauth/refresh-token',
+        );
+
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(fn (string $id): ?string => match ($id) {
+                'oauth/client-id' => 'my-client-id',
+                'oauth/client-secret' => 'my-client-secret',
+                'oauth/refresh-token' => 'old-refresh-token',
+                default => null,
+            });
+
+        $this->vaultService
+            ->expects(self::once())
+            ->method('store')
+            ->willThrowException(new \RuntimeException('vault write failed mid-OAuth-refresh'));
+
+        $response = $this->createSuccessfulTokenResponse([
+            'access_token' => 'new-access-token',
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+            'refresh_token' => 'new-refresh-token',
+        ]);
+
+        $this->httpClient
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($response);
+
+        // The logger must report the storage failure at error level so ops
+        // can notice and remediate.
+        $this->logger
+            ->expects(self::atLeastOnce())
+            ->method('error')
+            ->with(self::stringContains('vault store failed'));
+
+        $token = $this->subject->getAccessToken($config);
+
+        self::assertSame('new-access-token', $token, 'Access token must reach the caller even when vault store fails');
+    }
+
+    #[Test]
     public function getAccessTokenWithNoRefreshTokenSecretConfigDoesNotStoreRefreshToken(): void
     {
         // refreshTokenSecret = null → even if response contains refresh_token, do not store


### PR DESCRIPTION
## Summary

Addresses **H-7** from the multi-axis security review: `OAuthTokenManager::fetchToken()` previously propagated `vaultService->store()` exceptions when persisting a freshly-rotated `refresh_token`. The caller lost the just-obtained `access_token`, the OAuth server had already invalidated the old refresh_token, and the next refresh attempt failed — turning a transient storage glitch into a hard outage requiring manual re-auth.

## Changes

`Classes/Http/OAuth/OAuthTokenManager.php` (line 312-340 area):

- Wrap `vaultService->store()` in `try { } catch (Throwable)`.
- On failure:
  - Log at **error** level (token endpoint + exception message, no secrets).
  - Emit `oauth_refresh_store_failed` audit entry if `auditLogService` available.
  - **Continue** — return the just-obtained `access_token` to the caller.
- Next refresh attempt retrieves the stale refresh_token from vault, the OAuth server rejects it with `invalid_grant`, and `fetchTokenWithFallback()` recovers via `client_credentials` flow. **Auto-healing.**

## Why this approach

Three alternatives considered:

| Option | Trade-off |
|---|---|
| Propagate the throw (current) | ❌ caller loses access_token; next refresh fails until ops intervenes |
| Retry the store with backoff | Adds latency to OAuth flow; doesn't help if DB is durably down |
| Catch + log + return + auto-recover (this PR) | ✅ caller's current request succeeds; next refresh auto-falls-back via existing `fetchTokenWithFallback`; ops sees the failure in logs/audit |

The third option leverages the existing fallback machinery: PR #133 / pre-existing code already handles "refresh_token rejected → fall back to client_credentials". Combined with this fix, a transient vault outage during refresh-token rotation degrades to a single fallback round rather than a hard auth failure.

## Test coverage

New `getAccessTokenReturnsAccessTokenEvenWhenRefreshTokenStorageFails` — simulates `vaultService->store()` throwing mid-refresh and asserts:
1. `getAccessToken()` returns the new access_token.
2. Logger receives an `error`-level entry mentioning the failure.

**1743 unit tests pass** (was 1742; +1 new).

## Checklist

- [x] Unit tests (1743/1743)
- [x] CGL
- [ ] PHPStan — verified via CI
- [ ] Functional tests — verified via CI

## Test Plan

1. **Storage failure simulation**: configure a vault config where `refreshTokenSecret` resolves but the underlying DB is read-only. Trigger a token refresh. Assert: caller receives a valid `access_token`; an `error` log entry is emitted with the token endpoint; an `oauth_refresh_store_failed` audit entry is written (best-effort, may also fail if the same DB is down).
2. **Auto-recovery on next call**: with the same broken vault, recover writability. Call `getAccessToken()` again. The cached access_token is still valid → returned without OAuth call. Wait until cache expires. Next call: stale refresh_token rejected by OAuth → fallback to client_credentials → new access_token issued.
3. **Happy path still works**: existing `getAccessTokenStoresNewRefreshTokenInVault` test confirms a successful storage path still writes the refresh_token.