### PR TITLE
feat(security): close DNS-rebinding gap in HTTP client (CURLOPT_RESOLVE)

### DIFF
--- a/Classes/Http/DefaultDnsResolver.php
+++ b/Classes/Http/DefaultDnsResolver.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Http;
+
+/**
+ * Production DNS resolver — delegates to PHP's `dns_get_record()` with
+ * the `A | AAAA` filter so the SSRF defence sees both v4 and v6 records.
+ *
+ * Resolution failures (NXDOMAIN, SERVFAIL, timeouts, missing
+ * `dns_get_record` extension support for a given record type) collapse
+ * to the empty list — the caller treats that as "let the HTTP client
+ * surface the usual connection-error path".
+ */
+final class DefaultDnsResolver implements DnsResolverInterface
+{
+    public function resolve(string $host): array
+    {
+        // Suppress DNS-lookup warnings (banned `@` operator per phpstan-strict-rules).
+        set_error_handler(static fn (): bool => true);
+
+        try {
+            /** @var list<array<string, mixed>>|false $records */
+            $records = dns_get_record($host, DNS_A | DNS_AAAA);
+        } finally {
+            restore_error_handler();
+        }
+
+        if (!\is_array($records) || $records === []) {
+            return [];
+        }
+
+        $out = [];
+        foreach ($records as $record) {
+            $ip = $record['ip'] ?? null;
+            $ipv6 = $record['ipv6'] ?? null;
+            $entry = [];
+            if (\is_string($ip)) {
+                $entry['ip'] = $ip;
+            }
+            if (\is_string($ipv6)) {
+                $entry['ipv6'] = $ipv6;
+            }
+            if ($entry !== []) {
+                $out[] = $entry;
+            }
+        }
+
+        return $out;
+    }
+}

--- a/Classes/Http/DnsResolverInterface.php
+++ b/Classes/Http/DnsResolverInterface.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Http;
+
+/**
+ * Thin seam over `dns_get_record()` so the SSRF / DNS-rebinding defence
+ * can be exercised in unit tests without hitting the real DNS resolver.
+ *
+ * Two implementations:
+ *  - {@see DefaultDnsResolver} for production (delegates to
+ *    `dns_get_record(A | AAAA)`).
+ *  - in-memory test doubles supplied by individual tests.
+ */
+interface DnsResolverInterface
+{
+    /**
+     * Resolve the A + AAAA records for `$host`. Returns a list whose
+     * entries each carry an `ip` (IPv4) or `ipv6` (IPv6) string field —
+     * mirroring `dns_get_record()`'s shape so the SSRF defence can keep
+     * iterating the same structure.
+     *
+     * Returns the empty list when the host cannot be resolved; the
+     * caller treats that case as "let the HTTP client produce a normal
+     * connection-failure error".
+     *
+     * @return list<array{ip?: string, ipv6?: string}>
+     */
+    public function resolve(string $host): array;
+}

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -12,9 +12,12 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Http;
 
+use Closure;
 use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Log\LogManager;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
@@ -100,6 +103,12 @@ final class SecureHttpClientFactory
 
         // Create handler stack without any logging middleware
         $stack = HandlerStack::create();
+
+        // Push the DNS-rebinding defence middleware on top of the stack.
+        // It resolves the host AT REQUEST TIME and pins the resulting IP via
+        // curl's CURLOPT_RESOLVE so the upstream client can't re-resolve to
+        // a different (internal) address between our check and the connect.
+        $stack->push($this->buildSsrfDefenceMiddleware(), 'ssrf-dns-pin');
         $options['handler'] = $stack;
 
         return new Client($options);
@@ -172,6 +181,120 @@ final class SecureHttpClientFactory
         }
 
         return false;
+    }
+
+    /**
+     * Guzzle middleware factory: resolves and validates the request host on
+     * every outgoing request, then pins the resolved IP via curl's
+     * `CURLOPT_RESOLVE` option so curl skips its own (potentially rebound)
+     * DNS lookup at connect time.
+     *
+     * Why we cannot do this once in `create()`: that factory builds a
+     * URL-agnostic Guzzle Client. The host isn't known until a request is
+     * actually sent. A middleware fires per request and can inspect the URI.
+     *
+     * Behaviour:
+     *  - Host that resolves to one or more SAFE IPs → those IPs are pinned;
+     *    curl uses them without re-resolving.
+     *  - Host that resolves to a dangerous IP → the request is rejected
+     *    with a `RequestException` BEFORE the socket opens.
+     *  - Host that cannot be resolved at all → no pin is added; curl handles
+     *    the resolution failure with its usual error path. (The caller's
+     *    earlier `isHostAllowed()` check already rejected IP-literal targets
+     *    in dangerous ranges.)
+     *  - IP-literal hosts (already an IPv4/IPv6 address) → no pin needed;
+     *    `isHostAllowed()` validated the literal directly.
+     */
+    private function buildSsrfDefenceMiddleware(): Closure /** @phpstan-ignore missingType.callable (Guzzle's middleware contract is loosely-typed by design) */
+    {
+        return function (callable $handler): Closure { /** @phpstan-ignore missingType.callable */
+            return function (RequestInterface $request, array $options) use ($handler) {
+                $host = $request->getUri()->getHost();
+                $port = $request->getUri()->getPort()
+                    ?? (strtolower($request->getUri()->getScheme()) === 'https' ? 443 : 80);
+
+                $resolveEntries = $this->buildResolveEntries($host, $port);
+
+                if ($resolveEntries === null) {
+                    throw new RequestException(
+                        \sprintf(
+                            'Refused to send request: host "%s" resolves to a disallowed IP range '
+                            . '(DNS rebinding defence).',
+                            $host,
+                        ),
+                        $request,
+                    );
+                }
+
+                if ($resolveEntries !== []) {
+                    $curlOptions = \is_array($options['curl'] ?? null) ? $options['curl'] : [];
+                    /** @var list<string> $existing */
+                    $existing = \is_array($curlOptions[\CURLOPT_RESOLVE] ?? null)
+                        ? $curlOptions[\CURLOPT_RESOLVE]
+                        : [];
+                    $curlOptions[\CURLOPT_RESOLVE] = array_values(array_unique(
+                        array_merge($existing, $resolveEntries),
+                    ));
+                    $options['curl'] = $curlOptions;
+                }
+
+                return $handler($request, $options);
+            };
+        };
+    }
+
+    /**
+     * Resolve `$host` to one or more IP addresses and convert each safe entry
+     * into the `host:port:ip` form curl expects for `CURLOPT_RESOLVE`.
+     *
+     * Returns:
+     *  - `null` if the host resolved to AT LEAST ONE dangerous IP (the entire
+     *    request must be rejected — even if some A records look safe, the
+     *    presence of a dangerous answer signals an active rebinding attempt).
+     *  - `[]` if the host is an IP literal (no pin needed) OR if resolution
+     *    failed entirely (let curl handle the error path).
+     *  - `list<string>` of pin entries to add to `CURLOPT_RESOLVE` for safe
+     *    multi-record hosts.
+     *
+     * @return list<string>|null
+     */
+    private function buildResolveEntries(string $host, int $port): ?array
+    {
+        // IP literal — `isHostAllowed()` already validated it; no DNS to pin.
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return [];
+        }
+
+        // Suppress DNS lookup warnings (banned `@` operator).
+        set_error_handler(static fn (): bool => true);
+
+        try {
+            $records = dns_get_record($host, DNS_A | DNS_AAAA);
+        } finally {
+            restore_error_handler();
+        }
+
+        if (!\is_array($records) || $records === []) {
+            // Resolution failed — let curl produce the usual connection error.
+            return [];
+        }
+
+        $entries = [];
+        foreach ($records as $record) {
+            $ip = $record['ip'] ?? $record['ipv6'] ?? null;
+            if (!\is_string($ip)) {
+                continue;
+            }
+            if ($this->isDangerousIpLiteral($ip)) {
+                // ANY dangerous answer kills the entire request. A "split-horizon"
+                // rebinding setup could otherwise return one safe + one internal
+                // IP; if curl picked the internal one, we'd leak.
+                return null;
+            }
+            $entries[] = \sprintf('%s:%d:%s', $host, $port, $ip);
+        }
+
+        return $entries;
     }
 
     /**

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -43,6 +43,10 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 final class SecureHttpClientFactory
 {
+    public function __construct(
+        private readonly DnsResolverInterface $dnsResolver = new DefaultDnsResolver(),
+    ) {}
+
     /**
      * Create a PSR-18 HTTP client with TYPO3 settings and security hardening.
      */
@@ -110,6 +114,22 @@ final class SecureHttpClientFactory
         // a different (internal) address between our check and the connect.
         $stack->push($this->buildSsrfDefenceMiddleware(), 'ssrf-dns-pin');
         $options['handler'] = $stack;
+
+        // ext-curl absence: Guzzle's HandlerStack::create() falls back to
+        // StreamHandler, which IGNORES the curl-only `CURLOPT_RESOLVE` option.
+        // The middleware still rejects dangerous-resolving hosts at lookup
+        // time (defence-in-depth), but the race-free pinning guarantee is
+        // gone — between our DNS check and stream's own resolution, an
+        // attacker can still rebind. Warn so operators notice the gap.
+        if (!\function_exists('curl_init')) {
+            $this->getLogger()->warning(
+                'PHP ext-curl is not loaded; the nr-vault HTTP client falls back '
+                . 'to the stream handler. DNS rebinding is no longer race-protected '
+                . '(the pre-request resolve-and-check is still enforced, but the '
+                . 'connect-time IP can drift). Install ext-curl to restore the '
+                . 'CURLOPT_RESOLVE pin.',
+            );
+        }
 
         return new Client($options);
     }
@@ -209,7 +229,10 @@ final class SecureHttpClientFactory
     {
         return function (callable $handler): Closure { /** @phpstan-ignore missingType.callable */
             return function (RequestInterface $request, array $options) use ($handler) {
-                $host = $request->getUri()->getHost();
+                // PSR-7 `getHost()` returns IPv6 literals wrapped in brackets
+                // (`[::1]`). The IP validators and `dns_get_record()` reject
+                // that form, so normalise to the bare host first.
+                $host = $this->normaliseHost($request->getUri()->getHost());
                 $port = $request->getUri()->getPort()
                     ?? (strtolower($request->getUri()->getScheme()) === 'https' ? 443 : 80);
 
@@ -265,16 +288,8 @@ final class SecureHttpClientFactory
             return [];
         }
 
-        // Suppress DNS lookup warnings (banned `@` operator).
-        set_error_handler(static fn (): bool => true);
-
-        try {
-            $records = dns_get_record($host, DNS_A | DNS_AAAA);
-        } finally {
-            restore_error_handler();
-        }
-
-        if (!\is_array($records) || $records === []) {
+        $records = $this->dnsResolver->resolve($host);
+        if ($records === []) {
             // Resolution failed — let curl produce the usual connection error.
             return [];
         }
@@ -291,7 +306,11 @@ final class SecureHttpClientFactory
                 // IP; if curl picked the internal one, we'd leak.
                 return null;
             }
-            $entries[] = \sprintf('%s:%d:%s', $host, $port, $ip);
+            // libcurl's CURLOPT_RESOLVE format is `host:port:address`. IPv6
+            // addresses contain colons, so they MUST be bracketed or curl
+            // misparses the entry (see curl docs / CVE-2025-* class of bugs).
+            $formattedIp = str_contains($ip, ':') ? '[' . $ip . ']' : $ip;
+            $entries[] = \sprintf('%s:%d:%s', $host, $port, $formattedIp);
         }
 
         return $entries;
@@ -502,20 +521,7 @@ final class SecureHttpClientFactory
             return false;
         }
 
-        // Suppress DNS lookup warnings without using `@` (banned by phpstan-strict-rules).
-        set_error_handler(static fn (): bool => true);
-
-        try {
-            $records = dns_get_record($host, DNS_A | DNS_AAAA);
-        } finally {
-            restore_error_handler();
-        }
-
-        if (!\is_array($records) || $records === []) {
-            return false;
-        }
-
-        foreach ($records as $record) {
+        foreach ($this->dnsResolver->resolve($host) as $record) {
             $ip = $record['ip'] ?? $record['ipv6'] ?? null;
             if (\is_string($ip) && $this->isDangerousIpLiteral($ip)) {
                 return true;

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -32,6 +32,9 @@ services:
   Netresearch\NrVault\Http\VaultHttpClientFactoryInterface:
     alias: Netresearch\NrVault\Http\VaultHttpClientFactory
 
+  Netresearch\NrVault\Http\DnsResolverInterface:
+    alias: Netresearch\NrVault\Http\DefaultDnsResolver
+
   Netresearch\NrVault\Service\VaultServiceInterface:
     alias: Netresearch\NrVault\Service\VaultService
     # public: makeInstance call sites in FormEngine (VaultSecretElement,

--- a/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
@@ -9,12 +9,13 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Http;
 
-use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\PromiseInterface;
 use GuzzleHttp\Psr7\Response;
+use Netresearch\NrVault\Http\DnsResolverInterface;
 use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -41,12 +42,15 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
 {
     private SecureHttpClientFactory $subject;
 
+    private InMemoryDnsResolver $dnsResolver;
+
     private mixed $originalGlobals;
 
     protected function setUp(): void
     {
         parent::setUp();
-        $this->subject = new SecureHttpClientFactory();
+        $this->dnsResolver = new InMemoryDnsResolver();
+        $this->subject = new SecureHttpClientFactory($this->dnsResolver);
         $this->originalGlobals = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
         $GLOBALS['TYPO3_CONF_VARS'] = ['HTTP' => []];
     }
@@ -73,14 +77,49 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
     #[Test]
     public function buildResolveEntriesReturnsEmptyForUnresolvableHost(): void
     {
-        // Synthetic hostname that DNS cannot resolve — middleware lets curl
-        // produce the usual connection-failure error path.
-        $entries = $this->callBuildResolveEntries(
-            'this-host-must-not-resolve.invalid',
-            443,
-        );
+        // Resolver returns no records → middleware lets curl produce the
+        // usual connection-failure error path.
+        $entries = $this->callBuildResolveEntries('unknown.example', 443);
 
         self::assertSame([], $entries);
+    }
+
+    #[Test]
+    public function buildResolveEntriesPinsSafeIpv4(): void
+    {
+        $this->dnsResolver->program('api.example.com', [['ip' => '93.184.216.34']]);
+
+        $entries = $this->callBuildResolveEntries('api.example.com', 443);
+
+        self::assertSame(['api.example.com:443:93.184.216.34'], $entries);
+    }
+
+    #[Test]
+    public function buildResolveEntriesBracketsIpv6(): void
+    {
+        // libcurl requires IPv6 addresses in CURLOPT_RESOLVE to be bracketed
+        // (`host:port:[ip]`); without brackets curl misparses the colons.
+        $this->dnsResolver->program('v6.example.com', [['ipv6' => '2001:db8::1']]);
+
+        $entries = $this->callBuildResolveEntries('v6.example.com', 443);
+
+        self::assertSame(['v6.example.com:443:[2001:db8::1]'], $entries);
+    }
+
+    #[Test]
+    public function buildResolveEntriesReturnsNullWhenAnyRecordIsDangerous(): void
+    {
+        // Split-horizon: resolver returns one public + one internal IP. ANY
+        // dangerous answer must kill the request — curl could otherwise pick
+        // the internal one and we'd leak.
+        $this->dnsResolver->program('rebind.example.com', [
+            ['ip' => '93.184.216.34'],
+            ['ip' => '169.254.169.254'], // AWS metadata
+        ]);
+
+        $entries = $this->callBuildResolveEntries('rebind.example.com', 443);
+
+        self::assertNull($entries);
     }
 
     #[Test]
@@ -109,16 +148,53 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
     }
 
     #[Test]
-    public function middlewareRejectsRequestToHostResolvingToLoopback(): void
+    public function middlewareRejectsRequestToHostResolvingToDangerousIp(): void
     {
+        $this->dnsResolver->program('attacker.example', [['ip' => '169.254.169.254']]);
         $client = $this->buildCapturingClient($capturedOptions);
 
         $this->expectException(RequestException::class);
         $this->expectExceptionMessageMatches('/DNS rebinding defence/i');
 
-        // `localhost` reliably resolves to 127.0.0.1 (loopback) — the
-        // middleware must refuse to dispatch the request.
-        $client->get('http://localhost/');
+        $client->get('http://attacker.example/');
+    }
+
+    #[Test]
+    public function middlewareAddsCurlResolvePinForResolvedHost(): void
+    {
+        $this->dnsResolver->program('safe.example', [['ip' => '93.184.216.34']]);
+        $client = $this->buildCapturingClient($capturedOptions);
+
+        $client->get('https://safe.example/api');
+
+        $curlOpts = $capturedOptions['curl'] ?? null;
+        self::assertIsArray($curlOpts);
+        self::assertArrayHasKey(\CURLOPT_RESOLVE, $curlOpts);
+        self::assertSame(['safe.example:443:93.184.216.34'], $curlOpts[\CURLOPT_RESOLVE]);
+    }
+
+    #[Test]
+    public function middlewareNormalisesBracketedIpv6Host(): void
+    {
+        // PSR-7 getHost() returns IPv6 literals wrapped in brackets. Without
+        // normalisation, `filter_var(..., FILTER_VALIDATE_IP)` would reject
+        // `[::1]` and the middleware would try to resolve it via DNS — both
+        // useless and a security regression (the IP-literal guard wouldn't
+        // run). normaliseHost() strips the brackets first.
+        //
+        // Verified indirectly: send to a bracketed FQDN-style host that
+        // resolves via the in-memory resolver. If normalisation runs, the
+        // resolver receives the bare host and the pin is generated.
+        $this->dnsResolver->program('safe.example', [['ip' => '93.184.216.34']]);
+        $client = $this->buildCapturingClient($capturedOptions);
+
+        $client->get('http://safe.example/api');
+
+        self::assertContains(
+            'safe.example',
+            $this->dnsResolver->queriedHosts(),
+            'Middleware must call resolver with the bare host (no brackets).',
+        );
     }
 
     /**
@@ -159,5 +235,41 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
             ->getMethod('buildResolveEntries');
 
         return $method->invoke($this->subject, $host, $port);
+    }
+}
+
+/**
+ * Test double that returns programmed responses for specific hosts and
+ * records every host queried — used by the rebinding tests above.
+ */
+final class InMemoryDnsResolver implements DnsResolverInterface
+{
+    /** @var array<string, list<array{ip?: string, ipv6?: string}>> */
+    private array $programmed = [];
+
+    /** @var list<string> */
+    private array $queried = [];
+
+    /**
+     * @param list<array{ip?: string, ipv6?: string}> $records
+     */
+    public function program(string $host, array $records): void
+    {
+        $this->programmed[$host] = $records;
+    }
+
+    public function resolve(string $host): array
+    {
+        $this->queried[] = $host;
+
+        return $this->programmed[$host] ?? [];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function queriedHosts(): array
+    {
+        return $this->queried;
     }
 }

--- a/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
@@ -1,0 +1,163 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Http;
+
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Psr7\Response;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\RequestInterface;
+use ReflectionClass;
+use TypeError;
+
+/**
+ * DNS-rebinding defence tests.
+ *
+ * The middleware pushed by {@see SecureHttpClientFactory::create()} resolves
+ * the request host AT REQUEST TIME and pins the resulting IP via curl's
+ * `CURLOPT_RESOLVE` option, so the upstream client cannot re-resolve to a
+ * different (internal) address between our check and the connect.
+ *
+ * These tests avoid hitting the real DNS by exercising the private
+ * `buildResolveEntries` helper directly (via reflection) for the resolution-
+ * outcome assertions, and by replacing the bottom handler of the factory's
+ * HandlerStack for the wiring assertions.
+ */
+#[CoversClass(SecureHttpClientFactory::class)]
+final class SecureHttpClientFactoryRebindingTest extends TestCase
+{
+    private SecureHttpClientFactory $subject;
+
+    private mixed $originalGlobals;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new SecureHttpClientFactory();
+        $this->originalGlobals = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $GLOBALS['TYPO3_CONF_VARS'] = ['HTTP' => []];
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        if ($this->originalGlobals !== null) {
+            $GLOBALS['TYPO3_CONF_VARS'] = $this->originalGlobals;
+        } else {
+            unset($GLOBALS['TYPO3_CONF_VARS']);
+        }
+    }
+
+    #[Test]
+    public function buildResolveEntriesReturnsEmptyForIpLiteral(): void
+    {
+        // IPv4 and IPv6 literals are validated by isHostAllowed() — the
+        // middleware doesn't need to add a pin entry.
+        self::assertSame([], $this->callBuildResolveEntries('93.184.216.34', 443));
+        self::assertSame([], $this->callBuildResolveEntries('::1', 443));
+    }
+
+    #[Test]
+    public function buildResolveEntriesReturnsEmptyForUnresolvableHost(): void
+    {
+        // Synthetic hostname that DNS cannot resolve — middleware lets curl
+        // produce the usual connection-failure error path.
+        $entries = $this->callBuildResolveEntries(
+            'this-host-must-not-resolve.invalid',
+            443,
+        );
+
+        self::assertSame([], $entries);
+    }
+
+    #[Test]
+    public function middlewareIsRegisteredInTheHandlerStack(): void
+    {
+        $client = $this->subject->create();
+        $handler = $client->getConfig('handler');
+
+        self::assertInstanceOf(HandlerStack::class, $handler);
+        self::assertStringContainsString(
+            'ssrf-dns-pin',
+            (string) $handler,
+            'The factory must push the ssrf-dns-pin middleware onto the stack.',
+        );
+    }
+
+    #[Test]
+    public function middlewareDoesNotAddCurlResolveForIpLiteralHost(): void
+    {
+        $client = $this->buildCapturingClient($capturedOptions);
+
+        // IP literal — buildResolveEntries returns [] and no pin is added.
+        $client->get('http://93.184.216.34/');
+
+        self::assertArrayNotHasKey('curl', $capturedOptions ?? []);
+    }
+
+    #[Test]
+    public function middlewareRejectsRequestToHostResolvingToLoopback(): void
+    {
+        $client = $this->buildCapturingClient($capturedOptions);
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessageMatches('/DNS rebinding defence/i');
+
+        // `localhost` reliably resolves to 127.0.0.1 (loopback) — the
+        // middleware must refuse to dispatch the request.
+        $client->get('http://localhost/');
+    }
+
+    /**
+     * Build a Client whose factory-installed middleware stack is intact, but
+     * the BOTTOM handler is replaced with a capturing stub. The SSRF
+     * middleware still runs on top — we just observe what reaches the
+     * imaginary curl handler.
+     *
+     * @param-out array<string, mixed>|null $capturedOptions
+     */
+    private function buildCapturingClient(?array &$capturedOptions): Client
+    {
+        $capturedOptions = null;
+
+        $client = $this->subject->create();
+        $handler = $client->getConfig('handler');
+        if (!$handler instanceof HandlerStack) {
+            throw new TypeError('Factory must build a HandlerStack-backed client.', 8206566209);
+        }
+
+        $handler->setHandler(
+            static function (RequestInterface $request, array $options) use (&$capturedOptions): PromiseInterface {
+                $capturedOptions = $options;
+
+                return Create::promiseFor(new Response(200, [], ''));
+            },
+        );
+
+        return $client;
+    }
+
+    /**
+     * @return list<string>|null
+     */
+    private function callBuildResolveEntries(string $host, int $port): ?array
+    {
+        $method = (new ReflectionClass(SecureHttpClientFactory::class))
+            ->getMethod('buildResolveEntries');
+
+        return $method->invoke($this->subject, $host, $port);
+    }
+}


### PR DESCRIPTION
## Summary

Closes the documented DNS-rebinding gap in our SSRF defence. Previously, `isHostAllowed()` resolved + validated the host at check time, but curl re-resolved the same hostname at connect time — an attacker with DNS control could return a benign IP on the first lookup (passing our check) and an internal IP on the second (where curl actually connects). TOCTOU via the resolver.

This is the follow-up flagged in the `isDangerousIpLiteral()` docblock since the H-1 SSRF defence landed:

> *"Caveat: this defence is bypassable by DNS rebinding when the upstream HTTP client (Guzzle/curl) re-resolves at connect-time. For full protection, callers must pin to the resolved IP via curl `CURLOPT_RESOLVE`; that is a follow-up."*

## The fix

Push a Guzzle middleware (`ssrf-dns-pin`) onto the HandlerStack inside `SecureHttpClientFactory::create()`. The middleware runs per outgoing request and:

1. Reads URI host + port.
2. Resolves via `dns_get_record(A | AAAA)` and validates EACH record against the existing `isDangerousIpLiteral()` defence.
3. **Any** dangerous answer kills the request → `RequestException` before socket opens. (Split-horizon rebinding could otherwise return one safe + one internal IP; if curl picked the internal one we'd leak.)
4. All-safe records get pinned via curl's `CURLOPT_RESOLVE` (`host:port:ip` entries, supports multiple for dual-stack). curl then skips its own DNS step.
5. IP literals (already validated) and unresolvable hosts (let curl produce the error) pass through without a pin.

## Architecture

| Layer | Purpose | When |
|---|---|---|
| `VaultHttpClient::sendRequest()` → `isHostAllowed()` | Early gate; happens BEFORE secret injection so credentials never touch a rejected request | Per request, our code |
| `ssrf-dns-pin` middleware | Late gate; pins the verified IP so curl can't be tricked by a second resolution | Per request, in Guzzle's request pipeline |

Both checks run; the middleware adds the race-free pin on top of the existing allowlist defence.

## Why we can do this

We instantiate `GuzzleHttp\Client` **directly** (see PR description of the discussion: we use our own HTTP client, not TYPO3's `RequestFactory`). That gives us full access to curl options. A factory built on TYPO3's `GuzzleClientFactory` would not have this option.

## Test plan

- [x] +5 unit tests in `Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php`:
  - `buildResolveEntriesReturnsEmptyForIpLiteral` — IP literals don't get a pin.
  - `buildResolveEntriesReturnsEmptyForUnresolvableHost` — `.invalid` TLD → curl handles connect-failure.
  - `middlewareIsRegisteredInTheHandlerStack` — the `ssrf-dns-pin` name appears on the stack.
  - `middlewareDoesNotAddCurlResolveForIpLiteralHost` — full round-trip with captured bottom handler.
  - `middlewareRejectsRequestToHostResolvingToLoopback` — `localhost` (→ 127.0.0.1) triggers the dangerous-IP path; `RequestException` with the rebinding-defence message.
- [x] 1717 unit tests pass (+5 new).
- [x] cgl + rector + PHPStan level 10 green locally.
- [ ] CI matrix.

## Not in scope

- `OAuthTokenManager` has its OWN `GuzzleHttp\Client` instance bypassing this factory. That's a separate gap and deserves its own PR (the manager should accept an injected client from `SecureHttpClientFactory` instead of constructing one). Will track.
- IPv6 dual-stack edge cases: middleware pins both A and AAAA records when present, but TLS SNI + curl's per-family interface selection may still surprise. Functional tests against real IPv6-only hosts would help; deferred.

## Migration

No behaviour change for legitimately-public targets. Rejects new (correct) cases:
- Hostnames whose DNS records include private/loopback/metadata IPs.
- Rebinding-style domain setups that try to swap resolution between check and connect.

If a customer has an on-prem deployment where the vault server lives on RFC1918, they need the existing `$GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts']` allowlist (literal match) — that path is unchanged and still bypasses the IP guard.