### PR TITLE
refactor: address SonarCloud S1192 + S107 production findings

### DIFF
--- a/Classes/Audit/AuditLogInputs.php
+++ b/Classes/Audit/AuditLogInputs.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit;
+
+use SensitiveParameter;
+
+/**
+ * Caller-supplied inputs for a single audit-log write.
+ *
+ * Internal value object used between `AuditLogService::log()` (public API)
+ * and `AuditLogService::buildEntryData()` (private row builder). Exists to
+ * keep the row builder under PHP's "many parameters" smell threshold while
+ * preserving the public `log()` signature.
+ *
+ * @internal
+ */
+final readonly class AuditLogInputs
+{
+    public function __construct(
+        public string $secretIdentifier,
+        public string $action,
+        public bool $success,
+        public ?string $errorMessage = null,
+        public ?string $reason = null,
+        #[SensitiveParameter]
+        public ?string $hashBefore = null,
+        #[SensitiveParameter]
+        public ?string $hashAfter = null,
+        public ?AuditContextInterface $context = null,
+    ) {}
+}

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -59,14 +59,16 @@ final readonly class AuditLogService implements AuditLogServiceInterface
         try {
             $previousHash = $this->fetchPreviousHash($connection);
             $data = $this->buildEntryData(
-                $secretIdentifier,
-                $action,
-                $success,
-                $errorMessage,
-                $reason,
-                $hashBefore,
-                $hashAfter,
-                $context,
+                new AuditLogInputs(
+                    $secretIdentifier,
+                    $action,
+                    $success,
+                    $errorMessage,
+                    $reason,
+                    $hashBefore,
+                    $hashAfter,
+                    $context,
+                ),
                 $previousHash,
             );
             $this->insertAndUpdateHash($connection, $data, $previousHash);
@@ -484,25 +486,16 @@ final readonly class AuditLogService implements AuditLogServiceInterface
      * @return array<string, mixed>
      */
     private function buildEntryData(
-        string $secretIdentifier,
-        string $action,
-        bool $success,
-        ?string $errorMessage,
-        ?string $reason,
-        #[SensitiveParameter]
-        ?string $hashBefore,
-        #[SensitiveParameter]
-        ?string $hashAfter,
-        ?AuditContextInterface $context,
+        AuditLogInputs $inputs,
         string $previousHash,
     ): array {
         return [
             'pid' => 0,
-            'secret_identifier' => $secretIdentifier,
-            'action' => $action,
-            'success' => $success ? 1 : 0,
-            'error_message' => $errorMessage ?? '',
-            'reason' => $reason ?? '',
+            'secret_identifier' => $inputs->secretIdentifier,
+            'action' => $inputs->action,
+            'success' => $inputs->success ? 1 : 0,
+            'error_message' => $inputs->errorMessage ?? '',
+            'reason' => $inputs->reason ?? '',
             'actor_uid' => $this->accessControlService->getCurrentActorUid(),
             'actor_type' => $this->accessControlService->getCurrentActorType(),
             'actor_username' => $this->accessControlService->getCurrentActorUsername(),
@@ -511,11 +504,11 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             'user_agent' => $this->getUserAgent(),
             'request_id' => $this->getRequestId(),
             'previous_hash' => $previousHash,
-            'hash_before' => $hashBefore ?? '',
-            'hash_after' => $hashAfter ?? '',
+            'hash_before' => $inputs->hashBefore ?? '',
+            'hash_after' => $inputs->hashAfter ?? '',
             'crdate' => time(),
             'hmac_key_epoch' => $this->getCurrentEpoch(),
-            'context' => $context instanceof AuditContextInterface ? json_encode($context->toArray()) : '{}',
+            'context' => $inputs->context instanceof AuditContextInterface ? json_encode($inputs->context->toArray()) : '{}',
         ];
     }
 

--- a/Classes/Command/VaultListCommand.php
+++ b/Classes/Command/VaultListCommand.php
@@ -28,6 +28,10 @@ use Symfony\Component\Console\Style\SymfonyStyle;
 )]
 final class VaultListCommand extends Command
 {
+    private const DATE_FORMAT_SHORT = 'Y-m-d H:i';
+
+    private const DATE_FORMAT_LONG = 'Y-m-d H:i:s';
+
     public function __construct(
         private readonly VaultServiceInterface $vaultService,
     ) {
@@ -117,10 +121,10 @@ final class VaultListCommand extends Command
             $rows[] = [
                 $secret->identifier,
                 $secret->ownerUid,
-                date('Y-m-d H:i', $secret->createdAt),
-                date('Y-m-d H:i', $secret->updatedAt),
+                date(self::DATE_FORMAT_SHORT, $secret->createdAt),
+                date(self::DATE_FORMAT_SHORT, $secret->updatedAt),
                 $secret->readCount,
-                $secret->lastReadAt !== null ? date('Y-m-d H:i', $secret->lastReadAt) : '-',
+                $secret->lastReadAt !== null ? date(self::DATE_FORMAT_SHORT, $secret->lastReadAt) : '-',
             ];
         }
 
@@ -146,10 +150,10 @@ final class VaultListCommand extends Command
                 '%s,%d,%s,%s,%d,%s',
                 $this->escapeCsv($secret->identifier),
                 $secret->ownerUid,
-                date('Y-m-d H:i:s', $secret->createdAt),
-                date('Y-m-d H:i:s', $secret->updatedAt),
+                date(self::DATE_FORMAT_LONG, $secret->createdAt),
+                date(self::DATE_FORMAT_LONG, $secret->updatedAt),
                 $secret->readCount,
-                $secret->lastReadAt !== null ? date('Y-m-d H:i:s', $secret->lastReadAt) : '',
+                $secret->lastReadAt !== null ? date(self::DATE_FORMAT_LONG, $secret->lastReadAt) : '',
             ));
         }
     }

--- a/Classes/Controller/AuditController.php
+++ b/Classes/Controller/AuditController.php
@@ -37,6 +37,10 @@ final readonly class AuditController
 {
     private const MODULE_NAME = 'admin_vault_audit';
 
+    private const LL_PREFIX = 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:';
+
+    private const LL_TABS_TAB = self::LL_PREFIX . 'mlang_tabs_tab';
+
     public function __construct(
         private ModuleTemplateFactory $moduleTemplateFactory,
         private IconFactory $iconFactory,
@@ -56,7 +60,7 @@ final readonly class AuditController
         if (method_exists($moduleTemplate->getDocHeaderComponent(), 'setShortcutContext')) {
             $moduleTemplate->getDocHeaderComponent()->setShortcutContext(
                 routeIdentifier: self::MODULE_NAME,
-                displayName: $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:mlang_tabs_tab')
+                displayName: $this->getLanguageService()->sL(self::LL_TABS_TAB)
                     . ' - '
                     . $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.title'),
             );
@@ -143,7 +147,7 @@ final readonly class AuditController
         ]);
 
         $moduleTemplate->setTitle(
-            $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:mlang_tabs_tab')
+            $this->getLanguageService()->sL(self::LL_TABS_TAB)
             . ' - '
             . $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.title'),
         );
@@ -187,7 +191,7 @@ final readonly class AuditController
         ]);
 
         $moduleTemplate->setTitle(
-            $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:mlang_tabs_tab')
+            $this->getLanguageService()->sL(self::LL_TABS_TAB)
             . ' - '
             . $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.verify_chain'),
         );

--- a/Classes/Controller/MigrationController.php
+++ b/Classes/Controller/MigrationController.php
@@ -55,6 +55,10 @@ final readonly class MigrationController
      */
     private const ALLOWED_ACTIONS = ['index', 'scan', 'review', 'configure', 'execute', 'verify'];
 
+    private const LL_PREFIX = 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:';
+
+    private const LL_TABS_TAB = self::LL_PREFIX . 'mlang_tabs_tab';
+
     public function __construct(
         private ModuleTemplateFactory $moduleTemplateFactory,
         private SecretDetectionService $detectionService,
@@ -101,14 +105,14 @@ final readonly class MigrationController
         if (method_exists($moduleTemplate->getDocHeaderComponent(), 'setShortcutContext')) {
             $moduleTemplate->getDocHeaderComponent()->setShortcutContext(
                 routeIdentifier: self::MODULE_NAME,
-                displayName: $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:mlang_tabs_tab')
+                displayName: $this->getLanguageService()->sL(self::LL_TABS_TAB)
                     . ' - '
                     . $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:migration.title'),
             );
         }
 
         $moduleTemplate->setTitle(
-            $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:mlang_tabs_tab')
+            $this->getLanguageService()->sL(self::LL_TABS_TAB)
             . ' - '
             . $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:migration.title'),
         );
@@ -126,7 +130,7 @@ final readonly class MigrationController
         $this->addBackButton($moduleTemplate, 'index');
 
         $moduleTemplate->setTitle(
-            $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:mlang_tabs_tab')
+            $this->getLanguageService()->sL(self::LL_TABS_TAB)
             . ' - '
             . $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:migration.scan'),
         );
@@ -168,7 +172,7 @@ final readonly class MigrationController
         $this->addBackButton($moduleTemplate, 'scan');
 
         $moduleTemplate->setTitle(
-            $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:mlang_tabs_tab')
+            $this->getLanguageService()->sL(self::LL_TABS_TAB)
             . ' - '
             . $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:migration.review'),
         );
@@ -215,7 +219,7 @@ final readonly class MigrationController
         $this->addBackButton($moduleTemplate, 'review');
 
         $moduleTemplate->setTitle(
-            $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:mlang_tabs_tab')
+            $this->getLanguageService()->sL(self::LL_TABS_TAB)
             . ' - '
             . $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:migration.configure'),
         );
@@ -343,7 +347,7 @@ final readonly class MigrationController
         $this->addBackButton($moduleTemplate, 'index');
 
         $moduleTemplate->setTitle(
-            $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:mlang_tabs_tab')
+            $this->getLanguageService()->sL(self::LL_TABS_TAB)
             . ' - '
             . $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:migration.verify'),
         );

--- a/Classes/Controller/SecretsController.php
+++ b/Classes/Controller/SecretsController.php
@@ -42,6 +42,14 @@ final readonly class SecretsController
 {
     private const MODULE_NAME = 'admin_vault_secrets';
 
+    private const DATE_FORMAT = 'Y-m-d H:i:s';
+
+    private const LL_PREFIX = 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:';
+
+    private const LL_NO_IDENTIFIER = self::LL_PREFIX . 'secrets.noIdentifier';
+
+    private const LL_NOT_FOUND = self::LL_PREFIX . 'secrets.notFound';
+
     public function __construct(
         private ModuleTemplateFactory $moduleTemplateFactory,
         private IconFactory $iconFactory,
@@ -106,10 +114,10 @@ final readonly class SecretsController
                 'identifier' => $secret->identifier,
                 'owner_uid' => $ownerUid,
                 'owner_name' => $userCache[$ownerUid] ?? 'User #' . $ownerUid,
-                'created' => date('Y-m-d H:i:s', $secret->createdAt),
-                'updated' => date('Y-m-d H:i:s', $secret->updatedAt),
+                'created' => date(self::DATE_FORMAT, $secret->createdAt),
+                'updated' => date(self::DATE_FORMAT, $secret->updatedAt),
                 'read_count' => $secret->readCount,
-                'last_read' => $secret->lastReadAt !== null ? date('Y-m-d H:i:s', $secret->lastReadAt) : '-',
+                'last_read' => $secret->lastReadAt !== null ? date(self::DATE_FORMAT, $secret->lastReadAt) : '-',
                 'description' => $secret->description,
                 'hidden' => false,
             ];
@@ -166,7 +174,7 @@ final readonly class SecretsController
 
         if ($identifier === '') {
             $this->addFlashMessage(
-                $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.noIdentifier'),
+                $lang->sL(self::LL_NO_IDENTIFIER),
                 ContextualFeedbackSeverity::ERROR,
             );
 
@@ -180,7 +188,7 @@ final readonly class SecretsController
             $metadata = $this->vaultService->getMetadata($identifier);
         } catch (SecretNotFoundException) {
             $this->addFlashMessage(
-                \sprintf($lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.notFound'), $identifier),
+                \sprintf($lang->sL(self::LL_NOT_FOUND), $identifier),
                 ContextualFeedbackSeverity::ERROR,
             );
 
@@ -238,7 +246,7 @@ final readonly class SecretsController
                 return new JsonResponse(['success' => false, 'error' => 'No secret identifier provided'], 400);
             }
             $this->addFlashMessage(
-                $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.noIdentifier'),
+                $lang->sL(self::LL_NO_IDENTIFIER),
                 ContextualFeedbackSeverity::ERROR,
             );
 
@@ -314,7 +322,7 @@ final readonly class SecretsController
                 return new JsonResponse(['success' => false, 'error' => 'Secret not found'], 404);
             }
             $this->addFlashMessage(
-                \sprintf($lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.notFound'), $identifier),
+                \sprintf($lang->sL(self::LL_NOT_FOUND), $identifier),
                 ContextualFeedbackSeverity::ERROR,
             );
         } catch (Exception $e) {
@@ -351,7 +359,7 @@ final readonly class SecretsController
 
         if ($identifier === '') {
             $this->addFlashMessage(
-                $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.noIdentifier'),
+                $lang->sL(self::LL_NO_IDENTIFIER),
                 ContextualFeedbackSeverity::ERROR,
             );
 
@@ -370,7 +378,7 @@ final readonly class SecretsController
             );
         } catch (SecretNotFoundException) {
             $this->addFlashMessage(
-                \sprintf($lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.notFound'), $identifier),
+                \sprintf($lang->sL(self::LL_NOT_FOUND), $identifier),
                 ContextualFeedbackSeverity::ERROR,
             );
         } catch (AccessDeniedException) {


### PR DESCRIPTION
## Summary

Targets the **production-code** Sonar findings that remain after the test-noise bulk-accept (S1192 ×7, S107 ×3 in production). Test-only findings stay accepted in the Sonar UI with their own rationale.

## Changes

### S1192 — duplicate literals → constants (7 findings)

| File | Constants extracted | Replaces |
|---|---|---|
| `SecretsController.php` | `DATE_FORMAT`, `LL_PREFIX`, `LL_NO_IDENTIFIER`, `LL_NOT_FOUND` | 9 literal usages |
| `VaultListCommand.php` | `DATE_FORMAT_SHORT`, `DATE_FORMAT_LONG` | 6 literal usages |
| `MigrationController.php` | `LL_PREFIX`, `LL_TABS_TAB` | 6 literal usages |
| `AuditController.php` | `LL_PREFIX`, `LL_TABS_TAB` | 3 literal usages |

Same XLIFF prefix `LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:` is now referenced once per controller, with key suffixes added via `self::LL_PREFIX . 'key'`. Reading + editing the call sites gets much shorter.

### S107 — many parameters (1 of 3 fixed)

`Classes/Audit/AuditLogService::buildEntryData()` dropped from **9 → 2 parameters** by bundling caller-supplied inputs into a new internal value object:

```php
final readonly class AuditLogInputs {
    public function __construct(
        public string $secretIdentifier,
        public string $action,
        public bool $success,
        public ?string $errorMessage = null,
        public ?string $reason = null,
        #[SensitiveParameter] public ?string $hashBefore = null,
        #[SensitiveParameter] public ?string $hashAfter = null,
        public ?AuditContextInterface $context = null,
    ) {}
}
```

- `@internal` — only used between `log()` (public API) and `buildEntryData()` (private row builder).
- Hash fields wear `#[SensitiveParameter]` so they're scrubbed from stack traces / debug output.
- **Public `AuditLogServiceInterface::log()` signature unchanged.**

## Deferred S107 (2 remaining — will be accepted in Sonar UI)

- `Classes/Domain/Model/Secret.php:87` (15 params) — covered by the **H-5 readonly-conversion** item already on the backlog.
- `Classes/Audit/AuditLogServiceInterface.php:36` (8 params) — **stable public API contract**; changing the signature would break consumer extensions.

## Test plan

- [x] 1752 unit tests pass (unchanged count, no behavioural change).
- [x] cgl + rector + PHPStan level 10 green locally.
- [ ] CI matrix (PHP 8.2–8.5 × TYPO3 v13.4/v14.0).
- [ ] No functional-test regression.

Refs SonarCloud project `netresearch_t3x-nr-vault` and the follow-up to merged PR #138.