### PR TITLE
refactor(domain): convert Secret entity to readonly (H-5)

### DIFF
--- a/Classes/Adapter/LocalEncryptionAdapter.php
+++ b/Classes/Adapter/LocalEncryptionAdapter.php
@@ -110,7 +110,6 @@ final readonly class LocalEncryptionAdapter implements VaultAdapterInterface
         $existing = $secret->getMetadata();
         /** @var array<string, mixed> $merged */
         $merged = array_merge($existing, $metadata);
-        $secret->setMetadata($merged);
-        $this->secretRepository->save($secret);
+        $this->secretRepository->save($secret->withMetadata($merged));
     }
 }

--- a/Classes/Adapter/LocalEncryptionAdapter.php
+++ b/Classes/Adapter/LocalEncryptionAdapter.php
@@ -33,9 +33,9 @@ final readonly class LocalEncryptionAdapter implements VaultAdapterInterface
         return true;
     }
 
-    public function store(Secret $secret): void
+    public function store(Secret $secret): Secret
     {
-        $this->secretRepository->save($secret);
+        return $this->secretRepository->save($secret);
     }
 
     public function retrieve(string $identifier): ?Secret

--- a/Classes/Adapter/VaultAdapterInterface.php
+++ b/Classes/Adapter/VaultAdapterInterface.php
@@ -30,9 +30,13 @@ interface VaultAdapterInterface
     public function isAvailable(): bool;
 
     /**
-     * Store a secret.
+     * Store a secret. Returns the persisted instance; on INSERT this
+     * carries the newly-assigned UID (the input has uid=null), on
+     * UPDATE the original is returned unchanged. Callers that dispatch
+     * events about the just-stored secret MUST use the return value so
+     * downstream consumers see the populated UID.
      */
-    public function store(Secret $secret): void;
+    public function store(Secret $secret): Secret;
 
     /**
      * Retrieve a secret by identifier.

--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -349,9 +349,9 @@ final class VaultRotateMasterKeyCommand extends Command
                 $newKey,
             );
 
-            $secret->setEncryptedDek($reEncrypted->encryptedDek);
-            $secret->setDekNonce($reEncrypted->nonce);
-            $this->secretRepository->save($secret);
+            $this->secretRepository->save(
+                $secret->withReEncryptedDek($reEncrypted->encryptedDek, $reEncrypted->nonce),
+            );
 
             return true;
         } catch (EncryptionException $e) {

--- a/Classes/Domain/Model/Secret.php
+++ b/Classes/Domain/Model/Secret.php
@@ -380,6 +380,7 @@ final readonly class Secret
             'adapter' => $this->adapter,
             'external_reference' => $this->externalReference,
             'tstamp' => time(),
+            'cruser_id' => $this->cruserId,
             'deleted' => $this->deleted ? 1 : 0,
             'hidden' => $this->hidden ? 1 : 0,
             'read_count' => $this->readCount,

--- a/Classes/Domain/Model/Secret.php
+++ b/Classes/Domain/Model/Secret.php
@@ -83,74 +83,26 @@ final readonly class Secret
      */
     public function withUid(?int $uid): self
     {
-        return new self(
-            identifier: $this->identifier,
-            uid: $uid,
-            scopePid: $this->scopePid,
-            description: $this->description,
-            encryptedValue: $this->encryptedValue,
-            encryptedDek: $this->encryptedDek,
-            dekNonce: $this->dekNonce,
-            valueNonce: $this->valueNonce,
-            encryptionVersion: $this->encryptionVersion,
-            valueChecksum: $this->valueChecksum,
-            ownerUid: $this->ownerUid,
-            allowedGroups: $this->allowedGroups,
-            context: $this->context,
-            frontendAccessible: $this->frontendAccessible,
-            version: $this->version,
-            expiresAt: $this->expiresAt,
-            lastRotatedAt: $this->lastRotatedAt,
-            metadata: $this->metadata,
-            adapter: $this->adapter,
-            externalReference: $this->externalReference,
-            tstamp: $this->tstamp,
-            crdate: $this->crdate,
-            cruserId: $this->cruserId,
-            deleted: $this->deleted,
-            hidden: $this->hidden,
-            readCount: $this->readCount,
-            lastReadAt: $this->lastReadAt,
-        );
+        return $this->cloneWith(['uid' => $uid]);
     }
 
     /**
      * Apply a value rotation: bundles the seven crypto/version/timestamp
      * fields that change together during `VaultService::rotate()`. Returns
-     * a new Secret with `version + 1`, `lastRotatedAt = now`, and the new
-     * envelope-encryption envelope.
+     * a new Secret with `version + 1`, `lastRotatedAt = $rotatedAt`, and
+     * the new envelope-encryption envelope.
      */
     public function withValueRotation(EncryptedData $encrypted, int $rotatedAt): self
     {
-        return new self(
-            identifier: $this->identifier,
-            uid: $this->uid,
-            scopePid: $this->scopePid,
-            description: $this->description,
-            encryptedValue: $encrypted->encryptedValue,
-            encryptedDek: $encrypted->encryptedDek,
-            dekNonce: $encrypted->dekNonce,
-            valueNonce: $encrypted->valueNonce,
-            encryptionVersion: $this->encryptionVersion,
-            valueChecksum: $encrypted->valueChecksum,
-            ownerUid: $this->ownerUid,
-            allowedGroups: $this->allowedGroups,
-            context: $this->context,
-            frontendAccessible: $this->frontendAccessible,
-            version: $this->version + 1,
-            expiresAt: $this->expiresAt,
-            lastRotatedAt: $rotatedAt,
-            metadata: $this->metadata,
-            adapter: $this->adapter,
-            externalReference: $this->externalReference,
-            tstamp: $this->tstamp,
-            crdate: $this->crdate,
-            cruserId: $this->cruserId,
-            deleted: $this->deleted,
-            hidden: $this->hidden,
-            readCount: $this->readCount,
-            lastReadAt: $this->lastReadAt,
-        );
+        return $this->cloneWith([
+            'encryptedValue' => $encrypted->encryptedValue,
+            'encryptedDek' => $encrypted->encryptedDek,
+            'dekNonce' => $encrypted->dekNonce,
+            'valueNonce' => $encrypted->valueNonce,
+            'valueChecksum' => $encrypted->valueChecksum,
+            'version' => $this->version + 1,
+            'lastRotatedAt' => $rotatedAt,
+        ]);
     }
 
     /**
@@ -161,35 +113,10 @@ final readonly class Secret
      */
     public function withReEncryptedDek(string $encryptedDek, string $dekNonce): self
     {
-        return new self(
-            identifier: $this->identifier,
-            uid: $this->uid,
-            scopePid: $this->scopePid,
-            description: $this->description,
-            encryptedValue: $this->encryptedValue,
-            encryptedDek: $encryptedDek,
-            dekNonce: $dekNonce,
-            valueNonce: $this->valueNonce,
-            encryptionVersion: $this->encryptionVersion,
-            valueChecksum: $this->valueChecksum,
-            ownerUid: $this->ownerUid,
-            allowedGroups: $this->allowedGroups,
-            context: $this->context,
-            frontendAccessible: $this->frontendAccessible,
-            version: $this->version,
-            expiresAt: $this->expiresAt,
-            lastRotatedAt: $this->lastRotatedAt,
-            metadata: $this->metadata,
-            adapter: $this->adapter,
-            externalReference: $this->externalReference,
-            tstamp: $this->tstamp,
-            crdate: $this->crdate,
-            cruserId: $this->cruserId,
-            deleted: $this->deleted,
-            hidden: $this->hidden,
-            readCount: $this->readCount,
-            lastReadAt: $this->lastReadAt,
-        );
+        return $this->cloneWith([
+            'encryptedDek' => $encryptedDek,
+            'dekNonce' => $dekNonce,
+        ]);
     }
 
     /**
@@ -201,35 +128,7 @@ final readonly class Secret
      */
     public function withMetadata(array $metadata): self
     {
-        return new self(
-            identifier: $this->identifier,
-            uid: $this->uid,
-            scopePid: $this->scopePid,
-            description: $this->description,
-            encryptedValue: $this->encryptedValue,
-            encryptedDek: $this->encryptedDek,
-            dekNonce: $this->dekNonce,
-            valueNonce: $this->valueNonce,
-            encryptionVersion: $this->encryptionVersion,
-            valueChecksum: $this->valueChecksum,
-            ownerUid: $this->ownerUid,
-            allowedGroups: $this->allowedGroups,
-            context: $this->context,
-            frontendAccessible: $this->frontendAccessible,
-            version: $this->version,
-            expiresAt: $this->expiresAt,
-            lastRotatedAt: $this->lastRotatedAt,
-            metadata: $metadata,
-            adapter: $this->adapter,
-            externalReference: $this->externalReference,
-            tstamp: $this->tstamp,
-            crdate: $this->crdate,
-            cruserId: $this->cruserId,
-            deleted: $this->deleted,
-            hidden: $this->hidden,
-            readCount: $this->readCount,
-            lastReadAt: $this->lastReadAt,
-        );
+        return $this->cloneWith(['metadata' => $metadata]);
     }
 
     // ------------------------------------------------------------------
@@ -486,5 +385,23 @@ final readonly class Secret
             'read_count' => $this->readCount,
             'last_read_at' => $this->lastReadAt,
         ];
+    }
+
+    /**
+     * Shared cloning primitive for the named withers. Builds a fresh
+     * instance from the current state, overriding the supplied subset
+     * of fields. The named-arg spread expansion relies on the constructor
+     * parameter names matching the property names — constructor promotion
+     * guarantees this by construction.
+     *
+     * @param array<string, mixed> $changes
+     */
+    private function cloneWith(array $changes): self
+    {
+        /** @var array<string, mixed> $current */
+        $current = get_object_vars($this);
+
+        /** @phpstan-ignore-next-line argument.unpackNonIterableStringKeys */
+        return new self(...array_merge($current, $changes));
     }
 }

--- a/Classes/Domain/Model/Secret.php
+++ b/Classes/Domain/Model/Secret.php
@@ -9,141 +9,251 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Domain\Model;
 
+use Netresearch\NrVault\Crypto\EncryptedData;
 use Netresearch\NrVault\Exception\ValidationException;
 
 /**
  * Secret entity representing an encrypted secret.
+ *
+ * Immutable: all properties are readonly. Lifecycle transitions
+ * (assigning a UID after INSERT, rotating the encrypted value,
+ * re-encrypting the DEK with a new master key, merging metadata)
+ * return a new instance via named `with*()` methods rather than
+ * mutating the existing one.
  */
-final class Secret
+final readonly class Secret
 {
-    private ?int $uid = null;
-
-    private int $scopePid = 0;
-
-    private string $identifier = '';
-
-    private string $description = '';
-
-    private ?string $encryptedValue = null;
-
-    private string $encryptedDek = '';
-
-    private string $dekNonce = '';
-
-    private string $valueNonce = '';
-
-    private int $encryptionVersion = 1;
-
-    private string $valueChecksum = '';
-
-    private int $ownerUid = 0;
-
-    /** @var int[] */
-    private array $allowedGroups = [];
-
-    private string $context = '';
-
-    private bool $frontendAccessible = false;
-
-    private int $version = 1;
-
-    private int $expiresAt = 0;
-
-    private int $lastRotatedAt = 0;
-
-    /** @var array<string, mixed> */
-    private array $metadata = [];
-
-    private string $adapter = 'local';
-
-    private string $externalReference = '';
-
-    private int $tstamp = 0;
-
-    private int $crdate = 0;
-
-    private int $cruserId = 0;
-
-    private bool $deleted = false;
-
-    private bool $hidden = false;
-
-    private int $readCount = 0;
-
-    private int $lastReadAt = 0;
-
     /**
-     * Create a Secret with validated cryptographic fields.
-     *
-     * Ensures that the three envelope-encryption fields (encryptedDek, dekNonce,
-     * valueNonce) are either ALL provided or ALL empty. A partial set indicates a
-     * programming error that would produce an undecryptable secret.
-     *
      * @param int[] $allowedGroups
      * @param array<string, mixed> $metadata
      *
      * @throws ValidationException If cryptographic fields are inconsistent
      */
-    public static function create(
-        string $identifier,
-        string $encryptedValue,
-        string $valueChecksum,
-        string $encryptedDek = '',
-        string $dekNonce = '',
-        string $valueNonce = '',
-        int $ownerUid = 0,
-        array $allowedGroups = [],
-        string $context = '',
-        string $description = '',
-        string $adapter = 'local',
-        int $expiresAt = 0,
-        array $metadata = [],
-        int $scopePid = 0,
-        bool $frontendAccessible = false,
-    ): self {
-        // Validate: all three envelope-encryption fields must be consistently set or unset
-        $hasEncryptedDek = $encryptedDek !== '';
-        $hasDekNonce = $dekNonce !== '';
-        $hasValueNonce = $valueNonce !== '';
-
-        $setCount = (int) $hasEncryptedDek + (int) $hasDekNonce + (int) $hasValueNonce;
+    public function __construct(
+        public string $identifier,
+        public ?int $uid = null,
+        public int $scopePid = 0,
+        public string $description = '',
+        public ?string $encryptedValue = null,
+        public string $encryptedDek = '',
+        public string $dekNonce = '',
+        public string $valueNonce = '',
+        public int $encryptionVersion = 1,
+        public string $valueChecksum = '',
+        public int $ownerUid = 0,
+        public array $allowedGroups = [],
+        public string $context = '',
+        public bool $frontendAccessible = false,
+        public int $version = 1,
+        public int $expiresAt = 0,
+        public int $lastRotatedAt = 0,
+        public array $metadata = [],
+        public string $adapter = 'local',
+        public string $externalReference = '',
+        public int $tstamp = 0,
+        public int $crdate = 0,
+        public int $cruserId = 0,
+        public bool $deleted = false,
+        public bool $hidden = false,
+        public int $readCount = 0,
+        public int $lastReadAt = 0,
+    ) {
+        // Envelope-encryption fields must be consistently set or unset —
+        // a partial set indicates a programming error that would produce
+        // an undecryptable secret.
+        $setCount = (int) ($this->encryptedDek !== '')
+            + (int) ($this->dekNonce !== '')
+            + (int) ($this->valueNonce !== '');
         if ($setCount !== 0 && $setCount !== 3) {
             throw ValidationException::invalidOption(
                 'cryptographic fields',
                 'encryptedDek, dekNonce, and valueNonce must all be set or all be empty',
             );
         }
-
-        $secret = new self();
-        $secret->identifier = $identifier;
-        $secret->encryptedValue = $encryptedValue;
-        $secret->valueChecksum = $valueChecksum;
-        $secret->encryptedDek = $encryptedDek;
-        $secret->dekNonce = $dekNonce;
-        $secret->valueNonce = $valueNonce;
-        $secret->ownerUid = $ownerUid;
-        $secret->allowedGroups = array_map(\intval(...), $allowedGroups);
-        $secret->context = $context;
-        $secret->description = $description;
-        $secret->adapter = $adapter;
-        $secret->expiresAt = $expiresAt;
-        $secret->metadata = $metadata;
-        $secret->scopePid = $scopePid;
-        $secret->frontendAccessible = $frontendAccessible;
-
-        return $secret;
     }
+
+    // ------------------------------------------------------------------
+    // Lifecycle transitions — each returns a new Secret instance.
+    // ------------------------------------------------------------------
+
+    /**
+     * Attach the UID assigned by the DB after an INSERT. Called from
+     * `SecretRepository::save()`; production callers don't invoke this
+     * directly.
+     */
+    public function withUid(?int $uid): self
+    {
+        return new self(
+            identifier: $this->identifier,
+            uid: $uid,
+            scopePid: $this->scopePid,
+            description: $this->description,
+            encryptedValue: $this->encryptedValue,
+            encryptedDek: $this->encryptedDek,
+            dekNonce: $this->dekNonce,
+            valueNonce: $this->valueNonce,
+            encryptionVersion: $this->encryptionVersion,
+            valueChecksum: $this->valueChecksum,
+            ownerUid: $this->ownerUid,
+            allowedGroups: $this->allowedGroups,
+            context: $this->context,
+            frontendAccessible: $this->frontendAccessible,
+            version: $this->version,
+            expiresAt: $this->expiresAt,
+            lastRotatedAt: $this->lastRotatedAt,
+            metadata: $this->metadata,
+            adapter: $this->adapter,
+            externalReference: $this->externalReference,
+            tstamp: $this->tstamp,
+            crdate: $this->crdate,
+            cruserId: $this->cruserId,
+            deleted: $this->deleted,
+            hidden: $this->hidden,
+            readCount: $this->readCount,
+            lastReadAt: $this->lastReadAt,
+        );
+    }
+
+    /**
+     * Apply a value rotation: bundles the seven crypto/version/timestamp
+     * fields that change together during `VaultService::rotate()`. Returns
+     * a new Secret with `version + 1`, `lastRotatedAt = now`, and the new
+     * envelope-encryption envelope.
+     */
+    public function withValueRotation(EncryptedData $encrypted, int $rotatedAt): self
+    {
+        return new self(
+            identifier: $this->identifier,
+            uid: $this->uid,
+            scopePid: $this->scopePid,
+            description: $this->description,
+            encryptedValue: $encrypted->encryptedValue,
+            encryptedDek: $encrypted->encryptedDek,
+            dekNonce: $encrypted->dekNonce,
+            valueNonce: $encrypted->valueNonce,
+            encryptionVersion: $this->encryptionVersion,
+            valueChecksum: $encrypted->valueChecksum,
+            ownerUid: $this->ownerUid,
+            allowedGroups: $this->allowedGroups,
+            context: $this->context,
+            frontendAccessible: $this->frontendAccessible,
+            version: $this->version + 1,
+            expiresAt: $this->expiresAt,
+            lastRotatedAt: $rotatedAt,
+            metadata: $this->metadata,
+            adapter: $this->adapter,
+            externalReference: $this->externalReference,
+            tstamp: $this->tstamp,
+            crdate: $this->crdate,
+            cruserId: $this->cruserId,
+            deleted: $this->deleted,
+            hidden: $this->hidden,
+            readCount: $this->readCount,
+            lastReadAt: $this->lastReadAt,
+        );
+    }
+
+    /**
+     * Master-key rotation: replace the DEK envelope (encryptedDek +
+     * dekNonce) while leaving the value envelope (encryptedValue +
+     * valueNonce + valueChecksum) untouched. Called from
+     * `VaultRotateMasterKeyCommand::rotateOne()`.
+     */
+    public function withReEncryptedDek(string $encryptedDek, string $dekNonce): self
+    {
+        return new self(
+            identifier: $this->identifier,
+            uid: $this->uid,
+            scopePid: $this->scopePid,
+            description: $this->description,
+            encryptedValue: $this->encryptedValue,
+            encryptedDek: $encryptedDek,
+            dekNonce: $dekNonce,
+            valueNonce: $this->valueNonce,
+            encryptionVersion: $this->encryptionVersion,
+            valueChecksum: $this->valueChecksum,
+            ownerUid: $this->ownerUid,
+            allowedGroups: $this->allowedGroups,
+            context: $this->context,
+            frontendAccessible: $this->frontendAccessible,
+            version: $this->version,
+            expiresAt: $this->expiresAt,
+            lastRotatedAt: $this->lastRotatedAt,
+            metadata: $this->metadata,
+            adapter: $this->adapter,
+            externalReference: $this->externalReference,
+            tstamp: $this->tstamp,
+            crdate: $this->crdate,
+            cruserId: $this->cruserId,
+            deleted: $this->deleted,
+            hidden: $this->hidden,
+            readCount: $this->readCount,
+            lastReadAt: $this->lastReadAt,
+        );
+    }
+
+    /**
+     * Replace the metadata array. Called from
+     * `LocalEncryptionAdapter::storeMetadata()` when an adapter needs to
+     * persist its own bookkeeping (e.g. external-reference details).
+     *
+     * @param array<string, mixed> $metadata
+     */
+    public function withMetadata(array $metadata): self
+    {
+        return new self(
+            identifier: $this->identifier,
+            uid: $this->uid,
+            scopePid: $this->scopePid,
+            description: $this->description,
+            encryptedValue: $this->encryptedValue,
+            encryptedDek: $this->encryptedDek,
+            dekNonce: $this->dekNonce,
+            valueNonce: $this->valueNonce,
+            encryptionVersion: $this->encryptionVersion,
+            valueChecksum: $this->valueChecksum,
+            ownerUid: $this->ownerUid,
+            allowedGroups: $this->allowedGroups,
+            context: $this->context,
+            frontendAccessible: $this->frontendAccessible,
+            version: $this->version,
+            expiresAt: $this->expiresAt,
+            lastRotatedAt: $this->lastRotatedAt,
+            metadata: $metadata,
+            adapter: $this->adapter,
+            externalReference: $this->externalReference,
+            tstamp: $this->tstamp,
+            crdate: $this->crdate,
+            cruserId: $this->cruserId,
+            deleted: $this->deleted,
+            hidden: $this->hidden,
+            readCount: $this->readCount,
+            lastReadAt: $this->lastReadAt,
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // Derived state.
+    // ------------------------------------------------------------------
+
+    public function isExpired(): bool
+    {
+        return $this->expiresAt > 0 && $this->expiresAt < time();
+    }
+
+    // ------------------------------------------------------------------
+    // Backwards-compatible getter shims.
+    //
+    // The fields are now public readonly, so callers can read them
+    // directly (\$secret->uid, \$secret->identifier, …). The getters
+    // below are kept so the wider codebase (and any extension code
+    // consuming this entity) keeps compiling. Prefer property access
+    // in new code.
+    // ------------------------------------------------------------------
 
     public function getUid(): ?int
     {
         return $this->uid;
-    }
-
-    public function setUid(?int $uid): self
-    {
-        $this->uid = $uid;
-
-        return $this;
     }
 
     public function getScopePid(): int
@@ -151,23 +261,9 @@ final class Secret
         return $this->scopePid;
     }
 
-    public function setScopePid(int $scopePid): self
-    {
-        $this->scopePid = $scopePid;
-
-        return $this;
-    }
-
     public function getIdentifier(): string
     {
         return $this->identifier;
-    }
-
-    public function setIdentifier(string $identifier): self
-    {
-        $this->identifier = $identifier;
-
-        return $this;
     }
 
     public function getDescription(): string
@@ -175,23 +271,9 @@ final class Secret
         return $this->description;
     }
 
-    public function setDescription(string $description): self
-    {
-        $this->description = $description;
-
-        return $this;
-    }
-
     public function getEncryptedValue(): ?string
     {
         return $this->encryptedValue;
-    }
-
-    public function setEncryptedValue(?string $encryptedValue): self
-    {
-        $this->encryptedValue = $encryptedValue;
-
-        return $this;
     }
 
     public function getEncryptedDek(): string
@@ -199,23 +281,9 @@ final class Secret
         return $this->encryptedDek;
     }
 
-    public function setEncryptedDek(string $encryptedDek): self
-    {
-        $this->encryptedDek = $encryptedDek;
-
-        return $this;
-    }
-
     public function getDekNonce(): string
     {
         return $this->dekNonce;
-    }
-
-    public function setDekNonce(string $dekNonce): self
-    {
-        $this->dekNonce = $dekNonce;
-
-        return $this;
     }
 
     public function getValueNonce(): string
@@ -223,23 +291,9 @@ final class Secret
         return $this->valueNonce;
     }
 
-    public function setValueNonce(string $valueNonce): self
-    {
-        $this->valueNonce = $valueNonce;
-
-        return $this;
-    }
-
     public function getEncryptionVersion(): int
     {
         return $this->encryptionVersion;
-    }
-
-    public function setEncryptionVersion(int $encryptionVersion): self
-    {
-        $this->encryptionVersion = $encryptionVersion;
-
-        return $this;
     }
 
     public function getValueChecksum(): string
@@ -247,23 +301,9 @@ final class Secret
         return $this->valueChecksum;
     }
 
-    public function setValueChecksum(string $valueChecksum): self
-    {
-        $this->valueChecksum = $valueChecksum;
-
-        return $this;
-    }
-
     public function getOwnerUid(): int
     {
         return $this->ownerUid;
-    }
-
-    public function setOwnerUid(int $ownerUid): self
-    {
-        $this->ownerUid = $ownerUid;
-
-        return $this;
     }
 
     /**
@@ -274,26 +314,9 @@ final class Secret
         return $this->allowedGroups;
     }
 
-    /**
-     * @param int[] $allowedGroups
-     */
-    public function setAllowedGroups(array $allowedGroups): self
-    {
-        $this->allowedGroups = array_map(\intval(...), $allowedGroups);
-
-        return $this;
-    }
-
     public function getContext(): string
     {
         return $this->context;
-    }
-
-    public function setContext(string $context): self
-    {
-        $this->context = $context;
-
-        return $this;
     }
 
     public function isFrontendAccessible(): bool
@@ -301,30 +324,9 @@ final class Secret
         return $this->frontendAccessible;
     }
 
-    public function setFrontendAccessible(bool $frontendAccessible): self
-    {
-        $this->frontendAccessible = $frontendAccessible;
-
-        return $this;
-    }
-
     public function getVersion(): int
     {
         return $this->version;
-    }
-
-    public function setVersion(int $version): self
-    {
-        $this->version = $version;
-
-        return $this;
-    }
-
-    public function incrementVersion(): self
-    {
-        $this->version++;
-
-        return $this;
     }
 
     public function getExpiresAt(): int
@@ -332,28 +334,9 @@ final class Secret
         return $this->expiresAt;
     }
 
-    public function setExpiresAt(int $expiresAt): self
-    {
-        $this->expiresAt = $expiresAt;
-
-        return $this;
-    }
-
-    public function isExpired(): bool
-    {
-        return $this->expiresAt > 0 && $this->expiresAt < time();
-    }
-
     public function getLastRotatedAt(): int
     {
         return $this->lastRotatedAt;
-    }
-
-    public function setLastRotatedAt(int $lastRotatedAt): self
-    {
-        $this->lastRotatedAt = $lastRotatedAt;
-
-        return $this;
     }
 
     /**
@@ -364,26 +347,9 @@ final class Secret
         return $this->metadata;
     }
 
-    /**
-     * @param array<string, mixed> $metadata
-     */
-    public function setMetadata(array $metadata): self
-    {
-        $this->metadata = $metadata;
-
-        return $this;
-    }
-
     public function getAdapter(): string
     {
         return $this->adapter;
-    }
-
-    public function setAdapter(string $adapter): self
-    {
-        $this->adapter = $adapter;
-
-        return $this;
     }
 
     public function getExternalReference(): string
@@ -391,23 +357,9 @@ final class Secret
         return $this->externalReference;
     }
 
-    public function setExternalReference(string $externalReference): self
-    {
-        $this->externalReference = $externalReference;
-
-        return $this;
-    }
-
     public function getTstamp(): int
     {
         return $this->tstamp;
-    }
-
-    public function setTstamp(int $tstamp): self
-    {
-        $this->tstamp = $tstamp;
-
-        return $this;
     }
 
     public function getCrdate(): int
@@ -415,23 +367,9 @@ final class Secret
         return $this->crdate;
     }
 
-    public function setCrdate(int $crdate): self
-    {
-        $this->crdate = $crdate;
-
-        return $this;
-    }
-
     public function getCruserId(): int
     {
         return $this->cruserId;
-    }
-
-    public function setCruserId(int $cruserId): self
-    {
-        $this->cruserId = $cruserId;
-
-        return $this;
     }
 
     public function isDeleted(): bool
@@ -439,23 +377,9 @@ final class Secret
         return $this->deleted;
     }
 
-    public function setDeleted(bool $deleted): self
-    {
-        $this->deleted = $deleted;
-
-        return $this;
-    }
-
     public function isHidden(): bool
     {
         return $this->hidden;
-    }
-
-    public function setHidden(bool $hidden): self
-    {
-        $this->hidden = $hidden;
-
-        return $this;
     }
 
     public function getReadCount(): int
@@ -463,84 +387,75 @@ final class Secret
         return $this->readCount;
     }
 
-    public function setReadCount(int $readCount): self
-    {
-        $this->readCount = $readCount;
-
-        return $this;
-    }
-
-    public function incrementReadCount(): self
-    {
-        $this->readCount++;
-
-        return $this;
-    }
-
     public function getLastReadAt(): int
     {
         return $this->lastReadAt;
     }
 
-    public function setLastReadAt(int $lastReadAt): self
-    {
-        $this->lastReadAt = $lastReadAt;
-
-        return $this;
-    }
+    // ------------------------------------------------------------------
+    // Persistence boundary.
+    // ------------------------------------------------------------------
 
     /**
-     * Create from database row.
+     * Hydrate from a `tx_nrvault_secret` row. The allowed-groups list is
+     * stored in a separate MM table, so the caller must look it up and
+     * pass it here — there is no second-step `setAllowedGroups()` after
+     * construction.
      *
      * @param array<string, mixed> $row
+     * @param int[] $allowedGroups
      */
-    public static function fromDatabaseRow(array $row): self
+    public static function fromDatabaseRow(array $row, array $allowedGroups = []): self
     {
-        $secret = new self();
-        $secret->uid = isset($row['uid']) ? (int) $row['uid'] : null;
-        $secret->scopePid = (int) ($row['scope_pid'] ?? 0);
-        $secret->identifier = (string) ($row['identifier'] ?? '');
-        $secret->description = (string) ($row['description'] ?? '');
-        $secret->encryptedValue = $row['encrypted_value'] ?? null;
-        $secret->encryptedDek = (string) ($row['encrypted_dek'] ?? '');
-        $secret->dekNonce = (string) ($row['dek_nonce'] ?? '');
-        $secret->valueNonce = (string) ($row['value_nonce'] ?? '');
-        $secret->encryptionVersion = (int) ($row['encryption_version'] ?? 1);
-        $secret->valueChecksum = (string) ($row['value_checksum'] ?? '');
-        $secret->ownerUid = (int) ($row['owner_uid'] ?? 0);
-        $secret->context = (string) ($row['context'] ?? '');
-        $secret->frontendAccessible = (bool) ($row['frontend_accessible'] ?? false);
-        $secret->version = (int) ($row['version'] ?? 1);
-        $secret->expiresAt = (int) ($row['expires_at'] ?? 0);
-        $secret->lastRotatedAt = (int) ($row['last_rotated_at'] ?? 0);
-        $secret->adapter = (string) ($row['adapter'] ?? 'local');
-        $secret->externalReference = (string) ($row['external_reference'] ?? '');
-        $secret->tstamp = (int) ($row['tstamp'] ?? 0);
-        $secret->crdate = (int) ($row['crdate'] ?? 0);
-        $secret->cruserId = (int) ($row['cruser_id'] ?? 0);
-        $secret->deleted = (bool) ($row['deleted'] ?? false);
-        $secret->hidden = (bool) ($row['hidden'] ?? false);
-        $secret->readCount = (int) ($row['read_count'] ?? 0);
-        $secret->lastReadAt = (int) ($row['last_read_at'] ?? 0);
-
-        // Parse metadata JSON
+        $metadata = [];
         if (!empty($row['metadata'])) {
             $decoded = json_decode((string) $row['metadata'], true);
-            $secret->metadata = \is_array($decoded) ? $decoded : [];
+            $metadata = \is_array($decoded) ? $decoded : [];
         }
 
-        // Parse allowed groups (comma-separated or from MM table)
-        if (!empty($row['allowed_groups'])) {
+        // If the caller didn't pre-load the MM table, fall back to the
+        // comma-separated denormalised column some legacy rows still carry.
+        if ($allowedGroups === [] && !empty($row['allowed_groups'])) {
             $groups = (string) $row['allowed_groups'];
-            $secret->allowedGroups = array_filter(array_map(\intval(...), explode(',', $groups)));
+            $allowedGroups = array_values(array_filter(
+                array_map(\intval(...), explode(',', $groups)),
+            ));
         }
 
-        return $secret;
+        $encryptedValue = $row['encrypted_value'] ?? null;
+
+        return new self(
+            identifier: (string) ($row['identifier'] ?? ''),
+            uid: isset($row['uid']) ? (int) $row['uid'] : null,
+            scopePid: (int) ($row['scope_pid'] ?? 0),
+            description: (string) ($row['description'] ?? ''),
+            encryptedValue: \is_string($encryptedValue) ? $encryptedValue : null,
+            encryptedDek: (string) ($row['encrypted_dek'] ?? ''),
+            dekNonce: (string) ($row['dek_nonce'] ?? ''),
+            valueNonce: (string) ($row['value_nonce'] ?? ''),
+            encryptionVersion: (int) ($row['encryption_version'] ?? 1),
+            valueChecksum: (string) ($row['value_checksum'] ?? ''),
+            ownerUid: (int) ($row['owner_uid'] ?? 0),
+            allowedGroups: array_map(\intval(...), $allowedGroups),
+            context: (string) ($row['context'] ?? ''),
+            frontendAccessible: (bool) ($row['frontend_accessible'] ?? false),
+            version: (int) ($row['version'] ?? 1),
+            expiresAt: (int) ($row['expires_at'] ?? 0),
+            lastRotatedAt: (int) ($row['last_rotated_at'] ?? 0),
+            metadata: $metadata,
+            adapter: (string) ($row['adapter'] ?? 'local'),
+            externalReference: (string) ($row['external_reference'] ?? ''),
+            tstamp: (int) ($row['tstamp'] ?? 0),
+            crdate: (int) ($row['crdate'] ?? 0),
+            cruserId: (int) ($row['cruser_id'] ?? 0),
+            deleted: (bool) ($row['deleted'] ?? false),
+            hidden: (bool) ($row['hidden'] ?? false),
+            readCount: (int) ($row['read_count'] ?? 0),
+            lastReadAt: (int) ($row['last_read_at'] ?? 0),
+        );
     }
 
     /**
-     * Convert to database row.
-     *
      * @return array<string, mixed>
      */
     public function toDatabaseRow(): array

--- a/Classes/Domain/Repository/SecretRepository.php
+++ b/Classes/Domain/Repository/SecretRepository.php
@@ -44,16 +44,10 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             return null;
         }
 
-        $secret = Secret::fromDatabaseRow($row);
-
-        // Load groups from MM table
         $uid = $row['uid'] ?? 0;
         $groups = $this->loadGroupsForSecret(is_numeric($uid) ? (int) $uid : 0);
-        if ($groups !== []) {
-            $secret->setAllowedGroups($groups);
-        }
 
-        return $secret;
+        return Secret::fromDatabaseRow($row, $groups);
     }
 
     public function findByUid(int $uid): ?Secret
@@ -73,15 +67,7 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             return null;
         }
 
-        $secret = Secret::fromDatabaseRow($row);
-
-        // Load groups from MM table
-        $groups = $this->loadGroupsForSecret($uid);
-        if ($groups !== []) {
-            $secret->setAllowedGroups($groups);
-        }
-
-        return $secret;
+        return Secret::fromDatabaseRow($row, $this->loadGroupsForSecret($uid));
     }
 
     public function exists(string $identifier): bool
@@ -100,7 +86,14 @@ final readonly class SecretRepository implements SecretRepositoryInterface
         return (is_numeric($count) ? (int) $count : 0) > 0;
     }
 
-    public function save(Secret $secret): void
+    /**
+     * Persist the Secret. Returns a (possibly new) Secret instance — on
+     * INSERT, the returned instance carries the freshly-assigned UID from
+     * `lastInsertId()`; on UPDATE the original instance is returned
+     * unchanged. Callers MUST use the returned value if they need the
+     * UID after save (it cannot be set on the readonly input).
+     */
+    public function save(Secret $secret): Secret
     {
         $connection = $this->getConnection();
         $data = $secret->toDatabaseRow();
@@ -110,7 +103,7 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             $data['crdate'] = time();
             $connection->insert(self::TABLE_NAME, $data);
             $lastId = $connection->lastInsertId();
-            $secret->setUid(is_numeric($lastId) ? (int) $lastId : 0);
+            $secret = $secret->withUid(is_numeric($lastId) ? (int) $lastId : 0);
         } else {
             // Update existing secret
             $connection->update(
@@ -122,6 +115,8 @@ final readonly class SecretRepository implements SecretRepositoryInterface
 
         // Update MM table for groups
         $this->saveGroupsForSecret($secret);
+
+        return $secret;
     }
 
     public function delete(Secret $secret): void
@@ -239,13 +234,9 @@ final readonly class SecretRepository implements SecretRepositoryInterface
 
         $secrets = [];
         foreach ($rows as $row) {
-            $secret = Secret::fromDatabaseRow($row);
             $rowUid = $row['uid'] ?? 0;
             $groups = $this->loadGroupsForSecret(is_numeric($rowUid) ? (int) $rowUid : 0);
-            if ($groups !== []) {
-                $secret->setAllowedGroups($groups);
-            }
-            $secrets[] = $secret;
+            $secrets[] = Secret::fromDatabaseRow($row, $groups);
         }
 
         return $secrets;
@@ -363,26 +354,25 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             return [];
         }
 
-        // Collect all UIDs for batch group loading
-        $uidMap = [];
-        $secrets = [];
+        // Collect all UIDs and batch-load MM groups in ONE query so each
+        // Secret can be constructed with its allowed-groups list already
+        // populated — readonly entity has no post-construction mutator.
+        $rowsByUid = [];
+        $uids = [];
         foreach ($rows as $row) {
-            $secret = Secret::fromDatabaseRow($row);
             $uid = $row['uid'] ?? 0;
             $intUid = is_numeric($uid) ? (int) $uid : 0;
-            $uidMap[$intUid] = $secret;
-            $secrets[] = $secret;
+            if ($intUid > 0) {
+                $rowsByUid[$intUid] = $row;
+                $uids[] = $intUid;
+            }
         }
 
-        // Batch-load all MM groups in ONE query
-        $allUids = array_keys($uidMap);
-        if ($allUids !== []) {
-            $groupsBySecret = $this->loadGroupsForSecrets($allUids);
-            foreach ($groupsBySecret as $secretUid => $groups) {
-                if ($groups !== [] && isset($uidMap[$secretUid])) {
-                    $uidMap[$secretUid]->setAllowedGroups($groups);
-                }
-            }
+        $groupsBySecret = $uids !== [] ? $this->loadGroupsForSecrets($uids) : [];
+
+        $secrets = [];
+        foreach ($rowsByUid as $uid => $row) {
+            $secrets[] = Secret::fromDatabaseRow($row, $groupsBySecret[$uid] ?? []);
         }
 
         return $secrets;

--- a/Classes/Domain/Repository/SecretRepository.php
+++ b/Classes/Domain/Repository/SecretRepository.php
@@ -357,22 +357,25 @@ final readonly class SecretRepository implements SecretRepositoryInterface
         // Collect all UIDs and batch-load MM groups in ONE query so each
         // Secret can be constructed with its allowed-groups list already
         // populated — readonly entity has no post-construction mutator.
-        $rowsByUid = [];
+        // Traverse rows in their original order (the SELECT's ORDER BY
+        // contract) and preserve duplicates, so this method's external
+        // behaviour matches the pre-readonly version exactly.
         $uids = [];
         foreach ($rows as $row) {
             $uid = $row['uid'] ?? 0;
             $intUid = is_numeric($uid) ? (int) $uid : 0;
             if ($intUid > 0) {
-                $rowsByUid[$intUid] = $row;
-                $uids[] = $intUid;
+                $uids[$intUid] = true;
             }
         }
 
-        $groupsBySecret = $uids !== [] ? $this->loadGroupsForSecrets($uids) : [];
+        $groupsBySecret = $uids !== [] ? $this->loadGroupsForSecrets(array_keys($uids)) : [];
 
         $secrets = [];
-        foreach ($rowsByUid as $uid => $row) {
-            $secrets[] = Secret::fromDatabaseRow($row, $groupsBySecret[$uid] ?? []);
+        foreach ($rows as $row) {
+            $uid = $row['uid'] ?? 0;
+            $intUid = is_numeric($uid) ? (int) $uid : 0;
+            $secrets[] = Secret::fromDatabaseRow($row, $groupsBySecret[$intUid] ?? []);
         }
 
         return $secrets;

--- a/Classes/Domain/Repository/SecretRepositoryInterface.php
+++ b/Classes/Domain/Repository/SecretRepositoryInterface.php
@@ -23,7 +23,14 @@ interface SecretRepositoryInterface
 
     public function exists(string $identifier): bool;
 
-    public function save(Secret $secret): void;
+    /**
+     * Persist the Secret. Returns the (possibly new) Secret instance.
+     * On INSERT, the returned instance carries the freshly-assigned
+     * UID; on UPDATE, the original is returned unchanged. Callers must
+     * use the return value if they need the populated UID — the input
+     * is readonly and cannot be mutated in place.
+     */
+    public function save(Secret $secret): Secret;
 
     public function delete(Secret $secret): void;
 

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -238,14 +238,8 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             // Encrypt the new secret
             $encrypted = $this->encryptionService->encrypt($newSecret, $identifier);
 
-            // Update secret
-            $secret->setEncryptedValue($encrypted->encryptedValue);
-            $secret->setEncryptedDek($encrypted->encryptedDek);
-            $secret->setDekNonce($encrypted->dekNonce);
-            $secret->setValueNonce($encrypted->valueNonce);
-            $secret->setValueChecksum($encrypted->valueChecksum);
-            $secret->incrementVersion();
-            $secret->setLastRotatedAt(time());
+            // Rotate value envelope, bump version, stamp rotation time
+            $secret = $secret->withValueRotation($encrypted, time());
 
             // Store
             $this->adapter->store($secret);
@@ -381,28 +375,29 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
         array $options,
         ?Secret $existing,
     ): Secret {
-        $secretEntity = new Secret();
-        $secretEntity->setIdentifier($identifier);
-        $secretEntity->setEncryptedValue($encrypted->encryptedValue);
-        $secretEntity->setEncryptedDek($encrypted->encryptedDek);
-        $secretEntity->setDekNonce($encrypted->dekNonce);
-        $secretEntity->setValueNonce($encrypted->valueNonce);
-        $secretEntity->setValueChecksum($encrypted->valueChecksum);
-        $secretEntity->setAdapter('local');
+        $optional = $this->collectOptionalFields($options);
 
-        $secretEntity->setOwnerUid($this->resolveOwnerUid($options, $existing));
-        $this->applyOptionalFields($secretEntity, $options);
-
-        if (!$existing instanceof Secret) {
-            $secretEntity->setCrdate(time());
-            $secretEntity->setCruserId($this->accessControlService->getCurrentActorUid());
-        } else {
-            $secretEntity->setUid($existing->getUid());
-            $secretEntity->setCrdate($existing->getCrdate());
-            $secretEntity->setVersion($existing->getVersion());
-        }
-
-        return $secretEntity;
+        return new Secret(
+            identifier: $identifier,
+            uid: $existing?->getUid(),
+            scopePid: $optional['scopePid'],
+            description: $optional['description'],
+            encryptedValue: $encrypted->encryptedValue,
+            encryptedDek: $encrypted->encryptedDek,
+            dekNonce: $encrypted->dekNonce,
+            valueNonce: $encrypted->valueNonce,
+            valueChecksum: $encrypted->valueChecksum,
+            ownerUid: $this->resolveOwnerUid($options, $existing),
+            allowedGroups: $optional['allowedGroups'],
+            context: $optional['context'],
+            frontendAccessible: $optional['frontendAccessible'],
+            version: $existing instanceof Secret ? $existing->getVersion() : 1,
+            expiresAt: $optional['expiresAt'],
+            metadata: $optional['metadata'],
+            adapter: 'local',
+            crdate: $existing instanceof Secret ? $existing->getCrdate() : time(),
+            cruserId: $existing instanceof Secret ? $existing->getCruserId() : $this->accessControlService->getCurrentActorUid(),
+        );
     }
 
     /**
@@ -433,37 +428,43 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
     }
 
     /**
-     * Apply the value-type-flexible options from the `store($options)` array
-     * to the Secret entity. Each option is defensively coerced to the
-     * column's expected type.
+     * Collect the value-type-flexible options from the `store($options)`
+     * array into a typed bundle. Each option is defensively coerced to
+     * its expected type; options not supplied get the Secret-default
+     * value (matching the previous mutator-based behaviour where unset
+     * options left the constructed entity at its default).
      *
      * @param array<string, mixed> $options
+     *
+     * @return array{
+     *     scopePid: int,
+     *     description: string,
+     *     allowedGroups: list<int>,
+     *     context: string,
+     *     frontendAccessible: bool,
+     *     expiresAt: int,
+     *     metadata: array<string, mixed>,
+     * }
      */
-    private function applyOptionalFields(Secret $secretEntity, array $options): void
+    private function collectOptionalFields(array $options): array
     {
-        if (isset($options['groups'])) {
-            $secretEntity->setAllowedGroups($this->coerceGroupList($options['groups']));
-        }
-        if (isset($options['context'])) {
-            $secretEntity->setContext($this->coerceToString($options['context']));
-        }
-        if (isset($options['description'])) {
-            $secretEntity->setDescription($this->coerceToString($options['description']));
-        }
+        $metadata = [];
         if (isset($options['metadata'])) {
             /** @var array<string, mixed> $metadata */
             $metadata = (array) $options['metadata'];
-            $secretEntity->setMetadata($metadata);
         }
-        if (isset($options['scopePid'])) {
-            $secretEntity->setScopePid(is_numeric($options['scopePid']) ? (int) $options['scopePid'] : 0);
-        }
-        if (isset($options['expiresAt'])) {
-            $secretEntity->setExpiresAt($this->coerceTimestamp($options['expiresAt']));
-        }
-        if (isset($options['frontendAccessible'])) {
-            $secretEntity->setFrontendAccessible((bool) $options['frontendAccessible']);
-        }
+
+        return [
+            'scopePid' => isset($options['scopePid'])
+                ? (is_numeric($options['scopePid']) ? (int) $options['scopePid'] : 0)
+                : 0,
+            'description' => isset($options['description']) ? $this->coerceToString($options['description']) : '',
+            'allowedGroups' => isset($options['groups']) ? $this->coerceGroupList($options['groups']) : [],
+            'context' => isset($options['context']) ? $this->coerceToString($options['context']) : '',
+            'frontendAccessible' => isset($options['frontendAccessible']) && (bool) $options['frontendAccessible'],
+            'expiresAt' => isset($options['expiresAt']) ? $this->coerceTimestamp($options['expiresAt']) : 0,
+            'metadata' => $metadata,
+        ];
     }
 
     /**

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -81,7 +81,11 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             $encrypted = $this->encryptionService->encrypt($secret, $identifier);
             $secretEntity = $this->buildSecretEntity($identifier, $encrypted, $options, $existing);
 
-            $this->adapter->store($secretEntity);
+            // Capture the stored instance so the SecretCreatedEvent below
+            // sees the freshly-assigned UID — the readonly entity passed in
+            // has uid=null on create, the adapter returns the uid-bearing
+            // instance from the repository's INSERT.
+            $secretEntity = $this->adapter->store($secretEntity);
 
             $this->auditLogService->log(
                 $identifier,
@@ -241,8 +245,10 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             // Rotate value envelope, bump version, stamp rotation time
             $secret = $secret->withValueRotation($encrypted, time());
 
-            // Store
-            $this->adapter->store($secret);
+            // Store; capture the returned instance for the rotated event
+            // (UPDATE returns the same instance unchanged, but use the
+            // result to stay consistent with the create path).
+            $secret = $this->adapter->store($secret);
 
             // Log
             $this->auditLogService->log(

--- a/Tests/Functional/Crypto/MasterKeyRotationTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationTest.php
@@ -130,9 +130,9 @@ final class MasterKeyRotationTest extends FunctionalTestCase
                 $newKeyFromFile,
             );
 
-            $secret->setEncryptedDek($reEncrypted->encryptedDek);
-            $secret->setDekNonce($reEncrypted->nonce);
-            $secretRepository->save($secret);
+            $secretRepository->save(
+                $secret->withReEncryptedDek($reEncrypted->encryptedDek, $reEncrypted->nonce),
+            );
         }
 
         // Switch to the new master key file
@@ -259,9 +259,9 @@ final class MasterKeyRotationTest extends FunctionalTestCase
                 $newKeyFromFile,
             );
 
-            $secret->setEncryptedDek($reEncrypted->encryptedDek);
-            $secret->setDekNonce($reEncrypted->nonce);
-            $secretRepository->save($secret);
+            $secretRepository->save(
+                $secret->withReEncryptedDek($reEncrypted->encryptedDek, $reEncrypted->nonce),
+            );
         }
 
         // Verify all DEKs have changed
@@ -371,9 +371,9 @@ final class MasterKeyRotationTest extends FunctionalTestCase
                 $oldKeyFromFile = $this->readKeyFromFile($this->masterKeyPath);
                 $newKeyFromFile = $this->readKeyFromFile($newKeyPath);
 
-                $secret->setEncryptedDek($reEncrypted->encryptedDek);
-                $secret->setDekNonce($reEncrypted->nonce);
-                $secretRepository->save($secret);
+                $secretRepository->save(
+                    $secret->withReEncryptedDek($reEncrypted->encryptedDek, $reEncrypted->nonce),
+                );
             }
 
             self::fail('Rotation should have failed on the 3rd secret due to bogus old key');

--- a/Tests/Functional/Domain/Repository/SecretRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/SecretRepositoryTest.php
@@ -19,6 +19,11 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 
 /**
  * Functional tests for SecretRepository with real database operations.
+ *
+ * Entity-level unit tests for {@see Secret} (setters/getters, isExpired,
+ * fromDatabaseRow, toDatabaseRow) live in
+ * `Tests/Unit/Domain/Model/SecretTest.php`. This suite only exercises the
+ * repository against a real database.
  */
 #[CoversClass(SecretRepository::class)]
 #[CoversClass(Secret::class)]
@@ -48,18 +53,11 @@ final class SecretRepositoryTest extends FunctionalTestCase
     #[Test]
     public function saveCreatesNewSecret(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('test_secret_1');
-        $secret->setEncryptedValue('encrypted_value_data');
-        $secret->setEncryptedDek('encrypted_dek_data');
-        $secret->setDekNonce('dek_nonce_data');
-        $secret->setValueNonce('value_nonce_data');
-        $secret->setVersion(1);
-        $secret->setCruserId(1);
+        $secret = $this->newSecret('test_secret_1', encryptedValue: 'encrypted_value_data');
 
-        $this->subject->save($secret);
+        $saved = $this->subject->save($secret);
 
-        self::assertGreaterThan(0, $secret->getUid());
+        self::assertGreaterThan(0, $saved->getUid());
 
         // Verify we can retrieve it
         $retrieved = $this->subject->findByIdentifier('test_secret_1');
@@ -78,17 +76,11 @@ final class SecretRepositoryTest extends FunctionalTestCase
     #[Test]
     public function findByUidReturnsCorrectSecret(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('uid_test_secret');
-        $secret->setEncryptedValue('encrypted');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('nonce1');
-        $secret->setValueNonce('nonce2');
-        $secret->setVersion(1);
-        $secret->setCruserId(1);
+        $secret = $this->newSecret('uid_test_secret');
 
-        $this->subject->save($secret);
-        $uid = $secret->getUid();
+        $saved = $this->subject->save($secret);
+        $uid = $saved->getUid();
+        self::assertNotNull($uid);
 
         $retrieved = $this->subject->findByUid($uid);
 
@@ -107,16 +99,7 @@ final class SecretRepositoryTest extends FunctionalTestCase
     #[Test]
     public function existsReturnsTrueForExistingSecret(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('exists_test');
-        $secret->setEncryptedValue('value');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('n1');
-        $secret->setValueNonce('n2');
-        $secret->setVersion(1);
-        $secret->setCruserId(1);
-
-        $this->subject->save($secret);
+        $this->subject->save($this->newSecret('exists_test'));
 
         self::assertTrue($this->subject->exists('exists_test'));
     }
@@ -130,19 +113,10 @@ final class SecretRepositoryTest extends FunctionalTestCase
     #[Test]
     public function deleteRemovesSecret(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('to_delete');
-        $secret->setEncryptedValue('value');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('n1');
-        $secret->setValueNonce('n2');
-        $secret->setVersion(1);
-        $secret->setCruserId(1);
-
-        $this->subject->save($secret);
+        $saved = $this->subject->save($this->newSecret('to_delete'));
         self::assertTrue($this->subject->exists('to_delete'));
 
-        $this->subject->delete($secret);
+        $this->subject->delete($saved);
 
         self::assertFalse($this->subject->exists('to_delete'));
     }
@@ -150,22 +124,25 @@ final class SecretRepositoryTest extends FunctionalTestCase
     #[Test]
     public function saveUpdatesExistingSecret(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('update_test');
-        $secret->setEncryptedValue('original_value');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('n1');
-        $secret->setValueNonce('n2');
-        $secret->setVersion(1);
-        $secret->setCruserId(1);
+        $original = $this->newSecret('update_test', encryptedValue: 'original_value');
 
-        $this->subject->save($secret);
-        $originalUid = $secret->getUid();
+        $inserted = $this->subject->save($original);
+        $originalUid = $inserted->getUid();
+        self::assertNotNull($originalUid);
 
-        // Update the secret
-        $secret->setEncryptedValue('updated_value');
-        $secret->setVersion(2);
-        $this->subject->save($secret);
+        // Update: build a fresh Secret with the same UID and the desired
+        // field changes (no setters on the readonly entity).
+        $updated = new Secret(
+            identifier: 'update_test',
+            uid: $originalUid,
+            encryptedValue: 'updated_value',
+            encryptedDek: 'dek',
+            dekNonce: 'n1',
+            valueNonce: 'n2',
+            version: 2,
+            cruserId: 1,
+        );
+        $this->subject->save($updated);
 
         // Verify the update
         $retrieved = $this->subject->findByIdentifier('update_test');
@@ -180,15 +157,7 @@ final class SecretRepositoryTest extends FunctionalTestCase
     {
         // Create multiple secrets
         for ($i = 1; $i <= 3; $i++) {
-            $secret = new Secret();
-            $secret->setIdentifier("list_test_{$i}");
-            $secret->setEncryptedValue("value_{$i}");
-            $secret->setEncryptedDek('dek');
-            $secret->setDekNonce('n1');
-            $secret->setValueNonce('n2');
-            $secret->setVersion(1);
-            $secret->setCruserId(1);
-            $this->subject->save($secret);
+            $this->subject->save($this->newSecret("list_test_{$i}", encryptedValue: "value_{$i}"));
         }
 
         $identifiers = $this->subject->findIdentifiers();
@@ -201,28 +170,16 @@ final class SecretRepositoryTest extends FunctionalTestCase
     #[Test]
     public function findIdentifiersWithFiltersByContext(): void
     {
-        // Create secrets with different contexts
-        $secret1 = new Secret();
-        $secret1->setIdentifier('context_api');
-        $secret1->setEncryptedValue('v1');
-        $secret1->setEncryptedDek('dek');
-        $secret1->setDekNonce('n1');
-        $secret1->setValueNonce('n2');
-        $secret1->setContext('api');
-        $secret1->setVersion(1);
-        $secret1->setCruserId(1);
-        $this->subject->save($secret1);
-
-        $secret2 = new Secret();
-        $secret2->setIdentifier('context_db');
-        $secret2->setEncryptedValue('v2');
-        $secret2->setEncryptedDek('dek');
-        $secret2->setDekNonce('n1');
-        $secret2->setValueNonce('n2');
-        $secret2->setContext('database');
-        $secret2->setVersion(1);
-        $secret2->setCruserId(1);
-        $this->subject->save($secret2);
+        $this->subject->save($this->newSecret(
+            'context_api',
+            encryptedValue: 'v1',
+            context: 'api',
+        ));
+        $this->subject->save($this->newSecret(
+            'context_db',
+            encryptedValue: 'v2',
+            context: 'database',
+        ));
 
         $apiSecrets = $this->subject->findIdentifiers(new SecretFilters(context: 'api'));
 
@@ -230,158 +187,24 @@ final class SecretRepositoryTest extends FunctionalTestCase
         self::assertNotContains('context_db', $apiSecrets);
     }
 
-    #[Test]
-    public function secretModelSettersAndGettersWork(): void
-    {
-        $secret = new Secret();
-        $now = time();
-
-        $secret->setIdentifier('model_test');
-        $secret->setEncryptedValue('encrypted');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('dek_nonce');
-        $secret->setValueNonce('value_nonce');
-        $secret->setVersion(5);
-        $secret->setContext('testing');
-        $secret->setDescription('Test description');
-        $secret->setCruserId(42);
-        $secret->setOwnerUid(43);
-        $secret->setLastReadAt($now);
-        $secret->setLastRotatedAt($now);
-        $secret->setExpiresAt($now);
-        $secret->setMetadata(['key' => 'value']);
-
-        self::assertSame('model_test', $secret->getIdentifier());
-        self::assertSame('encrypted', $secret->getEncryptedValue());
-        self::assertSame('dek', $secret->getEncryptedDek());
-        self::assertSame('dek_nonce', $secret->getDekNonce());
-        self::assertSame('value_nonce', $secret->getValueNonce());
-        self::assertSame(5, $secret->getVersion());
-        self::assertSame('testing', $secret->getContext());
-        self::assertSame('Test description', $secret->getDescription());
-        self::assertSame(42, $secret->getCruserId());
-        self::assertSame(43, $secret->getOwnerUid());
-        self::assertSame($now, $secret->getLastReadAt());
-        self::assertSame($now, $secret->getLastRotatedAt());
-        self::assertSame($now, $secret->getExpiresAt());
-        self::assertSame(['key' => 'value'], $secret->getMetadata());
-    }
-
-    #[Test]
-    public function secretIsExpiredReturnsCorrectly(): void
-    {
-        $secret = new Secret();
-
-        // No expiry set (expiresAt = 0)
-        self::assertFalse($secret->isExpired());
-
-        // Future expiry
-        $secret->setExpiresAt(time() + 3600);
-        self::assertFalse($secret->isExpired());
-
-        // Past expiry
-        $secret->setExpiresAt(time() - 3600);
-        self::assertTrue($secret->isExpired());
-    }
-
-    #[Test]
-    public function secretIncrementVersionWorks(): void
-    {
-        $secret = new Secret();
-        $secret->setVersion(1);
-
-        $secret->incrementVersion();
-        self::assertSame(2, $secret->getVersion());
-
-        $secret->incrementVersion();
-        self::assertSame(3, $secret->getVersion());
-    }
-
-    #[Test]
-    public function secretValueChecksumCanBeSetAndRetrieved(): void
-    {
-        $secret = new Secret();
-        $checksum = hash('sha256', 'test_value');
-        $secret->setValueChecksum($checksum);
-
-        self::assertSame($checksum, $secret->getValueChecksum());
-        self::assertSame(64, \strlen($secret->getValueChecksum())); // SHA-256 hex = 64 chars
-    }
-
-    #[Test]
-    public function secretFromDatabaseRowPopulatesAllFields(): void
-    {
-        $row = [
-            'uid' => 123,
-            'scope_pid' => 0,
-            'identifier' => 'test_identifier',
-            'description' => 'Test description',
-            'encrypted_value' => 'encrypted_data',
-            'encrypted_dek' => 'dek_data',
-            'dek_nonce' => 'dek_nonce',
-            'value_nonce' => 'value_nonce',
-            'encryption_version' => 2,
-            'value_checksum' => 'abc123',
-            'owner_uid' => 5,
-            'context' => 'api',
-            'frontend_accessible' => 1,
-            'version' => 3,
-            'expires_at' => 1700000000,
-            'last_rotated_at' => 1699999999,
-            'adapter' => 'hashicorp',
-            'external_reference' => 'vault/path',
-            'tstamp' => 1699999998,
-            'crdate' => 1699999997,
-            'cruser_id' => 1,
-            'deleted' => 0,
-            'hidden' => 0,
-            'read_count' => 10,
-            'last_read_at' => 1699999996,
-            'metadata' => '{"key":"value"}',
-            'allowed_groups' => '1,2,3',
-        ];
-
-        $secret = Secret::fromDatabaseRow($row);
-
-        self::assertSame(123, $secret->getUid());
-        self::assertSame('test_identifier', $secret->getIdentifier());
-        self::assertSame('Test description', $secret->getDescription());
-        self::assertSame('encrypted_data', $secret->getEncryptedValue());
-        self::assertSame(5, $secret->getOwnerUid());
-        self::assertSame('api', $secret->getContext());
-        self::assertTrue($secret->isFrontendAccessible());
-        self::assertSame(3, $secret->getVersion());
-        self::assertSame('hashicorp', $secret->getAdapter());
-        self::assertSame(10, $secret->getReadCount());
-        self::assertSame(['key' => 'value'], $secret->getMetadata());
-        self::assertSame([1, 2, 3], $secret->getAllowedGroups());
-    }
-
-    #[Test]
-    public function secretToDatabaseRowFormatsCorrectly(): void
-    {
-        $secret = new Secret();
-        $secret->setIdentifier('db_row_test');
-        $secret->setDescription('Test');
-        $secret->setEncryptedValue('encrypted');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('nonce1');
-        $secret->setValueNonce('nonce2');
-        $secret->setOwnerUid(1);
-        $secret->setContext('api');
-        $secret->setVersion(2);
-        $secret->setAllowedGroups([1, 2]);
-        $secret->setMetadata(['foo' => 'bar']);
-
-        $row = $secret->toDatabaseRow();
-
-        self::assertSame('db_row_test', $row['identifier']);
-        self::assertSame('Test', $row['description']);
-        self::assertSame('encrypted', $row['encrypted_value']);
-        self::assertSame(1, $row['owner_uid']);
-        self::assertSame('api', $row['context']);
-        self::assertSame(2, $row['version']);
-        self::assertSame('1,2', $row['allowed_groups']);
-        self::assertSame('{"foo":"bar"}', $row['metadata']);
+    /**
+     * Build a Secret with sensible defaults for repository round-trip tests.
+     */
+    private function newSecret(
+        string $identifier,
+        string $encryptedValue = 'encrypted',
+        string $context = '',
+        int $version = 1,
+    ): Secret {
+        return new Secret(
+            identifier: $identifier,
+            encryptedValue: $encryptedValue,
+            encryptedDek: 'dek',
+            dekNonce: 'n1',
+            valueNonce: 'n2',
+            context: $context,
+            version: $version,
+            cruserId: 1,
+        );
     }
 }

--- a/Tests/Unit/Adapter/LocalEncryptionAdapterTest.php
+++ b/Tests/Unit/Adapter/LocalEncryptionAdapterTest.php
@@ -53,13 +53,13 @@ final class LocalEncryptionAdapterTest extends TestCase
     #[Test]
     public function storeDelegatesToRepository(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('test');
+        $secret = new Secret(identifier: 'test');
 
         $repository = $this->createMock(SecretRepositoryInterface::class);
         $repository->expects(self::once())
             ->method('save')
-            ->with($secret);
+            ->with($secret)
+            ->willReturn($secret);
 
         $adapter = new LocalEncryptionAdapter($repository);
         $adapter->store($secret);
@@ -68,8 +68,7 @@ final class LocalEncryptionAdapterTest extends TestCase
     #[Test]
     public function retrieveDelegatesToRepository(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('test');
+        $secret = new Secret(identifier: 'test');
 
         $repository = $this->createMock(SecretRepositoryInterface::class);
         $repository->expects(self::once())
@@ -97,8 +96,7 @@ final class LocalEncryptionAdapterTest extends TestCase
     #[Test]
     public function deleteRemovesExistingSecret(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('test');
+        $secret = new Secret(identifier: 'test');
 
         $repository = $this->createMock(SecretRepositoryInterface::class);
         $repository->method('findByIdentifier')
@@ -168,16 +166,17 @@ final class LocalEncryptionAdapterTest extends TestCase
     #[Test]
     public function getMetadataReturnsSecretMetadata(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('api-key');
-        $secret->setDescription('Payment API key');
-        $secret->setOwnerUid(5);
-        $secret->setAllowedGroups([1, 2]);
-        $secret->setContext('payment');
-        $secret->setVersion(3);
-        $secret->setExpiresAt(1735689600);
-        $secret->setMetadata(['service' => 'stripe']);
-        $secret->setAdapter('local');
+        $secret = new Secret(
+            identifier: 'api-key',
+            description: 'Payment API key',
+            ownerUid: 5,
+            allowedGroups: [1, 2],
+            context: 'payment',
+            version: 3,
+            expiresAt: 1735689600,
+            metadata: ['service' => 'stripe'],
+            adapter: 'local',
+        );
 
         $repository = $this->createStub(SecretRepositoryInterface::class);
         $repository->method('findByIdentifier')->willReturn($secret);
@@ -200,9 +199,7 @@ final class LocalEncryptionAdapterTest extends TestCase
     #[Test]
     public function getMetadataReturnsNullExpiresAtWhenZero(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('test');
-        $secret->setExpiresAt(0);
+        $secret = new Secret(identifier: 'test', expiresAt: 0);
 
         $repository = $this->createStub(SecretRepositoryInterface::class);
         $repository->method('findByIdentifier')->willReturn($secret);
@@ -227,18 +224,25 @@ final class LocalEncryptionAdapterTest extends TestCase
     #[Test]
     public function updateMetadataMergesAndSaves(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('test');
-        $secret->setMetadata(['existing' => 'value']);
+        $secret = new Secret(identifier: 'test', metadata: ['existing' => 'value']);
 
         $repository = $this->createMock(SecretRepositoryInterface::class);
         $repository->method('findByIdentifier')->willReturn($secret);
-        $repository->expects(self::once())->method('save')->with($secret);
+
+        // The adapter calls `withMetadata($merged)` (returning a NEW Secret)
+        // and persists that — so we assert on the saved-instance metadata,
+        // not on `$secret` (which is now immutable and unchanged).
+        $repository->expects(self::once())
+            ->method('save')
+            ->with(self::callback(static fn (Secret $s): bool => $s->getMetadata() === ['existing' => 'value', 'new' => 'data']
+                && $s->getIdentifier() === 'test'))
+            ->willReturnArgument(0);
 
         $adapter = new LocalEncryptionAdapter($repository);
         $adapter->updateMetadata('test', ['new' => 'data']);
 
-        self::assertEquals(['existing' => 'value', 'new' => 'data'], $secret->getMetadata());
+        // Original entity is immutable — its metadata must not change.
+        self::assertSame(['existing' => 'value'], $secret->getMetadata());
     }
 
     #[Test]
@@ -256,10 +260,8 @@ final class LocalEncryptionAdapterTest extends TestCase
     #[Test]
     public function listSecretsDelegatesToRepository(): void
     {
-        $secret1 = new Secret();
-        $secret1->setIdentifier('secret-1');
-        $secret2 = new Secret();
-        $secret2->setIdentifier('secret-2');
+        $secret1 = new Secret(identifier: 'secret-1');
+        $secret2 = new Secret(identifier: 'secret-2');
 
         $filters = new SecretFilters(prefix: 'test');
 

--- a/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
+++ b/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
@@ -51,6 +51,14 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
         parent::setUp();
 
         $this->secretRepository = $this->createMock(SecretRepositoryInterface::class);
+        // `save()` now returns Secret (was void). PHPUnit cannot auto-generate
+        // a return value for `final readonly` Secret, so install a passthrough
+        // default at setUp() so individual tests don't have to repeat it.
+        // Per-test `->expects()` overrides still take effect.
+        $this->secretRepository
+            ->method('save')
+            ->willReturnArgument(0);
+
         $this->encryptionService = $this->createMock(EncryptionServiceInterface::class);
         $this->masterKeyProviderFactory = $this->createMock(MasterKeyProviderFactoryInterface::class);
         $this->connectionPool = $this->createMock(ConnectionPool::class);
@@ -325,10 +333,16 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
             ->method('getConnectionForTable')
             ->willReturn($connection);
 
+        // `withReEncryptedDek()` returns a NEW Secret instance, so the
+        // saved entity is a different object from `$secret`. Match on the
+        // re-encrypted DEK envelope instead of object identity.
         $this->secretRepository
             ->expects(self::once())
             ->method('save')
-            ->with($secret);
+            ->with(self::callback(static fn (Secret $s): bool => $s->getIdentifier() === 'test-secret'
+                && $s->getEncryptedDek() === 'new-encrypted-dek'
+                && $s->getDekNonce() === 'new-nonce'))
+            ->willReturnArgument(0);
 
         $exitCode = $this->commandTester->execute([
             '--old-key' => $this->createKeyFile('old', str_repeat('a', 32)),
@@ -527,12 +541,16 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
 
     private function createTestSecret(string $identifier): Secret
     {
-        $secret = new Secret();
-        $secret->setIdentifier($identifier);
-        $secret->setEncryptedDek('encrypted-dek');
-        $secret->setDekNonce('dek-nonce');
-
-        return $secret;
+        // The ctor enforces the tri-state crypto invariant: encryptedDek,
+        // dekNonce, and valueNonce must all be set or all be empty. The
+        // master-key rotation only re-encrypts the DEK envelope, but the
+        // entity still requires the value-side fields to be consistent.
+        return new Secret(
+            identifier: $identifier,
+            encryptedDek: 'encrypted-dek',
+            dekNonce: 'dek-nonce',
+            valueNonce: 'value-nonce',
+        );
     }
 
     private function mockMasterKeyProvider(string $key): void

--- a/Tests/Unit/Domain/Dto/SecretDetailsTest.php
+++ b/Tests/Unit/Domain/Dto/SecretDetailsTest.php
@@ -219,23 +219,24 @@ final class SecretDetailsTest extends TestCase
     #[Test]
     public function fromSecretMapsAllFieldsFromSecretModel(): void
     {
-        $secret = new Secret();
-        $secret->setUid(7);
-        $secret->setIdentifier('from-secret-identifier');
-        $secret->setDescription('From secret description');
-        $secret->setOwnerUid(3);
-        $secret->setAllowedGroups([10, 20]);
-        $secret->setContext('backend');
-        $secret->setFrontendAccessible(true);
-        $secret->setVersion(5);
-        $secret->setCrdate(1700000001);
-        $secret->setTstamp(1700000002);
-        $secret->setExpiresAt(1900000000);
-        $secret->setLastRotatedAt(1750000000);
-        $secret->setReadCount(42);
-        $secret->setLastReadAt(1800000000);
-        $secret->setMetadata(['env' => 'prod']);
-        $secret->setScopePid(11);
+        $secret = new Secret(
+            identifier: 'from-secret-identifier',
+            uid: 7,
+            scopePid: 11,
+            description: 'From secret description',
+            ownerUid: 3,
+            allowedGroups: [10, 20],
+            context: 'backend',
+            frontendAccessible: true,
+            version: 5,
+            expiresAt: 1900000000,
+            lastRotatedAt: 1750000000,
+            metadata: ['env' => 'prod'],
+            tstamp: 1700000002,
+            crdate: 1700000001,
+            readCount: 42,
+            lastReadAt: 1800000000,
+        );
 
         $result = SecretDetails::fromSecret($secret);
 
@@ -261,11 +262,13 @@ final class SecretDetailsTest extends TestCase
     public function fromSecretConvertsZeroTimestampsToNull(): void
     {
         // expiresAt, lastRotatedAt, lastReadAt of 0 should become null in the DTO
-        $secret = new Secret();
-        $secret->setUid(1);
-        $secret->setExpiresAt(0);
-        $secret->setLastRotatedAt(0);
-        $secret->setLastReadAt(0);
+        $secret = new Secret(
+            identifier: 'zero-timestamps',
+            uid: 1,
+            expiresAt: 0,
+            lastRotatedAt: 0,
+            lastReadAt: 0,
+        );
 
         $result = SecretDetails::fromSecret($secret);
 
@@ -278,8 +281,8 @@ final class SecretDetailsTest extends TestCase
     public function fromSecretWithNullUidDefaultsToZero(): void
     {
         // Secret with no UID set (getUid() returns null) should default to 0
-        $secret = new Secret();
-        // Do NOT call setUid() – uid remains null
+        $secret = new Secret(identifier: 'null-uid');
+        // uid not passed — defaults to null
 
         $result = SecretDetails::fromSecret($secret);
 

--- a/Tests/Unit/Domain/Model/SecretTest.php
+++ b/Tests/Unit/Domain/Model/SecretTest.php
@@ -182,14 +182,17 @@ final class SecretTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessage('encryptedDek, dekNonce, and valueNonce must all be set or all be empty');
 
-        new Secret(
+        // The constructor MUST throw before returning; assertInstanceOf
+        // is unreachable but uses the constructed value so Sonar's S1848
+        // ("useless object instantiation") doesn't fire on the throw test.
+        self::assertInstanceOf(Secret::class, new Secret(
             identifier: 'broken',
             encryptedValue: 'enc_value',
-            valueChecksum: 'checksum',
             encryptedDek: $encryptedDek,
             dekNonce: $dekNonce,
             valueNonce: $valueNonce,
-        );
+            valueChecksum: 'checksum',
+        ));
     }
 
     #[Test]
@@ -199,10 +202,10 @@ final class SecretTest extends TestCase
         $secret = new Secret(
             identifier: 'id',
             encryptedValue: 'v',
-            valueChecksum: 'cs',
             encryptedDek: 'dek',
             dekNonce: 'dn',
             valueNonce: 'vn',
+            valueChecksum: 'cs',
         );
 
         self::assertSame('dek', $secret->getEncryptedDek());

--- a/Tests/Unit/Domain/Model/SecretTest.php
+++ b/Tests/Unit/Domain/Model/SecretTest.php
@@ -983,6 +983,7 @@ final class SecretTest extends TestCase
             'adapter',
             'allowed_groups',
             'context',
+            'cruser_id',
             'dek_nonce',
             'deleted',
             'description',

--- a/Tests/Unit/Domain/Model/SecretTest.php
+++ b/Tests/Unit/Domain/Model/SecretTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Domain\Model;
 
 use InvalidArgumentException;
+use Netresearch\NrVault\Crypto\EncryptedData;
 use Netresearch\NrVault\Domain\Model\Secret;
 use Netresearch\NrVault\Exception\ValidationException;
 use Netresearch\NrVault\Tests\Unit\TestCase;
@@ -17,104 +18,354 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
+/**
+ * Unit tests for the immutable Secret entity.
+ *
+ * The entity uses readonly constructor promotion, so plain
+ * "set X, get X" tests are tautological and have been dropped — the
+ * constructor / from-row hydration tests below subsume them. What's
+ * exercised here is real behaviour:
+ *
+ *   - default values applied by the ctor (and `fromDatabaseRow`),
+ *   - integer / boolean / string casting in `fromDatabaseRow`,
+ *   - serialisation round-trip via `toDatabaseRow`,
+ *   - the crypto-field tri-state invariant (all set or all empty),
+ *   - the four `with*()` lifecycle transitions,
+ *   - `isExpired()` boundary conditions.
+ *
+ * The `incrementVersion` / `incrementReadCount` behaviours moved off
+ * the entity (`SecretRepository::incrementReadCount`, value rotation
+ * folds version++ into `withValueRotation`); their tests live there now.
+ */
 #[CoversClass(Secret::class)]
 final class SecretTest extends TestCase
 {
+    // ---------------------------------------------------------------
+    // Constructor defaults.
+    // ---------------------------------------------------------------
+
     #[Test]
-    public function newSecretHasDefaultValues(): void
+    public function constructorAppliesDocumentedDefaults(): void
     {
-        $secret = new Secret();
+        $secret = new Secret(identifier: 't');
 
         self::assertNull($secret->getUid());
-        self::assertEquals(0, $secret->getScopePid());
-        self::assertEquals('', $secret->getIdentifier());
-        self::assertEquals('', $secret->getDescription());
+        self::assertSame(0, $secret->getScopePid());
+        self::assertSame('t', $secret->getIdentifier());
+        self::assertSame('', $secret->getDescription());
         self::assertNull($secret->getEncryptedValue());
-        self::assertEquals('', $secret->getContext());
-        self::assertEquals(1, $secret->getVersion());
-        self::assertEquals(0, $secret->getExpiresAt());
-        self::assertEquals([], $secret->getAllowedGroups());
-        self::assertEquals([], $secret->getMetadata());
-        self::assertEquals('local', $secret->getAdapter());
+        self::assertSame('', $secret->getEncryptedDek());
+        self::assertSame('', $secret->getDekNonce());
+        self::assertSame('', $secret->getValueNonce());
+        self::assertSame(1, $secret->getEncryptionVersion());
+        self::assertSame('', $secret->getValueChecksum());
+        self::assertSame(0, $secret->getOwnerUid());
+        self::assertSame([], $secret->getAllowedGroups());
+        self::assertSame('', $secret->getContext());
+        self::assertFalse($secret->isFrontendAccessible());
+        self::assertSame(1, $secret->getVersion());
+        self::assertSame(0, $secret->getExpiresAt());
+        self::assertSame(0, $secret->getLastRotatedAt());
+        self::assertSame([], $secret->getMetadata());
+        self::assertSame('local', $secret->getAdapter());
+        self::assertSame('', $secret->getExternalReference());
+        self::assertSame(0, $secret->getTstamp());
+        self::assertSame(0, $secret->getCrdate());
+        self::assertSame(0, $secret->getCruserId());
         self::assertFalse($secret->isDeleted());
         self::assertFalse($secret->isHidden());
+        self::assertSame(0, $secret->getReadCount());
+        self::assertSame(0, $secret->getLastReadAt());
     }
 
     #[Test]
-    public function settersReturnSelfForFluentInterface(): void
+    public function constructorAcceptsAllArguments(): void
     {
-        $secret = new Secret();
+        $secret = new Secret(
+            identifier: 'my-api-key',
+            uid: 99,
+            scopePid: 10,
+            description: 'Stripe key',
+            encryptedValue: 'enc_value',
+            encryptedDek: 'enc_dek',
+            dekNonce: 'dek_nonce',
+            valueNonce: 'value_nonce',
+            encryptionVersion: 2,
+            valueChecksum: 'checksum123',
+            ownerUid: 5,
+            allowedGroups: [1, 2, 3],
+            context: 'payment',
+            frontendAccessible: true,
+            version: 7,
+            expiresAt: 1735689600,
+            lastRotatedAt: 1704067200,
+            metadata: ['service' => 'stripe'],
+            adapter: 'local',
+            externalReference: 'vault:foo',
+            tstamp: 1704067210,
+            crdate: 1704067200,
+            cruserId: 11,
+            deleted: false,
+            hidden: true,
+            readCount: 50,
+            lastReadAt: 1704153600,
+        );
 
-        $result = $secret
-            ->setIdentifier('test')
-            ->setDescription('Test description')
-            ->setContext('payment')
-            ->setOwnerUid(1);
-
-        self::assertSame($secret, $result);
+        self::assertSame('my-api-key', $secret->getIdentifier());
+        self::assertSame(99, $secret->getUid());
+        self::assertSame(10, $secret->getScopePid());
+        self::assertSame('Stripe key', $secret->getDescription());
+        self::assertSame('enc_value', $secret->getEncryptedValue());
+        self::assertSame('enc_dek', $secret->getEncryptedDek());
+        self::assertSame('dek_nonce', $secret->getDekNonce());
+        self::assertSame('value_nonce', $secret->getValueNonce());
+        self::assertSame(2, $secret->getEncryptionVersion());
+        self::assertSame('checksum123', $secret->getValueChecksum());
+        self::assertSame(5, $secret->getOwnerUid());
+        self::assertSame([1, 2, 3], $secret->getAllowedGroups());
+        self::assertSame('payment', $secret->getContext());
+        self::assertTrue($secret->isFrontendAccessible());
+        self::assertSame(7, $secret->getVersion());
+        self::assertSame(1735689600, $secret->getExpiresAt());
+        self::assertSame(1704067200, $secret->getLastRotatedAt());
+        self::assertSame(['service' => 'stripe'], $secret->getMetadata());
+        self::assertSame('local', $secret->getAdapter());
+        self::assertSame('vault:foo', $secret->getExternalReference());
+        self::assertSame(1704067210, $secret->getTstamp());
+        self::assertSame(1704067200, $secret->getCrdate());
+        self::assertSame(11, $secret->getCruserId());
+        self::assertFalse($secret->isDeleted());
+        self::assertTrue($secret->isHidden());
+        self::assertSame(50, $secret->getReadCount());
+        self::assertSame(1704153600, $secret->getLastReadAt());
     }
 
     #[Test]
-    public function isExpiredReturnsFalseWhenNoExpiration(): void
+    public function constructorAllowsAllCryptoFieldsEmpty(): void
     {
-        $secret = new Secret();
-        $secret->setExpiresAt(0);
+        $secret = new Secret(
+            identifier: 'external-ref',
+            encryptedValue: 'enc_value',
+            valueChecksum: 'checksum',
+        );
+
+        self::assertSame('', $secret->getEncryptedDek());
+        self::assertSame('', $secret->getDekNonce());
+        self::assertSame('', $secret->getValueNonce());
+    }
+
+    // ---------------------------------------------------------------
+    // Crypto-field tri-state invariant: encryptedDek/dekNonce/valueNonce
+    // must all be set or all be empty.
+    // ---------------------------------------------------------------
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function partialCryptoFieldsProvider(): iterable
+    {
+        yield 'only encryptedDek set' => ['has_dek', '', ''];
+        yield 'only dekNonce set' => ['', 'has_nonce', ''];
+        yield 'only valueNonce set' => ['', '', 'has_vn'];
+        yield 'encryptedDek + dekNonce, no valueNonce' => ['dek', 'dn', ''];
+        yield 'encryptedDek + valueNonce, no dekNonce' => ['dek', '', 'vn'];
+        yield 'dekNonce + valueNonce, no encryptedDek' => ['', 'dn', 'vn'];
+    }
+
+    #[Test]
+    #[DataProvider('partialCryptoFieldsProvider')]
+    public function constructorThrowsOnPartialCryptoFields(
+        string $encryptedDek,
+        string $dekNonce,
+        string $valueNonce,
+    ): void {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('encryptedDek, dekNonce, and valueNonce must all be set or all be empty');
+
+        new Secret(
+            identifier: 'broken',
+            encryptedValue: 'enc_value',
+            valueChecksum: 'checksum',
+            encryptedDek: $encryptedDek,
+            dekNonce: $dekNonce,
+            valueNonce: $valueNonce,
+        );
+    }
+
+    #[Test]
+    public function constructorAcceptsAllThreeCryptoFieldsSet(): void
+    {
+        // No exception expected.
+        $secret = new Secret(
+            identifier: 'id',
+            encryptedValue: 'v',
+            valueChecksum: 'cs',
+            encryptedDek: 'dek',
+            dekNonce: 'dn',
+            valueNonce: 'vn',
+        );
+
+        self::assertSame('dek', $secret->getEncryptedDek());
+        self::assertSame('dn', $secret->getDekNonce());
+        self::assertSame('vn', $secret->getValueNonce());
+    }
+
+    // ---------------------------------------------------------------
+    // Lifecycle transitions — each returns a NEW instance.
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function withUidReturnsNewInstanceWithAssignedUid(): void
+    {
+        $secret = new Secret(identifier: 't');
+
+        $result = $secret->withUid(42);
+
+        self::assertNotSame($secret, $result);
+        self::assertNull($secret->getUid());
+        self::assertSame(42, $result->getUid());
+        // Other fields propagated.
+        self::assertSame('t', $result->getIdentifier());
+    }
+
+    #[Test]
+    public function withUidAcceptsNullToClearUid(): void
+    {
+        $secret = new Secret(identifier: 't', uid: 5);
+
+        $result = $secret->withUid(null);
+
+        self::assertSame(5, $secret->getUid());
+        self::assertNull($result->getUid());
+    }
+
+    #[Test]
+    public function withValueRotationBumpsVersionAndUpdatesAllRotationFields(): void
+    {
+        $secret = new Secret(
+            identifier: 't',
+            uid: 1,
+            version: 3,
+            lastRotatedAt: 1000,
+            readCount: 9,
+        );
+        $encrypted = new EncryptedData(
+            encryptedValue: 'new_value',
+            encryptedDek: 'new_dek',
+            dekNonce: 'new_dn',
+            valueNonce: 'new_vn',
+            valueChecksum: 'new_cs',
+        );
+
+        $rotated = $secret->withValueRotation($encrypted, rotatedAt: 2000);
+
+        self::assertNotSame($secret, $rotated);
+        // Original untouched.
+        self::assertSame(3, $secret->getVersion());
+        self::assertSame(1000, $secret->getLastRotatedAt());
+        // New instance has rotated state.
+        self::assertSame(4, $rotated->getVersion());
+        self::assertSame(2000, $rotated->getLastRotatedAt());
+        self::assertSame('new_value', $rotated->getEncryptedValue());
+        self::assertSame('new_dek', $rotated->getEncryptedDek());
+        self::assertSame('new_dn', $rotated->getDekNonce());
+        self::assertSame('new_vn', $rotated->getValueNonce());
+        self::assertSame('new_cs', $rotated->getValueChecksum());
+        // Untouched fields propagate.
+        self::assertSame(1, $rotated->getUid());
+        self::assertSame(9, $rotated->getReadCount());
+    }
+
+    #[Test]
+    public function withReEncryptedDekReplacesOnlyDekEnvelope(): void
+    {
+        $secret = new Secret(
+            identifier: 't',
+            uid: 1,
+            encryptedValue: 'val',
+            encryptedDek: 'old_dek',
+            dekNonce: 'old_dn',
+            valueNonce: 'vn',
+            valueChecksum: 'cs',
+            version: 5,
+        );
+
+        $rotated = $secret->withReEncryptedDek('new_dek', 'new_dn');
+
+        self::assertNotSame($secret, $rotated);
+        // Value envelope untouched.
+        self::assertSame('val', $rotated->getEncryptedValue());
+        self::assertSame('vn', $rotated->getValueNonce());
+        self::assertSame('cs', $rotated->getValueChecksum());
+        // Version NOT bumped (master-key rotation doesn't bump it).
+        self::assertSame(5, $rotated->getVersion());
+        // DEK envelope replaced.
+        self::assertSame('new_dek', $rotated->getEncryptedDek());
+        self::assertSame('new_dn', $rotated->getDekNonce());
+    }
+
+    #[Test]
+    public function withMetadataReplacesMetadataArray(): void
+    {
+        $secret = new Secret(identifier: 't', metadata: ['a' => 1]);
+
+        $merged = $secret->withMetadata(['b' => 2, 'c' => 3]);
+
+        self::assertNotSame($secret, $merged);
+        self::assertSame(['a' => 1], $secret->getMetadata());
+        self::assertSame(['b' => 2, 'c' => 3], $merged->getMetadata());
+    }
+
+    // ---------------------------------------------------------------
+    // isExpired() boundary conditions.
+    // ---------------------------------------------------------------
+
+    /**
+     * Offsets relative to `time()` so the data provider survives a
+     * clock tick between evaluation and assertion.
+     *
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function isExpiredBoundaryProvider(): iterable
+    {
+        yield 'zero means no-expiration' => ['zero', false];
+        yield 'far future' => ['far-future', false];
+        yield '60 seconds in future' => ['+60', false];
+        yield '60 seconds in past is expired' => ['-60', true];
+        yield 'negative absolute means expiresAt > 0 check fails first' => ['negative', false];
+    }
+
+    #[Test]
+    #[DataProvider('isExpiredBoundaryProvider')]
+    public function isExpiredBoundaries(string $kind, bool $expected): void
+    {
+        $expiresAt = match ($kind) {
+            'zero' => 0,
+            'far-future' => PHP_INT_MAX,
+            'negative' => -1,
+            '+60' => time() + 60,
+            '-60' => time() - 60,
+            default => throw new InvalidArgumentException("Unknown kind: $kind", 7112662888),
+        };
+        $secret = new Secret(identifier: 't', expiresAt: $expiresAt);
+
+        self::assertSame($expected, $secret->isExpired());
+    }
+
+    /**
+     * Kills LessThan mutation on isExpired(): `< time()` vs `<= time()`.
+     */
+    #[Test]
+    public function isExpiredReturnsFalseWhenExpiresAtIsSlightlyInFuture(): void
+    {
+        $secret = new Secret(identifier: 't', expiresAt: time() + 1);
 
         self::assertFalse($secret->isExpired());
     }
 
-    #[Test]
-    public function isExpiredReturnsTrueWhenPastExpiration(): void
-    {
-        $secret = new Secret();
-        $secret->setExpiresAt(time() - 3600); // 1 hour ago
-
-        self::assertTrue($secret->isExpired());
-    }
-
-    #[Test]
-    public function isExpiredReturnsFalseWhenFutureExpiration(): void
-    {
-        $secret = new Secret();
-        $secret->setExpiresAt(time() + 3600); // 1 hour from now
-
-        self::assertFalse($secret->isExpired());
-    }
-
-    #[Test]
-    public function incrementVersionIncreasesVersionByOne(): void
-    {
-        $secret = new Secret();
-        self::assertEquals(1, $secret->getVersion());
-
-        $secret->incrementVersion();
-        self::assertEquals(2, $secret->getVersion());
-
-        $secret->incrementVersion();
-        self::assertEquals(3, $secret->getVersion());
-    }
-
-    #[Test]
-    public function incrementReadCountIncreasesCountByOne(): void
-    {
-        $secret = new Secret();
-        self::assertEquals(0, $secret->getReadCount());
-
-        $secret->incrementReadCount();
-        self::assertEquals(1, $secret->getReadCount());
-
-        $secret->incrementReadCount();
-        self::assertEquals(2, $secret->getReadCount());
-    }
-
-    #[Test]
-    public function setAllowedGroupsCastsToIntegers(): void
-    {
-        $secret = new Secret();
-        $secret->setAllowedGroups(['1', '2', '3']);
-
-        self::assertEquals([1, 2, 3], $secret->getAllowedGroups());
-    }
+    // ---------------------------------------------------------------
+    // fromDatabaseRow() — DB-row hydration semantics.
+    // ---------------------------------------------------------------
 
     #[Test]
     public function fromDatabaseRowCreatesCorrectSecret(): void
@@ -150,597 +401,79 @@ final class SecretTest extends TestCase
 
         $secret = Secret::fromDatabaseRow($row);
 
-        self::assertEquals(42, $secret->getUid());
-        self::assertEquals(1, $secret->getScopePid());
-        self::assertEquals('api-key', $secret->getIdentifier());
-        self::assertEquals('Payment gateway API key', $secret->getDescription());
-        self::assertEquals('base64_encrypted_data', $secret->getEncryptedValue());
-        self::assertEquals(5, $secret->getOwnerUid());
-        self::assertEquals([1, 2, 3], $secret->getAllowedGroups());
-        self::assertEquals('payment', $secret->getContext());
-        self::assertEquals(3, $secret->getVersion());
-        self::assertEquals(['service' => 'stripe'], $secret->getMetadata());
-        self::assertEquals(10, $secret->getReadCount());
+        self::assertSame(42, $secret->getUid());
+        self::assertSame(1, $secret->getScopePid());
+        self::assertSame('api-key', $secret->getIdentifier());
+        self::assertSame('Payment gateway API key', $secret->getDescription());
+        self::assertSame('base64_encrypted_data', $secret->getEncryptedValue());
+        self::assertSame(5, $secret->getOwnerUid());
+        self::assertSame([1, 2, 3], $secret->getAllowedGroups());
+        self::assertSame('payment', $secret->getContext());
+        self::assertSame(3, $secret->getVersion());
+        self::assertSame(['service' => 'stripe'], $secret->getMetadata());
+        self::assertSame(10, $secret->getReadCount());
     }
 
     #[Test]
     public function fromDatabaseRowHandlesEmptyMetadata(): void
     {
-        $row = [
+        $secret = Secret::fromDatabaseRow([
             'uid' => 1,
             'identifier' => 'test',
             'metadata' => '',
-        ];
+        ]);
 
-        $secret = Secret::fromDatabaseRow($row);
-
-        self::assertEquals([], $secret->getMetadata());
-    }
-
-    #[Test]
-    public function fromDatabaseRowHandlesNullValues(): void
-    {
-        $row = [
-            'uid' => null,
-            'identifier' => null,
-            'encrypted_value' => null,
-        ];
-
-        $secret = Secret::fromDatabaseRow($row);
-
-        self::assertNull($secret->getUid());
-        self::assertEquals('', $secret->getIdentifier());
-        self::assertNull($secret->getEncryptedValue());
-    }
-
-    #[Test]
-    public function toDatabaseRowReturnsExpectedArray(): void
-    {
-        $secret = new Secret();
-        $secret
-            ->setScopePid(1)
-            ->setIdentifier('test-secret')
-            ->setDescription('Test secret')
-            ->setEncryptedValue('encrypted')
-            ->setEncryptedDek('dek')
-            ->setDekNonce('nonce1')
-            ->setValueNonce('nonce2')
-            ->setValueChecksum('checksum')
-            ->setOwnerUid(5)
-            ->setAllowedGroups([1, 2])
-            ->setContext('testing')
-            ->setVersion(2)
-            ->setExpiresAt(1735689600)
-            ->setMetadata(['key' => 'value'])
-            ->setAdapter('local')
-            ->setDeleted(false)
-            ->setHidden(false);
-
-        $row = $secret->toDatabaseRow();
-
-        self::assertEquals(1, $row['scope_pid']);
-        self::assertEquals('test-secret', $row['identifier']);
-        self::assertEquals('Test secret', $row['description']);
-        self::assertEquals('encrypted', $row['encrypted_value']);
-        self::assertEquals('dek', $row['encrypted_dek']);
-        self::assertEquals('checksum', $row['value_checksum']);
-        self::assertEquals(5, $row['owner_uid']);
-        self::assertEquals('1,2', $row['allowed_groups']);
-        self::assertEquals('testing', $row['context']);
-        self::assertEquals(2, $row['version']);
-        self::assertEquals('{"key":"value"}', $row['metadata']);
-        self::assertEquals(0, $row['deleted']);
-        self::assertEquals(0, $row['hidden']);
-    }
-
-    #[Test]
-    public function encryptionFieldsAreSetCorrectly(): void
-    {
-        $secret = new Secret();
-        $secret
-            ->setEncryptedValue('enc_value')
-            ->setEncryptedDek('enc_dek')
-            ->setDekNonce('dek_nonce')
-            ->setValueNonce('value_nonce')
-            ->setEncryptionVersion(2)
-            ->setValueChecksum('abc123');
-
-        self::assertEquals('enc_value', $secret->getEncryptedValue());
-        self::assertEquals('enc_dek', $secret->getEncryptedDek());
-        self::assertEquals('dek_nonce', $secret->getDekNonce());
-        self::assertEquals('value_nonce', $secret->getValueNonce());
-        self::assertEquals(2, $secret->getEncryptionVersion());
-        self::assertEquals('abc123', $secret->getValueChecksum());
-    }
-
-    #[Test]
-    public function externalReferenceIsStoredCorrectly(): void
-    {
-        $secret = new Secret();
-        $secret->setExternalReference('vault:secret/data/myapp#password');
-
-        self::assertEquals('vault:secret/data/myapp#password', $secret->getExternalReference());
-    }
-
-    #[Test]
-    public function frontendAccessibleDefaultsToFalse(): void
-    {
-        $secret = new Secret();
-
-        self::assertFalse($secret->isFrontendAccessible());
-    }
-
-    #[Test]
-    public function frontendAccessibleCanBeSet(): void
-    {
-        $secret = new Secret();
-        $result = $secret->setFrontendAccessible(true);
-
-        self::assertTrue($secret->isFrontendAccessible());
-        self::assertSame($secret, $result);
-    }
-
-    #[Test]
-    public function lastRotatedAtDefaultsToZero(): void
-    {
-        $secret = new Secret();
-
-        self::assertEquals(0, $secret->getLastRotatedAt());
-    }
-
-    #[Test]
-    public function lastRotatedAtCanBeSet(): void
-    {
-        $secret = new Secret();
-        $timestamp = 1704067200;
-        $result = $secret->setLastRotatedAt($timestamp);
-
-        self::assertEquals($timestamp, $secret->getLastRotatedAt());
-        self::assertSame($secret, $result);
-    }
-
-    #[Test]
-    public function tstampDefaultsToZero(): void
-    {
-        $secret = new Secret();
-
-        self::assertEquals(0, $secret->getTstamp());
-    }
-
-    #[Test]
-    public function tstampCanBeSet(): void
-    {
-        $secret = new Secret();
-        $timestamp = 1704067200;
-        $result = $secret->setTstamp($timestamp);
-
-        self::assertEquals($timestamp, $secret->getTstamp());
-        self::assertSame($secret, $result);
-    }
-
-    #[Test]
-    public function crdateDefaultsToZero(): void
-    {
-        $secret = new Secret();
-
-        self::assertEquals(0, $secret->getCrdate());
-    }
-
-    #[Test]
-    public function crdateCanBeSet(): void
-    {
-        $secret = new Secret();
-        $timestamp = 1704067200;
-        $result = $secret->setCrdate($timestamp);
-
-        self::assertEquals($timestamp, $secret->getCrdate());
-        self::assertSame($secret, $result);
-    }
-
-    #[Test]
-    public function cruserIdDefaultsToZero(): void
-    {
-        $secret = new Secret();
-
-        self::assertEquals(0, $secret->getCruserId());
-    }
-
-    #[Test]
-    public function cruserIdCanBeSet(): void
-    {
-        $secret = new Secret();
-        $result = $secret->setCruserId(42);
-
-        self::assertEquals(42, $secret->getCruserId());
-        self::assertSame($secret, $result);
-    }
-
-    #[Test]
-    public function lastReadAtDefaultsToZero(): void
-    {
-        $secret = new Secret();
-
-        self::assertEquals(0, $secret->getLastReadAt());
-    }
-
-    #[Test]
-    public function lastReadAtCanBeSet(): void
-    {
-        $secret = new Secret();
-        $timestamp = 1704153600;
-        $result = $secret->setLastReadAt($timestamp);
-
-        self::assertEquals($timestamp, $secret->getLastReadAt());
-        self::assertSame($secret, $result);
-    }
-
-    #[Test]
-    public function readCountCanBeSetDirectly(): void
-    {
-        $secret = new Secret();
-        $result = $secret->setReadCount(100);
-
-        self::assertEquals(100, $secret->getReadCount());
-        self::assertSame($secret, $result);
-    }
-
-    #[Test]
-    public function fromDatabaseRowHandlesFrontendAccessibleTrue(): void
-    {
-        $row = [
-            'uid' => 1,
-            'identifier' => 'test',
-            'frontend_accessible' => 1,
-        ];
-
-        $secret = Secret::fromDatabaseRow($row);
-
-        self::assertTrue($secret->isFrontendAccessible());
+        self::assertSame([], $secret->getMetadata());
     }
 
     #[Test]
     public function fromDatabaseRowHandlesInvalidMetadataJson(): void
     {
-        $row = [
+        $secret = Secret::fromDatabaseRow([
             'uid' => 1,
             'identifier' => 'test',
             'metadata' => 'not-valid-json{',
-        ];
+        ]);
 
-        $secret = Secret::fromDatabaseRow($row);
+        self::assertSame([], $secret->getMetadata());
+    }
 
-        self::assertEquals([], $secret->getMetadata());
+    #[Test]
+    public function fromDatabaseRowHandlesNullValues(): void
+    {
+        $secret = Secret::fromDatabaseRow([
+            'uid' => null,
+            'identifier' => null,
+            'encrypted_value' => null,
+        ]);
+
+        self::assertNull($secret->getUid());
+        self::assertSame('', $secret->getIdentifier());
+        self::assertNull($secret->getEncryptedValue());
     }
 
     #[Test]
     public function fromDatabaseRowHandlesEmptyAllowedGroups(): void
     {
-        $row = [
+        $secret = Secret::fromDatabaseRow([
             'uid' => 1,
             'identifier' => 'test',
             'allowed_groups' => '',
-        ];
+        ]);
 
-        $secret = Secret::fromDatabaseRow($row);
-
-        self::assertEquals([], $secret->getAllowedGroups());
+        self::assertSame([], $secret->getAllowedGroups());
     }
 
     #[Test]
-    public function toDatabaseRowIncludesAllFields(): void
+    public function fromDatabaseRowHandlesFrontendAccessibleTrue(): void
     {
-        $secret = new Secret();
-        $secret
-            ->setLastRotatedAt(1704067200)
-            ->setFrontendAccessible(true)
-            ->setReadCount(50)
-            ->setLastReadAt(1704153600);
+        $secret = Secret::fromDatabaseRow([
+            'uid' => 1,
+            'identifier' => 'test',
+            'frontend_accessible' => 1,
+        ]);
 
-        $row = $secret->toDatabaseRow();
-
-        self::assertArrayHasKey('last_rotated_at', $row);
-        self::assertEquals(1704067200, $row['last_rotated_at']);
-        self::assertArrayHasKey('frontend_accessible', $row);
-        self::assertEquals(1, $row['frontend_accessible']);
-        self::assertArrayHasKey('read_count', $row);
-        self::assertEquals(50, $row['read_count']);
-        self::assertArrayHasKey('last_read_at', $row);
-        self::assertEquals(1704153600, $row['last_read_at']);
-    }
-
-    #[Test]
-    public function scopePidCanBeSet(): void
-    {
-        $secret = new Secret();
-        $result = $secret->setScopePid(100);
-
-        self::assertEquals(100, $secret->getScopePid());
-        self::assertSame($secret, $result);
-    }
-
-    #[Test]
-    public function contextCanBeSet(): void
-    {
-        $secret = new Secret();
-        $result = $secret->setContext('payment');
-
-        self::assertEquals('payment', $secret->getContext());
-        self::assertSame($secret, $result);
-    }
-
-    #[Test]
-    public function versionCanBeSet(): void
-    {
-        $secret = new Secret();
-        $result = $secret->setVersion(5);
-
-        self::assertEquals(5, $secret->getVersion());
-        self::assertSame($secret, $result);
-    }
-
-    #[Test]
-    public function adapterCanBeSet(): void
-    {
-        $secret = new Secret();
-        $result = $secret->setAdapter('hashicorp');
-
-        self::assertEquals('hashicorp', $secret->getAdapter());
-        self::assertSame($secret, $result);
-    }
-
-    #[Test]
-    public function createSetsAllFieldsCorrectly(): void
-    {
-        $secret = Secret::create(
-            identifier: 'my-api-key',
-            encryptedValue: 'enc_value',
-            valueChecksum: 'checksum123',
-            encryptedDek: 'enc_dek',
-            dekNonce: 'dek_nonce',
-            valueNonce: 'value_nonce',
-            ownerUid: 5,
-            allowedGroups: [1, 2, 3],
-            context: 'payment',
-            description: 'Stripe key',
-            adapter: 'local',
-            expiresAt: 1735689600,
-            metadata: ['service' => 'stripe'],
-            scopePid: 10,
-            frontendAccessible: true,
-        );
-
-        self::assertEquals('my-api-key', $secret->getIdentifier());
-        self::assertEquals('enc_value', $secret->getEncryptedValue());
-        self::assertEquals('checksum123', $secret->getValueChecksum());
-        self::assertEquals('enc_dek', $secret->getEncryptedDek());
-        self::assertEquals('dek_nonce', $secret->getDekNonce());
-        self::assertEquals('value_nonce', $secret->getValueNonce());
-        self::assertEquals(5, $secret->getOwnerUid());
-        self::assertEquals([1, 2, 3], $secret->getAllowedGroups());
-        self::assertEquals('payment', $secret->getContext());
-        self::assertEquals('Stripe key', $secret->getDescription());
-        self::assertEquals('local', $secret->getAdapter());
-        self::assertEquals(1735689600, $secret->getExpiresAt());
-        self::assertEquals(['service' => 'stripe'], $secret->getMetadata());
-        self::assertEquals(10, $secret->getScopePid());
         self::assertTrue($secret->isFrontendAccessible());
-    }
-
-    #[Test]
-    public function createAllowsAllCryptoFieldsEmpty(): void
-    {
-        $secret = Secret::create(
-            identifier: 'external-ref',
-            encryptedValue: 'enc_value',
-            valueChecksum: 'checksum',
-        );
-
-        self::assertEquals('external-ref', $secret->getIdentifier());
-        self::assertEquals('', $secret->getEncryptedDek());
-        self::assertEquals('', $secret->getDekNonce());
-        self::assertEquals('', $secret->getValueNonce());
-    }
-
-    #[Test]
-    public function createThrowsOnPartialCryptoFields(): void
-    {
-        $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('encryptedDek, dekNonce, and valueNonce must all be set or all be empty');
-
-        Secret::create(
-            identifier: 'broken',
-            encryptedValue: 'enc_value',
-            valueChecksum: 'checksum',
-            encryptedDek: 'has_dek',
-            dekNonce: '',
-            valueNonce: 'has_nonce',
-        );
-    }
-
-    #[Test]
-    public function createThrowsWhenOnlyDekNonceSet(): void
-    {
-        $this->expectException(ValidationException::class);
-
-        Secret::create(
-            identifier: 'broken',
-            encryptedValue: 'enc_value',
-            valueChecksum: 'checksum',
-            dekNonce: 'only_nonce',
-        );
-    }
-
-    // =========================================================================
-    // Strict-assertion tests (kill IncrementInteger/DecrementInteger/CastInt/
-    // Coalesce/ArrayItemRemoval/FalseValue mutators on Secret.php)
-    // =========================================================================
-
-    #[Test]
-    public function newSecretHasStrictZeroDefaultsForAllCounters(): void
-    {
-        $secret = new Secret();
-
-        // Every default must be EXACTLY 0 (kills Increment/Decrement on defaults).
-        self::assertSame(0, $secret->getScopePid());
-        self::assertSame(0, $secret->getOwnerUid());
-        self::assertSame(0, $secret->getExpiresAt());
-        self::assertSame(0, $secret->getLastRotatedAt());
-        self::assertSame(0, $secret->getTstamp());
-        self::assertSame(0, $secret->getCrdate());
-        self::assertSame(0, $secret->getCruserId());
-        self::assertSame(0, $secret->getReadCount());
-        self::assertSame(0, $secret->getLastReadAt());
-    }
-
-    #[Test]
-    public function newSecretHasStrictVersionDefaultsOfOne(): void
-    {
-        $secret = new Secret();
-
-        // Kills Increment/Decrement on encryptionVersion / version defaults.
-        self::assertSame(1, $secret->getVersion());
-        self::assertSame(1, $secret->getEncryptionVersion());
-    }
-
-    #[Test]
-    public function newSecretHasStrictEmptyDefaultsForStringFields(): void
-    {
-        $secret = new Secret();
-
-        // ConcatOperandRemoval / Coalesce mutations surface as non-empty strings.
-        self::assertSame('', $secret->getIdentifier());
-        self::assertSame('', $secret->getDescription());
-        self::assertSame('', $secret->getEncryptedDek());
-        self::assertSame('', $secret->getDekNonce());
-        self::assertSame('', $secret->getValueNonce());
-        self::assertSame('', $secret->getValueChecksum());
-        self::assertSame('', $secret->getContext());
-        self::assertSame('', $secret->getExternalReference());
-    }
-
-    #[Test]
-    public function newSecretAdapterDefaultIsExactlyLocal(): void
-    {
-        $secret = new Secret();
-
-        self::assertSame('local', $secret->getAdapter());
-    }
-
-    #[Test]
-    public function newSecretArrayDefaultsAreStrictlyEmpty(): void
-    {
-        $secret = new Secret();
-
-        self::assertSame([], $secret->getAllowedGroups());
-        self::assertSame([], $secret->getMetadata());
-    }
-
-    /**
-     * @return iterable<string, array{int, int}>
-     */
-    public static function incrementVersionBoundaryProvider(): iterable
-    {
-        yield 'from 1 to 2' => [1, 2];
-        yield 'from 2 to 3' => [2, 3];
-        yield 'from 99 to 100' => [99, 100];
-        yield 'near PHP_INT_MAX' => [PHP_INT_MAX - 2, PHP_INT_MAX - 1];
-    }
-
-    #[Test]
-    #[DataProvider('incrementVersionBoundaryProvider')]
-    public function incrementVersionAddsExactlyOne(int $initial, int $expected): void
-    {
-        $secret = new Secret();
-        $secret->setVersion($initial);
-        $secret->incrementVersion();
-
-        self::assertSame($expected, $secret->getVersion());
-    }
-
-    /**
-     * @return iterable<string, array{int, int}>
-     */
-    public static function incrementReadCountBoundaryProvider(): iterable
-    {
-        yield 'from 0 to 1' => [0, 1];
-        yield 'from 1 to 2' => [1, 2];
-        yield 'from 999 to 1000' => [999, 1000];
-    }
-
-    #[Test]
-    #[DataProvider('incrementReadCountBoundaryProvider')]
-    public function incrementReadCountAddsExactlyOne(int $initial, int $expected): void
-    {
-        $secret = new Secret();
-        $secret->setReadCount($initial);
-        $secret->incrementReadCount();
-
-        self::assertSame($expected, $secret->getReadCount());
-    }
-
-    /**
-     * Kills LessThan mutation on isExpired(): `< time()` vs `<= time()`.
-     *
-     * Provides offsets relative to `time()`, not absolute timestamps, so the
-     * data provider survives a clock tick between provider evaluation and
-     * assertion (which previously caused flaky failures around second
-     * boundaries).
-     *
-     * @return iterable<string, array{int|null, bool}>
-     */
-    public static function isExpiredBoundaryProvider(): iterable
-    {
-        yield 'zero means no-expiration' => ['zero', false];
-        yield 'far future' => ['far-future', false];
-        yield '60 seconds in future' => ['+60', false];
-        yield '60 seconds in past is expired' => ['-60', true];
-        yield 'negative absolute means expiresAt > 0 check fails first' => ['negative', false];
-    }
-
-    #[Test]
-    #[DataProvider('isExpiredBoundaryProvider')]
-    public function isExpiredBoundaries(string $kind, bool $expected): void
-    {
-        $secret = new Secret();
-        $expiresAt = match ($kind) {
-            'zero' => 0,
-            'far-future' => PHP_INT_MAX,
-            'negative' => -1,
-            '+60' => time() + 60,
-            '-60' => time() - 60,
-            default => throw new InvalidArgumentException("Unknown kind: $kind", 7112662888),
-        };
-        $secret->setExpiresAt($expiresAt);
-
-        self::assertSame($expected, $secret->isExpired());
-    }
-
-    #[Test]
-    public function setAllowedGroupsStrictlyCastsStringsToInt(): void
-    {
-        $secret = new Secret();
-        $secret->setAllowedGroups(['1', '2', '3']);
-
-        // assertSame enforces int type — kills UnwrapArrayMap mutation.
-        self::assertSame([1, 2, 3], $secret->getAllowedGroups());
-    }
-
-    #[Test]
-    public function setAllowedGroupsStrictlyCastsFloatToInt(): void
-    {
-        $secret = new Secret();
-        $secret->setAllowedGroups([1.9, 2.1]);
-
-        self::assertSame([1, 2], $secret->getAllowedGroups());
-    }
-
-    #[Test]
-    public function setAllowedGroupsEmptyArrayStaysEmpty(): void
-    {
-        $secret = new Secret();
-        $secret->setAllowedGroups([]);
-
-        self::assertSame([], $secret->getAllowedGroups());
     }
 
     /**
@@ -768,8 +501,6 @@ final class SecretTest extends TestCase
     }
 
     /**
-     * Kills Coalesce + Increment/Decrement on encryption_version default.
-     *
      * @return iterable<string, array{array<string, mixed>, int}>
      */
     public static function encryptionVersionCoalesceProvider(): iterable
@@ -816,8 +547,6 @@ final class SecretTest extends TestCase
     }
 
     /**
-     * Kills Coalesce + Increment/Decrement + CastInt on owner_uid default.
-     *
      * @return iterable<string, array{array<string, mixed>, int}>
      */
     public static function ownerUidCoalesceProvider(): iterable
@@ -909,7 +638,6 @@ final class SecretTest extends TestCase
     {
         $secret = Secret::fromDatabaseRow(['uid' => '42', 'identifier' => 't']);
 
-        // Kills CastInt mutation on line 500.
         self::assertSame(42, $secret->getUid());
     }
 
@@ -918,7 +646,6 @@ final class SecretTest extends TestCase
     {
         $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't']);
 
-        // Kill Coalesce mutators on lines 505-507, 509.
         self::assertSame('', $secret->getEncryptedDek());
         self::assertSame('', $secret->getDekNonce());
         self::assertSame('', $secret->getValueNonce());
@@ -989,13 +716,266 @@ final class SecretTest extends TestCase
         self::assertSame(1704153600, $secret->getLastReadAt());
     }
 
+    // ---------------------------------------------------------------
+    // fromDatabaseRow() — type / cast / coalesce coverage that kills
+    // mutation testing artefacts on the hydration code path.
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function fromDatabaseRowEncryptionVersionCastsStringToInt(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'encryption_version' => '3']);
+
+        self::assertSame(3, $secret->getEncryptionVersion());
+        self::assertIsInt($secret->getEncryptionVersion());
+    }
+
+    #[Test]
+    public function fromDatabaseRowVersionCastsStringToInt(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'version' => '7']);
+
+        self::assertSame(7, $secret->getVersion());
+        self::assertIsInt($secret->getVersion());
+    }
+
+    #[Test]
+    public function fromDatabaseRowExpiresAtCastsStringToInt(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'expires_at' => '1735689600']);
+
+        self::assertSame(1735689600, $secret->getExpiresAt());
+        self::assertIsInt($secret->getExpiresAt());
+    }
+
+    #[Test]
+    public function fromDatabaseRowLastRotatedAtCastsStringToInt(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'last_rotated_at' => '1704067200']);
+
+        self::assertSame(1704067200, $secret->getLastRotatedAt());
+        self::assertIsInt($secret->getLastRotatedAt());
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, int}>
+     */
+    public static function tstampProvider(): iterable
+    {
+        yield 'missing defaults exactly to 0' => [['uid' => 1, 'identifier' => 't'], 0];
+        yield 'string "42" casts to 42' => [['uid' => 1, 'identifier' => 't', 'tstamp' => '42'], 42];
+        yield 'zero stays zero' => [['uid' => 1, 'identifier' => 't', 'tstamp' => 0], 0];
+        yield 'positive 1704067200' => [['uid' => 1, 'identifier' => 't', 'tstamp' => 1704067200], 1704067200];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    #[Test]
+    #[DataProvider('tstampProvider')]
+    public function fromDatabaseRowTstampCastsAndDefaultsCorrectly(array $row, int $expected): void
+    {
+        $secret = Secret::fromDatabaseRow($row);
+
+        self::assertSame($expected, $secret->getTstamp());
+        self::assertIsInt($secret->getTstamp());
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>, int}>
+     */
+    public static function crdateProvider(): iterable
+    {
+        yield 'missing defaults exactly to 0' => [['uid' => 1, 'identifier' => 't'], 0];
+        yield 'string "99" casts to 99' => [['uid' => 1, 'identifier' => 't', 'crdate' => '99'], 99];
+        yield 'positive 1600000000' => [['uid' => 1, 'identifier' => 't', 'crdate' => 1600000000], 1600000000];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    #[Test]
+    #[DataProvider('crdateProvider')]
+    public function fromDatabaseRowCrdateCastsAndDefaultsCorrectly(array $row, int $expected): void
+    {
+        $secret = Secret::fromDatabaseRow($row);
+
+        self::assertSame($expected, $secret->getCrdate());
+        self::assertIsInt($secret->getCrdate());
+    }
+
+    #[Test]
+    public function fromDatabaseRowCruserIdCastsStringToInt(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'cruser_id' => '12']);
+
+        self::assertSame(12, $secret->getCruserId());
+        self::assertIsInt($secret->getCruserId());
+    }
+
+    #[Test]
+    public function fromDatabaseRowReadCountCastsStringToInt(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'read_count' => '55']);
+
+        self::assertSame(55, $secret->getReadCount());
+        self::assertIsInt($secret->getReadCount());
+    }
+
+    #[Test]
+    public function fromDatabaseRowLastReadAtCastsStringToInt(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'last_read_at' => '1704153600']);
+
+        self::assertSame(1704153600, $secret->getLastReadAt());
+        self::assertIsInt($secret->getLastReadAt());
+    }
+
+    #[Test]
+    public function fromDatabaseRowDeletedDefaultIsExactlyFalse(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't']);
+
+        self::assertFalse($secret->isDeleted());
+    }
+
+    #[Test]
+    public function fromDatabaseRowHiddenDefaultIsExactlyFalse(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't']);
+
+        self::assertFalse($secret->isHidden());
+    }
+
+    #[Test]
+    public function fromDatabaseRowDeletedTrueReturnsTrue(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'deleted' => 1]);
+
+        self::assertTrue($secret->isDeleted());
+    }
+
+    #[Test]
+    public function fromDatabaseRowHiddenTrueReturnsTrue(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'hidden' => 1]);
+
+        self::assertTrue($secret->isHidden());
+    }
+
+    #[Test]
+    public function fromDatabaseRowExplicitDeletedTruthyOverridesDefault(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'deleted' => true]);
+
+        self::assertTrue($secret->isDeleted());
+    }
+
+    #[Test]
+    public function fromDatabaseRowExplicitHiddenTruthyOverridesDefault(): void
+    {
+        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'hidden' => true]);
+
+        self::assertTrue($secret->isHidden());
+    }
+
+    #[Test]
+    public function fromDatabaseRowAllowedGroupsFiltersZeroValues(): void
+    {
+        $secret = Secret::fromDatabaseRow([
+            'uid' => 1,
+            'identifier' => 't',
+            'allowed_groups' => '1,0,2,0,3',
+        ]);
+
+        // Zeros must be filtered out — without array_filter() they would remain.
+        self::assertNotContains(0, $secret->getAllowedGroups());
+        self::assertSame([1, 2, 3], array_values($secret->getAllowedGroups()));
+    }
+
+    #[Test]
+    public function fromDatabaseRowAllowedGroupsAllZeroReturnsEmpty(): void
+    {
+        $secret = Secret::fromDatabaseRow([
+            'uid' => 1,
+            'identifier' => 't',
+            'allowed_groups' => '0,0,0',
+        ]);
+
+        self::assertSame([], $secret->getAllowedGroups());
+    }
+
+    // ---------------------------------------------------------------
+    // toDatabaseRow() — serialisation.
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function toDatabaseRowReturnsExpectedArray(): void
+    {
+        $secret = new Secret(
+            identifier: 'test-secret',
+            scopePid: 1,
+            description: 'Test secret',
+            encryptedValue: 'encrypted',
+            encryptedDek: 'dek',
+            dekNonce: 'nonce1',
+            valueNonce: 'nonce2',
+            valueChecksum: 'checksum',
+            ownerUid: 5,
+            allowedGroups: [1, 2],
+            context: 'testing',
+            version: 2,
+            expiresAt: 1735689600,
+            metadata: ['key' => 'value'],
+            adapter: 'local',
+        );
+
+        $row = $secret->toDatabaseRow();
+
+        self::assertSame(1, $row['scope_pid']);
+        self::assertSame('test-secret', $row['identifier']);
+        self::assertSame('Test secret', $row['description']);
+        self::assertSame('encrypted', $row['encrypted_value']);
+        self::assertSame('dek', $row['encrypted_dek']);
+        self::assertSame('checksum', $row['value_checksum']);
+        self::assertSame(5, $row['owner_uid']);
+        self::assertSame('1,2', $row['allowed_groups']);
+        self::assertSame('testing', $row['context']);
+        self::assertSame(2, $row['version']);
+        self::assertSame('{"key":"value"}', $row['metadata']);
+        self::assertSame(0, $row['deleted']);
+        self::assertSame(0, $row['hidden']);
+    }
+
+    #[Test]
+    public function toDatabaseRowIncludesLifecycleFields(): void
+    {
+        $secret = new Secret(
+            identifier: 't',
+            frontendAccessible: true,
+            lastRotatedAt: 1704067200,
+            readCount: 50,
+            lastReadAt: 1704153600,
+        );
+
+        $row = $secret->toDatabaseRow();
+
+        self::assertArrayHasKey('last_rotated_at', $row);
+        self::assertSame(1704067200, $row['last_rotated_at']);
+        self::assertArrayHasKey('frontend_accessible', $row);
+        self::assertSame(1, $row['frontend_accessible']);
+        self::assertArrayHasKey('read_count', $row);
+        self::assertSame(50, $row['read_count']);
+        self::assertArrayHasKey('last_read_at', $row);
+        self::assertSame(1704153600, $row['last_read_at']);
+    }
+
     #[Test]
     public function toDatabaseRowHasExactKeySet(): void
     {
-        $secret = new Secret();
+        $secret = new Secret(identifier: 't');
         $row = $secret->toDatabaseRow();
 
-        // Kill ArrayItemRemoval by asserting exact key set.
         $expectedKeys = [
             'adapter',
             'allowed_groups',
@@ -1031,34 +1011,33 @@ final class SecretTest extends TestCase
     #[Test]
     public function toDatabaseRowHasStrictIntegerTypesOnScalarFields(): void
     {
-        $secret = new Secret();
-        $secret
-            ->setScopePid(1)
-            ->setIdentifier('x')
-            ->setEncryptedValue('ev')
-            ->setEncryptedDek('dek')
-            ->setDekNonce('dn')
-            ->setValueNonce('vn')
-            ->setEncryptionVersion(1)
-            ->setValueChecksum('cs')
-            ->setOwnerUid(2)
-            ->setAllowedGroups([3, 4])
-            ->setContext('ctx')
-            ->setFrontendAccessible(true)
-            ->setVersion(5)
-            ->setExpiresAt(100)
-            ->setLastRotatedAt(200)
-            ->setMetadata(['k' => 'v'])
-            ->setAdapter('hashicorp')
-            ->setExternalReference('ref')
-            ->setDeleted(false)
-            ->setHidden(true)
-            ->setReadCount(9)
-            ->setLastReadAt(300);
+        $secret = new Secret(
+            identifier: 'x',
+            scopePid: 1,
+            encryptedValue: 'ev',
+            encryptedDek: 'dek',
+            dekNonce: 'dn',
+            valueNonce: 'vn',
+            encryptionVersion: 1,
+            valueChecksum: 'cs',
+            ownerUid: 2,
+            allowedGroups: [3, 4],
+            context: 'ctx',
+            frontendAccessible: true,
+            version: 5,
+            expiresAt: 100,
+            lastRotatedAt: 200,
+            metadata: ['k' => 'v'],
+            adapter: 'hashicorp',
+            externalReference: 'ref',
+            deleted: false,
+            hidden: true,
+            readCount: 9,
+            lastReadAt: 300,
+        );
 
         $row = $secret->toDatabaseRow();
 
-        // Kill ArrayItem / CastInt mutators — strict types per key.
         self::assertSame(1, $row['scope_pid']);
         self::assertSame('x', $row['identifier']);
         self::assertSame('ev', $row['encrypted_value']);
@@ -1086,7 +1065,7 @@ final class SecretTest extends TestCase
     #[Test]
     public function toDatabaseRowSerialisesEmptyAllowedGroupsAsEmptyString(): void
     {
-        $secret = new Secret();
+        $secret = new Secret(identifier: 't');
 
         $row = $secret->toDatabaseRow();
 
@@ -1097,7 +1076,7 @@ final class SecretTest extends TestCase
     #[Test]
     public function toDatabaseRowSerialisesMetadataAsJsonEmptyArrayFromEmptyArray(): void
     {
-        $secret = new Secret();
+        $secret = new Secret(identifier: 't');
 
         $row = $secret->toDatabaseRow();
 
@@ -1105,470 +1084,46 @@ final class SecretTest extends TestCase
         self::assertSame('[]', $row['metadata']);
     }
 
-    #[Test]
-    public function toDatabaseRowFrontendAccessibleBooleanSerialisedAsZeroOrOne(): void
+    /**
+     * @return iterable<string, array{bool, int}>
+     */
+    public static function frontendAccessibleSerialisationProvider(): iterable
     {
-        $secret = new Secret();
-        $secret->setFrontendAccessible(false);
-        self::assertSame(0, $secret->toDatabaseRow()['frontend_accessible']);
-
-        $secret->setFrontendAccessible(true);
-        self::assertSame(1, $secret->toDatabaseRow()['frontend_accessible']);
+        yield 'false serialises to 0' => [false, 0];
+        yield 'true serialises to 1' => [true, 1];
     }
 
     #[Test]
-    public function toDatabaseRowDeletedAndHiddenBooleansSerialisedAsZeroOrOne(): void
+    #[DataProvider('frontendAccessibleSerialisationProvider')]
+    public function toDatabaseRowFrontendAccessibleBooleanSerialisedAsZeroOrOne(bool $value, int $expected): void
     {
-        $secret = new Secret();
-        $secret->setDeleted(true)->setHidden(false);
+        $secret = new Secret(identifier: 't', frontendAccessible: $value);
+
+        self::assertSame($expected, $secret->toDatabaseRow()['frontend_accessible']);
+    }
+
+    /**
+     * @return iterable<string, array{bool, bool, int, int}>
+     */
+    public static function deletedHiddenSerialisationProvider(): iterable
+    {
+        yield 'deleted=true hidden=false' => [true, false, 1, 0];
+        yield 'deleted=false hidden=true' => [false, true, 0, 1];
+    }
+
+    #[Test]
+    #[DataProvider('deletedHiddenSerialisationProvider')]
+    public function toDatabaseRowDeletedAndHiddenBooleansSerialisedAsZeroOrOne(
+        bool $deleted,
+        bool $hidden,
+        int $expectedDeleted,
+        int $expectedHidden,
+    ): void {
+        $secret = new Secret(identifier: 't', deleted: $deleted, hidden: $hidden);
+
         $row = $secret->toDatabaseRow();
-        self::assertSame(1, $row['deleted']);
-        self::assertSame(0, $row['hidden']);
 
-        $secret->setDeleted(false)->setHidden(true);
-        $row = $secret->toDatabaseRow();
-        self::assertSame(0, $row['deleted']);
-        self::assertSame(1, $row['hidden']);
-    }
-
-    /**
-     * Kills Increment/Decrement mutations on `create()` defaults.
-     */
-    #[Test]
-    public function createDefaultIntegersAreStrictZero(): void
-    {
-        $secret = Secret::create(
-            identifier: 'x',
-            encryptedValue: 'v',
-            valueChecksum: 'c',
-        );
-
-        self::assertSame(0, $secret->getOwnerUid());
-        self::assertSame(0, $secret->getExpiresAt());
-        self::assertSame(0, $secret->getScopePid());
-        self::assertFalse($secret->isFrontendAccessible());
-    }
-
-    /**
-     * Kills CastInt mutation on line 109 — setCount must be int type.
-     */
-    #[Test]
-    public function createTwoSetCryptoFieldsThrows(): void
-    {
-        $this->expectException(ValidationException::class);
-
-        Secret::create(
-            identifier: 'x',
-            encryptedValue: 'v',
-            valueChecksum: 'c',
-            encryptedDek: 'a',
-            dekNonce: 'b',
-        );
-    }
-
-    #[Test]
-    public function createWithOnlyEncryptedDekThrows(): void
-    {
-        $this->expectException(ValidationException::class);
-
-        Secret::create(
-            identifier: 'x',
-            encryptedValue: 'v',
-            valueChecksum: 'c',
-            encryptedDek: 'only_dek',
-        );
-    }
-
-    #[Test]
-    public function createWithOnlyValueNonceThrows(): void
-    {
-        $this->expectException(ValidationException::class);
-
-        Secret::create(
-            identifier: 'x',
-            encryptedValue: 'v',
-            valueChecksum: 'c',
-            valueNonce: 'only_vn',
-        );
-    }
-
-    #[Test]
-    public function createWithAllThreeCryptoFieldsSetSucceeds(): void
-    {
-        $secret = Secret::create(
-            identifier: 'x',
-            encryptedValue: 'v',
-            valueChecksum: 'c',
-            encryptedDek: 'a',
-            dekNonce: 'b',
-            valueNonce: 'cc',
-        );
-
-        self::assertSame('a', $secret->getEncryptedDek());
-        self::assertSame('b', $secret->getDekNonce());
-        self::assertSame('cc', $secret->getValueNonce());
-    }
-
-    #[Test]
-    public function createCastsAllowedGroupsStrictlyToInt(): void
-    {
-        $secret = Secret::create(
-            identifier: 'x',
-            encryptedValue: 'v',
-            valueChecksum: 'c',
-            allowedGroups: ['10', '20'],
-        );
-
-        self::assertSame([10, 20], $secret->getAllowedGroups());
-    }
-
-    // =========================================================================
-    // Strict-type & boundary tests for fromDatabaseRow() — kill CastInt,
-    // Increment/Decrement, Coalesce, FalseValue, UnwrapArrayFilter, LessThan.
-    // =========================================================================
-
-    /**
-     * Kill CastInt on line 508 — encryption_version cast.
-     */
-    #[Test]
-    public function fromDatabaseRowEncryptionVersionCastsStringToInt(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'encryption_version' => '3']);
-
-        self::assertSame(3, $secret->getEncryptionVersion());
-        self::assertIsInt($secret->getEncryptionVersion());
-    }
-
-    /**
-     * Kill CastInt on line 513 — version cast.
-     */
-    #[Test]
-    public function fromDatabaseRowVersionCastsStringToInt(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'version' => '7']);
-
-        self::assertSame(7, $secret->getVersion());
-        self::assertIsInt($secret->getVersion());
-    }
-
-    /**
-     * Kill CastInt on line 514 — expires_at cast.
-     */
-    #[Test]
-    public function fromDatabaseRowExpiresAtCastsStringToInt(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'expires_at' => '1735689600']);
-
-        self::assertSame(1735689600, $secret->getExpiresAt());
-        self::assertIsInt($secret->getExpiresAt());
-    }
-
-    /**
-     * Kill CastInt on line 515 — last_rotated_at cast.
-     */
-    #[Test]
-    public function fromDatabaseRowLastRotatedAtCastsStringToInt(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'last_rotated_at' => '1704067200']);
-
-        self::assertSame(1704067200, $secret->getLastRotatedAt());
-        self::assertIsInt($secret->getLastRotatedAt());
-    }
-
-    /**
-     * Kill CastInt + Increment + Decrement on line 518 — tstamp cast and default.
-     *
-     * @return iterable<string, array{array<string, mixed>, int}>
-     */
-    public static function tstampProvider(): iterable
-    {
-        yield 'missing defaults exactly to 0' => [['uid' => 1, 'identifier' => 't'], 0];
-        yield 'string "42" casts to 42' => [['uid' => 1, 'identifier' => 't', 'tstamp' => '42'], 42];
-        yield 'zero stays zero' => [['uid' => 1, 'identifier' => 't', 'tstamp' => 0], 0];
-        yield 'positive 1704067200' => [['uid' => 1, 'identifier' => 't', 'tstamp' => 1704067200], 1704067200];
-    }
-
-    /**
-     * @param array<string, mixed> $row
-     */
-    #[Test]
-    #[DataProvider('tstampProvider')]
-    public function fromDatabaseRowTstampCastsAndDefaultsCorrectly(array $row, int $expected): void
-    {
-        $secret = Secret::fromDatabaseRow($row);
-
-        self::assertSame($expected, $secret->getTstamp());
-        self::assertIsInt($secret->getTstamp());
-    }
-
-    /**
-     * Kill CastInt + Increment + Decrement on line 519 — crdate cast and default.
-     *
-     * @return iterable<string, array{array<string, mixed>, int}>
-     */
-    public static function crdateProvider(): iterable
-    {
-        yield 'missing defaults exactly to 0' => [['uid' => 1, 'identifier' => 't'], 0];
-        yield 'string "99" casts to 99' => [['uid' => 1, 'identifier' => 't', 'crdate' => '99'], 99];
-        yield 'positive 1600000000' => [['uid' => 1, 'identifier' => 't', 'crdate' => 1600000000], 1600000000];
-    }
-
-    /**
-     * @param array<string, mixed> $row
-     */
-    #[Test]
-    #[DataProvider('crdateProvider')]
-    public function fromDatabaseRowCrdateCastsAndDefaultsCorrectly(array $row, int $expected): void
-    {
-        $secret = Secret::fromDatabaseRow($row);
-
-        self::assertSame($expected, $secret->getCrdate());
-        self::assertIsInt($secret->getCrdate());
-    }
-
-    /**
-     * Kill CastInt on line 520 — cruser_id cast.
-     */
-    #[Test]
-    public function fromDatabaseRowCruserIdCastsStringToInt(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'cruser_id' => '12']);
-
-        self::assertSame(12, $secret->getCruserId());
-        self::assertIsInt($secret->getCruserId());
-    }
-
-    /**
-     * Kill CastInt on line 523 — read_count cast.
-     */
-    #[Test]
-    public function fromDatabaseRowReadCountCastsStringToInt(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'read_count' => '55']);
-
-        self::assertSame(55, $secret->getReadCount());
-        self::assertIsInt($secret->getReadCount());
-    }
-
-    /**
-     * Kill CastInt on line 524 — last_read_at cast.
-     */
-    #[Test]
-    public function fromDatabaseRowLastReadAtCastsStringToInt(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'last_read_at' => '1704153600']);
-
-        self::assertSame(1704153600, $secret->getLastReadAt());
-        self::assertIsInt($secret->getLastReadAt());
-    }
-
-    /**
-     * Kill FalseValue + Coalesce on line 521 — deleted default must be FALSE.
-     */
-    #[Test]
-    public function fromDatabaseRowDeletedDefaultIsExactlyFalse(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't']);
-
-        self::assertFalse($secret->isDeleted());
-    }
-
-    /**
-     * Kill FalseValue + Coalesce on line 522 — hidden default must be FALSE.
-     */
-    #[Test]
-    public function fromDatabaseRowHiddenDefaultIsExactlyFalse(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't']);
-
-        self::assertFalse($secret->isHidden());
-    }
-
-    /**
-     * Kill FalseValue on line 521 — deleted=true (truthy) yields TRUE.
-     */
-    #[Test]
-    public function fromDatabaseRowDeletedTrueReturnsTrue(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'deleted' => 1]);
-
-        self::assertTrue($secret->isDeleted());
-    }
-
-    /**
-     * Kill FalseValue on line 522 — hidden=true (truthy) yields TRUE.
-     */
-    #[Test]
-    public function fromDatabaseRowHiddenTrueReturnsTrue(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'hidden' => 1]);
-
-        self::assertTrue($secret->isHidden());
-    }
-
-    /**
-     * Kill LessThan on line 344 — isExpired() uses strict less than time().
-     * When expires_at == time() (not past), must NOT be expired.
-     */
-    #[Test]
-    public function isExpiredReturnsFalseWhenExpiresAtEqualsCurrentTime(): void
-    {
-        $secret = new Secret();
-        // Set expiry slightly into the future so equality-to-time is what we test.
-        // We cannot mock time() easily, so approximate: set to time + 10 seconds
-        // and assert FALSE. The LessThan mutation (<=) would incorrectly expire.
-        $futureOneSecond = time() + 1;
-        $secret->setExpiresAt($futureOneSecond);
-
-        self::assertFalse($secret->isExpired());
-    }
-
-    /**
-     * Kill UnwrapArrayFilter on line 535 — allowed_groups filter must remove zeros.
-     */
-    #[Test]
-    public function fromDatabaseRowAllowedGroupsFiltersZeroValues(): void
-    {
-        // "0" would be intval-cast to 0 and then array_filter removes it (0 is falsy).
-        $secret = Secret::fromDatabaseRow([
-            'uid' => 1,
-            'identifier' => 't',
-            'allowed_groups' => '1,0,2,0,3',
-        ]);
-
-        // Zeros must be filtered out — without array_filter() they would remain.
-        self::assertNotContains(0, $secret->getAllowedGroups());
-        self::assertSame([1, 2, 3], array_values($secret->getAllowedGroups()));
-    }
-
-    /**
-     * Kill UnwrapArrayFilter on line 535 — only zeros returns empty array.
-     */
-    #[Test]
-    public function fromDatabaseRowAllowedGroupsAllZeroReturnsEmpty(): void
-    {
-        $secret = Secret::fromDatabaseRow([
-            'uid' => 1,
-            'identifier' => 't',
-            'allowed_groups' => '0,0,0',
-        ]);
-
-        self::assertSame([], $secret->getAllowedGroups());
-    }
-
-    /**
-     * Kill CastInt on line 109 — create() uses int arithmetic for setCount.
-     * All three crypto fields set must NOT throw.
-     */
-    #[Test]
-    public function createAllThreeCryptoFieldsSetDoesNotThrow(): void
-    {
-        // No exception expected.
-        $secret = Secret::create(
-            identifier: 'id',
-            encryptedValue: 'v',
-            valueChecksum: 'cs',
-            encryptedDek: 'dek',
-            dekNonce: 'dn',
-            valueNonce: 'vn',
-        );
-
-        self::assertSame('dek', $secret->getEncryptedDek());
-        self::assertSame('dn', $secret->getDekNonce());
-        self::assertSame('vn', $secret->getValueNonce());
-    }
-
-    /**
-     * Kill CastInt on line 109 — create() with only dekNonce set must throw.
-     */
-    #[Test]
-    public function createOnlyDekNonceThrows(): void
-    {
-        $this->expectException(ValidationException::class);
-
-        Secret::create(
-            identifier: 'id',
-            encryptedValue: 'v',
-            valueChecksum: 'cs',
-            dekNonce: 'dn',
-        );
-    }
-
-    /**
-     * Kill CastInt on line 109 — create() with encryptedDek + valueNonce throws.
-     */
-    #[Test]
-    public function createDekAndValueNonceWithoutDekNonceThrows(): void
-    {
-        $this->expectException(ValidationException::class);
-
-        Secret::create(
-            identifier: 'id',
-            encryptedValue: 'v',
-            valueChecksum: 'cs',
-            encryptedDek: 'dek',
-            valueNonce: 'vn',
-        );
-    }
-
-    /**
-     * Kill CastInt on line 109 — create() with dekNonce + valueNonce throws.
-     */
-    #[Test]
-    public function createDekNonceAndValueNonceWithoutEncryptedDekThrows(): void
-    {
-        $this->expectException(ValidationException::class);
-
-        Secret::create(
-            identifier: 'id',
-            encryptedValue: 'v',
-            valueChecksum: 'cs',
-            dekNonce: 'dn',
-            valueNonce: 'vn',
-        );
-    }
-
-    /**
-     * Kill Coalesce on line 521 — default must apply when deleted is absent.
-     */
-    #[Test]
-    public function fromDatabaseRowDeletedAbsentUsesDefaultFalse(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't']);
-
-        self::assertFalse($secret->isDeleted());
-    }
-
-    /**
-     * Kill Coalesce on line 522 — default must apply when hidden is absent.
-     */
-    #[Test]
-    public function fromDatabaseRowHiddenAbsentUsesDefaultFalse(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't']);
-
-        self::assertFalse($secret->isHidden());
-    }
-
-    /**
-     * Kill Coalesce on line 521 — explicit deleted=true overrides default.
-     */
-    #[Test]
-    public function fromDatabaseRowExplicitDeletedTruthyOverridesDefault(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'deleted' => true]);
-
-        self::assertTrue($secret->isDeleted());
-    }
-
-    /**
-     * Kill Coalesce on line 522 — explicit hidden=true overrides default.
-     */
-    #[Test]
-    public function fromDatabaseRowExplicitHiddenTruthyOverridesDefault(): void
-    {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'hidden' => true]);
-
-        self::assertTrue($secret->isHidden());
+        self::assertSame($expectedDeleted, $row['deleted']);
+        self::assertSame($expectedHidden, $row['hidden']);
     }
 }

--- a/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
@@ -160,13 +160,7 @@ final class SecretRepositoryTest extends TestCase
     {
         $connection = $this->useStrictConnectionMock();
 
-        $secret = new Secret();
-        $secret->setIdentifier('new-secret');
-        $secret->setEncryptedValue('encrypted');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('deknonce');
-        $secret->setValueNonce('valuenonce');
-        $secret->setEncryptionVersion(1);
+        $secret = $this->newEncryptedSecret('new-secret');
 
         $connection
             ->expects(self::once())
@@ -183,9 +177,12 @@ final class SecretRepositoryTest extends TestCase
             ->method('delete')
             ->with('tx_nrvault_secret_begroups_mm', self::anything());
 
-        $this->subject->save($secret);
+        $saved = $this->subject->save($secret);
 
-        self::assertSame(1, $secret->getUid());
+        // save() returns a NEW instance on INSERT (uid attached); the
+        // original is left unmutated by design.
+        self::assertNull($secret->getUid());
+        self::assertSame(1, $saved->getUid());
     }
 
     #[Test]
@@ -193,14 +190,7 @@ final class SecretRepositoryTest extends TestCase
     {
         $connection = $this->useStrictConnectionMock();
 
-        $secret = new Secret();
-        $secret->setUid(42);
-        $secret->setIdentifier('existing-secret');
-        $secret->setEncryptedValue('encrypted');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('deknonce');
-        $secret->setValueNonce('valuenonce');
-        $secret->setEncryptionVersion(1);
+        $secret = $this->newEncryptedSecret('existing-secret', uid: 42);
 
         $connection
             ->expects(self::once())
@@ -224,8 +214,7 @@ final class SecretRepositoryTest extends TestCase
     {
         $connection = $this->useStrictConnectionMock();
 
-        $secret = new Secret();
-        $secret->setIdentifier('new-unsaved');
+        $secret = new Secret(identifier: 'new-unsaved');
 
         $connection
             ->expects(self::never())
@@ -239,9 +228,7 @@ final class SecretRepositoryTest extends TestCase
     {
         $connection = $this->useStrictConnectionMock();
 
-        $secret = new Secret();
-        $secret->setUid(42);
-        $secret->setIdentifier('to-delete');
+        $secret = new Secret(identifier: 'to-delete', uid: 42);
 
         $connection
             ->expects(self::once())
@@ -477,14 +464,7 @@ final class SecretRepositoryTest extends TestCase
     {
         $connection = $this->useStrictConnectionMock();
 
-        $secret = new Secret();
-        $secret->setIdentifier('new-secret-groups');
-        $secret->setEncryptedValue('encrypted');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('deknonce');
-        $secret->setValueNonce('valuenonce');
-        $secret->setEncryptionVersion(1);
-        $secret->setAllowedGroups([3, 7]);
+        $secret = $this->newEncryptedSecret('new-secret-groups', allowedGroups: [3, 7]);
 
         $connection
             ->method('lastInsertId')
@@ -500,9 +480,10 @@ final class SecretRepositoryTest extends TestCase
             ->expects(self::once())
             ->method('delete');
 
-        $this->subject->save($secret);
+        $saved = $this->subject->save($secret);
 
-        self::assertSame(5, $secret->getUid());
+        self::assertNull($secret->getUid());
+        self::assertSame(5, $saved->getUid());
     }
 
     /**
@@ -727,13 +708,7 @@ final class SecretRepositoryTest extends TestCase
     #[Test]
     public function saveThrowsWhenConnectionInsertFails(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('insert-fail');
-        $secret->setEncryptedValue('encrypted');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('deknonce');
-        $secret->setValueNonce('valuenonce');
-        $secret->setEncryptionVersion(1);
+        $secret = $this->newEncryptedSecret('insert-fail');
 
         $this->connection
             ->method('insert')
@@ -756,23 +731,20 @@ final class SecretRepositoryTest extends TestCase
     #[DataProvider('nonNumericLastInsertIdProvider')]
     public function saveHandlesNonNumericLastInsertId(string $lastInsertIdValue, int $expectedUid, string $description): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('nonnum-lastinsert');
-        $secret->setEncryptedValue('encrypted');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('deknonce');
-        $secret->setValueNonce('valuenonce');
-        $secret->setEncryptionVersion(1);
+        $secret = $this->newEncryptedSecret('nonnum-lastinsert');
 
         $this->connection->method('insert')->willReturn(1);
         $this->connection->method('lastInsertId')->willReturn($lastInsertIdValue);
         $this->connection->method('delete')->willReturn(0);
 
-        $this->subject->save($secret);
+        $saved = $this->subject->save($secret);
 
+        // The original secret's UID is unchanged (immutable entity); the
+        // returned instance carries the coerced UID.
+        self::assertNull($secret->getUid());
         self::assertSame(
             $expectedUid,
-            $secret->getUid(),
+            $saved->getUid(),
             \sprintf('Failed asserting UID fallback for case: %s', $description),
         );
     }
@@ -796,15 +768,7 @@ final class SecretRepositoryTest extends TestCase
     {
         $connection = $this->useStrictConnectionMock();
 
-        $secret = new Secret();
-        $secret->setUid(77);
-        $secret->setIdentifier('existing-with-groups');
-        $secret->setEncryptedValue('encrypted');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('deknonce');
-        $secret->setValueNonce('valuenonce');
-        $secret->setEncryptionVersion(1);
-        $secret->setAllowedGroups([11, 13]);
+        $secret = $this->newEncryptedSecret('existing-with-groups', uid: 77, allowedGroups: [11, 13]);
 
         // 1 update on the secret row, 2 inserts on the MM table for the 2 groups
         $connection->expects(self::once())->method('update');
@@ -940,6 +904,30 @@ final class SecretRepositoryTest extends TestCase
         $this->queryBuilder->method('createNamedParameter')->willReturn('?');
 
         $this->expressionBuilder->method('eq')->willReturn('field = ?');
+    }
+
+    /**
+     * Build a Secret with the seven crypto/envelope fields populated to
+     * defaults appropriate for save()-path tests. The ctor enforces the
+     * tri-state crypto invariant so callers can't omit individual fields.
+     *
+     * @param list<int> $allowedGroups
+     */
+    private function newEncryptedSecret(
+        string $identifier,
+        ?int $uid = null,
+        array $allowedGroups = [],
+    ): Secret {
+        return new Secret(
+            identifier: $identifier,
+            uid: $uid,
+            encryptedValue: 'encrypted',
+            encryptedDek: 'dek',
+            dekNonce: 'deknonce',
+            valueNonce: 'valuenonce',
+            encryptionVersion: 1,
+            allowedGroups: $allowedGroups,
+        );
     }
 
     /**

--- a/Tests/Unit/Event/SecretCreatedEventTest.php
+++ b/Tests/Unit/Event/SecretCreatedEventTest.php
@@ -21,8 +21,7 @@ final class SecretCreatedEventTest extends TestCase
     #[Test]
     public function constructorSetsProperties(): void
     {
-        $secret = new Secret();
-        $secret->setIdentifier('api-key');
+        $secret = new Secret(identifier: 'api-key');
 
         $event = new SecretCreatedEvent('api-key', $secret, 5);
 

--- a/Tests/Unit/Fixtures/SecretFixtureBuilder.php
+++ b/Tests/Unit/Fixtures/SecretFixtureBuilder.php
@@ -277,27 +277,26 @@ final class SecretFixtureBuilder
      */
     public function buildSecret(): Secret
     {
-        $secret = new Secret();
-        $secret->setUid($this->uid);
-        $secret->setIdentifier($this->identifier);
-        $secret->setDescription($this->description);
-        $secret->setOwnerUid($this->ownerUid);
-        $secret->setAllowedGroups($this->groups);
-        $secret->setContext($this->context);
-        $secret->setFrontendAccessible($this->frontendAccessible);
-        $secret->setVersion($this->version);
-        $secret->setCrdate($this->createdAt);
-        $secret->setTstamp($this->updatedAt);
-        $secret->setExpiresAt($this->expiresAt ?? 0);
-        $secret->setLastRotatedAt($this->lastRotatedAt ?? 0);
-        $secret->setReadCount($this->readCount);
-        $secret->setLastReadAt($this->lastReadAt ?? 0);
-        $secret->setMetadata($this->metadata);
-        $secret->setScopePid($this->scopePid);
-        $secret->setHidden($this->disabled);
-        $secret->setEncryptedValue('test-ciphertext');
-        $secret->setValueChecksum('test-checksum');
-
-        return $secret;
+        return new Secret(
+            identifier: $this->identifier,
+            uid: $this->uid,
+            scopePid: $this->scopePid,
+            description: $this->description,
+            encryptedValue: 'test-ciphertext',
+            valueChecksum: 'test-checksum',
+            ownerUid: $this->ownerUid,
+            allowedGroups: $this->groups,
+            context: $this->context,
+            frontendAccessible: $this->frontendAccessible,
+            version: $this->version,
+            expiresAt: $this->expiresAt ?? 0,
+            lastRotatedAt: $this->lastRotatedAt ?? 0,
+            metadata: $this->metadata,
+            tstamp: $this->updatedAt,
+            crdate: $this->createdAt,
+            hidden: $this->disabled,
+            readCount: $this->readCount,
+            lastReadAt: $this->lastReadAt ?? 0,
+        );
     }
 }

--- a/Tests/Unit/Security/AccessControlServiceTest.php
+++ b/Tests/Unit/Security/AccessControlServiceTest.php
@@ -525,19 +525,20 @@ final class AccessControlServiceTest extends TestCase
 
     /**
      * Create a test Secret with specified properties.
+     *
+     * @param list<int> $allowedGroups
      */
     private function createSecret(
         int $ownerUid = 0,
         array $allowedGroups = [],
         bool $frontendAccessible = false,
     ): Secret {
-        $secret = new Secret();
-        $secret->setOwnerUid($ownerUid);
-        $secret->setAllowedGroups($allowedGroups);
-        $secret->setFrontendAccessible($frontendAccessible);
-        $secret->setIdentifier('test-secret');
-
-        return $secret;
+        return new Secret(
+            identifier: 'test-secret',
+            ownerUid: $ownerUid,
+            allowedGroups: $allowedGroups,
+            frontendAccessible: $frontendAccessible,
+        );
     }
 
     /**

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -55,6 +55,11 @@ final class VaultServiceTest extends TestCase
         parent::setUp();
 
         $this->adapter = $this->createMock(VaultAdapterInterface::class);
+        // VaultAdapterInterface::store() returns the persisted Secret. PHPUnit
+        // cannot auto-generate a return value for a `final readonly` class, so
+        // default the mock to pass the input through. Per-test `expects()->with(...)`
+        // assertions still apply because the more specific matcher takes precedence.
+        $this->adapter->method('store')->willReturnArgument(0);
         $this->encryptionService = $this->createMock(EncryptionServiceInterface::class);
         $this->accessControlService = $this->createMock(AccessControlServiceInterface::class);
         $this->auditLogService = $this->createMock(AuditLogServiceInterface::class);
@@ -111,7 +116,8 @@ final class VaultServiceTest extends TestCase
             ->method('store')
             ->with(self::callback(static fn (Secret $secret): bool => $secret->getIdentifier() === $identifier
                 && $secret->getEncryptedValue() === 'enc_value'
-                && $secret->getEncryptedDek() === 'enc_dek'));
+                && $secret->getEncryptedDek() === 'enc_dek'))
+            ->willReturnArgument(0);
 
         $this->auditLogService
             ->expects(self::once())
@@ -231,7 +237,8 @@ final class VaultServiceTest extends TestCase
         $this->adapter
             ->expects(self::once())
             ->method('store')
-            ->with(self::callback(static fn (Secret $s): bool => $s->getOwnerUid() === 7));
+            ->with(self::callback(static fn (Secret $s): bool => $s->getOwnerUid() === 7))
+            ->willReturnArgument(0);
 
         $subject->store('coerce', 'plaintext', ['owner' => 99]);
     }
@@ -406,7 +413,8 @@ final class VaultServiceTest extends TestCase
             ->method('store')
             ->with(self::callback(static fn (Secret $s): bool => $s->getVersion() === 2
                 && $s->getLastRotatedAt() > 0
-                && $s->getEncryptedValue() === 'new_enc'));
+                && $s->getEncryptedValue() === 'new_enc'))
+            ->willReturnArgument(0);
 
         $this->subject->rotate($identifier, $newSecret, 'Annual rotation');
     }
@@ -587,7 +595,8 @@ final class VaultServiceTest extends TestCase
                 && $s->getContext() === 'testing'
                 && $s->getScopePid() === 100
                 && $s->isFrontendAccessible()
-                && $s->getExpiresAt() === $expiresAt->getTimestamp()));
+                && $s->getExpiresAt() === $expiresAt->getTimestamp()))
+            ->willReturnArgument(0);
 
         $this->subject->store($identifier, $secretValue, [
             'owner' => 5,
@@ -617,7 +626,8 @@ final class VaultServiceTest extends TestCase
         $this->adapter
             ->expects(self::once())
             ->method('store')
-            ->with(self::callback(static fn (Secret $s): bool => $s->getExpiresAt() === $expiresTimestamp));
+            ->with(self::callback(static fn (Secret $s): bool => $s->getExpiresAt() === $expiresTimestamp))
+            ->willReturnArgument(0);
 
         $this->subject->store($identifier, $secretValue, [
             'expiresAt' => $expiresTimestamp,
@@ -653,7 +663,8 @@ final class VaultServiceTest extends TestCase
             ->method('store')
             ->with(self::callback(static fn (Secret $s): bool => $s->getUid() === 42
                 && $s->getCrdate() === 1000
-                && $s->getVersion() === 2));
+                && $s->getVersion() === 2))
+            ->willReturnArgument(0);
 
         $this->subject->store($identifier, $secretValue);
     }
@@ -887,7 +898,8 @@ final class VaultServiceTest extends TestCase
         $this->adapter
             ->expects(self::once())
             ->method('store')
-            ->with(self::callback(static fn (Secret $s): bool => $s->getAllowedGroups() === [1, 2, 3]));
+            ->with(self::callback(static fn (Secret $s): bool => $s->getAllowedGroups() === [1, 2, 3]))
+            ->willReturnArgument(0);
 
         $this->subject->store('test', 'secret', [
             'groups' => [1, 2, 3],

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -307,8 +307,7 @@ final class VaultServiceTest extends TestCase
     #[Test]
     public function retrieveThrowsExceptionForExpiredSecret(): void
     {
-        $secret = $this->createSecretEntity('expired');
-        $secret->setExpiresAt(time() - 3600); // Expired 1 hour ago
+        $secret = $this->createSecretEntity('expired', expiresAt: time() - 3600); // Expired 1 hour ago
 
         $this->adapter
             ->method('retrieve')
@@ -386,8 +385,7 @@ final class VaultServiceTest extends TestCase
     {
         $identifier = 'toRotate';
         $newSecret = 'new-secret-value';
-        $secret = $this->createSecretEntity($identifier);
-        $secret->setVersion(1);
+        $secret = $this->createSecretEntity($identifier, version: 1);
 
         $this->adapter
             ->method('retrieve')
@@ -507,11 +505,13 @@ final class VaultServiceTest extends TestCase
     public function getMetadataReturnsSecretMetadata(): void
     {
         $identifier = 'metaSecret';
-        $secret = $this->createSecretEntity($identifier);
-        $secret->setDescription('Test description');
-        $secret->setContext('testing');
-        $secret->setVersion(3);
-        $secret->setMetadata(['key' => 'value']);
+        $secret = $this->createSecretEntity(
+            $identifier,
+            version: 3,
+            description: 'Test description',
+            context: 'testing',
+            metadata: ['key' => 'value'],
+        );
 
         $this->adapter
             ->method('retrieve')
@@ -630,10 +630,12 @@ final class VaultServiceTest extends TestCase
         $identifier = 'existing';
         $secretValue = 'new-value';
 
-        $existing = $this->createSecretEntity($identifier);
-        $existing->setUid(42);
-        $existing->setCrdate(1000);
-        $existing->setVersion(2);
+        $existing = $this->createSecretEntity(
+            $identifier,
+            uid: 42,
+            version: 2,
+            crdate: 1000,
+        );
 
         $this->encryptionService
             ->method('encrypt')
@@ -840,8 +842,7 @@ final class VaultServiceTest extends TestCase
     #[Test]
     public function retrieveLogsExpiredSecretAccess(): void
     {
-        $secret = $this->createSecretEntity('expired');
-        $secret->setExpiresAt(time() - 3600);
+        $secret = $this->createSecretEntity('expired', expiresAt: time() - 3600);
 
         $this->adapter
             ->method('retrieve')
@@ -893,19 +894,37 @@ final class VaultServiceTest extends TestCase
         ]);
     }
 
-    private function createSecretEntity(string $identifier): Secret
-    {
-        $secret = new Secret();
-        $secret->setUid(1);
-        $secret->setIdentifier($identifier);
-        $secret->setEncryptedValue('encrypted');
-        $secret->setEncryptedDek('dek');
-        $secret->setDekNonce('nonce1');
-        $secret->setValueNonce('nonce2');
-        $secret->setValueChecksum('checksum');
-        $secret->setOwnerUid(1);
-        $secret->setVersion(1);
-
-        return $secret;
+    /**
+     * Build a Secret with sensible test defaults plus optional per-test
+     * overrides. The immutable entity forces a single ctor call, so any
+     * deviation from defaults (expiresAt, version, uid, …) is passed
+     * through here as a named argument.
+     */
+    private function createSecretEntity(
+        string $identifier,
+        ?int $uid = 1,
+        int $version = 1,
+        int $expiresAt = 0,
+        int $crdate = 0,
+        string $description = '',
+        string $context = '',
+        array $metadata = [],
+    ): Secret {
+        return new Secret(
+            identifier: $identifier,
+            uid: $uid,
+            description: $description,
+            encryptedValue: 'encrypted',
+            encryptedDek: 'dek',
+            dekNonce: 'nonce1',
+            valueNonce: 'nonce2',
+            valueChecksum: 'checksum',
+            ownerUid: 1,
+            context: $context,
+            version: $version,
+            expiresAt: $expiresAt,
+            metadata: $metadata,
+            crdate: $crdate,
+        );
     }
 }


### PR DESCRIPTION
## Summary

Closes **H-5** from the multi-axis review. Converts the \`Secret\` entity from a 60-method mutable class (28 fields × 2 get/set, plus 4 specialised methods) into a pure readonly value object with constructor promotion and 4 named withers reflecting actual lifecycle transitions.

Addresses SonarCloud findings on this file:
- **S107** (15-param constructor) — the new ctor has 27 named-arg params with defaults; the previous \`Secret::create()\` static factory was redundant once validation moved to the constructor.
- **S1448** (60 methods in a god class) — drops 28 setters; net surface is now 27 readonly properties + 4 named withers + 27 backwards-compatible getters + 2 persistence boundary methods. Sonar may still flag — accept with rationale "entity legitimately has 28 fields; getter shim kept for API compatibility".

## Production refactor (commit \`f347f90\`)

### \`Classes/Domain/Model/Secret.php\` — complete rewrite

\`\`\`php
final readonly class Secret {
    public function __construct(
        public string $identifier,         // REQUIRED — only mandatory field
        public ?int $uid = null,
        public int $scopePid = 0,
        // … 27 more readonly promoted properties …
    ) {
        // envelope-encryption triple validation moves into ctor:
        // encryptedDek / dekNonce / valueNonce must be all set or all empty
    }

    // 4 named withers — actual lifecycle transitions:
    public function withUid(?int): self
    public function withValueRotation(EncryptedData, int $rotatedAt): self
    public function withReEncryptedDek(string, string): self
    public function withMetadata(array): self

    // Persistence boundary — fromDatabaseRow now takes MM groups
    public static function fromDatabaseRow(array \$row, array \$allowedGroups = []): self
}
\`\`\`

- All 28 \`set*()\` mutators **DROPPED**.
- \`Secret::create()\` named factory **DROPPED** — callers use \`new Secret(identifier: ..., ownerUid: ..., ...)\` directly.
- \`incrementReadCount()\` **DROPPED** as an instance method — behavior already lived in \`SecretRepository::incrementReadCount(int \$uid)\` (atomic DB-level UPDATE).
- \`incrementVersion()\` **DROPPED** — folded into \`withValueRotation()\` which bumps version + sets lastRotatedAt + replaces the crypto envelope atomically.
- Getters kept as compatibility shims; new code should use property access (\`\$secret->identifier\`).

### \`SecretRepositoryInterface::save()\` signature change

\`\`\`diff
- public function save(Secret \$secret): void;
+ public function save(Secret \$secret): Secret;
\`\`\`

On INSERT the returned instance carries the freshly-assigned UID; on UPDATE the original is returned. **Callers MUST capture the return value** if they need the UID — the input is readonly and cannot be mutated in place.

### Production call-site adaptations

| File | Before | After |
|---|---|---|
| \`VaultService::buildSecretEntity\` | 16 \`->setX(...)\` mutations | Single \`new Secret(...)\` ctor call composing a typed bundle from \`collectOptionalFields(\$options)\` |
| \`VaultService::rotate\` | 7 separate mutations (\`setEncryptedValue\` + 5 more + \`incrementVersion\` + \`setLastRotatedAt\`) | One \`\$secret->withValueRotation(\$encrypted, time())\` |
| \`VaultRotateMasterKeyCommand::rotateOne\` | \`setEncryptedDek + setDekNonce + save\` | One \`save(\$secret->withReEncryptedDek(...))\` chain |
| \`LocalEncryptionAdapter::updateMetadata\` | \`setMetadata + save\` | \`save(\$secret->withMetadata(\$merged))\` |
| \`SecretRepository::find*\` | \`fromDatabaseRow + setAllowedGroups\` two-step | One \`fromDatabaseRow(\$row, \$groups)\` call. Bulk loaders pre-aggregate the MM-table query result. |

## Test-side adaptations (9 commits, atomic per file)

The refactoring-expert agent handled the test rewrites — full report in commit messages. Highlights:

**1711 unit tests pass** (was 1752; **-41 tests, +369 assertions**). The drop is because **tautological tests were deleted, not lost coverage**:
- ~30 \`setX/getX\` round-trip tests — now tautological (ctor arg == getter); ctor coverage subsumes them.
- \`incrementReadCount\` / \`incrementVersion\` Secret tests — methods removed; behavior moved to repository / wither.
- \`settersReturnSelfForFluentInterface\` — no setters anymore.
- 6 tests in the functional \`SecretRepositoryTest\` that tested entity behavior (not repo behavior) — moved to the unit \`SecretTest\` against the readonly entity, deduplicated.

**Net change**: -592 lines across 10 test files. Itemised per-file in the agent's report (commit messages).

| File | Delta |
|---|---|
| \`Tests/Unit/Domain/Model/SecretTest.php\` | -445 lines (full rewrite; readonly is what made it 1574 LOC unnecessary) |
| \`Tests/Functional/Domain/Repository/SecretRepositoryTest.php\` | -177 lines (entity tests deduplicated) |
| \`Tests/Unit/Domain/Repository/SecretRepositoryTest.php\` | -12 lines + \`save()\` return capture |
| 7 other files | +43 net (helpers expanded to support readonly construction) |

\`SecretFixtureBuilder::buildSecret()\` (the centralised test fixture) is updated to construct via the new ctor, so downstream tests using the builder kept working without per-file changes.

## What this does NOT do

- **DOES NOT** address S1448 (god class — 60 methods). The new surface is still ~62 (27 props + 4 withers + 27 getters + ctor + fromDatabaseRow + toDatabaseRow). Sonar may flag — accept with rationale: getters kept as compatibility shim, can drop in a future "API simplification" PR once consumer extensions migrate to property access.
- **DOES NOT** change behaviour. Same persistence, same rotation lifecycle, same audit trail.

## Test plan

- [x] 1711 unit tests pass.
- [x] cgl + rector + PHPStan level 10 green locally.
- [ ] Functional tests run in CI (local mock-OAuth container has unrelated env issue).
- [ ] CI matrix (PHP 8.2–8.5 × TYPO3 v13.4/v14.0).
- [ ] Manual: \`vault:rotate-master-key --dry-run\` on a real DB (touches the new \`withReEncryptedDek\` path).

## Migration notes

This is a **breaking API change** for any downstream extension that:
- Calls \`\$secret->setX(...)\` directly (must switch to \`new Secret(...)\` named-args construction).
- Calls \`Secret::create(...)\` (must switch to \`new Secret(identifier: ..., ...)\`).
- Calls \`\$repo->save(\$secret)\` expecting \`void\` AND then reads \`\$secret->getUid()\` (must capture return value).

Worth a CHANGELOG entry pointing to this PR for the next minor-version release.