### PR TITLE
fix: pin web-dir to .Build/web for local functional tests

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -66,7 +66,8 @@
     },
     "extra": {
         "typo3/cms": {
-            "extension-key": "nr_vault"
+            "extension-key": "nr_vault",
+            "web-dir": ".Build/web"
         },
         "branch-alias": {
             "dev-main": "0.5.x-dev"


### PR DESCRIPTION
## Summary

Local \`Build/Scripts/runTests.sh -s functional\` was dying at bootstrap with:

\`\`\`
Unable to determine path to entry script. Please check your path or
set an environment variable 'TYPO3_PATH_ROOT' to your root path.
\`\`\`

Root cause: \`typo3/cms-composer-installers\` v5 defaults \`web-dir\` to \`<root>/public\` when the extension doesn't override it in \`extras.typo3/cms\`. \`composer install\` therefore created \`<root>/public/index.php\` and \`autoload-include.php\` pointed \`TYPO3_PATH_ROOT\` there. \`runTests.sh\` simultaneously created and mounted \`.Build/web/typo3temp/...\` — the two paths never agreed and the bootstrap couldn't find \`index.php\`.

This didn't surface in CI because the reusable workflow doesn't invoke \`runTests.sh\`; it just runs \`phpunit -c Build/FunctionalTests.xml\` against whichever install path \`autoload-include.php\` produced.

## What changed

One line in \`composer.json\`:

\`\`\`json
\"typo3/cms\": {
    \"extension-key\": \"nr_vault\",
+   \"web-dir\": \".Build/web\"
}
\`\`\`

This pins the install root to \`.Build/web/\` so \`runTests.sh\`'s tmpfs path and TYPO3's bootstrap path agree, and \`rm -rf .Build\` remains a clean reset (no \`public/\` dir left at project root).

## Verification

Before the fix, every functional test died at bootstrap with the path error (0 assertions).

After the fix, \`composer install\` creates \`.Build/web/index.php\` and \`autoload-include.php\` correctly sets \`TYPO3_PATH_ROOT=.../.Build/web\`. Direct \`.Build/bin/phpunit -c Build/FunctionalTests.xml Tests/Functional/Http/OAuth/OAuthIntegrationTest.php\` reaches the test bootstrap and runs the suite — 9 tests / 29 assertions executed.

## Out of scope (follow-ups)

- \`runTests.sh\` default \`-p 8.2\` is incompatible with the PHPUnit version pulled in by dev deps (requires PHP ≥ 8.3). Pass \`-p 8.3\` or higher locally; bumping the default is a separate concern that affects CI conventions.
- The same \`runTests.sh\` SQLite path emits \`unable to open database file\` inside the test container even with bootstrap fixed (tmpfs permission interaction with \`--user\`). Direct \`phpunit\` outside Docker doesn't trip this. Separate investigation needed.
- The mock-OAuth allowlist gate (\`Host \"localhost\" is not in the allowed hosts list\`) blocks 5 OAuth tests when run outside the runTests.sh-managed Docker network. Pre-existing environment-specific concern; not a bootstrap issue.

## Test plan

- [x] \`composer install\` creates \`.Build/web/index.php\`
- [x] \`.Build/vendor/typo3/autoload-include.php\` sets \`TYPO3_PATH_ROOT\` to \`.../.Build/web\`
- [x] Direct \`phpunit\` reaches test bootstrap (29 assertions executed vs 0 before fix)
- [ ] CI functional-test jobs still pass (will surface on this PR)