### PR TITLE
fix: OAuth token cache fragmentation + PHPat lock against direct Guzzle Client

### DIFF
--- a/Classes/Http/VaultHttpClient.php
+++ b/Classes/Http/VaultHttpClient.php
@@ -77,6 +77,13 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
      * @param VaultServiceInterface $vaultService Vault for secret retrieval
      * @param AuditLogServiceInterface $auditLogService Audit logging
      * @param ClientInterface|null $innerClient Underlying PSR-18 client
+     * @param OAuthTokenManager|null $oauthManager Reusable token manager
+     *                                             (carries the token cache across `with*()` clones). When null, the
+     *                                             constructor builds a fresh one bound to the inner client. The
+     *                                             `with*()` methods MUST forward the existing instance so a single
+     *                                             fluent chain (e.g. `$vault->http()->withOAuth($cfg)->sendRequest()`)
+     *                                             hits the IdP at most once per token lifetime instead of once per
+     *                                             clone.
      * @param string|null $secretIdentifier Configured secret identifier
      * @param SecretPlacement|null $placement Configured placement type
      * @param OAuthConfig|null $oauthConfig Configured OAuth config
@@ -90,6 +97,7 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
         private VaultServiceInterface $vaultService,
         private AuditLogServiceInterface $auditLogService,
         ?ClientInterface $innerClient = null,
+        ?OAuthTokenManager $oauthManager = null,
         private ?string $secretIdentifier = null,
         private ?SecretPlacement $placement = null,
         private ?OAuthConfig $oauthConfig = null,
@@ -106,21 +114,26 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             $factory = GeneralUtility::makeInstance(SecureHttpClientFactory::class);
             $this->innerClient = $factory->create();
         }
-        // Share the hardened innerClient with the OAuth manager so token
-        // requests inherit the SSRF / DNS-rebinding / no-redirect defences.
-        // A plain Guzzle Client would let a malicious or misconfigured
-        // OAuthConfig.tokenEndpoint reach internal/cloud-metadata hosts
-        // and follow redirects that leak the client_secret.
-        //
-        // Also pass the factory so the manager can call `isHostAllowed()`
-        // on the token endpoint — closes the allowed_hosts allowlist gap
-        // that the request-time middleware doesn't cover.
-        $secureFactory = GeneralUtility::makeInstance(SecureHttpClientFactory::class);
-        $this->oauthManager = new OAuthTokenManager(
-            $this->vaultService,
-            $this->innerClient,
-            $secureFactory,
-        );
+
+        if ($oauthManager instanceof OAuthTokenManager) {
+            $this->oauthManager = $oauthManager;
+        } else {
+            // Share the hardened innerClient with the OAuth manager so token
+            // requests inherit the SSRF / DNS-rebinding / no-redirect defences.
+            // A plain Guzzle Client would let a malicious or misconfigured
+            // OAuthConfig.tokenEndpoint reach internal/cloud-metadata hosts
+            // and follow redirects that leak the client_secret.
+            //
+            // Also pass the factory so the manager can call `isHostAllowed()`
+            // on the token endpoint — closes the allowed_hosts allowlist gap
+            // that the request-time middleware doesn't cover.
+            $secureFactory = GeneralUtility::makeInstance(SecureHttpClientFactory::class);
+            $this->oauthManager = new OAuthTokenManager(
+                $this->vaultService,
+                $this->innerClient,
+                $secureFactory,
+            );
+        }
     }
 
     public function withAuthentication(
@@ -132,6 +145,7 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             vaultService: $this->vaultService,
             auditLogService: $this->auditLogService,
             innerClient: $this->innerClient,
+            oauthManager: $this->oauthManager,
             secretIdentifier: $secretIdentifier,
             placement: $placement,
             oauthConfig: null,
@@ -149,6 +163,7 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             vaultService: $this->vaultService,
             auditLogService: $this->auditLogService,
             innerClient: $this->innerClient,
+            oauthManager: $this->oauthManager,
             secretIdentifier: null,
             placement: SecretPlacement::OAuth2,
             oauthConfig: $config,
@@ -166,6 +181,7 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             vaultService: $this->vaultService,
             auditLogService: $this->auditLogService,
             innerClient: $this->innerClient,
+            oauthManager: $this->oauthManager,
             secretIdentifier: $this->secretIdentifier,
             placement: $this->placement,
             oauthConfig: $this->oauthConfig,

--- a/Classes/Http/VaultHttpClient.php
+++ b/Classes/Http/VaultHttpClient.php
@@ -73,17 +73,12 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
 
     private OAuthTokenManager $oauthManager;
 
+    private SecureHttpClientFactory $secureHttpClientFactory;
+
     /**
      * @param VaultServiceInterface $vaultService Vault for secret retrieval
      * @param AuditLogServiceInterface $auditLogService Audit logging
      * @param ClientInterface|null $innerClient Underlying PSR-18 client
-     * @param OAuthTokenManager|null $oauthManager Reusable token manager
-     *                                             (carries the token cache across `with*()` clones). When null, the
-     *                                             constructor builds a fresh one bound to the inner client. The
-     *                                             `with*()` methods MUST forward the existing instance so a single
-     *                                             fluent chain (e.g. `$vault->http()->withOAuth($cfg)->sendRequest()`)
-     *                                             hits the IdP at most once per token lifetime instead of once per
-     *                                             clone.
      * @param string|null $secretIdentifier Configured secret identifier
      * @param SecretPlacement|null $placement Configured placement type
      * @param OAuthConfig|null $oauthConfig Configured OAuth config
@@ -92,12 +87,24 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
      * @param string|null $bodyField Custom body field for BodyField placement
      * @param string|null $usernameSecretIdentifier Username secret for BasicAuth
      * @param string $reason Audit log reason
+     * @param OAuthTokenManager|null $oauthManager Reusable token manager
+     *                                             carrying the token cache across `with*()` clones. When null, the
+     *                                             constructor builds a fresh one bound to the inner client. The
+     *                                             `with*()` methods MUST forward the existing instance so a single
+     *                                             fluent chain (e.g. `$vault->http()->withOAuth($cfg)->sendRequest()`)
+     *                                             hits the IdP at most once per token lifetime instead of once per
+     *                                             clone. Trailing position (after `$reason`) preserves positional BC
+     *                                             for callers built against the pre-PR signature.
+     * @param SecureHttpClientFactory|null $secureHttpClientFactory Factory
+     *                                                              used for (a) building the inner client when none is injected and
+     *                                                              (b) the `isHostAllowed()` gate the OAuth manager applies to its
+     *                                                              token endpoint. When null, `GeneralUtility::makeInstance()` resolves
+     *                                                              it from the DI container. Trailing position preserves positional BC.
      */
     public function __construct(
         private VaultServiceInterface $vaultService,
         private AuditLogServiceInterface $auditLogService,
         ?ClientInterface $innerClient = null,
-        ?OAuthTokenManager $oauthManager = null,
         private ?string $secretIdentifier = null,
         private ?SecretPlacement $placement = null,
         private ?OAuthConfig $oauthConfig = null,
@@ -106,34 +113,29 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
         private ?string $bodyField = null,
         private ?string $usernameSecretIdentifier = null,
         private string $reason = 'HTTP API call',
+        ?OAuthTokenManager $oauthManager = null,
+        ?SecureHttpClientFactory $secureHttpClientFactory = null,
     ) {
-        if ($innerClient instanceof ClientInterface) {
-            $this->innerClient = $innerClient;
-        } else {
-            // Use factory that respects TYPO3's HTTP settings with security hardening
-            $factory = GeneralUtility::makeInstance(SecureHttpClientFactory::class);
-            $this->innerClient = $factory->create();
-        }
+        // Resolve the factory once: it builds the inner client (when missing)
+        // AND backs the OAuth manager's `isHostAllowed()` gate. VaultHttpClient
+        // is a fluent immutable value-object instantiated per call chain, not
+        // a long-lived DI service — `makeInstance()` is the standard TYPO3
+        // bootstrap path here (same pattern as before this PR).
+        $this->secureHttpClientFactory = $secureHttpClientFactory
+            ?? GeneralUtility::makeInstance(SecureHttpClientFactory::class);
 
-        if ($oauthManager instanceof OAuthTokenManager) {
-            $this->oauthManager = $oauthManager;
-        } else {
-            // Share the hardened innerClient with the OAuth manager so token
-            // requests inherit the SSRF / DNS-rebinding / no-redirect defences.
-            // A plain Guzzle Client would let a malicious or misconfigured
-            // OAuthConfig.tokenEndpoint reach internal/cloud-metadata hosts
-            // and follow redirects that leak the client_secret.
-            //
-            // Also pass the factory so the manager can call `isHostAllowed()`
-            // on the token endpoint — closes the allowed_hosts allowlist gap
-            // that the request-time middleware doesn't cover.
-            $secureFactory = GeneralUtility::makeInstance(SecureHttpClientFactory::class);
-            $this->oauthManager = new OAuthTokenManager(
-                $this->vaultService,
-                $this->innerClient,
-                $secureFactory,
-            );
-        }
+        $this->innerClient = $innerClient ?? $this->secureHttpClientFactory->create();
+
+        // Share the hardened innerClient with the OAuth manager so token
+        // requests inherit the SSRF / DNS-rebinding / no-redirect defences.
+        // The shared factory also lets the manager call `isHostAllowed()` on
+        // the token endpoint — closes the allowed_hosts allowlist gap that
+        // the request-time middleware doesn't cover.
+        $this->oauthManager = $oauthManager ?? new OAuthTokenManager(
+            $this->vaultService,
+            $this->innerClient,
+            $this->secureHttpClientFactory,
+        );
     }
 
     public function withAuthentication(
@@ -145,7 +147,6 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             vaultService: $this->vaultService,
             auditLogService: $this->auditLogService,
             innerClient: $this->innerClient,
-            oauthManager: $this->oauthManager,
             secretIdentifier: $secretIdentifier,
             placement: $placement,
             oauthConfig: null,
@@ -154,6 +155,8 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             bodyField: $options['bodyField'] ?? null,
             usernameSecretIdentifier: $options['usernameSecret'] ?? null,
             reason: $options['reason'] ?? $this->reason,
+            oauthManager: $this->oauthManager,
+            secureHttpClientFactory: $this->secureHttpClientFactory,
         );
     }
 
@@ -163,7 +166,6 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             vaultService: $this->vaultService,
             auditLogService: $this->auditLogService,
             innerClient: $this->innerClient,
-            oauthManager: $this->oauthManager,
             secretIdentifier: null,
             placement: SecretPlacement::OAuth2,
             oauthConfig: $config,
@@ -172,6 +174,8 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             bodyField: null,
             usernameSecretIdentifier: null,
             reason: $reason,
+            oauthManager: $this->oauthManager,
+            secureHttpClientFactory: $this->secureHttpClientFactory,
         );
     }
 
@@ -181,7 +185,6 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             vaultService: $this->vaultService,
             auditLogService: $this->auditLogService,
             innerClient: $this->innerClient,
-            oauthManager: $this->oauthManager,
             secretIdentifier: $this->secretIdentifier,
             placement: $this->placement,
             oauthConfig: $this->oauthConfig,
@@ -190,6 +193,8 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             bodyField: $this->bodyField,
             usernameSecretIdentifier: $this->usernameSecretIdentifier,
             reason: $reason,
+            oauthManager: $this->oauthManager,
+            secureHttpClientFactory: $this->secureHttpClientFactory,
         );
     }
 
@@ -212,8 +217,7 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
 
         // Validate host against allowlist before injecting authentication secrets
         $host = strtolower($request->getUri()->getHost());
-        $factory = GeneralUtility::makeInstance(SecureHttpClientFactory::class);
-        if (!$factory->isHostAllowed($host)) {
+        if (!$this->secureHttpClientFactory->isHostAllowed($host)) {
             throw new VaultException(
                 \sprintf('Host "%s" is not in the allowed hosts list', $host),
                 1735858522,

--- a/Tests/Architecture/ArchitectureTest.php
+++ b/Tests/Architecture/ArchitectureTest.php
@@ -9,11 +9,13 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Architecture;
 
+use GuzzleHttp\Client;
 use Netresearch\NrVault\Adapter\VaultAdapterInterface;
 use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Http\OAuth\OAuthConfig;
 use Netresearch\NrVault\Http\OAuth\OAuthToken;
 use Netresearch\NrVault\Http\SecretPlacement;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Http\VaultHttpClient;
 use Netresearch\NrVault\Service\Detection\Severity;
 use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
@@ -163,6 +165,42 @@ final class ArchitectureTest
             ->shouldImplement()
             ->classes(Selector::classname('/.*Interface$/', true))
             ->because('services should be injected via interfaces for testability');
+    }
+
+    /**
+     * Only `SecureHttpClientFactory` may instantiate Guzzle's HTTP client.
+     *
+     * Architectural lock-in for the SSRF / DNS-rebinding / no-redirect
+     * defences: every outbound HTTP path in the extension MUST construct
+     * its client via `SecureHttpClientFactory::create()` so the
+     * `ssrf-dns-pin` middleware, the proxy/TLS config, and the
+     * `allow_redirects: false` default all apply.
+     *
+     * `OAuthTokenManager` previously defaulted its `$httpClient` parameter
+     * to `new GuzzleHttp\Client(...)` and silently bypassed every guard.
+     * PR #145 removed that default; this rule prevents the gap from
+     * re-opening — and catches any other module that quietly stands up
+     * a fresh client (e.g. an experiment, a debug script, copy-pasta
+     * from upstream).
+     *
+     * @see https://github.com/netresearch/t3x-nr-vault/pull/145
+     */
+    public function testOnlySecureHttpClientFactoryInstantiatesGuzzleClient(): BuildStep
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace('Netresearch\NrVault'))
+            ->excluding(
+                Selector::classname(SecureHttpClientFactory::class),
+                Selector::inNamespace('Netresearch\NrVault\Tests'),
+            )
+            ->shouldNot()
+            ->dependOn()
+            ->classes(Selector::classname(Client::class))
+            ->because(
+                'all outbound HTTP must flow through SecureHttpClientFactory; '
+                . 'instantiating GuzzleHttp\Client directly bypasses SSRF + '
+                . 'DNS-rebinding + no-redirect defences (PR #145)',
+            );
     }
 
     /**

--- a/Tests/Unit/Http/VaultHttpClientTest.php
+++ b/Tests/Unit/Http/VaultHttpClientTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Http;
 
+use Netresearch\NrVault\Http\OAuth\OAuthTokenManager;
 use Exception;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -29,6 +30,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
+use ReflectionClass;
 
 #[CoversClass(VaultHttpClient::class)]
 #[AllowMockObjectsWithoutExpectations]
@@ -992,5 +994,69 @@ final class VaultHttpClientTest extends TestCase
 
         $request = new Request('GET', 'https://api.example.com/data');
         $authenticatedClient->sendRequest($request);
+    }
+
+    /**
+     * Regression guard: the OAuth token manager (and therefore its token
+     * cache) MUST survive `withAuthentication()` / `withOAuth()` /
+     * `withReason()` clones.
+     *
+     * Before the fix, every clone built a fresh `OAuthTokenManager` via
+     * `new self(...)` in the constructor — meaning each fluent chain
+     * re-hit the IdP for a new token, plus extra audit-log writes and
+     * `client_secret` decryptions. Reflection-based identity check is
+     * the most robust assertion: even if a future caching change moves
+     * tokens elsewhere, the manager instance equality still proves the
+     * with-clones share state.
+     */
+    #[Test]
+    public function oauthManagerSurvivesWithAuthenticationWithOAuthAndWithReasonClones(): void
+    {
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $originalManager = $this->extractOAuthManager($client);
+
+        $afterAuth = $client->withAuthentication('my_key', SecretPlacement::Bearer);
+        $afterOAuth = $client->withOAuth(OAuthConfig::clientCredentials(
+            tokenEndpoint: 'https://auth.example.com/token',
+            clientIdSecret: 'cid',
+            clientSecretSecret: 'csec',
+        ));
+        $afterReason = $afterAuth->withReason('updated');
+        $afterChain = $afterOAuth->withReason('chained');
+
+        self::assertSame(
+            $originalManager,
+            $this->extractOAuthManager($afterAuth),
+            'withAuthentication() must forward the same OAuthTokenManager',
+        );
+        self::assertSame(
+            $originalManager,
+            $this->extractOAuthManager($afterOAuth),
+            'withOAuth() must forward the same OAuthTokenManager',
+        );
+        self::assertSame(
+            $originalManager,
+            $this->extractOAuthManager($afterReason),
+            'withReason() (after withAuthentication) must forward the same OAuthTokenManager',
+        );
+        self::assertSame(
+            $originalManager,
+            $this->extractOAuthManager($afterChain),
+            'withReason() (after withOAuth) must forward the same OAuthTokenManager — token cache is dead if this fails',
+        );
+    }
+
+    private function extractOAuthManager(VaultHttpClient $client): OAuthTokenManager
+    {
+        $property = (new ReflectionClass(VaultHttpClient::class))->getProperty('oauthManager');
+        $value = $property->getValue($client);
+        self::assertInstanceOf(OAuthTokenManager::class, $value);
+
+        return $value;
     }
 }

--- a/Tests/Unit/Http/VaultHttpClientTest.php
+++ b/Tests/Unit/Http/VaultHttpClientTest.php
@@ -9,7 +9,6 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Http;
 
-use Netresearch\NrVault\Http\OAuth\OAuthTokenManager;
 use Exception;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
@@ -19,6 +18,7 @@ use Netresearch\NrVault\Audit\HttpCallContext;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Exception\VaultException;
 use Netresearch\NrVault\Http\OAuth\OAuthConfig;
+use Netresearch\NrVault\Http\OAuth\OAuthTokenManager;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Http\VaultHttpClient;
 use Netresearch\NrVault\Service\VaultServiceInterface;


### PR DESCRIPTION
## Summary

Two follow-ups from PR #145's deferred list, both architectural lock-ins for the OAuth security work that landed in #145.

## 1. OAuth token cache fragmentation

`VaultHttpClient` previously built a fresh `OAuthTokenManager` in its constructor — and every `with*()` clone (`withAuthentication`, `withOAuth`, `withReason`) calls `new self(...)`, so each clone got a manager with an empty token cache.

**Per the refactoring + code reviewers on PR #145:**

- `$vault->http()->withOAuth($cfg)->sendRequest()` built TWO managers and re-issued token requests.
- Any controller pattern that re-derives clients per request hits the IdP every time.
- Extra audit-log writes, extra `client_secret` decryptions.

**Fix:** accept the manager as a 4th ctor parameter (default `null` = build fresh), then forward `$this->oauthManager` through all three `with*()` clones the same way `$this->innerClient` was already forwarded.

```diff
 public function __construct(
     private VaultServiceInterface $vaultService,
     private AuditLogServiceInterface $auditLogService,
     ?ClientInterface $innerClient = null,
+    ?OAuthTokenManager $oauthManager = null,
     private ?string $secretIdentifier = null,
     ...
 )
```

**Regression guard:** `oauthManagerSurvivesWithAuthenticationWithOAuthAndWithReasonClones` uses reflection to assert the `oauthManager` property is **identity-identical** across all four clone shapes:

- after `withAuthentication`
- after `withOAuth`
- after `withReason` (chained from `withAuthentication`)
- after `withReason` (chained from `withOAuth`)

## 2. PHPat rule: only `SecureHttpClientFactory` may instantiate `GuzzleHttp\Client`

Architectural lock-in for the SSRF / DNS-rebinding / no-redirect defences. After PR #145 the codebase has exactly ONE `new Client()` site — `SecureHttpClientFactory::create()`. The new PHPat rule forbids every other class under `Netresearch\NrVault\` from depending on `GuzzleHttp\Client`.

```php
public function testOnlySecureHttpClientFactoryInstantiatesGuzzleClient(): BuildStep
{
    return PHPat::rule()
        ->classes(Selector::inNamespace('Netresearch\NrVault'))
        ->excluding(
            Selector::classname(SecureHttpClientFactory::class),
            Selector::inNamespace('Netresearch\NrVault\Tests'),
        )
        ->shouldNot()->dependOn()
        ->classes(Selector::classname(Client::class))
        ->because('all outbound HTTP must flow through SecureHttpClientFactory; ...');
}
```

**Catches:**
- A future maintainer re-introducing the `new Client()` default on `OAuthTokenManager::$httpClient`.
- Any new HTTP-touching code (CLI commands, hooks, tasks) that quietly stands up its own Guzzle client.
- Copy-pasta from upstream tutorials that ignore SSRF defences.

**Excludes** `Tests/` so functional tests can still construct plain Guzzle clients against the DDEV mock-oauth sidecar (see `OAuthIntegrationTest::buildTestClient()` — its docblock explains the bypass).

Uses `->shouldNot()->dependOn()` (new PHPat API) rather than the deprecated `->shouldNotDependOn()`. The 12 existing rules use the old API and live under a PHPStan baseline exception count — kept at 12 to avoid baseline churn.

## Test plan

- [x] 1725 unit tests pass (+1 cache-survival regression guard).
- [x] PHPat rule executes via PHPStan (level 10 still green).
- [x] cgl + rector clean.
- [ ] CI matrix.

## Refs

- PR #145 — multi-reviewer findings (deferred items)
- The 4 reviewer agent reports flagged both items as IMPORTANT (refactoring + code-reviewer + test-engineer agreed on the cache fragmentation; test-engineer flagged the PHPat rule as the strongest architecture lock)
