### PR TITLE
refactor: split high-CC methods (S138 + S3776)

### DIFF
--- a/Classes/Command/VaultCleanupOrphansCommand.php
+++ b/Classes/Command/VaultCleanupOrphansCommand.php
@@ -79,81 +79,25 @@ final class VaultCleanupOrphansCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
-        $dryRun = $input->getOption('dry-run');
-        $retentionDaysOption = $input->getOption('retention-days');
-        $retentionDays = is_numeric($retentionDaysOption) ? (int) $retentionDaysOption : 0;
-        $tableFilterOption = $input->getOption('table');
-        $tableFilter = \is_string($tableFilterOption) ? $tableFilterOption : null;
-        $batchSizeOption = $input->getOption('batch-size');
-        $batchSize = is_numeric($batchSizeOption) ? (int) $batchSizeOption : 100;
+        $options = $this->parseOptions($input);
 
         $io->title('Vault Orphan Cleanup');
         $io->text([
-            \sprintf('Mode: <info>%s</info>', $dryRun !== false ? 'Dry Run' : 'Live'),
-            \sprintf('Retention: <info>%d days</info>', $retentionDays),
-            $tableFilter !== null ? \sprintf('Table filter: <info>%s</info>', $tableFilter) : '',
+            \sprintf('Mode: <info>%s</info>', $options['dryRun'] ? 'Dry Run' : 'Live'),
+            \sprintf('Retention: <info>%d days</info>', $options['retentionDays']),
+            $options['tableFilter'] !== null ? \sprintf('Table filter: <info>%s</info>', $options['tableFilter']) : '',
         ]);
 
-        // Get all TCA-sourced secrets
-        $secrets = $this->getTcaSecrets($tableFilter);
-        $totalSecrets = \count($secrets);
-
-        if ($totalSecrets === 0) {
+        $secrets = $this->getTcaSecrets($options['tableFilter']);
+        if ($secrets === []) {
             $io->success('No TCA-sourced secrets found');
 
             return Command::SUCCESS;
         }
 
-        $io->text(\sprintf('Found <info>%d</info> TCA-sourced secrets to check', $totalSecrets));
+        $io->text(\sprintf('Found <info>%d</info> TCA-sourced secrets to check', \count($secrets)));
 
-        // Find orphans
-        $io->section('Checking for orphaned secrets...');
-        $progressBar = $io->createProgressBar($totalSecrets);
-        $progressBar->start();
-
-        $orphans = [];
-        $retentionCutoff = $retentionDays > 0 ? time() - ($retentionDays * 86400) : PHP_INT_MAX;
-
-        $effectiveBatchSize = $batchSize > 0 ? $batchSize : 100;
-        foreach (array_chunk($secrets, $effectiveBatchSize) as $batch) {
-            foreach ($batch as $secret) {
-                $identifier = $secret['identifier'];
-                $metadata = $secret['metadata'];
-                $createdAt = $secret['created_at'] ?? 0;
-
-                // Get table/field/uid from metadata (UUIDs don't encode this)
-                $tableValue = $metadata['table'] ?? '';
-                $table = \is_string($tableValue) ? $tableValue : '';
-                $fieldValue = $metadata['field'] ?? $metadata['flexField'] ?? '';
-                $field = \is_string($fieldValue) ? $fieldValue : '';
-                $uidValue = $metadata['uid'] ?? 0;
-                $uid = is_numeric($uidValue) ? (int) $uidValue : 0;
-
-                if ($table === '' || $uid === 0) {
-                    $progressBar->advance();
-                    continue;
-                }
-
-                // Check if record still exists
-                // Only include if older than retention period
-                if (!$this->recordExists($table, $uid) && $createdAt < $retentionCutoff) {
-                    $orphans[] = [
-                        'identifier' => $identifier,
-                        'table' => $table,
-                        'field' => $field,
-                        'uid' => $uid,
-                        'created_at' => $createdAt,
-                    ];
-                }
-
-                $progressBar->advance();
-            }
-        }
-
-        $progressBar->finish();
-        $io->newLine(2);
-
-        // Show results
+        $orphans = $this->findOrphans($io, $secrets, $options['retentionDays'], $options['batchSize']);
         $orphanCount = \count($orphans);
         if ($orphanCount === 0) {
             $io->success('No orphaned secrets found');
@@ -163,21 +107,124 @@ final class VaultCleanupOrphansCommand extends Command
 
         $io->text(\sprintf('Found <comment>%d</comment> orphaned secrets', $orphanCount));
 
-        if ($dryRun) {
+        if ($options['dryRun']) {
             $io->section('Orphaned secrets that would be deleted:');
             $this->showOrphanTable($io, $orphans);
 
             return Command::SUCCESS;
         }
 
-        // Confirm deletion
         if (!$io->confirm(\sprintf('Delete %d orphaned secrets?', $orphanCount), false)) {
             $io->warning('Cleanup cancelled');
 
             return Command::SUCCESS;
         }
 
-        // Delete orphans
+        return $this->deleteOrphans($io, $orphans);
+    }
+
+    /**
+     * Parse CLI options into a typed shape so the main flow stays readable.
+     *
+     * @return array{dryRun: bool, retentionDays: int, tableFilter: ?string, batchSize: int}
+     */
+    private function parseOptions(InputInterface $input): array
+    {
+        $retentionDaysOption = $input->getOption('retention-days');
+        $tableFilterOption = $input->getOption('table');
+        $batchSizeOption = $input->getOption('batch-size');
+
+        return [
+            'dryRun' => (bool) $input->getOption('dry-run'),
+            'retentionDays' => is_numeric($retentionDaysOption) ? (int) $retentionDaysOption : 0,
+            'tableFilter' => \is_string($tableFilterOption) ? $tableFilterOption : null,
+            'batchSize' => is_numeric($batchSizeOption) && (int) $batchSizeOption > 0 ? (int) $batchSizeOption : 100,
+        ];
+    }
+
+    /**
+     * Iterate TCA-sourced secrets and classify each as orphaned when the
+     * backing record no longer exists AND the secret is older than the
+     * configured retention cutoff.
+     *
+     * @param array<int, array{identifier: string, metadata: array<string, mixed>, created_at: int}> $secrets
+     *
+     * @return list<array{identifier: string, table: string, field: string, uid: int, created_at: int}>
+     */
+    private function findOrphans(SymfonyStyle $io, array $secrets, int $retentionDays, int $batchSize): array
+    {
+        $io->section('Checking for orphaned secrets...');
+        $progressBar = $io->createProgressBar(\count($secrets));
+        $progressBar->start();
+
+        $orphans = [];
+        $retentionCutoff = $retentionDays > 0 ? time() - ($retentionDays * 86400) : PHP_INT_MAX;
+        $effectiveBatchSize = max(1, $batchSize);
+
+        foreach (array_chunk($secrets, $effectiveBatchSize) as $batch) {
+            foreach ($batch as $secret) {
+                $orphan = $this->classifyOrphan($secret, $retentionCutoff);
+                if ($orphan !== null) {
+                    $orphans[] = $orphan;
+                }
+                $progressBar->advance();
+            }
+        }
+
+        $progressBar->finish();
+        $io->newLine(2);
+
+        return $orphans;
+    }
+
+    /**
+     * Classify a single secret. Returns the orphan payload if the backing
+     * record is gone and retention has elapsed, otherwise null.
+     *
+     * @param array{identifier: string, metadata: array<string, mixed>, created_at: int} $secret
+     *
+     * @return array{identifier: string, table: string, field: string, uid: int, created_at: int}|null
+     */
+    private function classifyOrphan(array $secret, int $retentionCutoff): ?array
+    {
+        $identifier = $secret['identifier'];
+        $metadata = $secret['metadata'];
+        $createdAtRaw = $secret['created_at'] ?? 0;
+        $createdAt = is_numeric($createdAtRaw) ? (int) $createdAtRaw : 0;
+
+        $tableValue = $metadata['table'] ?? '';
+        $table = \is_string($tableValue) ? $tableValue : '';
+        $fieldValue = $metadata['field'] ?? $metadata['flexField'] ?? '';
+        $field = \is_string($fieldValue) ? $fieldValue : '';
+        $uidValue = $metadata['uid'] ?? 0;
+        $uid = is_numeric($uidValue) ? (int) $uidValue : 0;
+
+        if ($table === '' || $uid === 0) {
+            return null;
+        }
+
+        if ($this->recordExists($table, $uid) || $createdAt >= $retentionCutoff) {
+            return null;
+        }
+
+        return [
+            'identifier' => $identifier,
+            'table' => $table,
+            'field' => $field,
+            'uid' => $uid,
+            'created_at' => $createdAt,
+        ];
+    }
+
+    /**
+     * Delete the confirmed orphan list, printing a summary table. Returns
+     * FAILURE if any deletion threw; the rest still proceed (best-effort
+     * cleanup — vault state is consistent either way).
+     *
+     * @param list<array{identifier: string, table: string, field: string, uid: int, created_at: int}> $orphans
+     */
+    private function deleteOrphans(SymfonyStyle $io, array $orphans): int
+    {
         $io->section('Deleting orphaned secrets...');
         $deleted = 0;
         $failed = 0;
@@ -186,17 +233,16 @@ final class VaultCleanupOrphansCommand extends Command
         foreach ($orphans as $orphan) {
             try {
                 $this->vaultService->delete($orphan['identifier'], 'Orphan cleanup');
-                $deleted++;
+                ++$deleted;
             } catch (VaultException $e) {
-                $failed++;
+                ++$failed;
                 $errors[] = \sprintf('%s: %s', $orphan['identifier'], $e->getMessage());
             }
         }
 
-        // Summary
         $io->section('Cleanup Summary');
         $io->definitionList(
-            ['Orphans found' => $orphanCount],
+            ['Orphans found' => \count($orphans)],
             ['Successfully deleted' => $deleted],
             ['Failed' => $failed],
         );

--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -89,10 +89,6 @@ final class VaultRotateMasterKeyCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        $dryRun = (bool) $input->getOption('dry-run');
-        $confirmed = (bool) $input->getOption('confirm');
-
-        // Get keys
         try {
             $oldKeyPath = $input->getOption('old-key');
             $newKeyPath = $input->getOption('new-key');
@@ -104,23 +100,42 @@ final class VaultRotateMasterKeyCommand extends Command
             return Command::FAILURE;
         }
 
-        // Validate we have different keys
-        if (hash_equals($oldKey, $newKey)) {
-            $io->error('Old and new master keys are identical. Nothing to rotate.');
+        try {
+            return $this->runRotation(
+                $io,
+                $oldKey,
+                $newKey,
+                (bool) $input->getOption('dry-run'),
+                (bool) $input->getOption('confirm'),
+            );
+        } finally {
             sodium_memzero($oldKey);
             sodium_memzero($newKey);
+        }
+    }
+
+    /**
+     * Orchestrates the rotation pipeline. Pre-flight checks → confirmation →
+     * key verification → dry-run short-circuit → transactional re-encryption.
+     */
+    private function runRotation(
+        SymfonyStyle $io,
+        string $oldKey,
+        string $newKey,
+        bool $dryRun,
+        bool $confirmed,
+    ): int {
+        if (hash_equals($oldKey, $newKey)) {
+            $io->error('Old and new master keys are identical. Nothing to rotate.');
 
             return Command::FAILURE;
         }
 
-        // Get all secret identifiers
         $identifiers = $this->secretRepository->findIdentifiers();
         $totalSecrets = \count($identifiers);
 
         if ($totalSecrets === 0) {
             $io->warning('No secrets found in the vault.');
-            sodium_memzero($oldKey);
-            sodium_memzero($newKey);
 
             return Command::SUCCESS;
         }
@@ -128,31 +143,68 @@ final class VaultRotateMasterKeyCommand extends Command
         $io->title('Master Key Rotation');
         $io->text(\sprintf('Found %d secret(s) to re-encrypt.', $totalSecrets));
 
+        if (!$this->confirmExecution($io, $dryRun, $confirmed)) {
+            return Command::FAILURE;
+        }
+
+        if (!$this->verifyOldKey($io, $identifiers[0], $oldKey, $newKey)) {
+            return Command::FAILURE;
+        }
+
+        if ($dryRun) {
+            $io->success(\sprintf(
+                '[DRY RUN] Would re-encrypt %d secret(s). No changes made.',
+                $totalSecrets,
+            ));
+
+            return Command::SUCCESS;
+        }
+
+        return $this->rotateAllSecrets($io, $identifiers, $oldKey, $newKey, $totalSecrets);
+    }
+
+    /**
+     * Show the dry-run notice or require explicit --confirm for irreversible
+     * runs. Returns false to abort with FAILURE if the user must opt in first.
+     */
+    private function confirmExecution(SymfonyStyle $io, bool $dryRun, bool $confirmed): bool
+    {
         if ($dryRun) {
             $io->note('DRY RUN MODE - No changes will be made.');
-        } elseif (!$confirmed) {
+
+            return true;
+        }
+
+        if (!$confirmed) {
             $io->warning([
                 'This operation will re-encrypt all DEKs with the new master key.',
                 'This is irreversible. Ensure you have backed up the old key.',
                 'Use --confirm to proceed or --dry-run to simulate.',
             ]);
-            sodium_memzero($oldKey);
-            sodium_memzero($newKey);
 
-            return Command::FAILURE;
+            return false;
         }
 
-        // Verify old key works by attempting to decrypt first secret
+        return true;
+    }
+
+    /**
+     * Smoke-test the old master key by attempting a single re-encryption.
+     * Catches a wrong-key scenario before touching the rest of the vault.
+     */
+    private function verifyOldKey(
+        SymfonyStyle $io,
+        string $firstIdentifier,
+        string $oldKey,
+        string $newKey,
+    ): bool {
         $io->text('Verifying old master key...');
-        $firstIdentifier = $identifiers[0];
         $firstSecret = $this->secretRepository->findByIdentifier($firstIdentifier);
 
         if (!$firstSecret instanceof Secret) {
             $io->error('Failed to load first secret for verification.');
-            sodium_memzero($oldKey);
-            sodium_memzero($newKey);
 
-            return Command::FAILURE;
+            return false;
         }
 
         try {
@@ -164,35 +216,34 @@ final class VaultRotateMasterKeyCommand extends Command
                 $newKey,
             );
             $io->text('<info>Old master key verified successfully.</info>');
+
+            return true;
         } catch (EncryptionException $e) {
             $io->error([
                 'Failed to decrypt with old master key.',
                 'Error: ' . $e->getMessage(),
                 'Ensure you provided the correct old key.',
             ]);
-            sodium_memzero($oldKey);
-            sodium_memzero($newKey);
 
-            return Command::FAILURE;
+            return false;
         }
+    }
 
-        if ($dryRun) {
-            $io->success(\sprintf(
-                '[DRY RUN] Would re-encrypt %d secret(s). No changes made.',
-                $totalSecrets,
-            ));
-            sodium_memzero($oldKey);
-            sodium_memzero($newKey);
-
-            return Command::SUCCESS;
-        }
-
-        // Begin transaction
+    /**
+     * Main rotation loop wrapped in a transaction. Per-secret failures are
+     * collected; ANY failure rolls back the whole batch (atomic rotation).
+     *
+     * @param list<string> $identifiers
+     */
+    private function rotateAllSecrets(
+        SymfonyStyle $io,
+        array $identifiers,
+        string $oldKey,
+        string $newKey,
+        int $totalSecrets,
+    ): int {
         $connection = $this->connectionPool->getConnectionForTable('tx_nrvault_secrets');
         $connection->beginTransaction();
-
-        $successCount = 0;
-        $failedSecrets = [];
 
         // Audit the start of the rotation lifecycle. We log BEFORE any state
         // change so that even a catastrophic crash mid-loop leaves a trail.
@@ -205,62 +256,27 @@ final class VaultRotateMasterKeyCommand extends Command
         );
 
         $io->progressStart($totalSecrets);
+        $failedSecrets = [];
+        $successCount = 0;
 
         try {
             foreach ($identifiers as $identifier) {
-                $secret = $this->secretRepository->findByIdentifier($identifier);
-                if (!$secret instanceof Secret) {
-                    $failedSecrets[] = ['identifier' => $identifier, 'error' => 'Not found'];
-                    $io->progressAdvance();
-
-                    continue;
-                }
-
-                try {
-                    $reEncrypted = $this->encryptionService->reEncryptDek(
-                        $secret->getEncryptedDek(),
-                        $secret->getDekNonce(),
-                        $secret->getIdentifier(),
-                        $oldKey,
-                        $newKey,
-                    );
-
-                    // Update the secret
-                    $secret->setEncryptedDek($reEncrypted->encryptedDek);
-                    $secret->setDekNonce($reEncrypted->nonce);
-                    $this->secretRepository->save($secret);
-
+                if ($this->rotateOne($identifier, $oldKey, $newKey, $failedSecrets)) {
                     ++$successCount;
-                } catch (EncryptionException $e) {
-                    $failedSecrets[] = ['identifier' => $identifier, 'error' => $e->getMessage()];
                 }
-
                 $io->progressAdvance();
             }
-
             $io->progressFinish();
 
             if ($failedSecrets !== []) {
                 $connection->rollBack();
-                $io->error(\sprintf(
-                    'Rotation failed for %d secret(s). Transaction rolled back.',
-                    \count($failedSecrets),
-                ));
-                $io->table(
-                    ['Identifier', 'Error'],
-                    array_map(
-                        static fn (array $f): array => [$f['identifier'], $f['error']],
-                        $failedSecrets,
-                    ),
-                );
+                $this->reportFailures($io, $failedSecrets);
                 $this->auditLogService->log(
                     self::AUDIT_PSEUDO_IDENTIFIER,
                     'master_key_rotate_end',
                     false,
                     \sprintf('Rotation failed for %d secret(s); transaction rolled back', \count($failedSecrets)),
                 );
-                sodium_memzero($oldKey);
-                sodium_memzero($newKey);
 
                 return Command::FAILURE;
             }
@@ -277,8 +293,6 @@ final class VaultRotateMasterKeyCommand extends Command
                 false,
                 'Unexpected error during rotation; transaction rolled back',
             );
-            sodium_memzero($oldKey);
-            sodium_memzero($newKey);
 
             return Command::FAILURE;
         }
@@ -303,10 +317,68 @@ final class VaultRotateMasterKeyCommand extends Command
             '3. Test secret retrieval to verify the rotation',
         ]);
 
-        sodium_memzero($oldKey);
-        sodium_memzero($newKey);
-
         return Command::SUCCESS;
+    }
+
+    /**
+     * Re-encrypt a single secret's DEK and persist. Returns false (with the
+     * failure recorded by reference) on missing-secret or EncryptionException;
+     * the caller advances the progress bar and decides whether to roll back.
+     *
+     * @param list<array{identifier: string, error: string}> $failedSecrets
+     */
+    private function rotateOne(
+        string $identifier,
+        string $oldKey,
+        string $newKey,
+        array &$failedSecrets,
+    ): bool {
+        $secret = $this->secretRepository->findByIdentifier($identifier);
+        if (!$secret instanceof Secret) {
+            $failedSecrets[] = ['identifier' => $identifier, 'error' => 'Not found'];
+
+            return false;
+        }
+
+        try {
+            $reEncrypted = $this->encryptionService->reEncryptDek(
+                $secret->getEncryptedDek(),
+                $secret->getDekNonce(),
+                $secret->getIdentifier(),
+                $oldKey,
+                $newKey,
+            );
+
+            $secret->setEncryptedDek($reEncrypted->encryptedDek);
+            $secret->setDekNonce($reEncrypted->nonce);
+            $this->secretRepository->save($secret);
+
+            return true;
+        } catch (EncryptionException $e) {
+            $failedSecrets[] = ['identifier' => $identifier, 'error' => $e->getMessage()];
+
+            return false;
+        }
+    }
+
+    /**
+     * Render the failure table after a rolled-back rotation.
+     *
+     * @param list<array{identifier: string, error: string}> $failedSecrets
+     */
+    private function reportFailures(SymfonyStyle $io, array $failedSecrets): void
+    {
+        $io->error(\sprintf(
+            'Rotation failed for %d secret(s). Transaction rolled back.',
+            \count($failedSecrets),
+        ));
+        $io->table(
+            ['Identifier', 'Error'],
+            array_map(
+                static fn (array $f): array => [$f['identifier'], $f['error']],
+                $failedSecrets,
+            ),
+        );
     }
 
     /**

--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -242,7 +242,7 @@ final class VaultRotateMasterKeyCommand extends Command
         string $newKey,
         int $totalSecrets,
     ): int {
-        $connection = $this->connectionPool->getConnectionForTable('tx_nrvault_secrets');
+        $connection = $this->connectionPool->getConnectionForTable('tx_nrvault_secret');
         $connection->beginTransaction();
 
         // Audit the start of the rotation lifecycle. We log BEFORE any state

--- a/Classes/Form/Element/VaultSecretElement.php
+++ b/Classes/Form/Element/VaultSecretElement.php
@@ -29,7 +29,11 @@ final class VaultSecretElement extends AbstractFormElement
 {
     private const LINE_FEED = "\n";
 
-    public function __construct(private readonly IconFactory $iconFactory) {}
+    public function __construct(
+        private readonly IconFactory $iconFactory,
+        private readonly VaultFieldPermissionService $permissionService,
+        private readonly VaultServiceInterface $vaultService,
+    ) {}
 
     /**
      * @return array<string, mixed>
@@ -118,8 +122,6 @@ final class VaultSecretElement extends AbstractFormElement
         $fieldValue = $data['fieldName'] ?? '';
         $field = \is_string($fieldValue) ? $fieldValue : '';
 
-        $permissionService = GeneralUtility::makeInstance(VaultFieldPermissionService::class);
-
         $itemFormElValue = $parameterArray['itemFormElValue'] ?? '';
         $vaultIdentifier = \is_string($itemFormElValue) ? $itemFormElValue : '';
 
@@ -130,13 +132,13 @@ final class VaultSecretElement extends AbstractFormElement
             'vaultIdentifier' => $vaultIdentifier,
             'config' => $config,
             'fieldConf' => $fieldConf,
-            'permissions' => $permissionService->getPermissions($table, $field),
+            'permissions' => $this->permissionService->getPermissions($table, $field),
         ];
     }
 
     /**
      * Decide whether the vault has a value the user is allowed to see.
-     * \getMetadata() throws SecretNotFoundException when the identifier
+     * getMetadata() throws SecretNotFoundException when the identifier
      * doesn't exist and AccessDeniedException when it exists but the
      * current user lacks read permission — both render as "no value".
      */
@@ -147,8 +149,7 @@ final class VaultSecretElement extends AbstractFormElement
         }
 
         try {
-            $vaultService = GeneralUtility::makeInstance(VaultServiceInterface::class);
-            $vaultService->getMetadata($vaultIdentifier);
+            $this->vaultService->getMetadata($vaultIdentifier);
 
             return true;
         } catch (Throwable) {

--- a/Classes/Form/Element/VaultSecretElement.php
+++ b/Classes/Form/Element/VaultSecretElement.php
@@ -39,10 +39,70 @@ final class VaultSecretElement extends AbstractFormElement
         /** @var array<string, mixed> $resultArray */
         $resultArray = $this->initializeResultArray();
 
+        $context = $this->extractRenderContext();
+        $hasValue = $this->probeHasValue($context['vaultIdentifier']);
+        $placeholder = $this->resolvePlaceholder($hasValue, $context['config']);
+        $attributes = $this->buildInputAttributes($context, $hasValue, $placeholder);
+
+        $html = [];
+        $html[] = $this->renderLabel($context['fieldId']);
+        $html[] = '<div class="formengine-field-item t3js-formengine-field-item">';
+
+        /** @var array<string, mixed> $fieldInformationResult */
+        $fieldInformationResult = $this->renderFieldInformation();
+        $html[] = \is_string($fieldInformationResult['html'] ?? null) ? $fieldInformationResult['html'] : '';
+        /** @var array<string, mixed> $resultArray */
+        $resultArray = $this->mergeChildReturnIntoExistingResult($resultArray, $fieldInformationResult, false);
+
+        $descriptionHtml = $this->renderVaultDescription($context['fieldConf']);
+        if ($descriptionHtml !== '') {
+            $html[] = $descriptionHtml;
+        }
+
+        $html[] = '<div class="form-wizards-wrap">';
+        $html[] = '<div class="form-wizards-element">';
+        $html[] = '<div class="form-control-wrap" style="max-width: ' . $context['width'] . 'px">';
+        $html[] = $this->renderInputGroup($attributes, $context['permissions'], $hasValue);
+        $html[] = '</div>'; // form-control-wrap
+        $html[] = '</div>'; // form-wizards-element
+
+        /** @var array<string, mixed> $fieldWizardResult */
+        $fieldWizardResult = $this->renderFieldWizard();
+        $html[] = \is_string($fieldWizardResult['html'] ?? null) ? $fieldWizardResult['html'] : '';
+        /** @var array<string, mixed> $resultArray */
+        $resultArray = $this->mergeChildReturnIntoExistingResult($resultArray, $fieldWizardResult, false);
+
+        $html[] = '</div>'; // form-wizards-wrap
+        $html[] = '</div>'; // formengine-field-item
+        $html[] = $this->renderHiddenFields($context['itemName'], $context['vaultIdentifier'], $hasValue);
+
+        $resultArray['html'] = implode(self::LINE_FEED, $html);
+        $resultArray['javaScriptModules'] = $this->appendJsModule($resultArray);
+
+        return $resultArray;
+    }
+
+    /**
+     * Unpack the FormEngine `$data` shape into a typed bundle so render()
+     * doesn't drown in `\is_array(...) ? ... : []` guards.
+     *
+     * @return array{
+     *     itemName: string,
+     *     fieldId: string,
+     *     width: int,
+     *     vaultIdentifier: string,
+     *     config: array<string, mixed>,
+     *     fieldConf: array<string, mixed>,
+     *     permissions: array<string, bool>,
+     * }
+     */
+    private function extractRenderContext(): array
+    {
         /** @var array<string, mixed> $data */
         $data = $this->data;
         /** @var array<string, mixed> $parameterArray */
         $parameterArray = \is_array($data['parameterArray'] ?? null) ? $data['parameterArray'] : [];
+        /** @var array<string, mixed> $fieldConf */
         $fieldConf = \is_array($parameterArray['fieldConf'] ?? null) ? $parameterArray['fieldConf'] : [];
         /** @var array<string, mixed> $config */
         $config = \is_array($fieldConf['config'] ?? null) ? $fieldConf['config'] : [];
@@ -50,7 +110,6 @@ final class VaultSecretElement extends AbstractFormElement
         $itemNameValue = $parameterArray['itemFormElName'] ?? '';
         $itemName = \is_string($itemNameValue) ? $itemNameValue : '';
 
-        $fieldId = StringUtility::getUniqueId('formengine-vault-');
         $sizeValue = $config['size'] ?? 30;
         $width = $this->formMaxWidth(is_numeric($sizeValue) ? (int) $sizeValue : 30);
 
@@ -59,57 +118,92 @@ final class VaultSecretElement extends AbstractFormElement
         $fieldValue = $data['fieldName'] ?? '';
         $field = \is_string($fieldValue) ? $fieldValue : '';
 
-        // Get field permissions from TSconfig
         $permissionService = GeneralUtility::makeInstance(VaultFieldPermissionService::class);
-        $permissions = $permissionService->getPermissions($table, $field);
 
-        // UUID is stored directly in the field value
         $itemFormElValue = $parameterArray['itemFormElValue'] ?? '';
         $vaultIdentifier = \is_string($itemFormElValue) ? $itemFormElValue : '';
 
-        // Check if secret exists in vault (UUID is non-empty)
-        $hasValue = false;
-        if ($vaultIdentifier !== '') {
-            try {
-                $vaultService = GeneralUtility::makeInstance(VaultServiceInterface::class);
-                // Call for its side effect: getMetadata() throws
-                // SecretNotFoundException when the identifier doesn't exist
-                // and AccessDeniedException when the secret exists but the
-                // current user lacks read permission. Either way the field
-                // should render in "no value" mode.
-                $vaultService->getMetadata($vaultIdentifier);
-                $hasValue = true;
-            } catch (Throwable) {
-                // Secret missing or not visible to the current user — render
-                // the field as if no value were set.
-            }
+        return [
+            'itemName' => $itemName,
+            'fieldId' => StringUtility::getUniqueId('formengine-vault-'),
+            'width' => $width,
+            'vaultIdentifier' => $vaultIdentifier,
+            'config' => $config,
+            'fieldConf' => $fieldConf,
+            'permissions' => $permissionService->getPermissions($table, $field),
+        ];
+    }
+
+    /**
+     * Decide whether the vault has a value the user is allowed to see.
+     * \getMetadata() throws SecretNotFoundException when the identifier
+     * doesn't exist and AccessDeniedException when it exists but the
+     * current user lacks read permission — both render as "no value".
+     */
+    private function probeHasValue(string $vaultIdentifier): bool
+    {
+        if ($vaultIdentifier === '') {
+            return false;
         }
 
-        // Determine placeholder text
-        $placeholder = '';
+        try {
+            $vaultService = GeneralUtility::makeInstance(VaultServiceInterface::class);
+            $vaultService->getMetadata($vaultIdentifier);
+
+            return true;
+        } catch (Throwable) {
+            return false;
+        }
+    }
+
+    /**
+     * "Has value" → bullets; otherwise → TCA-configured placeholder.
+     *
+     * @param array<string, mixed> $config
+     */
+    private function resolvePlaceholder(bool $hasValue, array $config): string
+    {
         if ($hasValue) {
-            $placeholder = $this->getLanguageService()->sL(
+            return $this->getLanguageService()->sL(
                 'LLL:EXT:nr_vault/Resources/Private/Language/locallang.xlf:vault_secret.placeholder_exists',
             ) ?: '••••••••';
-        } else {
-            $placeholderValue = $config['placeholder'] ?? '';
-            $placeholder = \is_string($placeholderValue) ? $placeholderValue : '';
         }
 
-        // Build attributes
+        $placeholderValue = $config['placeholder'] ?? '';
+
+        return \is_string($placeholderValue) ? $placeholderValue : '';
+    }
+
+    /**
+     * Build the `<input>` attribute array — password-manager opt-out flags,
+     * data-* probes for the JS module, readonly/required toggles.
+     *
+     * @param array{
+     *     itemName: string,
+     *     fieldId: string,
+     *     width: int,
+     *     vaultIdentifier: string,
+     *     config: array<string, mixed>,
+     *     fieldConf: array<string, mixed>,
+     *     permissions: array<string, bool>,
+     * } $context
+     *
+     * @return array<string, string>
+     */
+    private function buildInputAttributes(array $context, bool $hasValue, string $placeholder): array
+    {
+        $config = $context['config'];
+        $permissions = $context['permissions'];
+
         $attributes = [
             'type' => 'password',
-            'id' => $fieldId,
-            'name' => $itemName . '[value]',
+            'id' => $context['fieldId'],
+            'name' => $context['itemName'] . '[value]',
             'value' => '',
-            'class' => implode(' ', [
-                'form-control',
-                't3js-clearable',
-                'hasDefaultValue',
-            ]),
+            'class' => implode(' ', ['form-control', 't3js-clearable', 'hasDefaultValue']),
             'data-formengine-validation-rules' => $this->getValidationDataAsJsonString($config),
-            'data-formengine-input-name' => $itemName,
-            'data-vault-identifier' => $vaultIdentifier,
+            'data-formengine-input-name' => $context['itemName'],
+            'data-vault-identifier' => $context['vaultIdentifier'],
             'data-vault-has-value' => $hasValue ? '1' : '0',
             'data-vault-can-reveal' => $permissions['reveal'] ? '1' : '0',
             'data-vault-can-copy' => $permissions['copy'] ? '1' : '0',
@@ -132,7 +226,6 @@ final class VaultSecretElement extends AbstractFormElement
             $attributes['maxlength'] = (string) (int) $maxValue;
         }
 
-        // Apply readOnly from TCA config or TSconfig permissions
         $readOnlyConfig = $config['readOnly'] ?? false;
         if ($readOnlyConfig || $permissions['readOnly'] || !$permissions['edit']) {
             $attributes['readonly'] = 'readonly';
@@ -142,91 +235,97 @@ final class VaultSecretElement extends AbstractFormElement
             $attributes['required'] = 'required';
         }
 
-        // Build HTML
-        $html = [];
+        return $attributes;
+    }
 
-        // Render field label
-        $html[] = $this->renderLabel($fieldId);
-
-        $html[] = '<div class="formengine-field-item t3js-formengine-field-item">';
-
-        // Render field information (description/help text)
-        /** @var array<string, mixed> $fieldInformationResult */
-        $fieldInformationResult = $this->renderFieldInformation();
-        $html[] = \is_string($fieldInformationResult['html'] ?? null) ? $fieldInformationResult['html'] : '';
-        /** @var array<string, mixed> $resultArray */
-        $resultArray = $this->mergeChildReturnIntoExistingResult($resultArray, $fieldInformationResult, false);
-
-        // Render field description if present
+    /**
+     * Optional field description from TCA — empty string if none.
+     *
+     * @param array<string, mixed> $fieldConf
+     */
+    private function renderVaultDescription(array $fieldConf): string
+    {
         $fieldDescriptionValue = $fieldConf['description'] ?? '';
-        $fieldDescription = \is_string($fieldDescriptionValue) ? $fieldDescriptionValue : '';
-        if ($fieldDescription !== '') {
-            $description = $this->getLanguageService()->sL($fieldDescription);
-            if ($description !== '') {
-                $html[] = '<div class="form-description">' . htmlspecialchars($description) . '</div>';
-            }
+        if (!\is_string($fieldDescriptionValue) || $fieldDescriptionValue === '') {
+            return '';
         }
 
-        $html[] = '<div class="form-wizards-wrap">';
-        $html[] = '<div class="form-wizards-element">';
-        $html[] = '<div class="form-control-wrap" style="max-width: ' . $width . 'px">';
-        $html[] = '<div class="input-group">';
-        $html[] = '<input ' . GeneralUtility::implodeAttributes($attributes, true) . ' />';
+        $description = $this->getLanguageService()->sL($fieldDescriptionValue);
+        if ($description === '') {
+            return '';
+        }
 
-        // Toggle visibility button (only if reveal permission is granted)
+        return '<div class="form-description">' . htmlspecialchars($description) . '</div>';
+    }
+
+    /**
+     * Render the `<input>` + per-permission action buttons (reveal / copy /
+     * clear) wrapped in `<div class="input-group">`.
+     *
+     * @param array<string, string> $attributes
+     * @param array<string, bool> $permissions
+     */
+    private function renderInputGroup(array $attributes, array $permissions, bool $hasValue): string
+    {
+        $parts = ['<div class="input-group">'];
+        $parts[] = '<input ' . GeneralUtility::implodeAttributes($attributes, true) . ' />';
+
         if ($permissions['reveal']) {
-            $html[] = '<button type="button" class="btn btn-secondary t3js-vault-toggle-visibility" title="Toggle visibility">';
-            $html[] = $this->renderIcon('actions-eye');
-            $html[] = '</button>';
+            $parts[] = '<button type="button" class="btn btn-secondary t3js-vault-toggle-visibility" title="Toggle visibility">';
+            $parts[] = $this->renderIcon('actions-eye');
+            $parts[] = '</button>';
         }
 
-        // Copy button (only if copy permission is granted and value exists)
         if ($permissions['copy'] && $hasValue) {
-            $html[] = '<button type="button" class="btn btn-secondary t3js-vault-copy" title="Copy to clipboard">';
-            $html[] = $this->renderIcon('actions-clipboard');
-            $html[] = '</button>';
+            $parts[] = '<button type="button" class="btn btn-secondary t3js-vault-copy" title="Copy to clipboard">';
+            $parts[] = $this->renderIcon('actions-clipboard');
+            $parts[] = '</button>';
         }
 
-        // Clear button if value exists and edit permission is granted
         if ($hasValue && $permissions['edit'] && !$permissions['readOnly']) {
-            $html[] = '<button type="button" class="btn btn-secondary t3js-vault-clear" title="Clear secret">';
-            $html[] = $this->renderIcon('actions-delete');
-            $html[] = '</button>';
+            $parts[] = '<button type="button" class="btn btn-secondary t3js-vault-clear" title="Clear secret">';
+            $parts[] = $this->renderIcon('actions-delete');
+            $parts[] = '</button>';
         }
 
-        $html[] = '</div>'; // input-group
-        $html[] = '</div>'; // form-control-wrap
-        $html[] = '</div>'; // form-wizards-element
+        $parts[] = '</div>'; // input-group
 
-        // Render field wizards
-        /** @var array<string, mixed> $fieldWizardResult */
-        $fieldWizardResult = $this->renderFieldWizard();
-        $html[] = \is_string($fieldWizardResult['html'] ?? null) ? $fieldWizardResult['html'] : '';
-        /** @var array<string, mixed> $resultArray */
-        $resultArray = $this->mergeChildReturnIntoExistingResult($resultArray, $fieldWizardResult, false);
+        return implode(self::LINE_FEED, $parts);
+    }
 
-        $html[] = '</div>'; // form-wizards-wrap
-        $html[] = '</div>'; // formengine-field-item
+    /**
+     * Hidden identifier + change-detection checksum. The checksum lets the
+     * DataHandler hook tell "user typed a new value" from "user didn't
+     * touch the field" without ever having the plaintext in the form.
+     */
+    private function renderHiddenFields(string $itemName, string $vaultIdentifier, bool $hasValue): string
+    {
+        $parts = [];
+        $parts[] = '<input type="hidden" name="' . htmlspecialchars($itemName) . '[_vault_identifier]" value="' . htmlspecialchars($vaultIdentifier) . '" />';
 
-        // Hidden field to track vault identifier
-        $html[] = '<input type="hidden" name="' . htmlspecialchars($itemName) . '[_vault_identifier]" value="' . htmlspecialchars($vaultIdentifier) . '" />';
-
-        // Hidden checksum field to detect update vs. new operations
         if ($hasValue && $vaultIdentifier !== '') {
-            $html[] = '<input type="hidden" name="' . htmlspecialchars($itemName) . '[_vault_checksum]" value="' . htmlspecialchars(hash('sha256', $vaultIdentifier)) . '" />';
+            $parts[] = '<input type="hidden" name="' . htmlspecialchars($itemName) . '[_vault_checksum]" value="' . htmlspecialchars(hash('sha256', $vaultIdentifier)) . '" />';
         }
 
-        $resultArray['html'] = implode(self::LINE_FEED, $html);
+        return implode(self::LINE_FEED, $parts);
+    }
 
-        // Add JavaScript module
+    /**
+     * Append the JS module to FormEngine's javaScriptModules array.
+     *
+     * @param array<string, mixed> $resultArray
+     *
+     * @return list<JavaScriptModuleInstruction>
+     */
+    private function appendJsModule(array $resultArray): array
+    {
         /** @var list<JavaScriptModuleInstruction> $javaScriptModules */
         $javaScriptModules = \is_array($resultArray['javaScriptModules'] ?? null) ? $resultArray['javaScriptModules'] : [];
         $javaScriptModules[] = JavaScriptModuleInstruction::create(
             '@netresearch/nr-vault/vault-secret-element.js',
         );
-        $resultArray['javaScriptModules'] = $javaScriptModules;
 
-        return $resultArray;
+        return $javaScriptModules;
     }
 
     /**

--- a/Tests/Unit/Form/Element/VaultSecretElementTest.php
+++ b/Tests/Unit/Form/Element/VaultSecretElementTest.php
@@ -67,8 +67,6 @@ final class VaultSecretElementTest extends TestCase
         // VaultFieldPermissionService is final, so we use a real instance
         // (admin user gives: reveal=true, copy=true, edit=true, readOnly=false)
         $permissionService = new VaultFieldPermissionService();
-        GeneralUtility::setSingletonInstance(VaultFieldPermissionService::class, $permissionService);
-        GeneralUtility::addInstance(VaultServiceInterface::class, $this->vaultService);
 
         // Build a real IconFactory with mocked dependencies
         $icon = $this->createMock(Icon::class);
@@ -84,7 +82,7 @@ final class VaultSecretElementTest extends TestCase
             $runtimeCache,
         );
 
-        $this->subject = new VaultSecretElement($iconFactory);
+        $this->subject = new VaultSecretElement($iconFactory, $permissionService, $this->vaultService);
 
         // Set up NodeFactory mock for renderFieldInformation/renderFieldWizard
         $nodeFactory = $this->createMock(NodeFactory::class);


### PR DESCRIPTION
## Summary

Follow-up to PR #140 — tackles the **genuine high-CC** Sonar findings (CC ≥ 30 + S138). Lower-CC findings (≤24) and the rule-incompatibility findings (S1142 multi-return vs. project's guard-clause style, S1172/S100 TYPO3 hook-API constraints) are deferred to bulk-Accept in Sonar UI.

## Refactored

### \`VaultRotateMasterKeyCommand::execute\` — was 175 LOC + CC 17 + 10 returns (**S138 + S3776 + S1142**)

\`\`\`
execute()            — option resolution + try/finally for memzero
 └─ runRotation()    — pipeline: pre-flight → confirm → verify → loop
     ├─ confirmExecution() — dry-run notice OR require --confirm
     ├─ verifyOldKey()     — smoke-test before touching the vault
     └─ rotateAllSecrets() — transactional batch with progress bar
         ├─ rotateOne()    — re-encrypt one DEK, collect failures
         └─ reportFailures() — render the rollback table
\`\`\`

The 8 duplicate \`sodium_memzero(\$oldKey); sodium_memzero(\$newKey);\` cleanup paths collapse into a single try/finally in execute() — clearer AND more correct (any Throwable now reliably scrubs the keys).

### \`VaultCleanupOrphansCommand::execute\` — was CC 38 + 6 returns (**S3776 + S1142**)

\`\`\`
execute()            — title + delegate
 ├─ parseOptions()    — typed CLI option shape
 ├─ findOrphans()     — outer progress loop
 │   └─ classifyOrphan() — single-secret check
 └─ deleteOrphans()   — delete + summary table + error reporting
\`\`\`

### \`VaultSecretElement::render\` — was 194 LOC + CC 41 (**S3776**)

\`\`\`
render()                  — orchestrator
 ├─ extractRenderContext() — unpack \$this->data into typed bundle
 ├─ probeHasValue()        — getMetadata() existence + access probe
 ├─ resolvePlaceholder()   — "has value" → bullets, else TCA hint
 ├─ buildInputAttributes() — <input> attrs incl. password-manager opt-outs
 ├─ renderVaultDescription() — optional XLIFF description block
 ├─ renderInputGroup()     — <input> + per-permission action buttons
 ├─ renderHiddenFields()   — UUID identifier + change-detect checksum
 └─ appendJsModule()       — push JavaScriptModuleInstruction
\`\`\`

Each helper is well under the CC 15 threshold; \`extractRenderContext()\` owns the FormEngine data-shape translation so downstream helpers receive typed array shapes.

## Skipped — Sonar findings stale (will reconcile on next scan)

- \`VaultService::store\` (CC 50/44) — refactored in PR #138 (H-4), Sonar snapshot pre-dates the merge.
- \`SecureHttpClientFactory::isDangerousIpLiteral\` (CC 41 + 17 returns) — already split into \`isDangerousIpv4\` + \`isDangerousIpv6\` in PR #137.

## Deferred — accept in Sonar UI

| Rule | Count | Why |
|---|---|---|
| \`S1142\` (multi-return) | 39 | Project uses guard-clause / early-return style; forcing single-return produces worse code |
| \`S3776\` ≤ 24 | ~20 | Just-over-threshold CC; refactor adds ceremony helpers without clarity gain |
| \`S1172\` | 9 | TYPO3 hook signatures mandated (\`\$pasteUpdate\`, \`\$fieldArray\`, \`\$value\`) |
| \`S100\` | 11 | TYPO3 hook naming mandated (\`processDatamap_*\`) |
| \`S1448\` ×3 | 3 | God classes (Secret = H-5, AuditLogService, VaultHttpResponse) |
| \`S107\` ×2 | 2 | Secret.php = H-5; AuditLogServiceInterface = stable public API |

## Test plan

- [x] 1752 unit tests pass (unchanged, no behaviour change)
- [x] cgl + rector + PHPStan level 10 green locally
- [ ] CI matrix
- [ ] Manual smoke-test of \`vault:rotate-master-key --dry-run\` (large refactor of secret-touching command)