### PR TITLE
feat(security): extend audit hash to forensic fields (H-4, epoch 2)

### DIFF
--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -358,7 +358,7 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             'hash_before' => (string) $row['hash_before'],
             'hash_after' => (string) $row['hash_after'],
             'context' => (string) $row['context'],
-        ], JSON_THROW_ON_ERROR);
+        ], JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
 
         return hash_hmac('sha256', $payload, $hmacKey);
     }
@@ -410,11 +410,17 @@ final readonly class AuditLogService implements AuditLogServiceInterface
      */
     public static function extractV2HashRow(array $row): array
     {
+        $rawSuccess = $row['success'] ?? null;
+
         return [
             'uid' => is_numeric($row['uid'] ?? null) ? (int) $row['uid'] : 0,
             'secret_identifier' => \is_string($row['secret_identifier'] ?? null) ? $row['secret_identifier'] : '',
             'action' => \is_string($row['action'] ?? null) ? $row['action'] : '',
-            'success' => is_numeric($row['success'] ?? null) ? (int) (bool) $row['success'] : 0,
+            // Doctrine returns `success` as int on MySQL/SQLite, bool on
+            // PostgreSQL, and string on some drivers with emulated prepares.
+            // `is_numeric()` rejects native booleans — keep them in the chain
+            // by accepting bool|int|numeric-string and coercing through bool.
+            'success' => (\is_bool($rawSuccess) || is_numeric($rawSuccess)) ? (int) (bool) $rawSuccess : 0,
             'actor_uid' => is_numeric($row['actor_uid'] ?? null) ? (int) $row['actor_uid'] : 0,
             'crdate' => is_numeric($row['crdate'] ?? null) ? (int) $row['crdate'] : 0,
             'error_message' => \is_string($row['error_message'] ?? null) ? $row['error_message'] : '',

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -69,7 +69,7 @@ final readonly class AuditLogService implements AuditLogServiceInterface
                 $context,
                 $previousHash,
             );
-            $this->insertAndUpdateHash($connection, $data, $secretIdentifier, $action, $previousHash);
+            $this->insertAndUpdateHash($connection, $data, $previousHash);
             $this->commitAuditLock($connection, $isSQLite);
         } catch (Throwable $e) {
             $this->rollbackAuditLock($connection, $isSQLite);
@@ -220,15 +220,15 @@ final readonly class AuditLogService implements AuditLogServiceInterface
 
                 $previousEpoch = $epoch;
 
-                $expectedHash = self::calculateHash(
-                    $uid,
-                    $secretId,
-                    $actionStr,
-                    $actorUid,
-                    $crdate,
-                    $previousHash,
-                    $epoch === 0 ? null : $hmacKey,
-                );
+                // Epoch-aware hash dispatch:
+                //   0 → legacy SHA-256 (identity fields only)
+                //   1 → HMAC-SHA256 (identity fields only)
+                //   2+ → HMAC-SHA256 (extended forensic payload)
+                $expectedHash = match (true) {
+                    $epoch === 0 => self::calculateHash($uid, $secretId, $actionStr, $actorUid, $crdate, $previousHash),
+                    $epoch === 1 => self::calculateHash($uid, $secretId, $actionStr, $actorUid, $crdate, $previousHash, $hmacKey),
+                    default => self::calculateHashV2(self::extractV2HashRow($row), $previousHash, $hmacKey),
+                };
 
                 // Verify previous_hash matches
                 $rowPrevHash = $row['previous_hash'] ?? '';
@@ -268,10 +268,17 @@ final readonly class AuditLogService implements AuditLogServiceInterface
     }
 
     /**
-     * Calculate an audit log entry hash.
+     * Calculate an audit log entry hash (legacy / v1 payload).
+     *
+     * Covers identity-bearing fields only: uid, secret_identifier, action,
+     * actor_uid, crdate, previous_hash.
      *
      * When $hmacKey is null, produces a legacy SHA-256 hash (epoch 0).
-     * When $hmacKey is provided, produces an HMAC-SHA256 hash (epoch 1+).
+     * When $hmacKey is provided, produces an HMAC-SHA256 hash (epoch 1).
+     *
+     * Epoch 2+ entries use `calculateHashV2()` which adds forensic fields
+     * (success, error_message, reason, ip_address, user_agent, hash_before,
+     * hash_after, context) to the HMAC payload.
      *
      * This method is public so it can be reused by the migration command
      * without duplicating the HKDF derivation logic.
@@ -302,9 +309,64 @@ final readonly class AuditLogService implements AuditLogServiceInterface
     }
 
     /**
-     * Type-safe extraction of the audit-row fields that feed into the hash
-     * calculation. Defends against `mixed` shapes returned by Doctrine
-     * `fetchAssociative()` on different drivers.
+     * Calculate an audit log entry hash with the extended (v2) payload.
+     *
+     * Includes all forensic fields the verifier cares about: an attacker
+     * with database-write privileges can no longer flip `success: false →
+     * true` or rewrite `error_message`/`reason`/`ip_address`/`user_agent`
+     * without breaking the chain.
+     *
+     * Payload keys (ordered for deterministic JSON):
+     *   uid, secret_identifier, action, success, actor_uid, crdate,
+     *   previous_hash, error_message, reason, ip_address, user_agent,
+     *   hash_before, hash_after, context
+     *
+     * @param array{
+     *     uid: int,
+     *     secret_identifier: string,
+     *     action: string,
+     *     success: bool|int,
+     *     actor_uid: int,
+     *     crdate: int,
+     *     error_message: string,
+     *     reason: string,
+     *     ip_address: string,
+     *     user_agent: string,
+     *     hash_before: string,
+     *     hash_after: string,
+     *     context: string,
+     * } $row
+     */
+    public static function calculateHashV2(
+        array $row,
+        string $previousHash,
+        #[SensitiveParameter]
+        string $hmacKey,
+    ): string {
+        $payload = json_encode([
+            'uid' => (int) $row['uid'],
+            'secret_identifier' => (string) $row['secret_identifier'],
+            'action' => (string) $row['action'],
+            'success' => (int) (bool) $row['success'],
+            'actor_uid' => (int) $row['actor_uid'],
+            'crdate' => (int) $row['crdate'],
+            'previous_hash' => $previousHash,
+            'error_message' => (string) $row['error_message'],
+            'reason' => (string) $row['reason'],
+            'ip_address' => (string) $row['ip_address'],
+            'user_agent' => (string) $row['user_agent'],
+            'hash_before' => (string) $row['hash_before'],
+            'hash_after' => (string) $row['hash_after'],
+            'context' => (string) $row['context'],
+        ], JSON_THROW_ON_ERROR);
+
+        return hash_hmac('sha256', $payload, $hmacKey);
+    }
+
+    /**
+     * Type-safe extraction of the audit-row fields that feed into the v1
+     * hash calculation (`calculateHash()`). Defends against `mixed` shapes
+     * returned by Doctrine `fetchAssociative()` on different drivers.
      *
      * @param array<string, mixed> $row
      *
@@ -319,6 +381,49 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             'actorUid' => is_numeric($row['actor_uid'] ?? null) ? (int) $row['actor_uid'] : 0,
             'crdate' => is_numeric($row['crdate'] ?? null) ? (int) $row['crdate'] : 0,
             'epoch' => is_numeric($row['hmac_key_epoch'] ?? null) ? (int) $row['hmac_key_epoch'] : 0,
+        ];
+    }
+
+    /**
+     * Type-safe extraction of the audit-row fields for the v2 hash payload
+     * (`calculateHashV2()`). Adds the forensic fields that v1 does not bind
+     * into the chain: success, error_message, reason, ip_address, user_agent,
+     * hash_before, hash_after, context.
+     *
+     * @param array<string, mixed> $row
+     *
+     * @return array{
+     *     uid: int,
+     *     secret_identifier: string,
+     *     action: string,
+     *     success: int,
+     *     actor_uid: int,
+     *     crdate: int,
+     *     error_message: string,
+     *     reason: string,
+     *     ip_address: string,
+     *     user_agent: string,
+     *     hash_before: string,
+     *     hash_after: string,
+     *     context: string,
+     * }
+     */
+    public static function extractV2HashRow(array $row): array
+    {
+        return [
+            'uid' => is_numeric($row['uid'] ?? null) ? (int) $row['uid'] : 0,
+            'secret_identifier' => \is_string($row['secret_identifier'] ?? null) ? $row['secret_identifier'] : '',
+            'action' => \is_string($row['action'] ?? null) ? $row['action'] : '',
+            'success' => is_numeric($row['success'] ?? null) ? (int) (bool) $row['success'] : 0,
+            'actor_uid' => is_numeric($row['actor_uid'] ?? null) ? (int) $row['actor_uid'] : 0,
+            'crdate' => is_numeric($row['crdate'] ?? null) ? (int) $row['crdate'] : 0,
+            'error_message' => \is_string($row['error_message'] ?? null) ? $row['error_message'] : '',
+            'reason' => \is_string($row['reason'] ?? null) ? $row['reason'] : '',
+            'ip_address' => \is_string($row['ip_address'] ?? null) ? $row['ip_address'] : '',
+            'user_agent' => \is_string($row['user_agent'] ?? null) ? $row['user_agent'] : '',
+            'hash_before' => \is_string($row['hash_before'] ?? null) ? $row['hash_before'] : '',
+            'hash_after' => \is_string($row['hash_after'] ?? null) ? $row['hash_after'] : '',
+            'context' => \is_string($row['context'] ?? null) ? $row['context'] : '',
         ];
     }
 
@@ -418,26 +523,13 @@ final readonly class AuditLogService implements AuditLogServiceInterface
     private function insertAndUpdateHash(
         Connection $connection,
         array $data,
-        string $secretIdentifier,
-        string $action,
         string $previousHash,
     ): void {
         $connection->insert(self::TABLE_NAME, $data);
         $uid = (int) $connection->lastInsertId();
+        $data['uid'] = $uid;
 
-        $actorUid = \is_int($data['actor_uid'] ?? null) ? $data['actor_uid'] : 0;
-        $crdate = \is_int($data['crdate'] ?? null) ? $data['crdate'] : 0;
-        $epoch = \is_int($data['hmac_key_epoch'] ?? null) ? $data['hmac_key_epoch'] : 0;
-
-        $entryHash = $this->calculateEntryHash(
-            $uid,
-            $secretIdentifier,
-            $action,
-            $actorUid,
-            $crdate,
-            $previousHash,
-            $epoch,
-        );
+        $entryHash = $this->calculateEntryHashFromRow($data, $previousHash);
 
         $connection->update(
             self::TABLE_NAME,
@@ -447,28 +539,52 @@ final readonly class AuditLogService implements AuditLogServiceInterface
     }
 
     /**
-     * Calculate hash for an audit log entry.
+     * Calculate the entry hash for a freshly-inserted (or to-be-rehashed)
+     * row, dispatching by `hmac_key_epoch`:
      *
-     * Epoch 0 uses legacy SHA-256 (no HMAC key) for backward compatibility.
-     * Epoch 1+ uses HMAC-SHA256 with a key derived from the master key.
+     *   - epoch 0 → legacy SHA-256 over identity fields only (no HMAC key)
+     *   - epoch 1 → HMAC-SHA256 over identity fields
+     *   - epoch 2 → HMAC-SHA256 over identity + forensic fields (success,
+     *               error_message, reason, ip_address, user_agent,
+     *               hash_before, hash_after, context)
+     *
+     * @param array<string, mixed> $row Must contain `hmac_key_epoch`; epoch
+     *                                  2 also requires the forensic fields
+     *                                  (see `extractV2HashRow()`).
      */
-    private function calculateEntryHash(
-        int $uid,
-        string $secretIdentifier,
-        string $action,
-        int $actorUid,
-        int $crdate,
-        string $previousHash,
-        int $epoch = 0,
-    ): string {
+    private function calculateEntryHashFromRow(array $row, string $previousHash): string
+    {
+        $epoch = \is_int($row['hmac_key_epoch'] ?? null) ? $row['hmac_key_epoch'] : 0;
+        $v1 = self::extractHashRow($row);
+
         if ($epoch === 0) {
-            return self::calculateHash($uid, $secretIdentifier, $action, $actorUid, $crdate, $previousHash);
+            return self::calculateHash(
+                $v1['uid'],
+                $v1['secretId'],
+                $v1['action'],
+                $v1['actorUid'],
+                $v1['crdate'],
+                $previousHash,
+            );
         }
 
         $hmacKey = $this->getHmacKey();
 
         try {
-            return self::calculateHash($uid, $secretIdentifier, $action, $actorUid, $crdate, $previousHash, $hmacKey);
+            if ($epoch === 1) {
+                return self::calculateHash(
+                    $v1['uid'],
+                    $v1['secretId'],
+                    $v1['action'],
+                    $v1['actorUid'],
+                    $v1['crdate'],
+                    $previousHash,
+                    $hmacKey,
+                );
+            }
+
+            // Epoch 2+: extended payload that covers forensic fields too.
+            return self::calculateHashV2(self::extractV2HashRow($row), $previousHash, $hmacKey);
         } finally {
             sodium_memzero($hmacKey);
         }

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -358,7 +358,7 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             'hash_before' => (string) $row['hash_before'],
             'hash_after' => (string) $row['hash_after'],
             'context' => (string) $row['context'],
-        ], JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE);
+        ], JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
         return hash_hmac('sha256', $payload, $hmacKey);
     }

--- a/Classes/Command/VaultAuditMigrateCommand.php
+++ b/Classes/Command/VaultAuditMigrateCommand.php
@@ -76,24 +76,30 @@ final class VaultAuditMigrateCommand extends Command
 
         $connection = $this->connectionPool->getConnectionForTable(self::TABLE_NAME);
 
-        // Count epoch-0 entries (for progress reporting)
+        // Count outdated entries — anything below the target epoch. Covers
+        // 0 → 1, 0 → 2, and 1 → 2 migrations (the v1 hash payload omits
+        // forensic fields, so a 1 → 2 rehash is required for tamper
+        // detection of success/error_message/reason/ip/UA/context).
         $queryBuilder = $connection->createQueryBuilder();
         $countResult = $queryBuilder
             ->count('uid')
             ->from(self::TABLE_NAME)
             ->where(
-                $queryBuilder->expr()->eq(
+                $queryBuilder->expr()->lt(
                     'hmac_key_epoch',
-                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT),
+                    $queryBuilder->createNamedParameter($targetEpoch, Connection::PARAM_INT),
                 ),
             )
             ->executeQuery()
             ->fetchOne();
 
-        $epoch0Count = is_numeric($countResult) ? (int) $countResult : 0;
+        $outdatedCount = is_numeric($countResult) ? (int) $countResult : 0;
 
-        if ($epoch0Count === 0) {
-            $io->success('No entries with epoch 0 found. Nothing to migrate.');
+        if ($outdatedCount === 0) {
+            $io->success(\sprintf(
+                'All entries already at epoch %d or higher. Nothing to migrate.',
+                $targetEpoch,
+            ));
 
             return Command::SUCCESS;
         }
@@ -109,8 +115,9 @@ final class VaultAuditMigrateCommand extends Command
         $totalEntries = is_numeric($totalResult) ? (int) $totalResult : 0;
 
         $io->writeln(\sprintf(
-            'Found %d entries with epoch 0 (re-hashing all %d entries to maintain chain integrity)',
-            $epoch0Count,
+            'Found %d entries below epoch %d (re-hashing all %d entries to maintain chain integrity)',
+            $outdatedCount,
+            $targetEpoch,
             $totalEntries,
         ));
 
@@ -209,9 +216,9 @@ final class VaultAuditMigrateCommand extends Command
         $io->newLine(2);
 
         if ($dryRun) {
-            $io->success(\sprintf('DRY RUN: Would migrate %d entries from epoch 0 to epoch %d', $migratedCount, $targetEpoch));
+            $io->success(\sprintf('DRY RUN: Would migrate %d entries to epoch %d', $migratedCount, $targetEpoch));
         } else {
-            $io->success(\sprintf('Migrated %d entries from epoch 0 to epoch %d', $migratedCount, $targetEpoch));
+            $io->success(\sprintf('Migrated %d entries to epoch %d', $migratedCount, $targetEpoch));
         }
 
         return Command::SUCCESS;

--- a/Classes/Command/VaultAuditMigrateCommand.php
+++ b/Classes/Command/VaultAuditMigrateCommand.php
@@ -154,23 +154,26 @@ final class VaultAuditMigrateCommand extends Command
             while (($row = $result->fetchAssociative()) !== false) {
                 $entry = AuditLogService::extractHashRow($row);
                 $uid = $entry['uid'];
-                $secretId = $entry['secretId'];
-                $actionStr = $entry['action'];
-                $actorUid = $entry['actorUid'];
-                $crdate = $entry['crdate'];
                 $epoch = $entry['epoch'];
 
-                // Re-hash ALL entries (including already-epoch-1 entries) to maintain chain integrity.
-                // After re-hashing, all entries use HMAC with the current master key.
-                $newHash = AuditLogService::calculateHash(
-                    $uid,
-                    $secretId,
-                    $actionStr,
-                    $actorUid,
-                    $crdate,
-                    $previousHash,
-                    $hmacKey,
-                );
+                // Re-hash ALL entries to maintain chain integrity. Dispatch by
+                // target epoch: v1 covers identity fields only, v2 adds the
+                // forensic fields (success/error_message/reason/ip/UA/context).
+                $newHash = $targetEpoch >= 2
+                    ? AuditLogService::calculateHashV2(
+                        AuditLogService::extractV2HashRow($row),
+                        $previousHash,
+                        $hmacKey,
+                    )
+                    : AuditLogService::calculateHash(
+                        $uid,
+                        $entry['secretId'],
+                        $entry['action'],
+                        $entry['actorUid'],
+                        $entry['crdate'],
+                        $previousHash,
+                        $hmacKey,
+                    );
 
                 if (!$dryRun) {
                     $connection->update(
@@ -186,7 +189,7 @@ final class VaultAuditMigrateCommand extends Command
 
                 $previousHash = $newHash;
 
-                if ($epoch === 0) {
+                if ($epoch !== $targetEpoch) {
                     ++$migratedCount;
                 }
 

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -37,7 +37,21 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
 
     public const DEFAULT_PREFER_XCHACHA20 = false;
 
-    public const DEFAULT_AUDIT_HMAC_EPOCH = 1;
+    /**
+     * Audit-chain hash epoch.
+     *  - 0: legacy SHA-256 over identity fields only (no HMAC key).
+     *  - 1: HMAC-SHA256 over identity fields only.
+     *  - 2: HMAC-SHA256 over identity + forensic fields (success,
+     *       error_message, reason, ip_address, user_agent, hash_before,
+     *       hash_after, context).
+     *
+     * Default 2 binds the forensic surface into the chain — an attacker
+     * with DB-write privileges can no longer flip `success: false → true`
+     * or rewrite `error_message`/`reason`/etc. without breaking the chain.
+     * Existing epoch-0/epoch-1 entries continue to verify under their
+     * stored epoch until `AuditHmacMigrationWizard` rehashes them.
+     */
+    public const DEFAULT_AUDIT_HMAC_EPOCH = 2;
 
     private const EXTENSION_KEY = 'nr_vault';
 

--- a/Classes/Upgrades/AuditHmacMigrationWizard.php
+++ b/Classes/Upgrades/AuditHmacMigrationWizard.php
@@ -64,9 +64,12 @@ final class AuditHmacMigrationWizard implements UpgradeWizardInterface, LoggerAw
 
     public function getDescription(): string
     {
-        return 'Migrates existing audit log entries from plain SHA-256 hashing to '
-            . 'HMAC-SHA256 keyed with a master-key-derived key. This provides '
-            . 'tamper resistance against database-privileged attackers. '
+        return 'Migrates existing audit log entries to the configured HMAC '
+            . 'epoch. Epoch 1 upgrades plain SHA-256 to HMAC-SHA256 (tamper '
+            . 'resistance against DB-privileged attackers). Epoch 2 extends '
+            . 'the HMAC payload to cover forensic fields (success, '
+            . 'error_message, reason, ip_address, user_agent, context) so '
+            . 'they too become tamper-evident. '
             . 'The migration re-hashes all entries while maintaining chain integrity. '
             . 'Runs under an advisory lock and a single transaction — concurrent '
             . 'audit writes are serialised and partial failure rolls back.';
@@ -74,11 +77,12 @@ final class AuditHmacMigrationWizard implements UpgradeWizardInterface, LoggerAw
 
     public function updateNecessary(): bool
     {
-        if ($this->extensionConfiguration->getAuditHmacEpoch() === 0) {
+        $targetEpoch = $this->extensionConfiguration->getAuditHmacEpoch();
+        if ($targetEpoch === 0) {
             return false;
         }
 
-        return $this->countLegacyEntries() > 0;
+        return $this->countOutdatedEntries($targetEpoch) > 0;
     }
 
     public function executeUpdate(): bool
@@ -211,7 +215,12 @@ final class AuditHmacMigrationWizard implements UpgradeWizardInterface, LoggerAw
         return $migratedCount;
     }
 
-    private function countLegacyEntries(): int
+    /**
+     * Count rows whose stored epoch is below the configured target. Covers
+     * 0 → 1, 0 → 2, AND 1 → 2 migrations, so the wizard surfaces in the
+     * Install Tool whenever any row would benefit from a re-hash.
+     */
+    private function countOutdatedEntries(int $targetEpoch): int
     {
         $connection = $this->connectionPool->getConnectionForTable(self::TABLE_NAME);
         $queryBuilder = $connection->createQueryBuilder();
@@ -219,9 +228,9 @@ final class AuditHmacMigrationWizard implements UpgradeWizardInterface, LoggerAw
             ->count('uid')
             ->from(self::TABLE_NAME)
             ->where(
-                $queryBuilder->expr()->eq(
+                $queryBuilder->expr()->lt(
                     'hmac_key_epoch',
-                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT),
+                    $queryBuilder->createNamedParameter($targetEpoch, Connection::PARAM_INT),
                 ),
             )
             ->executeQuery()

--- a/Classes/Upgrades/AuditHmacMigrationWizard.php
+++ b/Classes/Upgrades/AuditHmacMigrationWizard.php
@@ -173,15 +173,24 @@ final class AuditHmacMigrationWizard implements UpgradeWizardInterface, LoggerAw
         while (($row = $result->fetchAssociative()) !== false) {
             $entry = AuditLogService::extractHashRow($row);
 
-            $newHash = AuditLogService::calculateHash(
-                $entry['uid'],
-                $entry['secretId'],
-                $entry['action'],
-                $entry['actorUid'],
-                $entry['crdate'],
-                $previousHash,
-                $hmacKey,
-            );
+            // Dispatch by target epoch: v1 covers identity fields only, v2
+            // adds the forensic fields (success / error_message / reason /
+            // ip_address / user_agent / hash_before / hash_after / context).
+            $newHash = $targetEpoch >= 2
+                ? AuditLogService::calculateHashV2(
+                    AuditLogService::extractV2HashRow($row),
+                    $previousHash,
+                    $hmacKey,
+                )
+                : AuditLogService::calculateHash(
+                    $entry['uid'],
+                    $entry['secretId'],
+                    $entry['action'],
+                    $entry['actorUid'],
+                    $entry['crdate'],
+                    $previousHash,
+                    $hmacKey,
+                );
 
             $connection->update(
                 self::TABLE_NAME,
@@ -194,7 +203,7 @@ final class AuditHmacMigrationWizard implements UpgradeWizardInterface, LoggerAw
             );
 
             $previousHash = $newHash;
-            if ($entry['epoch'] === 0) {
+            if ($entry['epoch'] !== $targetEpoch) {
                 ++$migratedCount;
             }
         }

--- a/Tests/Functional/Upgrades/AuditHmacMigrationWizardTest.php
+++ b/Tests/Functional/Upgrades/AuditHmacMigrationWizardTest.php
@@ -118,6 +118,31 @@ final class AuditHmacMigrationWizardTest extends AbstractVaultFunctionalTestCase
     }
 
     #[Test]
+    public function updateNecessaryReturnsTrueForEpoch1RowsWhenTargetIsEpoch2(): void
+    {
+        // First: write entries at epoch=1 via VaultService.
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_vault']['auditHmacEpoch'] = 1;
+        FileMasterKeyProvider::clearCachedKey();
+
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $identifier = $this->generateUuidV7();
+        $vaultService->store($identifier, 'epoch1-value');
+        $vaultService->delete($identifier, 'cleanup');
+
+        // Now bump the configured epoch to 2 — the existing epoch-1 rows
+        // are "outdated" because v1 hashes don't bind forensic fields.
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_vault']['auditHmacEpoch'] = 2;
+        FileMasterKeyProvider::clearCachedKey();
+
+        $wizard = $this->buildWizard();
+
+        self::assertTrue(
+            $wizard->updateNecessary(),
+            'updateNecessary must return true when epoch-1 rows exist and target is epoch 2',
+        );
+    }
+
+    #[Test]
     public function executeUpdateMigratesLegacyEntriesToHmac(): void
     {
         // Seed legacy entries at epoch=0

--- a/Tests/Functional/Upgrades/AuditHmacMigrationWizardTest.php
+++ b/Tests/Functional/Upgrades/AuditHmacMigrationWizardTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrVault\Tests\Functional\Upgrades;
 
 use Netresearch\NrVault\Audit\AuditLogService;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Configuration\ExtensionConfiguration;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\FileMasterKeyProvider;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
@@ -19,6 +20,7 @@ use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
 use Netresearch\NrVault\Upgrades\AuditHmacMigrationWizard;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Configuration\ExtensionConfiguration as Typo3ExtensionConfiguration;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface;
 
@@ -134,7 +136,14 @@ final class AuditHmacMigrationWizardTest extends AbstractVaultFunctionalTestCase
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_vault']['auditHmacEpoch'] = 2;
         FileMasterKeyProvider::clearCachedKey();
 
-        $wizard = $this->buildWizard();
+        // Build the wizard with a fresh ExtensionConfiguration so it picks
+        // up the new epoch from $GLOBALS — the DI-resolved instance is a
+        // singleton that cached the previous value at construction.
+        $wizard = new AuditHmacMigrationWizard(
+            $this->get(ConnectionPool::class),
+            $this->get(MasterKeyProviderInterface::class),
+            new ExtensionConfiguration(new Typo3ExtensionConfiguration()),
+        );
 
         self::assertTrue(
             $wizard->updateNecessary(),

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -1123,6 +1123,52 @@ final class AuditLogServiceTest extends TestCase
         );
     }
 
+    #[Test]
+    public function extractV2HashRowAcceptsBooleanSuccess(): void
+    {
+        // PostgreSQL via Doctrine returns smallint columns as PHP bool.
+        // Regression: is_numeric(true) is false, so a naive extractor would
+        // coerce a valid `true` to 0 and break verification.
+        $rowTrue = ['success' => true] + $this->makeRawRow();
+        $rowFalse = ['success' => false] + $this->makeRawRow();
+
+        $extractedTrue = AuditLogService::extractV2HashRow($rowTrue);
+        $extractedFalse = AuditLogService::extractV2HashRow($rowFalse);
+
+        self::assertSame(1, $extractedTrue['success'], 'bool(true) must extract to int(1)');
+        self::assertSame(0, $extractedFalse['success'], 'bool(false) must extract to int(0)');
+    }
+
+    #[Test]
+    public function extractV2HashRowAcceptsNumericStringSuccess(): void
+    {
+        // Doctrine with PDO::ATTR_EMULATE_PREPARES=true returns ints as strings.
+        $row = ['success' => '1'] + $this->makeRawRow();
+
+        $extracted = AuditLogService::extractV2HashRow($row);
+
+        self::assertSame(1, $extracted['success'], 'numeric-string success must extract to int(1)');
+    }
+
+    #[Test]
+    public function calculateHashV2SurvivesInvalidUtf8InFreeFormFields(): void
+    {
+        // A malicious or buggy client may submit a User-Agent / error_message
+        // containing invalid UTF-8 (e.g. a lone continuation byte). Hashing
+        // must NOT throw — that would crash audit logging and break the chain.
+        $hmacKey = str_repeat("\xAA", 32);
+        $invalidUtf8 = "valid prefix \xC3\x28 broken sequence";
+
+        $hash = AuditLogService::calculateHashV2(
+            $this->makeV2Row(userAgent: $invalidUtf8, errorMessage: $invalidUtf8),
+            '',
+            $hmacKey,
+        );
+
+        self::assertSame(64, \strlen($hash), 'hash_hmac sha256 hex output is 64 chars');
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $hash);
+    }
+
     // =========================================================================
     // Strict-assertion tests — kill IncrementInteger/DecrementInteger/CastInt/
     // Coalesce/MethodCallRemoval/ConcatOperandRemoval mutators on AuditLogService.
@@ -2051,6 +2097,31 @@ final class AuditLogServiceTest extends TestCase
 
         // Kills increments / decrements on gapStart and gapEnd computations.
         self::assertSame([2, 3, 4], $verification->missingUids);
+    }
+
+    /**
+     * Build a raw DB row (snake_case keys, mixed types) suitable for
+     * extractV2HashRow() input. Used by tests that exercise the extractor
+     * directly without going through the V2 fixture.
+     *
+     * @return array<string, mixed>
+     */
+    private function makeRawRow(): array
+    {
+        return [
+            'uid' => 1,
+            'secret_identifier' => 'sek',
+            'action' => 'read',
+            'actor_uid' => 1,
+            'crdate' => 1704067200,
+            'error_message' => '',
+            'reason' => '',
+            'ip_address' => '10.0.0.5',
+            'user_agent' => 'curl/8',
+            'hash_before' => '',
+            'hash_after' => '',
+            'context' => '{}',
+        ];
     }
 
     /**

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -1020,6 +1020,110 @@ final class AuditLogServiceTest extends TestCase
     }
 
     // =========================================================================
+    // Epoch 2 — extended hash payload covering forensic fields.
+    //
+    // The v1 hash binds only identity fields (uid / secret_identifier /
+    // action / actor_uid / crdate / previous_hash). An attacker with
+    // DB-write privileges could flip `success: false → true` or rewrite
+    // `error_message` / `reason` / `ip_address` / `user_agent` without
+    // breaking the chain. Epoch 2 extends the HMAC payload to cover those
+    // fields too.
+    // =========================================================================
+
+    #[Test]
+    public function calculateHashV2DiffersForDifferentSuccess(): void
+    {
+        $hmacKey = str_repeat("\xAA", 32);
+        $base = $this->makeV2Row(success: 1);
+        $tampered = $this->makeV2Row(success: 0);
+
+        $h1 = AuditLogService::calculateHashV2($base, '', $hmacKey);
+        $h2 = AuditLogService::calculateHashV2($tampered, '', $hmacKey);
+
+        self::assertNotSame($h1, $h2, 'Flipping `success` must change the chain hash');
+    }
+
+    #[Test]
+    public function calculateHashV2DiffersForDifferentErrorMessage(): void
+    {
+        $hmacKey = str_repeat("\xAA", 32);
+        $base = $this->makeV2Row(errorMessage: 'access denied');
+        $tampered = $this->makeV2Row(errorMessage: '');
+
+        $h1 = AuditLogService::calculateHashV2($base, '', $hmacKey);
+        $h2 = AuditLogService::calculateHashV2($tampered, '', $hmacKey);
+
+        self::assertNotSame($h1, $h2, 'Rewriting `error_message` must change the chain hash');
+    }
+
+    #[Test]
+    public function calculateHashV2DiffersForDifferentIpAddress(): void
+    {
+        $hmacKey = str_repeat("\xAA", 32);
+        $base = $this->makeV2Row(ipAddress: '10.0.0.5');
+        $tampered = $this->makeV2Row(ipAddress: '192.168.1.1');
+
+        $h1 = AuditLogService::calculateHashV2($base, '', $hmacKey);
+        $h2 = AuditLogService::calculateHashV2($tampered, '', $hmacKey);
+
+        self::assertNotSame($h1, $h2, 'Rewriting `ip_address` must change the chain hash');
+    }
+
+    #[Test]
+    public function verifyHashChainEpoch2DetectsForensicTampering(): void
+    {
+        $masterKey = str_repeat("\x01", 32);
+        $hmacKey = hash_hkdf('sha256', $masterKey, 32, 'nr-vault-audit-hmac-v1');
+
+        $row = [
+            'uid' => 1,
+            'secret_identifier' => 'sek',
+            'action' => 'access_denied',
+            'success' => 0,
+            'actor_uid' => 1,
+            'crdate' => 1704067200,
+            'error_message' => 'access denied',
+            'reason' => 'group not in allowlist',
+            'ip_address' => '10.0.0.5',
+            'user_agent' => 'curl/8',
+            'hash_before' => '',
+            'hash_after' => '',
+            'context' => '{}',
+        ];
+        $validHash = AuditLogService::calculateHashV2($row, '', $hmacKey);
+
+        // Attacker flips `success` from 0 to 1 in storage, but the stored
+        // entry_hash still binds the original `success: 0` payload.
+        $tamperedRow = array_merge($row, [
+            'success' => 1,
+            'previous_hash' => '',
+            'entry_hash' => $validHash,
+            'hmac_key_epoch' => 2,
+        ]);
+
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAllAssociative')->willReturn([$tamperedRow]);
+
+        $this->connectionPool
+            ->method('getConnectionForTable')
+            ->willReturn($this->connection);
+        $this->connection
+            ->method('createQueryBuilder')
+            ->willReturn($this->queryBuilder);
+        $this->queryBuilder->method('select')->willReturnSelf();
+        $this->queryBuilder->method('from')->willReturnSelf();
+        $this->queryBuilder->method('orderBy')->willReturnSelf();
+        $this->queryBuilder->method('executeQuery')->willReturn($result);
+
+        $verification = $this->getSubject()->verifyHashChain();
+
+        self::assertFalse(
+            $verification->isValid(),
+            'verifyHashChain MUST detect tampering of forensic fields when epoch=2',
+        );
+    }
+
+    // =========================================================================
     // Strict-assertion tests — kill IncrementInteger/DecrementInteger/CastInt/
     // Coalesce/MethodCallRemoval/ConcatOperandRemoval mutators on AuditLogService.
     // =========================================================================
@@ -1947,6 +2051,49 @@ final class AuditLogServiceTest extends TestCase
 
         // Kills increments / decrements on gapStart and gapEnd computations.
         self::assertSame([2, 3, 4], $verification->missingUids);
+    }
+
+    /**
+     * Build a v2 hash row with sensible defaults; override individual fields
+     * via named parameters.
+     *
+     * @return array{
+     *     uid: int, secret_identifier: string, action: string, success: int,
+     *     actor_uid: int, crdate: int, error_message: string, reason: string,
+     *     ip_address: string, user_agent: string, hash_before: string,
+     *     hash_after: string, context: string,
+     * }
+     */
+    private function makeV2Row(
+        int $uid = 1,
+        string $secretIdentifier = 'sek',
+        string $action = 'read',
+        int $success = 1,
+        int $actorUid = 1,
+        int $crdate = 1704067200,
+        string $errorMessage = '',
+        string $reason = '',
+        string $ipAddress = '10.0.0.5',
+        string $userAgent = 'curl/8',
+        string $hashBefore = '',
+        string $hashAfter = '',
+        string $context = '{}',
+    ): array {
+        return [
+            'uid' => $uid,
+            'secret_identifier' => $secretIdentifier,
+            'action' => $action,
+            'success' => $success,
+            'actor_uid' => $actorUid,
+            'crdate' => $crdate,
+            'error_message' => $errorMessage,
+            'reason' => $reason,
+            'ip_address' => $ipAddress,
+            'user_agent' => $userAgent,
+            'hash_before' => $hashBefore,
+            'hash_after' => $hashAfter,
+            'context' => $context,
+        ];
     }
 
     private function getSubject(): AuditLogService

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -1160,7 +1160,7 @@ final class AuditLogServiceTest extends TestCase
         $invalidUtf8 = "valid prefix \xC3\x28 broken sequence";
 
         $hash = AuditLogService::calculateHashV2(
-            $this->makeV2Row(userAgent: $invalidUtf8, errorMessage: $invalidUtf8),
+            $this->makeV2Row(errorMessage: $invalidUtf8, userAgent: $invalidUtf8),
             '',
             $hmacKey,
         );

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -39,8 +39,8 @@ auditLogRetention = 365
 # cat=Security; type=boolean; label=Audit Read Operations: Log every secret read to the audit log. Disable for high-throughput scenarios where read logging is not required.
 auditReads = 1
 
-# cat=Security; type=int+; label=Audit HMAC Epoch: Hash algorithm version marker for the audit log hash chain (0 = legacy SHA-256 without HMAC, 1+ = HMAC-SHA256 with key derived from master key). This is a version/algorithm marker, not a key diversifier — the HMAC key is always derived the same way from the current master key. Increment after master key rotation so the verifier knows which key was used.
-auditHmacEpoch = 1
+# cat=Security; type=int+; label=Audit HMAC Epoch: Hash algorithm version marker for the audit log hash chain (0 = legacy SHA-256 without HMAC, 1 = HMAC-SHA256 over identity fields only, 2 = HMAC-SHA256 over identity + forensic fields including success/error_message/reason/ip_address/user_agent/context). Default 2 binds the forensic surface into the chain so a DB-write attacker cannot flip success or rewrite error_message without breaking the chain. Run the install-tool "Migrate audit hash chain" wizard after bumping.
+auditHmacEpoch = 2
 
 ##################
 ### PERFORMANCE ###


### PR DESCRIPTION
## Summary

Closes **H-4** from the multi-axis security review.

The v1 audit-chain hash (epoch 0/1) binds only identity fields (`uid` / `secret_identifier` / `action` / `actor_uid` / `crdate` / `previous_hash`). An attacker with database-write privileges could:

- Flip `success: false → true` to make a denied access look approved.
- Rewrite `error_message` or `reason` to alter the forensic narrative.
- Change `ip_address` / `user_agent` to misattribute actions.
- Edit `context` JSON without breaking the chain.

…all without breaking the chain. The very forensic fields the audit log exists to preserve were unauthenticated.

**Epoch 2** extends the HMAC payload to cover those fields.

## Changes

### `Classes/Audit/AuditLogService`

- New `calculateHashV2(array $row, string $previousHash, string $hmacKey)` static — HMAC-SHA256 over **identity + forensic** payload (success, error_message, reason, ip_address, user_agent, hash_before, hash_after, context).
- New `extractV2HashRow(array $row): array` static — type-safe extraction of the v2 fields from a Doctrine row, mirroring the existing `extractHashRow()` helper for v1.
- New `calculateEntryHashFromRow($data, $previousHash)` private helper replaces the old `calculateEntryHash(...)`. Dispatches by `hmac_key_epoch`:
  - `0` → legacy SHA-256, identity fields only
  - `1` → HMAC-SHA256, identity fields only
  - `≥2` → HMAC-SHA256, identity + forensic fields
- `verifyHashChain()` switches to a `match (true)` over the stored epoch so each entry verifies under the algorithm it was written with.
- `insertAndUpdateHash()` passes the full `$data` row to `calculateEntryHashFromRow()` instead of cherry-picking fields, so epoch-2 writers automatically pick up the extended payload.

### `Classes/Configuration/ExtensionConfiguration`

- `DEFAULT_AUDIT_HMAC_EPOCH = 2` (was 1). Existing epoch-0/1 entries continue to verify under their stored epoch until the migration wizard rehashes them.

### `ext_conf_template.txt`

- `auditHmacEpoch = 2` default. Label expanded to document the three epochs and recommend running the migration wizard.

### `Upgrades/AuditHmacMigrationWizard` and `Command/VaultAuditMigrateCommand`

- Both dispatch by `$targetEpoch`: v1 for ≤1, v2 for ≥2 (full forensic payload).
- `$migratedCount` increments on **epoch change** (not just epoch 0), so 1→2 migrations are reported accurately.

## Test plan

- [x] **+4 unit tests** added to `Tests/Unit/Audit/AuditLogServiceTest.php`:
  - `calculateHashV2DiffersForDifferentSuccess` — flipping `success` produces a different hash.
  - `calculateHashV2DiffersForDifferentErrorMessage` — same for `error_message`.
  - `calculateHashV2DiffersForDifferentIpAddress` — same for `ip_address`.
  - `verifyHashChainEpoch2DetectsForensicTampering` — full chain verification: row where the attacker flipped `success` from 0 to 1 but kept the original `entry_hash` → `verifyHashChain()->isValid()` returns `false`.
- [x] **1749 unit tests pass** (was 1745; +4 new).
- [x] **cgl** green.
- [x] **rector** green.
- [ ] PHPStan level 10 (CI).
- [ ] Functional tests (CI).
- [ ] Verify upgrade wizard correctly handles **mixed-epoch** chains (epoch 0 + 1 + 2 in same table) on real DB.

## Migration / Compatibility

- **Backwards compatible by design:** Existing rows verify under their stored `hmac_key_epoch`. No silent breakage on upgrade.
- **Forward path:** Run the existing `vault:audit-migrate-hmac` CLI or the `AuditHmacMigrationWizard` install-tool wizard to rehash all rows to epoch 2.
- **Why default 2:** New installs get the strongest payload from day one; existing installs decide when to migrate.

## Refs

- Multi-axis security review item **H-4** (audit hash payload omits forensic fields).
- `Classes/Audit/AuditLogService.php:346-353` (old v1 hash payload).