### PR TITLE
fix(domain): route MM-table operations through their own DB connection

### DIFF
--- a/Classes/Domain/Repository/SecretRepository.php
+++ b/Classes/Domain/Repository/SecretRepository.php
@@ -198,10 +198,8 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             return [];
         }
 
-        $connection = $this->getConnection();
-
-        // Find secret UIDs that have any of the specified groups
-        $mmQuery = $connection->createQueryBuilder();
+        // First query hits the MM table — must use the MM connection.
+        $mmQuery = $this->getMmConnection()->createQueryBuilder();
         $intGroupUids = [];
         foreach ($groupUids as $gid) {
             $intGroupUids[] = (int) $gid;
@@ -221,7 +219,9 @@ final readonly class SecretRepository implements SecretRepositoryInterface
         foreach ($secretUids as $sid) {
             $intSecretUids[] = is_numeric($sid) ? (int) $sid : 0;
         }
-        $queryBuilder = $connection->createQueryBuilder();
+
+        // Second query hits the secret table — uses the main connection.
+        $queryBuilder = $this->getConnection()->createQueryBuilder();
         $rows = $queryBuilder
             ->select('*')
             ->from(self::TABLE_NAME)
@@ -406,7 +406,7 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             return [];
         }
 
-        $queryBuilder = $this->getConnection()->createQueryBuilder();
+        $queryBuilder = $this->getMmConnection()->createQueryBuilder();
         $rows = $queryBuilder
             ->select('uid_local', 'uid_foreign')
             ->from(self::MM_TABLE_NAME)
@@ -433,7 +433,7 @@ final readonly class SecretRepository implements SecretRepositoryInterface
      */
     private function loadGroupsForSecret(int $secretUid): array
     {
-        $queryBuilder = $this->getConnection()->createQueryBuilder();
+        $queryBuilder = $this->getMmConnection()->createQueryBuilder();
         $rows = $queryBuilder
             ->select('uid_foreign')
             ->from(self::MM_TABLE_NAME)
@@ -460,15 +460,15 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             return;
         }
 
-        $connection = $this->getConnection();
+        $mmConnection = $this->getMmConnection();
 
         // Delete existing relations
-        $connection->delete(self::MM_TABLE_NAME, ['uid_local' => $secret->getUid()]);
+        $mmConnection->delete(self::MM_TABLE_NAME, ['uid_local' => $secret->getUid()]);
 
         // Insert new relations
         $groups = $secret->getAllowedGroups();
         foreach ($groups as $sorting => $groupUid) {
-            $connection->insert(self::MM_TABLE_NAME, [
+            $mmConnection->insert(self::MM_TABLE_NAME, [
                 'uid_local' => $secret->getUid(),
                 'uid_foreign' => $groupUid,
                 'sorting' => $sorting,
@@ -480,5 +480,18 @@ final readonly class SecretRepository implements SecretRepositoryInterface
     private function getConnection(): Connection
     {
         return $this->connectionPool->getConnectionForTable(self::TABLE_NAME);
+    }
+
+    /**
+     * Resolve the connection for the MM-relations table separately from the
+     * main secret table. TYPO3 supports per-table connection routing via
+     * \$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']; an admin who maps
+     * the MM table to a different DB would otherwise see MM operations
+     * issued against the WRONG connection (silently lost on a single-DB
+     * setup; failing entirely on a sharded one).
+     */
+    private function getMmConnection(): Connection
+    {
+        return $this->connectionPool->getConnectionForTable(self::MM_TABLE_NAME);
     }
 }

--- a/Classes/Domain/Repository/SecretRepository.php
+++ b/Classes/Domain/Repository/SecretRepository.php
@@ -484,11 +484,14 @@ final readonly class SecretRepository implements SecretRepositoryInterface
 
     /**
      * Resolve the connection for the MM-relations table separately from the
-     * main secret table. TYPO3 supports per-table connection routing via
-     * \$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']; an admin who maps
-     * the MM table to a different DB would otherwise see MM operations
-     * issued against the WRONG connection (silently lost on a single-DB
-     * setup; failing entirely on a sharded one).
+     * main secret table. TYPO3 routes per-table connections via
+     * `$GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping']` (the connection
+     * targets themselves live under `['DB']['Connections']`). On the common
+     * single-DB setup both tables map to `Default`, so this returns the same
+     * connection as `getConnection()` — the indirection only matters on
+     * sharded setups, where an admin may have mapped the MM table to a
+     * different DB. The original code lost that distinction; MM operations
+     * issued via the secret-table connection would have hit the wrong DB.
      */
     private function getMmConnection(): Connection
     {

--- a/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
@@ -788,6 +788,84 @@ final class SecretRepositoryTest extends TestCase
     }
 
     /**
+     * Regression guard for the table-routing audit: MM-table operations
+     * MUST resolve their connection via `getConnectionForTable(MM_TABLE)`,
+     * not via the secret-table connection. On the single-DB setup this
+     * isn't visible (TYPO3 returns the same connection for any unmapped
+     * table), but on sharded setups the MM ops would otherwise silently
+     * hit the wrong DB. See PR #143.
+     */
+    #[Test]
+    public function findByIdentifierResolvesMmConnectionForGroupsLookup(): void
+    {
+        $secretRow = [
+            'uid' => 42,
+            'identifier' => 'route-test',
+            'encrypted_value' => 'enc',
+            'encrypted_dek' => 'dek',
+            'dek_nonce' => 'dn',
+            'value_nonce' => 'vn',
+            'value_checksum' => 'cs',
+        ];
+
+        $secretResult = $this->createStub(Result::class);
+        $secretResult->method('fetchAssociative')->willReturn($secretRow);
+
+        $mmResult = $this->createStub(Result::class);
+        $mmResult->method('fetchAllAssociative')->willReturn([]);
+
+        // Two separate Connection stubs — one per table.
+        $secretConnection = $this->createStub(Connection::class);
+        $secretQueryBuilder = $this->createStub(QueryBuilder::class);
+        $secretQueryBuilder->method('expr')->willReturn($this->expressionBuilder);
+        $secretQueryBuilder->method('select')->willReturnSelf();
+        $secretQueryBuilder->method('from')->willReturnSelf();
+        $secretQueryBuilder->method('where')->willReturnSelf();
+        $secretQueryBuilder->method('createNamedParameter')->willReturn('?');
+        $secretQueryBuilder->method('executeQuery')->willReturn($secretResult);
+        $secretConnection->method('createQueryBuilder')->willReturn($secretQueryBuilder);
+
+        $mmConnection = $this->createStub(Connection::class);
+        $mmQueryBuilder = $this->createStub(QueryBuilder::class);
+        $mmQueryBuilder->method('expr')->willReturn($this->expressionBuilder);
+        $mmQueryBuilder->method('select')->willReturnSelf();
+        $mmQueryBuilder->method('from')->willReturnSelf();
+        $mmQueryBuilder->method('where')->willReturnSelf();
+        $mmQueryBuilder->method('orderBy')->willReturnSelf();
+        $mmQueryBuilder->method('executeQuery')->willReturn($mmResult);
+        $mmConnection->method('createQueryBuilder')->willReturn($mmQueryBuilder);
+
+        // Spy on the routing: ConnectionPool::getConnectionForTable() must
+        // be called with BOTH 'tx_nrvault_secret' (for the row fetch) AND
+        // 'tx_nrvault_secret_begroups_mm' (for the groups lookup).
+        $requestedTables = [];
+        $pool = $this->createMock(ConnectionPool::class);
+        $pool->method('getConnectionForTable')->willReturnCallback(
+            static function (string $table) use (&$requestedTables, $secretConnection, $mmConnection): Connection {
+                $requestedTables[] = $table;
+
+                return $table === 'tx_nrvault_secret_begroups_mm'
+                    ? $mmConnection
+                    : $secretConnection;
+            },
+        );
+
+        $subject = new SecretRepository($pool);
+        $subject->findByIdentifier('route-test');
+
+        self::assertContains(
+            'tx_nrvault_secret',
+            $requestedTables,
+            'Secret-row fetch must route via tx_nrvault_secret connection',
+        );
+        self::assertContains(
+            'tx_nrvault_secret_begroups_mm',
+            $requestedTables,
+            'MM-table groups lookup must route via tx_nrvault_secret_begroups_mm connection',
+        );
+    }
+
+    /**
      * Swap the default Connection stub for a strict MockObject and re-wire the
      * connection pool. Call BEFORE any test-specific stubbing. Use from tests
      * that need $connection->expects(...) verification.


### PR DESCRIPTION
## Summary

Follow-up audit triggered by the table-name bug in PR #141. That bug was a typo (\`tx_nrvault_secrets\` plural); **this** one is the same _shape_ — wrong connection used for table operations — but it works accidentally on single-DB setups and silently breaks on sharded ones.

## Audit scope

| Pattern | Sites checked | Issues found |
|---|---|---|
| \`beginTransaction()\` openings | 2 (VaultRotateMasterKeyCommand, AuditChainLockTrait) | 0 — both bind to the right table after PR #141; trait callers all pass the audit-log connection |
| \`getConnectionForTable(X)\` followed by writes to a different table Y | All call sites | 1 — \`SecretRepository\` ↔ MM table |
| Hook DataHandler integration | DataHandlerHook, FlexFormVaultHook | 0 — each hook uses \`getConnectionForTable(\$table)\` for that exact table |
| Cross-table JOINs | All | 0 — codebase doesn't use SQL JOINs (PHP-side composition only) |

## The bug

\`SecretRepository::getConnection()\` is hardcoded to return the connection for \`tx_nrvault_secret\`. That connection was then used for ALL operations against \`tx_nrvault_secret_begroups_mm\`:

| Method | MM operation |
|---|---|
| \`saveGroupsForSecret()\` | DELETE + INSERT on MM |
| \`loadGroupsForSecret()\` | SELECT from MM |
| \`loadGroupsForSecrets()\` | bulk SELECT from MM |
| \`findByGroups()\` | DISTINCT MM query + secret-table query |

### When this breaks

TYPO3 supports per-table connection routing via \`\$GLOBALS['TYPO3_CONF_VARS']['DB']['Connections']\`. An admin who maps the MM table to a different DB would see the MM operations hit the WRONG connection:
- best case: "table doesn't exist" on the secret-DB connection
- worst case: silent writes to a sibling DB that happens to have a same-named table (e.g., across staging copies)

### Fix

New \`getMmConnection()\` alongside \`getConnection()\`. Both backed by \`ConnectionPool::getConnectionForTable\` with the right table constant. All five MM sites routed through the new helper.

\`findByGroups()\` correctly uses **both** connections — MM query on the MM connection, secret-table query on the main connection — since cross-DB JOINs aren't possible.

## Test plan

- [x] 1711 unit tests pass (unchanged behaviour on the common single-DB setup).
- [x] cgl + rector + PHPStan level 10 green locally.
- [ ] CI matrix.
- [ ] Manual: verify functional tests still pass against SQLite (single-DB context — should be unaffected).

## Migration / Compatibility

Zero behaviour change on the common single-DB setup (the most common TYPO3 deployment). On sharded setups, this **fixes** previously-broken behaviour.

Refs PR #141 — bug pattern audit follow-up.