### PR TITLE
fix(security): drop in-memory reveal cache that bypassed the audit log

### DIFF
--- a/Resources/Public/JavaScript/SecretsList.js
+++ b/Resources/Public/JavaScript/SecretsList.js
@@ -9,7 +9,11 @@ import Severity from '@typo3/backend/severity.js';
 
 class SecretsList {
     constructor() {
-        this.revealedSecrets = new Map();
+        // No in-memory secret cache: every reveal MUST hit the AJAX endpoint
+        // so VaultService::retrieve() fires and an audit-log row is written.
+        // Caching the plaintext across reveal-modal opens would silently bypass
+        // the audit log on every reveal-after-first (violation of the
+        // "Audit every access" rule — see Classes/AGENTS.md security item 5).
         this.init();
     }
 
@@ -183,12 +187,6 @@ class SecretsList {
             return;
         }
 
-        // Check cache first
-        if (this.revealedSecrets.has(identifier)) {
-            this.showRevealModal(identifier, this.revealedSecrets.get(identifier));
-            return;
-        }
-
         // Show loading modal
         const loadingModal = Modal.advanced({
             title: 'Loading Secret',
@@ -211,7 +209,6 @@ class SecretsList {
             loadingModal.hideModal();
 
             if (data.success && data.secret !== undefined) {
-                this.revealedSecrets.set(identifier, data.secret);
                 this.showRevealModal(identifier, data.secret);
             } else {
                 Notification.error('Error', data.error || 'Failed to reveal secret', 5);
@@ -351,8 +348,6 @@ class SecretsList {
 
             if (data.success) {
                 modal.hideModal();
-                // Clear cached secret since it's been rotated
-                this.revealedSecrets.delete(identifier);
                 Notification.success('Success', data.message || 'Secret rotated successfully', 3);
             } else {
                 Notification.error('Error', data.error || 'Failed to rotate secret', 5);

--- a/Resources/Public/JavaScript/SecretsList.js
+++ b/Resources/Public/JavaScript/SecretsList.js
@@ -13,7 +13,8 @@ class SecretsList {
         // so VaultService::retrieve() fires and an audit-log row is written.
         // Caching the plaintext across reveal-modal opens would silently bypass
         // the audit log on every reveal-after-first (violation of the
-        // "Audit every access" rule — see Classes/AGENTS.md security item 5).
+        // "Audit every access" rule — see root AGENTS.md, Security
+        // Requirements item 5).
         this.init();
     }
 

--- a/Resources/Public/JavaScript/vault-secret-element.js
+++ b/Resources/Public/JavaScript/vault-secret-element.js
@@ -8,7 +8,9 @@
  */
 class VaultSecretElement {
     constructor() {
-        this.revealedSecrets = new Map();
+        // No in-memory secret cache: every reveal MUST hit the AJAX endpoint
+        // so the server writes an audit row. Copy reads the value from the
+        // visible input field (DOM is the source of truth while revealed).
         this.originalButtonContents = new WeakMap();
         this.init();
     }
@@ -61,12 +63,6 @@ class VaultSecretElement {
             return;
         }
 
-        // If we have a cached secret, show it directly
-        if (identifier && this.revealedSecrets.has(identifier)) {
-            this.showSecret(input, button, inputGroup, this.revealedSecrets.get(identifier));
-            return;
-        }
-
         // No identifier means no stored secret — just toggle input type locally
         if (!identifier) {
             input.type = input.type === 'password' ? 'text' : 'password';
@@ -95,7 +91,6 @@ class VaultSecretElement {
             const data = await response.json();
 
             if (data.success && data.secret !== undefined) {
-                this.revealedSecrets.set(identifier, data.secret);
                 this.restoreButton(button);
                 this.showSecret(input, button, inputGroup, data.secret);
             } else {
@@ -153,9 +148,15 @@ class VaultSecretElement {
      */
     async handleCopy(event) {
         const button = event.currentTarget;
-        const identifier = this.getIdentifier(button);
+        const inputGroup = button.closest('.input-group');
+        const input = inputGroup?.querySelector('input[type="text"], input[type="password"]');
 
-        const secret = identifier ? this.revealedSecrets.get(identifier) : null;
+        // Source of truth = the visible DOM input. When revealed, its value
+        // holds the plaintext; when hidden, the value is empty (cleared by
+        // handleToggleVisibility) so copy refuses.
+        const secret = (input && input.type === 'text' && input.dataset.vaultRevealed === '1')
+            ? input.value
+            : '';
         if (!secret) {
             if (top.TYPO3?.Notification) {
                 top.TYPO3.Notification.warning('Warning', 'Reveal the secret first before copying');
@@ -191,12 +192,6 @@ class VaultSecretElement {
             input.value = '';
             input.placeholder = '';
             input.dataset.vaultRevealed = '0';
-
-            // Clear from cache
-            const identifier = this.getIdentifier(button);
-            if (identifier) {
-                this.revealedSecrets.delete(identifier);
-            }
 
             // Mark as cleared by removing the checksum
             const checksumField = input.closest('.formengine-field-item')

--- a/Resources/Public/JavaScript/vault-secret-input.js
+++ b/Resources/Public/JavaScript/vault-secret-input.js
@@ -8,7 +8,9 @@
  */
 class VaultSecretInput {
     constructor() {
-        this.revealedSecrets = new Map();
+        // No in-memory secret cache: every reveal MUST hit the AJAX endpoint
+        // so the server writes an audit row. Copy reads the value from the
+        // visible input field (DOM is the source of truth while revealed).
         this.init();
     }
 
@@ -68,12 +70,6 @@ class VaultSecretInput {
             return;
         }
 
-        // Check cache first
-        if (this.revealedSecrets.has(identifier)) {
-            this.showRevealedSecret(button, this.revealedSecrets.get(identifier));
-            return;
-        }
-
         // Show loading state
         button.disabled = true;
         const originalChildren = Array.from(button.childNodes);
@@ -98,7 +94,6 @@ class VaultSecretInput {
             const data = await response.json();
 
             if (data.success && data.secret !== undefined) {
-                this.revealedSecrets.set(identifier, data.secret);
                 // Restore icon before showing revealed secret
                 button.replaceChildren(...originalChildren);
                 this.showRevealedSecret(button, data.secret);
@@ -186,10 +181,15 @@ class VaultSecretInput {
      */
     async handleCopy(event) {
         const button = event.currentTarget;
-        const identifier = button.dataset.identifier;
+        const inputGroup = button.closest('.input-group');
+        const displayInput = inputGroup?.querySelector('input[data-vault-display]');
 
-        // Get from cache
-        const secret = this.revealedSecrets.get(identifier);
+        // Source of truth = the visible DOM input. When revealed, its value
+        // holds the plaintext; when hidden (input.type === 'password'), it
+        // holds the placeholder dots.
+        const secret = (displayInput && displayInput.type === 'text')
+            ? displayInput.value
+            : '';
         if (!secret) {
             if (top.TYPO3?.Notification) {
                 top.TYPO3.Notification.warning('Warning', 'Reveal the secret first before copying');

--- a/Tests/E2E/user-pathways/secrets.spec.ts
+++ b/Tests/E2E/user-pathways/secrets.spec.ts
@@ -713,6 +713,82 @@ test.describe('Secrets Module User Pathways', () => {
         expect(json?.secret).toBe(plaintext);
       }
     });
+
+    /**
+     * Regression for PR #151 (HIGH-severity audit-bypass fix).
+     *
+     * The JS modules used to keep an in-memory `revealedSecrets` Map
+     * that short-circuited the AJAX request on second-and-subsequent
+     * reveals. That silently bypassed the server-side audit log:
+     * `AjaxController::reveal()` → `VaultService::retrieve()` →
+     * `AuditLogService::log()` only fired on the FIRST reveal of a
+     * browser session. Every later reveal/copy left no trail.
+     *
+     * This test clicks reveal twice (with a modal-close in between)
+     * and asserts BOTH clicks produce a POST to `/vault/reveal`. If
+     * the cache ever comes back, the second AJAX request never
+     * leaves the browser and the test fails.
+     */
+    test('reveals twice — both hit the AJAX endpoint (audit-bypass guard)', async ({
+      authenticatedPage: page,
+    }) => {
+      const testIdentifier = generateTestId();
+      const plaintext = 'second-reveal-test-value';
+
+      // Create the secret.
+      await page.goto('/typo3/module/admin/vault/secrets/create');
+      await waitForModuleContent(page);
+      let frame = getModuleFrame(page);
+      await frame.locator('input[data-formengine-input-name*="identifier"]').fill(testIdentifier);
+      await frame.locator('input[data-vault-is-new="1"]').first().fill(plaintext);
+      await saveFormEngine(page, frame);
+
+      // Navigate to the list and filter down to our row.
+      await page.goto('/typo3/module/admin/vault/secrets');
+      await waitForModuleContent(page);
+      frame = await applyIdentifierFilter(page, getModuleFrame(page), testIdentifier);
+      const row = frame.locator(`[data-testid="secret-row-${testIdentifier}"]`);
+      const revealButton = row.getByTestId('vault-reveal-btn').first();
+
+      // First reveal — must hit /vault/reveal.
+      const firstRevealPromise = page.waitForResponse(
+        (resp) => resp.url().includes('/vault/reveal') && resp.request().method() === 'POST',
+        { timeout: 10000 },
+      );
+      await revealButton.click();
+      const firstResp = await firstRevealPromise;
+      expect(firstResp.status()).toBe(200);
+      const firstJson = (await firstResp.json().catch(() => null)) as
+        | { success?: boolean; secret?: string }
+        | null;
+      expect(firstJson?.success).toBe(true);
+      expect(firstJson?.secret).toBe(plaintext);
+
+      // Close the reveal modal so the next click re-enters handleReveal.
+      const closeBtn = page.getByRole('button', { name: 'Close' }).first();
+      await closeBtn.waitFor({ state: 'visible', timeout: 5000 });
+      await closeBtn.click();
+
+      // Second reveal — MUST also hit /vault/reveal (regression guard).
+      // If the in-memory cache regresses, this waitForResponse times out.
+      const secondRevealPromise = page.waitForResponse(
+        (resp) => resp.url().includes('/vault/reveal') && resp.request().method() === 'POST',
+        { timeout: 10000 },
+      );
+      await revealButton.click();
+      const secondResp = await secondRevealPromise;
+      expect(
+        secondResp.status(),
+        'Second reveal click must produce a fresh POST to /vault/reveal — '
+          + 'otherwise the JS layer is caching plaintext and the audit log '
+          + 'misses every reveal-after-first (root AGENTS.md security rule 5).',
+      ).toBe(200);
+      const secondJson = (await secondResp.json().catch(() => null)) as
+        | { success?: boolean; secret?: string }
+        | null;
+      expect(secondJson?.success).toBe(true);
+      expect(secondJson?.secret).toBe(plaintext);
+    });
   });
 
   test.describe('UP-SEC-007: Edit Secret Metadata', () => {


### PR DESCRIPTION
## Summary

**HIGH severity security fix.** Three backend JavaScript modules kept an in-memory \`revealedSecrets\` Map keyed by identifier. On the second click of the reveal button (and every subsequent click), the JS short-circuited the AJAX request and rendered the cached plaintext locally — silently bypassing the server-side audit log.

A user could open the reveal modal an unlimited number of times, copy the value, hide it, re-open it, and the audit trail would record **exactly one access**. Direct violation of the non-negotiable rule in [\`AGENTS.md\`](../blob/main/AGENTS.md):

> 5. Audit every access — reads/writes/rotations/deletes all create audit log entries.

Surfaced by the UI/UX/DX review run in the multi-axis review session.

## What changed

Every reveal click now hits the AJAX endpoint. \`AjaxController::reveal()\` → \`VaultService::retrieve()\` → \`AuditLogService::log()\` fires per click.

The clipboard-copy flow no longer reads from the (now-removed) cache; it reads from the visible DOM input — its value IS the source of truth while revealed, and is empty/dot-placeholder while hidden so copy refuses.

## Files

| File | Change |
|------|--------|
| \`Resources/Public/JavaScript/SecretsList.js\` | Modal reveal path; copy already used the closure variable passed into \`showRevealModal()\` so only the outer-handler cache lookup needed removing |
| \`Resources/Public/JavaScript/vault-secret-input.js\` | TCA widget; copy now reads \`displayInput.value\` when revealed |
| \`Resources/Public/JavaScript/vault-secret-element.js\` | TCA element; copy now reads \`input.value\` when \`input.type === 'text' && dataset.vaultRevealed === '1'\` |

## Behaviour change for users

- A small AJAX round-trip on each subsequent reveal (a few hundred ms).
- One audit row per reveal click — which is the documented contract.
- No change to the copy or rotate UX paths.

## Test plan

- [x] JS syntax valid (\`node --check\` on all three modules)
- [x] No \`revealedSecrets\` references remain (\`grep\` clean)
- [ ] Existing E2E test \`UP-SEC-006\` (Reveal Secret Value AJAX) still passes — should be unaffected since it already asserts the AJAX call fires
- [ ] CI: full test matrix on this PR

## Follow-ups (not in scope)

A dedicated "second-reveal-also-fires-AJAX" regression test belongs at the E2E layer to lock in the audit-bypass guarantee. Listed in the gap analysis at \`.review-notes/e2e-coverage-gaps.md\` (Tier 1 — must add).