### PR TITLE
refactor: address SonarCloud easy-win production findings

### DIFF
--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -240,7 +240,7 @@ final class VaultRotateMasterKeyCommand extends Command
 
             $io->progressFinish();
 
-            if (\count($failedSecrets) > 0) {
+            if ($failedSecrets !== []) {
                 $connection->rollBack();
                 $io->error(\sprintf(
                     'Rotation failed for %d secret(s). Transaction rolled back.',

--- a/Classes/Controller/AuditController.php
+++ b/Classes/Controller/AuditController.php
@@ -265,6 +265,9 @@ final readonly class AuditController
             try {
                 $since = new DateTimeImmutable($sinceValue);
             } catch (Exception) {
+                // Malformed date input from the user — leave $since/$until null
+                // so the filter is simply not applied. The form re-renders the
+                // raw value so the user can correct it.
             }
         }
 
@@ -274,6 +277,9 @@ final readonly class AuditController
             try {
                 $until = new DateTimeImmutable($untilValue);
             } catch (Exception) {
+                // Malformed date input from the user — leave $since/$until null
+                // so the filter is simply not applied. The form re-renders the
+                // raw value so the user can correct it.
             }
         }
 
@@ -406,9 +412,8 @@ final readonly class AuditController
 
     private function getLanguageService(): LanguageService
     {
-        /** @var LanguageService $lang */
-        $lang = $GLOBALS['LANG'];
+        \assert($GLOBALS['LANG'] instanceof LanguageService);
 
-        return $lang;
+        return $GLOBALS['LANG'];
     }
 }

--- a/Classes/Controller/MigrationController.php
+++ b/Classes/Controller/MigrationController.php
@@ -525,10 +525,9 @@ final readonly class MigrationController
 
     private function getLanguageService(): LanguageService
     {
-        /** @var LanguageService $lang */
-        $lang = $GLOBALS['LANG'];
+        \assert($GLOBALS['LANG'] instanceof LanguageService);
 
-        return $lang;
+        return $GLOBALS['LANG'];
     }
 
     /**

--- a/Classes/Controller/OverviewController.php
+++ b/Classes/Controller/OverviewController.php
@@ -230,9 +230,8 @@ final readonly class OverviewController
 
     private function getLanguageService(): LanguageService
     {
-        /** @var LanguageService $languageService */
-        $languageService = $GLOBALS['LANG'];
+        \assert($GLOBALS['LANG'] instanceof LanguageService);
 
-        return $languageService;
+        return $GLOBALS['LANG'];
     }
 }

--- a/Classes/Controller/SecretsController.php
+++ b/Classes/Controller/SecretsController.php
@@ -444,10 +444,9 @@ final readonly class SecretsController
 
     private function getLanguageService(): LanguageService
     {
-        /** @var LanguageService $lang */
-        $lang = $GLOBALS['LANG'];
+        \assert($GLOBALS['LANG'] instanceof LanguageService);
 
-        return $lang;
+        return $GLOBALS['LANG'];
     }
 
     /**
@@ -481,7 +480,12 @@ final readonly class SecretsController
         while ($row = $result->fetchAssociative()) {
             $realName = $row['realName'] ?? '';
             $username = $row['username'] ?? '';
-            $displayName = (\is_string($realName) && $realName !== '') ? $realName : (\is_string($username) ? $username : '');
+            $displayName = '';
+            if (\is_string($realName) && $realName !== '') {
+                $displayName = $realName;
+            } elseif (\is_string($username)) {
+                $displayName = $username;
+            }
             $uidVal = $row['uid'] ?? 0;
             $cache[is_numeric($uidVal) ? (int) $uidVal : 0] = $displayName;
         }

--- a/Classes/Form/Element/VaultSecretElement.php
+++ b/Classes/Form/Element/VaultSecretElement.php
@@ -72,10 +72,12 @@ final class VaultSecretElement extends AbstractFormElement
         if ($vaultIdentifier !== '') {
             try {
                 $vaultService = GeneralUtility::makeInstance(VaultServiceInterface::class);
-                $metadata = $vaultService->getMetadata($vaultIdentifier);
+                // Probe for existence — throws SecretNotFoundException (or
+                // AccessDeniedException) when the identifier doesn't resolve.
+                $vaultService->getMetadata($vaultIdentifier);
                 $hasValue = true;
             } catch (Throwable) {
-                // Secret doesn't exist yet
+                // Secret doesn't exist yet (or current user can't read it)
             }
         }
 

--- a/Classes/Form/Element/VaultSecretElement.php
+++ b/Classes/Form/Element/VaultSecretElement.php
@@ -72,12 +72,16 @@ final class VaultSecretElement extends AbstractFormElement
         if ($vaultIdentifier !== '') {
             try {
                 $vaultService = GeneralUtility::makeInstance(VaultServiceInterface::class);
-                // Probe for existence — throws SecretNotFoundException (or
-                // AccessDeniedException) when the identifier doesn't resolve.
+                // Call for its side effect: getMetadata() throws
+                // SecretNotFoundException when the identifier doesn't exist
+                // and AccessDeniedException when the secret exists but the
+                // current user lacks read permission. Either way the field
+                // should render in "no value" mode.
                 $vaultService->getMetadata($vaultIdentifier);
                 $hasValue = true;
             } catch (Throwable) {
-                // Secret doesn't exist yet (or current user can't read it)
+                // Secret missing or not visible to the current user — render
+                // the field as if no value were set.
             }
         }
 

--- a/Classes/Form/Element/VaultSecretInputElement.php
+++ b/Classes/Form/Element/VaultSecretInputElement.php
@@ -265,13 +265,7 @@ final class VaultSecretInputElement extends AbstractFormElement
             'name' => $itemName,
             'value' => '',
             'class' => 'form-control',
-            'placeholder' => $hasSecret
-                ? ($this->getLanguageService()->sL(
-                    'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:vault_secret_input.placeholder_rotate',
-                ) ?: 'Enter new secret value to rotate')
-                : ($this->getLanguageService()->sL(
-                    'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:vault_secret_input.placeholder_new',
-                ) ?: 'Enter secret value'),
+            'placeholder' => $this->resolvePlaceholder($hasSecret),
             'autocomplete' => 'off',
             'data-formengine-input-name' => $itemName,
             'data-vault-identifier' => $identifier,
@@ -352,5 +346,21 @@ final class VaultSecretInputElement extends AbstractFormElement
         $iconFactory = $this->iconFactory;
 
         return $iconFactory->getIcon($identifier, IconSize::SMALL)->render();
+    }
+
+    /**
+     * Pick the appropriate placeholder text based on whether the record
+     * already has a secret stored — rotate hint for existing secrets,
+     * create hint for new ones. Falls back to English defaults when the
+     * XLIFF lookup returns an empty string.
+     */
+    private function resolvePlaceholder(bool $hasSecret): string
+    {
+        $key = $hasSecret
+            ? 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:vault_secret_input.placeholder_rotate'
+            : 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:vault_secret_input.placeholder_new';
+        $fallback = $hasSecret ? 'Enter new secret value to rotate' : 'Enter secret value';
+
+        return $this->getLanguageService()->sL($key) ?: $fallback;
     }
 }

--- a/Classes/Hook/DataHandlerHook.php
+++ b/Classes/Hook/DataHandlerHook.php
@@ -155,8 +155,15 @@ final class DataHandlerHook
                     $this->vaultService->rotate($vaultIdentifier, $secretValue, 'TCA field updated');
                 }
             } catch (Throwable $e) {
-                // Roll back the dangling UUID - clear the field so no orphan reference remains
-                $this->rollBackField($table, $uid, $fieldName, $isNew ? '' : ($pending->originalChecksum !== '' ? $vaultIdentifier : ''));
+                // Roll back the dangling UUID - clear the field so no orphan
+                // reference remains. New records always clear (no prior value);
+                // updates keep the prior identifier IFF a prior checksum was
+                // captured (i.e. the old secret actually existed).
+                $rollbackValue = '';
+                if (!$isNew && $pending->originalChecksum !== '') {
+                    $rollbackValue = $vaultIdentifier;
+                }
+                $this->rollBackField($table, $uid, $fieldName, $rollbackValue);
 
                 /** @phpstan-ignore method.internal */
                 $dataHandler->log(

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -153,7 +153,13 @@ final class AccessControlService implements AccessControlServiceInterface
         /** @var list<int> $result */
         $result = [];
         foreach ($groups as $groupId) {
-            $result[] = \is_int($groupId) ? $groupId : (is_numeric($groupId) ? (int) $groupId : 0);
+            $normalised = 0;
+            if (\is_int($groupId)) {
+                $normalised = $groupId;
+            } elseif (is_numeric($groupId)) {
+                $normalised = (int) $groupId;
+            }
+            $result[] = $normalised;
         }
 
         return $result;


### PR DESCRIPTION
## Summary

Picks off the **low-effort** production-code Sonar findings as a follow-up to PR #139. Structural items (S1142 multi-return, S3776 cognitive complexity, S1448 god classes, S107 Secret/Interface) and TYPO3-mandated hook violations (S1172 unused params, S100 hook naming) are **accepted in the Sonar UI** with their own rationale and tracked under H-5 / future refactors.

## Changes

| Rule | Count | Fix |
|---|---|---|
| `S108` | 2 | Add explanatory comments to deliberately-silent catch blocks in \`AuditController\` |
| `S1488` | 4 | Replace \`/** @var X */ \$x = \$GLOBALS['LANG']; return \$x;\` with \`assert + return\` |
| `S1155` | 1 | \`\count(\$x) > 0\` → \`\$x !== []\` in \`VaultRotateMasterKeyCommand\` |
| `S1481` | 1 | Drop unused \`\$metadata\` assignment in \`VaultSecretElement\` |
| `S3358` | 4 | Extract nested ternaries to \`if/elseif\` / helper methods in 4 files |

### S108 — empty catch blocks
The catches are deliberately silent: \`\$since/\$until\` stay \`null\` on malformed date input, the form re-renders the raw value so the user can correct it. Added comments to make the intent explicit.

### S1488 — useless temp var
Old pattern needed the docblock for PHPStan narrowing:
\`\`\`php
/** @var LanguageService \$lang */
\$lang = \$GLOBALS['LANG'];
return \$lang;
\`\`\`
New pattern is more compact and PHPStan-friendly:
\`\`\`php
\assert(\$GLOBALS['LANG'] instanceof LanguageService);
return \$GLOBALS['LANG'];
\`\`\`

### S3358 — nested ternaries
- \`DataHandlerHook.php:159\` — rollback value → \`\$rollbackValue\` variable
- \`SecretsController.php:484\` — display name → if/elseif chain
- \`AccessControlService.php:156\` — groupId normalisation → if/elseif chain
- \`VaultSecretInputElement.php:272\` — placeholder → \`resolvePlaceholder()\` helper

## Not in this PR — accept in Sonar UI later

| Rule | Count | Why |
|---|---|---|
| \`S1172\` | 9 | TYPO3 hook signatures mandated (\`\$pasteUpdate\`, \`\$fieldArray\`, \`\$value\`, \`\$recordWasDeleted\`) |
| \`S100\` | 11 | TYPO3 hook naming mandated (\`processDatamap_*\`, \`processCmdmap_*\`) |
| \`S1142\` | 39 | Multi-return; substantial refactor across HTTP/OAuth/SecureHttp |
| \`S3776\` | 28 | Cognitive complexity hotspots; per-method refactors |
| \`S1448\` | 3 | God classes (Secret, AuditLogService, VaultHttpResponse) — H-5 territory |
| \`S107\` | 2 | \`Secret.php:87\` covered by H-5; \`AuditLogServiceInterface.php:36\` stable public API |
| \`S138\` | 1 | \`VaultRotateMasterKeyCommand::execute\` 175 LOC — own PR |
| S3358 (VaultService) | 1 | Sonar parser false positive on \`??\` (no line attached) |

## Test plan

- [x] 1752 unit tests pass (unchanged count, no behavioural change)
- [x] cgl + rector + PHPStan level 10 green locally
- [ ] CI matrix