### PR TITLE
fix: 3 carried-forward LOW review items (sL fallback + OAuth cache key + redaction)

### DIFF
--- a/Classes/Exception/OAuthException.php
+++ b/Classes/Exception/OAuthException.php
@@ -61,7 +61,7 @@ final class OAuthException extends VaultException
         );
     }
 
-    public static function requestFailed(string $message, Throwable $previous): self
+    public static function requestFailed(string $message, ?Throwable $previous = null): self
     {
         return new self(
             \sprintf('OAuth token request failed: %s', $message),

--- a/Classes/Form/Element/VaultSecretElement.php
+++ b/Classes/Form/Element/VaultSecretElement.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrVault\Form\Element;
 
 use Netresearch\NrVault\Service\VaultFieldPermissionService;
 use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Utility\LocalisationHelper;
 use Throwable;
 use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -165,9 +166,11 @@ final class VaultSecretElement extends AbstractFormElement
     private function resolvePlaceholder(bool $hasValue, array $config): string
     {
         if ($hasValue) {
-            return $this->getLanguageService()->sL(
+            return LocalisationHelper::translateOrFallback(
+                $this->getLanguageService(),
                 'LLL:EXT:nr_vault/Resources/Private/Language/locallang.xlf:vault_secret.placeholder_exists',
-            ) ?: '••••••••';
+                '••••••••',
+            );
         }
 
         $placeholderValue = $config['placeholder'] ?? '';

--- a/Classes/Form/Element/VaultSecretInputElement.php
+++ b/Classes/Form/Element/VaultSecretInputElement.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Form\Element;
 
 use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Utility\LocalisationHelper;
 use Throwable;
 use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
 use TYPO3\CMS\Core\Imaging\IconFactory;
@@ -361,6 +362,6 @@ final class VaultSecretInputElement extends AbstractFormElement
             : 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:vault_secret_input.placeholder_new';
         $fallback = $hasSecret ? 'Enter new secret value to rotate' : 'Enter secret value';
 
-        return $this->getLanguageService()->sL($key) ?: $fallback;
+        return LocalisationHelper::translateOrFallback($this->getLanguageService(), $key, $fallback);
     }
 }

--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -191,7 +191,7 @@ final class OAuthTokenManager
 
             $this->logger?->warning('OAuth refresh_token rejected, falling back to client_credentials', [
                 'token_endpoint' => $config->tokenEndpoint,
-                'original_error' => $e->getMessage(),
+                'original_error' => $this->redactCredentials($e->getMessage()),
             ]);
 
             // Audit the failed refresh attempt so the fallback is not silent.
@@ -199,7 +199,7 @@ final class OAuthTokenManager
                 $config->refreshTokenSecret ?? $config->clientIdSecret,
                 'oauth_refresh_failed',
                 false,
-                $e->getMessage(),
+                $this->redactCredentials($e->getMessage()),
                 'refresh_token rejected by OAuth server (HTTP non-200)',
             );
 
@@ -257,9 +257,10 @@ final class OAuthTokenManager
 
             return $token;
         } catch (ClientExceptionInterface $e) {
-            $this->logger?->error('OAuth token request failed', ['error' => $e->getMessage()]);
+            $redacted = $this->redactCredentials($e->getMessage());
+            $this->logger?->error('OAuth token request failed', ['error' => $redacted]);
 
-            throw OAuthException::requestFailed($e->getMessage(), $e);
+            throw OAuthException::requestFailed($redacted, $e);
         } catch (JsonException $e) {
             throw OAuthException::invalidJsonResponse($e);
         } finally {
@@ -477,17 +478,18 @@ final class OAuthTokenManager
         $message = 'OAuth refresh_token rotation: vault store failed — returning access_token but '
             . 'subsequent refresh will fail until vault is writeable (auto-recovers via '
             . 'fetchTokenWithFallback()).';
+        $redactedError = $this->redactCredentials($storeException->getMessage());
         $context = [
             'token_endpoint' => $config->tokenEndpoint,
             'refresh_token_secret_hash' => $secretIdHash,
-            'error' => $storeException->getMessage(),
+            'error' => $redactedError,
         ];
 
         try {
             $this->logger?->error($message, $context);
         } catch (Throwable) {
             // Last-resort: PHP's own error log is independent of DB / logger backend.
-            error_log('nr-vault: ' . $message . ' [' . $storeException->getMessage() . ']');
+            error_log('nr-vault: ' . $message . ' [' . $redactedError . ']');
         }
 
         try {
@@ -513,12 +515,63 @@ final class OAuthTokenManager
      * collision-resistant enough for cache-keying; we avoid md5/sha1 because
      * Sonar flags them across the board, and avoid sha256 because the extra
      * cost is wasted for a non-security use.
+     *
+     * `clientSecretSecret` is included so two configs that share the same
+     * client_id-secret identifier but reference different client_secret-secret
+     * identifiers don't collide on the cache (e.g. a key rotation that swaps
+     * the secret identifier without changing the client_id). The cache holds
+     * the access token, NOT the client_secret value — the identifier is
+     * non-sensitive enough to feed into a cache key.
      */
+    /**
+     * Defensive redaction of common credential patterns from upstream error
+     * messages before they reach the logger / audit log / OAuthException.
+     *
+     * Guzzle's `RequestException::getMessage()` typically includes the RESPONSE
+     * body, not the request — so a well-behaved server doesn't leak the
+     * `client_secret` we sent. But:
+     *
+     *  - OAuth servers sometimes echo the offending input back ("Invalid
+     *    client_secret 'xyz'"). RFC 6749 doesn't forbid it.
+     *  - A future refactor could land HTTP Basic auth (`Authorization: Basic
+     *    base64(client_id:client_secret)`) which DOES appear in
+     *    `RequestException::getMessage()` when verbose error formatting kicks
+     *    in.
+     *  - Generic Bearer tokens shouldn't appear here today but the same
+     *    pattern would mask them too.
+     *
+     * Defence in depth: never trust upstream error messages to be free of
+     * credentials. Cheap to apply, eliminates an entire class of accidental
+     * leaks through logs/audit/exception chains.
+     */
+    private function redactCredentials(string $message): string
+    {
+        return (string) preg_replace(
+            [
+                // form-encoded `client_secret=...` (request bodies, query strings)
+                '/(client_secret=)[^&\s"\'<>]+/i',
+                // form-encoded `refresh_token=...`
+                '/(refresh_token=)[^&\s"\'<>]+/i',
+                // Bearer / Basic Authorization headers (any case)
+                '/(Authorization:\s*Bearer\s+)\S+/i',
+                '/(Authorization:\s*Basic\s+)\S+/i',
+            ],
+            [
+                '$1[REDACTED]',
+                '$1[REDACTED]',
+                '$1[REDACTED]',
+                '$1[REDACTED]',
+            ],
+            $message,
+        );
+    }
+
     private function getCacheKey(OAuthConfig $config): string
     {
         return hash('xxh128', implode(':', [
             $config->tokenEndpoint,
             $config->clientIdSecret,
+            $config->clientSecretSecret,
             $config->grantType,
             $config->getScopesString(),
         ]));

--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -258,9 +258,14 @@ final class OAuthTokenManager
             return $token;
         } catch (ClientExceptionInterface $e) {
             $redacted = $this->redactCredentials($e->getMessage());
-            $this->logger?->error('OAuth token request failed', ['error' => $redacted]);
+            $this->logger?->error('OAuth token request failed', [
+                'error' => $redacted,
+                'previous_class' => $e::class,
+            ]);
 
-            throw OAuthException::requestFailed($redacted, $e);
+            throw OAuthException::requestFailed(
+                $redacted . \sprintf(' (caused by %s)', $e::class),
+            );
         } catch (JsonException $e) {
             throw OAuthException::invalidJsonResponse($e);
         } finally {
@@ -523,6 +528,17 @@ final class OAuthTokenManager
      * the access token, NOT the client_secret value — the identifier is
      * non-sensitive enough to feed into a cache key.
      */
+    private function getCacheKey(OAuthConfig $config): string
+    {
+        return hash('xxh128', implode(':', [
+            $config->tokenEndpoint,
+            $config->clientIdSecret,
+            $config->clientSecretSecret,
+            $config->grantType,
+            $config->getScopesString(),
+        ]));
+    }
+
     /**
      * Defensive redaction of common credential patterns from upstream error
      * messages before they reach the logger / audit log / OAuthException.
@@ -564,16 +580,5 @@ final class OAuthTokenManager
             ],
             $message,
         );
-    }
-
-    private function getCacheKey(OAuthConfig $config): string
-    {
-        return hash('xxh128', implode(':', [
-            $config->tokenEndpoint,
-            $config->clientIdSecret,
-            $config->clientSecretSecret,
-            $config->grantType,
-            $config->getScopesString(),
-        ]));
     }
 }

--- a/Classes/Utility/LocalisationHelper.php
+++ b/Classes/Utility/LocalisationHelper.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Utility;
+
+use TYPO3\CMS\Core\Localization\LanguageService;
+
+/**
+ * Helper around `LanguageService::sL()` with a SAFE fallback contract.
+ *
+ * Why this exists:
+ *
+ * `LanguageService::sL($key)` does NOT return an empty string when the
+ * XLIFF translation is missing — it returns the input key verbatim
+ * (`'LLL:EXT:foo/Resources/...:my_key'`). The widely-used idiom
+ *
+ *     $label = $lang->sL($key) ?: 'fallback';
+ *
+ * therefore NEVER triggers the fallback for a missing translation — the
+ * user sees the raw `LLL:…` key in the UI, which looks like a bug.
+ *
+ * `translateOrFallback()` checks for the `LLL:` prefix and the empty
+ * string before returning, so the fallback fires reliably when the key
+ * is unresolved.
+ */
+final class LocalisationHelper
+{
+    /**
+     * Resolve a `LLL:` key via the language service; return `$fallback`
+     * if the key is missing (empty string OR returned unchanged).
+     *
+     * Plain (non-`LLL:`) inputs are returned as-is — matches the
+     * existing `LanguageService::sL()` shape so this is a drop-in
+     * replacement for the `sL($key) ?: $fallback` idiom.
+     */
+    public static function translateOrFallback(
+        LanguageService $languageService,
+        string $key,
+        string $fallback,
+    ): string {
+        $translated = $languageService->sL($key);
+
+        if ($translated === '' || str_starts_with($translated, 'LLL:')) {
+            return $fallback;
+        }
+
+        return $translated;
+    }
+}

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -146,6 +146,64 @@ final class OAuthTokenManagerTest extends TestCase
         self::assertSame('cached-token', $token2);
     }
 
+    /**
+     * Regression for PR #145/#148: the cache key MUST include
+     * `clientSecretSecret`. Two configs identical except for their
+     * client-secret vault handle must fetch separate tokens — otherwise
+     * a credential rotation that points the config at a new vault entry
+     * would silently keep serving the pre-rotation token.
+     */
+    #[Test]
+    public function cacheKeyFragmentsOnClientSecretSecret(): void
+    {
+        $configA = OAuthConfig::clientCredentials(
+            tokenEndpoint: 'https://auth.example.com/token',
+            clientIdSecret: 'oauth/client-id',
+            clientSecretSecret: 'oauth/client-secret-v1',
+        );
+        $configB = OAuthConfig::clientCredentials(
+            tokenEndpoint: 'https://auth.example.com/token',
+            clientIdSecret: 'oauth/client-id',
+            clientSecretSecret: 'oauth/client-secret-v2',
+        );
+
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(fn (string $id): ?string => match ($id) {
+                'oauth/client-id' => 'same-client-id',
+                'oauth/client-secret-v1' => 'old-secret',
+                'oauth/client-secret-v2' => 'rotated-secret',
+                default => null,
+            });
+
+        $this->httpClient
+            ->expects(self::exactly(2))
+            ->method('sendRequest')
+            ->willReturnOnConsecutiveCalls(
+                $this->createSuccessfulTokenResponse([
+                    'access_token' => 'token-from-v1',
+                    'token_type' => 'Bearer',
+                    'expires_in' => 3600,
+                ]),
+                $this->createSuccessfulTokenResponse([
+                    'access_token' => 'token-from-v2',
+                    'token_type' => 'Bearer',
+                    'expires_in' => 3600,
+                ]),
+            );
+
+        $tokenA = $this->subject->getAccessToken($configA);
+        $tokenB = $this->subject->getAccessToken($configB);
+
+        self::assertSame('token-from-v1', $tokenA);
+        self::assertSame(
+            'token-from-v2',
+            $tokenB,
+            'configB must NOT reuse configA\'s cached token — cache key collision means a '
+            . 'credential rotation never takes effect at runtime',
+        );
+    }
+
     #[Test]
     public function getAccessTokenRefreshesExpiredToken(): void
     {
@@ -326,6 +384,70 @@ final class OAuthTokenManagerTest extends TestCase
         $this->expectExceptionMessage('OAuth token request failed: Connection timeout');
 
         $this->subject->getAccessToken($config);
+    }
+
+    /**
+     * Regression for PR #148 (Gemini HIGH): when the token request raises a
+     * `ClientExceptionInterface`, we must NOT attach the original exception as
+     * `previous`. Guzzle exceptions for token requests routinely embed the
+     * request/response body in their message — which carries the very
+     * credentials `redactCredentials()` just stripped from the outer message.
+     * Chaining the unredacted previous gives any
+     * `getPrevious()->getMessage()`-walking error handler a free pass to the
+     * secret. Keep the diagnostic value by including the previous class name
+     * in the outer message instead.
+     */
+    #[Test]
+    public function getAccessTokenDropsUnredactedPreviousOnClientException(): void
+    {
+        $config = OAuthConfig::clientCredentials(
+            tokenEndpoint: 'https://auth.example.com/token',
+            clientIdSecret: 'oauth/client-id',
+            clientSecretSecret: 'oauth/client-secret',
+        );
+
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(fn (string $id): ?string => match ($id) {
+                'oauth/client-id' => 'my-client-id',
+                'oauth/client-secret' => 'my-client-secret',
+                default => null,
+            });
+
+        // Guzzle-like exception whose message would leak a credential if a
+        // logger walked the chain.
+        $exception = new class ('client_secret=topSecr3t was rejected') extends RuntimeException implements ClientExceptionInterface {};
+
+        $this->httpClient
+            ->method('sendRequest')
+            ->willThrowException($exception);
+
+        try {
+            $this->subject->getAccessToken($config);
+            self::fail('Expected OAuthException');
+        } catch (OAuthException $oauthException) {
+            self::assertNull(
+                $oauthException->getPrevious(),
+                'OAuthException must not chain the original exception — its message '
+                . 'carries credentials that redactCredentials() already scrubbed from '
+                . 'the outer message',
+            );
+            self::assertStringContainsString(
+                'client_secret=[REDACTED]',
+                $oauthException->getMessage(),
+                'Outer message must carry the redacted form so operators still see what failed',
+            );
+            self::assertStringNotContainsString(
+                'topSecr3t',
+                $oauthException->getMessage(),
+                'Outer message must NOT carry the raw credential',
+            );
+            self::assertStringContainsString(
+                '(caused by ',
+                $oauthException->getMessage(),
+                'Outer message must include the previous-class hint for diagnostics',
+            );
+        }
     }
 
     #[Test]

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -23,6 +23,7 @@ use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -33,6 +34,7 @@ use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Http\Message\StreamInterface;
 use Psr\Log\LoggerInterface;
+use ReflectionClass;
 use RuntimeException;
 
 #[CoversClass(OAuthTokenManager::class)]
@@ -1097,6 +1099,60 @@ final class OAuthTokenManagerTest extends TestCase
                 unset($GLOBALS['TYPO3_CONF_VARS']);
             }
         }
+    }
+
+    /**
+     * Security gate: `redactCredentials()` must scrub bearer / basic auth /
+     * client_secret / refresh_token from upstream error messages before they
+     * reach the logger, audit log, or OAuthException. Cheap defence against
+     * a future OAuth server (or refactor) that echoes credentials back in
+     * its error responses.
+     */
+    #[Test]
+    #[DataProvider('credentialPatternsProvider')]
+    public function redactCredentialsScrubsKnownPatterns(string $raw, string $expected): void
+    {
+        // `redactCredentials` is private; invoke via reflection. Handles
+        // both static and instance method forms so cgl / rector can flip
+        // it freely without breaking the regression guard.
+        $method = (new ReflectionClass(OAuthTokenManager::class))->getMethod('redactCredentials');
+        $target = $method->isStatic() ? null : $this->subject;
+        self::assertSame($expected, $method->invoke($target, $raw));
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function credentialPatternsProvider(): iterable
+    {
+        yield 'client_secret in form body' => [
+            'POST /token grant_type=client_credentials&client_secret=topSecr3t&scope=read',
+            'POST /token grant_type=client_credentials&client_secret=[REDACTED]&scope=read',
+        ];
+        yield 'refresh_token in form body' => [
+            'grant_type=refresh_token&refresh_token=eyJabc.def.ghi&scope=read',
+            'grant_type=refresh_token&refresh_token=[REDACTED]&scope=read',
+        ];
+        yield 'Bearer Authorization header' => [
+            'response headers: Authorization: Bearer abc123def456 — rejected',
+            'response headers: Authorization: Bearer [REDACTED] — rejected',
+        ];
+        yield 'Basic Authorization header' => [
+            'sent: Authorization: Basic dXNlcjpwYXNz== to endpoint',
+            'sent: Authorization: Basic [REDACTED] to endpoint',
+        ];
+        yield 'mixed multiple credentials' => [
+            'client_secret=abc&refresh_token=def — Authorization: Bearer xyz',
+            'client_secret=[REDACTED]&refresh_token=[REDACTED] — Authorization: Bearer [REDACTED]',
+        ];
+        yield 'case-insensitive Authorization header' => [
+            'authorization: bearer ABC123',
+            'authorization: bearer [REDACTED]',
+        ];
+        yield 'safe message passes through' => [
+            'Connection refused (timeout after 10s)',
+            'Connection refused (timeout after 10s)',
+        ];
     }
 
     private function setupRequestFactory(): void


### PR DESCRIPTION
## Summary

Phase 1 of the post-session backlog work. Three small items deferred 1–3× across PRs #140/#145/#146 of this session, bundled together because they're all defensive hardening of the same surface area (OAuth manager + FormEngine elements).

## What changed

### 1. `sL()` fallback for missing translations (Gemini × 3)

`LanguageService::sL($key)` returns the input key verbatim (`'LLL:EXT:foo/Resources/...:my_key'`) when the XLIFF translation is missing — NOT an empty string. So `$lang->sL($key) ?: 'fallback'` **never triggers the fallback** for missing translations, and users see the raw `LLL:…` key rendered in the UI.

Two callsites affected:
- `VaultSecretElement::resolvePlaceholder()`
- `VaultSecretInputElement::resolvePlaceholder()`

New shared helper `Utility/LocalisationHelper::translateOrFallback()`:

```php
public static function translateOrFallback(
    LanguageService $languageService,
    string $key,
    string $fallback,
): string {
    $translated = $languageService->sL($key);
    if ($translated === '' || str_starts_with($translated, 'LLL:')) {
        return $fallback;
    }
    return $translated;
}
```

The "why this exists" docblock spells out the TYPO3 quirk so a future reader doesn't simplify it back.

### 2. OAuth `getCacheKey` cache collision (security-auditor LOW)

`OAuthTokenManager::getCacheKey()` hashed `(tokenEndpoint, clientIdSecret, grantType, scopes)`. Two configs sharing the same `clientIdSecret` identifier but referencing DIFFERENT `clientSecretSecret` identifiers (e.g. during a credential rotation that updates the secret-store key without changing the client_id) collided in cache.

Added `clientSecretSecret` to the cache-key inputs. The identifier is the vault lookup key, not the secret value — safe to feed into a cache hash.

### 3. OAuth audit-log redaction shim (security-auditor LOW)

`OAuthTokenManager` logs `$e->getMessage()` in 4 places (PSR-3 logger, audit-log, the `OAuthException::requestFailed` chain, the refresh-token-store-failure error_log fallback).

New private `redactCredentials($message)` static helper scrubs:
- `client_secret=...` form-encoded values
- `refresh_token=...` form-encoded values
- `Authorization: Bearer ...` headers (case-insensitive)
- `Authorization: Basic ...` headers (case-insensitive)

Defence in depth — today's Guzzle `RequestException::getMessage()` doesn't normally leak request bodies, but a future Basic-auth refactor would put credentials directly into the message string. Cheap to apply, eliminates an entire class of accidental leaks.

7 parameterised unit tests cover each pattern + a safe-message passthrough.

## Test plan

- [x] 1732 unit tests pass (+8 new).
- [x] cgl + rector + PHPStan level 10 green locally.
- [ ] CI matrix.

## Refs

- Multi-PR carried-forward items: PRs #140 / #145 / #146.
- Session recap items: "audit-log redaction shim", "OAuthTokenManager cache key excludes clientSecretSecret", "sL() ?: $fallback returns the LLL: key on missing translations".