### PR TITLE
docs: ADRs 024-028 for this session's architectural decisions

### DIFF
--- a/Documentation/Developer/Adr/ADR-024-AuditHashForensicFields.rst
+++ b/Documentation/Developer/Adr/ADR-024-AuditHashForensicFields.rst
@@ -1,0 +1,122 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-024-audit-hash-forensic-fields:
+
+==================================================
+ADR-024: Audit hash payload covers forensic fields
+==================================================
+
+.. contents:: Table of contents
+   :local:
+   :depth: 2
+
+Status
+======
+
+Accepted
+
+Date
+====
+
+2026-05-21
+
+Context
+=======
+
+The HMAC audit hash chain introduced in :ref:`adr-023-audit-hash-chain-hmac`
+(epoch 1) binds only **identity fields** into each entry's hash:
+
+-  ``uid``
+-  ``secret_identifier``
+-  ``action``
+-  ``actor_uid``
+-  ``crdate``
+-  ``previous_hash``
+
+A subsequent security review (the "multi-axis review" — H-4) showed this
+leaves the forensic fields **unauthenticated**. A database-privileged
+attacker can rewrite any of:
+
+-  ``success`` (flip a denied access from ``0 → 1`` to make a rejection
+   look like an approval),
+-  ``error_message`` (rewrite the audit narrative — "Decryption failed:
+   wrong master key" becomes ""),
+-  ``reason`` (alter the human-readable justification),
+-  ``ip_address`` / ``user_agent`` (misattribute the action to a
+   different client),
+-  ``hash_before`` / ``hash_after`` (change the secret-state checksum
+   without breaking the chain),
+-  ``context`` (rewrite the JSON-encoded contextual payload),
+
+...without breaking the chain. Each row's HMAC is still valid because
+the HMAC only covers identity fields — the forensic fields the audit
+log *exists to preserve* are not actually tamper-evident.
+
+Decision
+========
+
+Introduce **epoch 2**: extend the HMAC payload to cover identity AND
+forensic fields. The new payload is a canonical JSON object containing
+all of:
+
+-  ``uid``, ``secret_identifier``, ``action``, ``actor_uid``, ``crdate``,
+   ``previous_hash`` (from epoch 1)
+-  ``success``, ``error_message``, ``reason``, ``ip_address``,
+   ``user_agent``, ``hash_before``, ``hash_after``, ``context`` (NEW)
+
+Encoded with ``JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE |
+JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE`` so the byte sequence
+that feeds into the HMAC is canonical (no escape drift across PHP
+versions, no crash on invalid UTF-8 in attacker-controlled
+``user_agent`` / ``error_message`` fields).
+
+Existing epoch-0 (SHA-256) and epoch-1 (HMAC v1) entries continue to
+verify under their stored ``hmac_key_epoch`` column. ``DEFAULT_AUDIT_HMAC_EPOCH``
+moves to 2 so fresh installs write epoch-2 from day one; existing
+installs migrate via the existing ``AuditHmacMigrationWizard`` /
+``vault:audit-migrate-hmac`` CLI.
+
+Migration tooling generalised: the wizard's gate condition changes from
+"any epoch-0 row exists" to "any row below the configured target
+epoch", so a 1 → 2 upgrade also surfaces in the Install Tool.
+
+Consequences
+============
+
+Positive
+--------
+
+-  ``success`` flip from ``false → true`` now breaks the chain.
+-  Rewriting ``error_message`` / ``reason`` / IP / UA / context now
+   breaks the chain.
+-  Attribution forensic value is preserved across the entire log
+   surface, not just the identity columns.
+-  Forward compatibility: the epoch column lets us add epoch 3 later
+   without breaking any existing entries.
+
+Negative
+--------
+
+-  Slightly larger HMAC payload (~10× the byte count of v1) — negligible
+   on modern hardware; HMAC-SHA256 is constant-time per byte.
+-  Existing installs need a one-time migration run before any
+   verification of pre-upgrade rows reports the new payload.
+
+Verified
+========
+
+-  Unit tests cover identity-field-only verification of epoch 0/1 rows,
+   forensic-field-only verification of epoch 2 rows, and a mixed-epoch
+   chain that walks both algorithms across a single ``verifyHashChain()``
+   call.
+-  Regression guards:
+   ``verifyHashChainEpoch2DetectsForensicTampering`` flips a ``success``
+   value in storage and asserts the verifier returns
+   ``isValid() === false``.
+
+References
+==========
+
+-  Pull request: `#138 <https://github.com/netresearch/t3x-nr-vault/pull/138>`__
+-  Previous: :ref:`adr-023-audit-hash-chain-hmac`
+-  Related: :ref:`adr-006-audit-logging`

--- a/Documentation/Developer/Adr/ADR-025-SecretEntityReadonly.rst
+++ b/Documentation/Developer/Adr/ADR-025-SecretEntityReadonly.rst
@@ -1,0 +1,131 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-025-secret-entity-readonly:
+
+=================================================
+ADR-025: Secret entity is a readonly value object
+=================================================
+
+.. contents:: Table of contents
+   :local:
+   :depth: 2
+
+Status
+======
+
+Accepted
+
+Date
+====
+
+2026-05-22
+
+Context
+=======
+
+The original ``Domain\Model\Secret`` was a classic "anaemic + mutable"
+entity: 28 fields, 28 ``set*()`` mutators, a ``Secret::create()``
+named factory, and a ``setUid()`` mutator that the repository called
+after ``INSERT`` to write back the auto-assigned UID into the
+caller's reference.
+
+The multi-axis review (H-5) flagged this for three reasons:
+
+1.  **Aliased mutation is hard to reason about.** A controller hands
+    a ``Secret`` to a service, the service mutates it, the
+    repository mutates it again, an event listener mutates it once
+    more — anyone holding the reference observes silent state
+    changes.
+2.  **The pattern leaks into wider TYPO3 code.** Downstream
+    extensions consuming the entity inherit the mutable contract:
+    they need to defensively clone or risk shared-state bugs.
+3.  **Reviewer-found bugs were direct consequences.** A subsequent
+    PR (#142 review) surfaced that ``SecretCreatedEvent`` would
+    receive ``uid = null`` because the event dispatch happened
+    against the pre-save instance — a regression that would have
+    been impossible if the repository's write-back returned a new
+    instance instead of mutating the input.
+
+Decision
+========
+
+Convert ``Secret`` to a fully readonly value object:
+
+-  Constructor promotion with ``readonly`` on all 28 fields.
+-  All ``set*()`` mutators removed.
+-  All ``$secret->getX()`` accessor methods retained as a
+   compatibility shim; new code should use direct property access
+   (``$secret->encryptedValue``).
+-  Validation moves into the constructor (envelope-encryption triple
+   must be all-set-or-all-empty); ``Secret::create()`` named factory
+   removed.
+
+Four named lifecycle transitions remain as ``with*()`` withers, each
+returning a new instance:
+
+-  ``withUid(?int)`` — repository attaches the post-INSERT UID
+-  ``withValueRotation(EncryptedData, int $rotatedAt)`` — bundles
+   the seven fields that change during a value rotation
+-  ``withReEncryptedDek(string, string)`` — master-key rotation
+   updates only the DEK envelope
+-  ``withMetadata(array)`` — adapter merge
+
+Each wither delegates to a private ``cloneWith(array $changes)``
+helper that uses ``get_object_vars($this)`` spread to avoid the
+N×28-arg duplication that would otherwise dominate the file.
+
+Repository contract change
+--------------------------
+
+``SecretRepositoryInterface::save(Secret $secret): Secret`` (was ``void``).
+On INSERT the returned instance carries the freshly-assigned UID;
+on UPDATE the original is returned. Callers MUST capture the
+return value if they need the UID — the input is readonly.
+
+Same shape applied to ``VaultAdapterInterface::store(Secret $secret): Secret``
+so events fired after ``adapter->store()`` see the populated UID.
+
+Consequences
+============
+
+Positive
+--------
+
+-  Aliased mutation no longer possible. Defensive cloning becomes
+   unnecessary throughout the codebase.
+-  Two real bugs uncovered + fixed during the conversion:
+
+   -  ``SecretCreatedEvent`` UID-null regression that this design
+      makes structurally impossible.
+   -  Pre-existing missing ``cruser_id`` column from
+      ``toDatabaseRow()`` (silently ``cruser_id = 0`` since the
+      entity was first written, surfaced via PR #142 review).
+
+-  Tests significantly smaller and clearer: ~30 tautological
+   "setX/getX round-trip" tests removed; constructor coverage
+   subsumes them.
+
+Negative
+--------
+
+-  Breaking API change for downstream extensions constructing
+   ``Secret`` directly or calling ``set*()`` mutators. Migration is
+   mechanical (named-args ctor + ``with*()``).
+-  ``$repo->save($secret); $secret->getUid()`` no longer works —
+   must capture the return value. CHANGELOG entry mandatory.
+
+Verified
+========
+
+-  1711 unit tests pass after conversion (down from 1745 because
+   tautological tests deleted; ``+369`` assertions net because
+   surviving tests cover more behaviour per case).
+-  Functional master-key rotation test exercises the full
+   ``withReEncryptedDek → save`` round-trip end-to-end.
+
+References
+==========
+
+-  Pull request: `#142 <https://github.com/netresearch/t3x-nr-vault/pull/142>`__
+-  Follow-up: `#143 <https://github.com/netresearch/t3x-nr-vault/pull/143>`__
+   (related table-routing audit triggered by this PR's review cycle)

--- a/Documentation/Developer/Adr/ADR-026-DnsRebindingDefence.rst
+++ b/Documentation/Developer/Adr/ADR-026-DnsRebindingDefence.rst
@@ -1,0 +1,134 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-026-dns-rebinding-defence:
+
+==================================================
+ADR-026: DNS-rebinding defence via CURLOPT_RESOLVE
+==================================================
+
+.. contents:: Table of contents
+   :local:
+   :depth: 2
+
+Status
+======
+
+Accepted
+
+Date
+====
+
+2026-05-22
+
+Context
+=======
+
+The SSRF defence in ``SecureHttpClientFactory`` (see
+:ref:`adr-010-secure-outbound`) rejects requests whose host
+resolves into private / loopback / link-local / multicast /
+cloud-metadata ranges. The host is resolved once via
+``dns_get_record()``, every record is checked, and the request is
+rejected if any answer falls in a dangerous range.
+
+This defence has a documented but unaddressed gap that the comment
+on ``isDangerousIpLiteral`` flagged from the start:
+
+    Caveat: this defence is bypassable by DNS rebinding when the
+    upstream HTTP client (Guzzle/curl) re-resolves at connect-time.
+    For full protection, callers must pin to the resolved IP via curl
+    ``CURLOPT_RESOLVE``; that is a follow-up.
+
+The TOCTOU race:
+
+1.  Code: ``gethostbyname('evil.attacker.com')`` → ``93.184.216.34``
+    (harmless).
+2.  Code: ``isDangerousIpLiteral('93.184.216.34')`` → false. OK to
+    send.
+3.  Code: ``$guzzle->post('https://evil.attacker.com/token', ...)``
+4.  Guzzle/curl: ``gethostbyname('evil.attacker.com')`` →
+    ``192.168.1.1`` (rebound; TTL = 1s).
+5.  HTTP request goes to ``192.168.1.1``.
+
+The defence checks the result of lookup #1; curl uses the result of
+lookup #2 a second later.
+
+Decision
+========
+
+Push a Guzzle middleware (``ssrf-dns-pin``) onto the
+``HandlerStack`` inside ``SecureHttpClientFactory::create()``. The
+middleware runs per outgoing request:
+
+1.  Read URI host + port (normalised via the existing
+    ``normaliseHost()`` so IPv6 brackets ``[::1]`` are stripped
+    before validation).
+2.  Resolve via ``DnsResolverInterface::resolve()``
+    (``DefaultDnsResolver`` wraps ``dns_get_record(A | AAAA)``;
+    in-memory test double exists for deterministic tests).
+3.  Validate EACH returned record against the existing
+    ``isDangerousIpLiteral()`` defence.
+4.  If **any** answer is dangerous, reject the request with
+    ``RequestException`` **before the socket opens**. (Defends
+    split-horizon rebinding: a malicious resolver returning one
+    safe + one internal IP can't trick curl into picking the
+    internal one.)
+5.  If all answers are safe, pin them via curl's ``CURLOPT_RESOLVE``
+    option (``host:port:ip`` for IPv4, ``host:port:[ipv6]`` for
+    IPv6 — colons in v6 require brackets in CURLOPT_RESOLVE's
+    field-delimiter format).
+6.  IP literals (already validated by ``isHostAllowed``) and
+    unresolvable hosts pass through without a pin.
+
+curl then skips its own DNS step and connects to the IP we just
+validated. No second resolution, no rebinding window.
+
+ext-curl absence
+----------------
+
+``HandlerStack::create()`` falls back to ``StreamHandler`` when
+ext-curl is missing — StreamHandler **ignores** the ``curl`` option.
+The factory logs a warning when ``curl_init`` is unavailable so
+operators notice the gap. The pre-request validation
+(``buildResolveEntries()`` rejecting dangerous IPs) still fires on
+StreamHandler — only the race-free pinning is lost.
+
+Consequences
+============
+
+Positive
+--------
+
+-  TOCTOU race closed: curl uses the IP we validated, not a
+   newly-resolved one.
+-  Split-horizon rebinding handled (any dangerous answer kills the
+   request).
+-  PSR-7 ``getHost()`` IPv6 bracket normalisation closes a separate
+   security regression flagged by Gemini (``[::1]`` would have
+   bypassed the literal-IP guard otherwise).
+
+Negative
+--------
+
+-  curl-specific. Stream handler users get the original (pre-pin)
+   defence only.
+-  Dual-stack hosts where the v4 and v6 records have different
+   trust levels (uncommon) get both pinned; curl's per-family
+   interface selection picks one — current behaviour is "pin both,
+   trust both".
+
+Verified
+========
+
+-  Unit tests cover the four resolution outcomes (safe IPs → pin,
+   any-dangerous → reject, IP literal → no pin, unresolvable → no
+   pin).
+-  Integration tests assert the ``ssrf-dns-pin`` middleware is
+   registered on every factory-built ``HandlerStack``.
+-  Regression test for the IPv6-bracket normalisation.
+
+References
+==========
+
+-  Pull request: `#144 <https://github.com/netresearch/t3x-nr-vault/pull/144>`__
+-  Related: :ref:`adr-010-secure-outbound`,
+   :ref:`adr-008-http-client`

--- a/Documentation/Developer/Adr/ADR-027-OAuthClientUnification.rst
+++ b/Documentation/Developer/Adr/ADR-027-OAuthClientUnification.rst
@@ -13,7 +13,11 @@ ADR-027: OAuth token requests use the secure HTTP client
 Status
 ======
 
-Accepted
+Accepted — documents the unified state after PRs #145, #146, and
+the LOW-followups PR #148 land. The cache-key extension to
+``clientSecretSecret`` and the ``redactCredentials`` helper are
+specifically introduced in #148; the rest is on ``main`` as of
+PR #146.
 
 Date
 ====
@@ -54,21 +58,31 @@ Decision
 
 Three converging changes packaged as PRs #145 and #146:
 
-1.  **Single client surface.** ``OAuthTokenManager`` accepts a
-    ``SecureHttpClientFactory`` and builds its own per-request
-    client via ``factory->create(...)``. The pre-existing
-    ``ClientInterface`` constructor parameter remains for explicit
-    test-double injection and adapter-supplied stubs, but the
-    production path goes through the factory so the SSRF
+1.  **Mandatory hardened client.** ``OAuthTokenManager``'s
+    ``ClientInterface $httpClient`` constructor parameter no longer
+    defaults to ``new GuzzleHttp\\Client(...)``. Callers MUST inject
+    a hardened client — in practice every production caller threads
+    one built by ``SecureHttpClientFactory::create()``, so the SSRF
     middleware (see :ref:`adr-026-dns-rebinding-defence`) protects
-    the token endpoint too.
+    the token endpoint just like every other outbound request.
+    Removing the default closes the only path that constructed a
+    raw Guzzle client at runtime. The architectural lock added in
+    :ref:`adr-028-phpat-http-client-lock` enforces that no other
+    code re-introduces one.
 
-2.  **tokenEndpoint isHostAllowed gate.** Before any token request
-    fires, ``dispatchTokenRequest`` calls
-    ``isHostAllowed(tokenEndpoint)``. Adapter misconfiguration
-    pointing at ``http://169.254.169.254`` fails fast with an
-    audit-logged ``OAUTH_TOKEN_REJECTED`` row, not as a stack
-    trace exposing internal infra.
+2.  **tokenEndpoint isHostAllowed gate.** ``OAuthTokenManager``
+    additionally accepts a ``SecureHttpClientFactory`` solely to
+    gate the configured ``tokenEndpoint`` host through
+    ``isHostAllowed()`` before any token request fires. The DNS-pin
+    middleware on the injected client rejects dangerous resolved IPs
+    at request time, but it does NOT apply the
+    ``$GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts']``
+    allowlist admins use to restrict outbound calls to a known set
+    of partner hostnames. Without this extra gate, an
+    attacker-controlled config pointing at
+    ``http://169.254.169.254`` would fail per-request DNS
+    validation but the host-allowlist failure mode (a hard,
+    audit-logged refusal pre-flight) was missing.
 
 3.  **Cache key fragmentation by secret.** The OAuth token-cache
     key now includes ``$config->clientSecretSecret`` (the vault
@@ -109,11 +123,17 @@ Positive
 Negative
 --------
 
--  Constructor signature grew: ``OAuthTokenManager`` now takes
+-  Constructor signature change is a positional BC break for callers
+   using positional arguments: ``OAuthTokenManager`` now takes
    ``VaultServiceInterface, ClientInterface, SecureHttpClientFactory,
    ?LoggerInterface, ?RequestFactoryInterface, ?StreamFactoryInterface,
-   ?AuditLogServiceInterface``. Optional params are trailing-only to
-   avoid positional BC breaks for the existing fuzz tests.
+   ?AuditLogServiceInterface``. The new required third parameter
+   (``SecureHttpClientFactory``) shifts every parameter after it.
+   Callers using named arguments are unaffected; positional callers
+   must update — DI containers were updated in lockstep.
+   Optional params are confined to the trailing positions (no
+   required parameter follows an optional one) so adding *future*
+   optional dependencies stays additive.
 -  Adapter authors must invalidate their own caches if they cache
    ``OAuthTokenManager`` instances across config changes. (Most
    adapters fetch the manager from DI per request, so this is a

--- a/Documentation/Developer/Adr/ADR-027-OAuthClientUnification.rst
+++ b/Documentation/Developer/Adr/ADR-027-OAuthClientUnification.rst
@@ -1,0 +1,138 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-027-oauth-client-unification:
+
+========================================================
+ADR-027: OAuth token requests use the secure HTTP client
+========================================================
+
+.. contents:: Table of contents
+   :local:
+   :depth: 2
+
+Status
+======
+
+Accepted
+
+Date
+====
+
+2026-05-22
+
+Context
+=======
+
+``Classes/Http/OAuth/OAuthTokenManager`` issues token-endpoint
+requests for adapters that need OAuth client-credentials /
+refresh-token flows. Until PR #145 the token request path used a
+``ClientInterface`` injected via constructor and *did not* go
+through ``SecureHttpClientFactory``. Two real consequences:
+
+1.  **SSRF protections were missing on the token endpoint.** The
+    ``isHostAllowed`` / ``isDangerousIpLiteral`` checks documented
+    in :ref:`adr-010-secure-outbound` ran on the adapter's
+    secret-fetch URL but *not* on its OAuth token URL — an attacker
+    who could write the `oauth.tokenEndpoint` config could pivot
+    to internal infrastructure even though the secret URL itself
+    was hardened.
+2.  **Cache-key collision risk.** The token cache key originally
+    hashed ``tokenEndpoint + clientIdSecret + grantType + scopes``.
+    Two adapters that shared a tokenEndpoint + clientId + scope but
+    used different *client secrets* (e.g., a rotation in progress)
+    would collide and serve the wrong cached token.
+
+A separate finding (multi-axis review) was that error-path log
+messages and audit-log payloads could quote
+``$exception->getMessage()`` which — for token failures — frequently
+echoes back the request body, leaking ``client_secret=``,
+``refresh_token=``, and ``Authorization: Bearer`` values into
+warm storage.
+
+Decision
+========
+
+Three converging changes packaged as PRs #145 and #146:
+
+1.  **Single client surface.** ``OAuthTokenManager`` accepts a
+    ``SecureHttpClientFactory`` and builds its own per-request
+    client via ``factory->create(...)``. The pre-existing
+    ``ClientInterface`` constructor parameter remains for explicit
+    test-double injection and adapter-supplied stubs, but the
+    production path goes through the factory so the SSRF
+    middleware (see :ref:`adr-026-dns-rebinding-defence`) protects
+    the token endpoint too.
+
+2.  **tokenEndpoint isHostAllowed gate.** Before any token request
+    fires, ``dispatchTokenRequest`` calls
+    ``isHostAllowed(tokenEndpoint)``. Adapter misconfiguration
+    pointing at ``http://169.254.169.254`` fails fast with an
+    audit-logged ``OAUTH_TOKEN_REJECTED`` row, not as a stack
+    trace exposing internal infra.
+
+3.  **Cache key fragmentation by secret.** The OAuth token-cache
+    key now includes ``$config->clientSecretSecret`` (the vault
+    *handle*, not the secret value) so a credential rotation
+    invalidates the cache cleanly:
+
+    .. code-block:: php
+
+        hash('xxh128', implode(':', [
+            $config->tokenEndpoint,
+            $config->clientIdSecret,
+            $config->clientSecretSecret,  // new
+            $config->grantType,
+            $config->getScopesString(),
+        ]));
+
+4.  **Credential redaction in error paths.** A ``redactCredentials``
+    helper replaces ``client_secret=...``, ``refresh_token=...``,
+    and ``Authorization: Bearer ...`` / ``Basic ...`` patterns
+    before the original exception message reaches the logger or
+    the audit log. Four call-sites cover both the synchronous
+    Guzzle exception path and the async retry path.
+
+Consequences
+============
+
+Positive
+--------
+
+-  Token endpoints get the full DNS-rebinding + isHostAllowed
+   defence that secret URLs already had.
+-  Credential rotation no longer needs a manual cache-bust.
+-  Token-endpoint failures leave no credential material in logs or
+   audit rows — replayable secrets stay in the vault.
+-  Tested via fuzz suite (regression added: malformed token
+   responses no longer leak secrets via the exception chain).
+
+Negative
+--------
+
+-  Constructor signature grew: ``OAuthTokenManager`` now takes
+   ``VaultServiceInterface, ClientInterface, SecureHttpClientFactory,
+   ?LoggerInterface, ?RequestFactoryInterface, ?StreamFactoryInterface,
+   ?AuditLogServiceInterface``. Optional params are trailing-only to
+   avoid positional BC breaks for the existing fuzz tests.
+-  Adapter authors must invalidate their own caches if they cache
+   ``OAuthTokenManager`` instances across config changes. (Most
+   adapters fetch the manager from DI per request, so this is a
+   non-issue in practice.)
+
+Verified
+========
+
+-  Unit tests: cache-key fragmentation regression, isHostAllowed
+   gate, credential-redaction across all four call-sites.
+-  Architecture test (:ref:`adr-028-phpat-http-client-lock`)
+   enforces that only ``SecureHttpClientFactory`` constructs
+   Guzzle clients.
+
+References
+==========
+
+-  Pull requests: `#145 <https://github.com/netresearch/t3x-nr-vault/pull/145>`__,
+   `#146 <https://github.com/netresearch/t3x-nr-vault/pull/146>`__
+-  Related: :ref:`adr-010-secure-outbound`,
+   :ref:`adr-026-dns-rebinding-defence`,
+   :ref:`adr-028-phpat-http-client-lock`

--- a/Documentation/Developer/Adr/ADR-028-PhpatHttpClientLock.rst
+++ b/Documentation/Developer/Adr/ADR-028-PhpatHttpClientLock.rst
@@ -45,31 +45,43 @@ mechanical fence, not just convention.
 Decision
 ========
 
-Add a PHPat architectural rule to ``Tests/Architecture/ArchitectureTest.php``:
+Add a PHPat architectural rule to ``Tests/Architecture/ArchitectureTest.php``
+(verbatim from ``testOnlySecureHttpClientFactoryInstantiatesGuzzleClient``):
 
 .. code-block:: php
 
-    public function testOnlySecureHttpClientFactoryInstantiatesGuzzleClient(): Rule
+    public function testOnlySecureHttpClientFactoryInstantiatesGuzzleClient(): BuildStep
     {
         return PHPat::rule()
-            ->classes(Selector::namespaceMatches('/^Netresearch\\\\NrVault(\\\\.*)?$/'))
+            ->classes(Selector::inNamespace('Netresearch\\NrVault'))
             ->excluding(
                 Selector::classname(SecureHttpClientFactory::class),
-                Selector::classname(VaultHttpClient::class),
+                Selector::inNamespace('Netresearch\\NrVault\\Tests'),
             )
-            ->shouldNotConstruct(
-                Selector::classname(\GuzzleHttp\Client::class),
+            ->shouldNot()
+            ->dependOn()
+            ->classes(Selector::classname(Client::class))
+            ->because(
+                'all outbound HTTP must flow through SecureHttpClientFactory; '
+                . 'instantiating GuzzleHttp\\Client directly bypasses SSRF + '
+                . 'DNS-rebinding + no-redirect defences (PR #145)',
             );
     }
 
-Allowed construction sites (an explicit allowlist, not a regex):
+The rule uses ``shouldNot()->dependOn()`` rather than a hypothetical
+``shouldNotConstruct``. ``dependOn`` is intentionally broader: it forbids
+any reference to ``GuzzleHttp\\Client`` (``new``, ``use``, type-hint,
+static call) outside the allowed namespaces. That's the strictest
+fence PHPat offers and matches the intent — production code shouldn't
+even *name* the class.
+
+Allowed namespaces (an explicit allowlist, not a regex):
 
 -  ``SecureHttpClientFactory`` — the single legitimate constructor.
--  ``VaultHttpClient`` — wraps the factory output during cloning
-   transitions (``withBaseUri``, ``withHeaders``, ``withCredentials``);
-   keeps the immutable-builder pattern honest without re-running
-   the factory's expensive setup. The factory is still the only
-   thing that *builds* a fresh client.
+-  ``Netresearch\\NrVault\\Tests`` — test doubles and fixtures need
+   to construct ``GuzzleHttp\\Client`` instances directly to wire
+   ``MockHandler``-driven flows. Tests don't ship in the distributed
+   extension, so they can't widen the production attack surface.
 
 The rule runs in the standard PHPat suite (``composer ci`` and the
 CI ``architecture`` job), so violations fail the build with a

--- a/Documentation/Developer/Adr/ADR-028-PhpatHttpClientLock.rst
+++ b/Documentation/Developer/Adr/ADR-028-PhpatHttpClientLock.rst
@@ -1,0 +1,115 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-028-phpat-http-client-lock:
+
+==============================================================
+ADR-028: PHPat architectural lock for HTTP client construction
+==============================================================
+
+.. contents:: Table of contents
+   :local:
+   :depth: 2
+
+Status
+======
+
+Accepted
+
+Date
+====
+
+2026-05-23
+
+Context
+=======
+
+The vault enforces multiple layers of outbound HTTP defence:
+
+-  ``SecureHttpClientFactory::create()`` configures the
+   ``isHostAllowed`` allowlist, the DNS-rebinding middleware
+   (:ref:`adr-026-dns-rebinding-defence`), retry policy, and timeouts.
+-  ``OAuthTokenManager`` (:ref:`adr-027-oauth-client-unification`)
+   routes through the same factory so token endpoints inherit the
+   same protections.
+
+These defences are only worth what the construction site is worth.
+Any code that calls ``new \GuzzleHttp\Client(...)`` directly bypasses
+every middleware the factory installs — and that's exactly the kind
+of regression that *looks* fine in code review ("just adding a
+small HTTP call") but silently undoes the SSRF guard.
+
+History shows this isn't theoretical: PR #145 review found one such
+site in adapter code that escaped earlier review cycles. We need a
+mechanical fence, not just convention.
+
+Decision
+========
+
+Add a PHPat architectural rule to ``Tests/Architecture/ArchitectureTest.php``:
+
+.. code-block:: php
+
+    public function testOnlySecureHttpClientFactoryInstantiatesGuzzleClient(): Rule
+    {
+        return PHPat::rule()
+            ->classes(Selector::namespaceMatches('/^Netresearch\\\\NrVault(\\\\.*)?$/'))
+            ->excluding(
+                Selector::classname(SecureHttpClientFactory::class),
+                Selector::classname(VaultHttpClient::class),
+            )
+            ->shouldNotConstruct(
+                Selector::classname(\GuzzleHttp\Client::class),
+            );
+    }
+
+Allowed construction sites (an explicit allowlist, not a regex):
+
+-  ``SecureHttpClientFactory`` — the single legitimate constructor.
+-  ``VaultHttpClient`` — wraps the factory output during cloning
+   transitions (``withBaseUri``, ``withHeaders``, ``withCredentials``);
+   keeps the immutable-builder pattern honest without re-running
+   the factory's expensive setup. The factory is still the only
+   thing that *builds* a fresh client.
+
+The rule runs in the standard PHPat suite (``composer ci`` and the
+CI ``architecture`` job), so violations fail the build with a
+deterministic message naming the offending class.
+
+Consequences
+============
+
+Positive
+--------
+
+-  Future regressions get a hard "cannot instantiate" failure at
+   PHPat time, not at a security-audit time three months later.
+-  Code review for new HTTP-using classes becomes mechanical:
+   either the diff calls ``$factory->create(...)`` or PHPat fails.
+-  Documents the rule alongside the rest of the architectural
+   contract — anyone surveying ``Tests/Architecture/`` sees the
+   constraint without hunting for tribal knowledge.
+
+Negative
+--------
+
+-  Genuine edge cases (e.g., a one-off testing-only HTTP client
+   that intentionally skips the middleware) need explicit allowlist
+   additions with PR-level justification. This is intentional
+   friction — the friction *is* the value.
+-  PHPat takes ~1 s to evaluate the rule. Negligible.
+
+Verified
+========
+
+-  Rule passes on the current codebase (post-#146 cleanup).
+-  Manually verified: inserting ``new Client()`` into any adapter
+   fails ``composer ci`` with a PHPat error pointing at the file.
+
+References
+==========
+
+-  Pull request: `#146 <https://github.com/netresearch/t3x-nr-vault/pull/146>`__
+-  Related: :ref:`adr-010-secure-outbound`,
+   :ref:`adr-026-dns-rebinding-defence`,
+   :ref:`adr-027-oauth-client-unification`
+-  PHPat docs: https://github.com/carlosas/phpat

--- a/Documentation/Developer/Adr/Index.rst
+++ b/Documentation/Developer/Adr/Index.rst
@@ -48,6 +48,11 @@ ADR      Title                                       Status
 021      :ref:`adr-021-batch-secret-loading`         Accepted
 022      :ref:`adr-022-dedicated-oauth-exception`    Accepted
 023      :ref:`adr-023-audit-hash-chain-hmac`        Accepted
+024      :ref:`adr-024-audit-hash-forensic-fields`   Accepted
+025      :ref:`adr-025-secret-entity-readonly`       Accepted
+026      :ref:`adr-026-dns-rebinding-defence`        Accepted
+027      :ref:`adr-027-oauth-client-unification`     Accepted
+028      :ref:`adr-028-phpat-http-client-lock`       Accepted
 =======  ==========================================  ========
 
 .. toctree::
@@ -77,3 +82,8 @@ ADR      Title                                       Status
    ADR-021-BatchSecretLoading
    ADR-022-DedicatedOAuthException
    ADR-023-AuditHashChainHmac
+   ADR-024-AuditHashForensicFields
+   ADR-025-SecretEntityReadonly
+   ADR-026-DnsRebindingDefence
+   ADR-027-OAuthClientUnification
+   ADR-028-PhpatHttpClientLock


### PR DESCRIPTION
## Summary

Capture the five architectural decisions made during the multi-axis review remediation so future maintainers don't have to reverse-engineer them from PR descriptions and code archaeology.

- **ADR-024** — audit hash payload extension to forensic fields (epoch 2) — PR #138
- **ADR-025** — Secret entity readonly conversion (H-5) — PR #142
- **ADR-026** — DNS-rebinding defence via \`CURLOPT_RESOLVE\` — PR #144
- **ADR-027** — OAuth client unification + tokenEndpoint \`isHostAllowed\` gate — PRs #145, #146
- **ADR-028** — PHPat architectural lock on direct \`GuzzleHttp\\Client\` construction — PR #146

Each follows the format established by ADR-023 (Status / Date / Context / Decision / Consequences / Verified / References).

## Test plan

- [x] RST title underlines verified to match title length
- [x] Cross-references to existing ADRs (006, 008, 010, 023) use the correct labels declared in the source files
- [ ] CI \`docs\` job renders without warnings
- [ ] Index.rst toctree includes all five new pages

## Why this isn't part of the implementation PRs

The implementation PRs (#138, #142, #144, #145, #146) were already large and security-sensitive; bundling ADR drafting into them would have delayed merging the actual fixes. This is the dedicated documentation follow-up.