### PR TITLE
test: fix flaky decryptWithTamperedDataThrowsException (~1/256 false-pass)

### DIFF
--- a/Tests/Unit/Crypto/EncryptionServiceTest.php
+++ b/Tests/Unit/Crypto/EncryptionServiceTest.php
@@ -151,10 +151,17 @@ final class EncryptionServiceTest extends TestCase
 
         $encrypted = $this->subject->encrypt($plaintext, $identifier);
 
-        // Tamper with the encrypted value
-        $tamperedValue = base64_encode(
-            substr(base64_decode($encrypted->encryptedValue, true), 0, -1) . 'X',
-        );
+        // Flip every bit in the last ciphertext byte. The previous
+        // implementation appended a literal 'X' which collided with the
+        // original byte on ~1/256 runs (when it happened to already be
+        // 0x58) and let decryption succeed correctly — a real CI flake
+        // (see PR #147 / main-CI on 222009c). XOR-with-0xFF guarantees
+        // a different byte regardless of the underlying value.
+        $raw = base64_decode($encrypted->encryptedValue, true);
+        self::assertIsString($raw, 'EncryptedData::$encryptedValue must be valid base64');
+        $lastIndex = \strlen($raw) - 1;
+        $flipped = \chr(\ord($raw[$lastIndex]) ^ 0xFF);
+        $tamperedValue = base64_encode(substr($raw, 0, $lastIndex) . $flipped);
 
         $this->expectException(EncryptionException::class);
 


### PR DESCRIPTION
## Summary

Fix a pre-existing flaky test that brought down main-CI on commit `222009c` (PR #146 merge): `ci / Unit Tests (8.2, ^14.0)` failed with *"Failed asserting that exception of type EncryptionException is thrown"*. The matrix cell + the PR are unrelated to the failure cause; the test would flake on any matrix cell, any PR, ~1 run in 256.

## Root cause

The "tamper" step appended the literal byte `'X'` (0x58) to the truncated ciphertext:

```php
$tamperedValue = base64_encode(
    substr(base64_decode($encrypted->encryptedValue, true), 0, -1) . 'X',
);
```

When the original ciphertext's last byte was ALSO 0x58 (about 1 in 256 runs, since GCM ciphertext is effectively uniform random), the "tampered" value was **identical** to the original. Decryption then succeeded correctly, GCM didn't fail authentication, and the expected `EncryptionException` was never thrown — test failure.

Introduced in commit `9a337fe` (well before this session); slipped past most CI matrix runs because each cell only takes one shot at the dice.

## Fix

Replace the literal-byte append with a guaranteed bit-flip:

```diff
- $tamperedValue = base64_encode(
-     substr(base64_decode($encrypted->encryptedValue, true), 0, -1) . 'X',
- );
+ $raw = base64_decode($encrypted->encryptedValue, true);
+ self::assertIsString($raw, 'EncryptedData::$encryptedValue must be valid base64');
+ $lastIndex = \strlen($raw) - 1;
+ $flipped = \chr(\ord($raw[$lastIndex]) ^ 0xFF);
+ $tamperedValue = base64_encode(substr($raw, 0, $lastIndex) . $flipped);
```

XOR-with-0xFF flips every bit of the last byte, so the value ALWAYS changes regardless of what it was. GCM authentication-tag mismatch is now deterministic.

## Test plan

- [x] Local stability check: **50 / 50 runs pass** (pre-fix: ~99.6% pass rate, drift visible across hundreds of CI runs).
- [x] 1725 unit tests pass (no count change).
- [x] cgl + PHPStan level 10 green.
- [ ] CI matrix.

Refs main-CI run [26327731844](https://github.com/netresearch/t3x-nr-vault/actions/runs/26327731844) on commit `222009c`.