### PR TITLE
Grade-A remediation: security hardening, ACL split, audit enum + scheduler DI fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,13 @@ jobs:
     permissions:
       contents: read
 
+  docs:
+    # Renders the documentation and (once the upstream version-check step lands)
+    # asserts Documentation/guides.xml == ext_emconf.php so version drift fails CI.
+    uses: netresearch/typo3-ci-workflows/.github/workflows/docs.yml@main
+    permissions:
+      contents: read
+
   codeql:
     uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,13 @@ test-results/
 playwright/.cache/
 .Build/infection/
 composer.phar
+
+# nr-vault: transient multi-agent review artifacts are NOT committed — only the
+# curated, hand-maintained notes (README.md, e2e-coverage-gaps.md,
+# ui-ux-dx-review.md) stay tracked. Dated run reports, per-axis agent scratch,
+# the _pr154 review pass, and generated HTML are local-only working artifacts.
+/.review-notes/_agents/
+/.review-notes/_pr154/
+/.review-notes/_*.txt
+/.review-notes/*.html
+/.review-notes/20*-*.md

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,13 +27,13 @@
 | Lint (syntax) | `make lint` | `php -l` across sources |
 | CS check | `make cgl` | php-cs-fixer --dry-run |
 | CS fix | `make fix` | alias of `make cgl-fix` |
-| PHPStan | `make phpstan` | Static analysis |
+| PHPStan | `make phpstan` | Static analysis. In a fresh git worktree use `.Build/bin/phpstan analyse --configuration=Build/phpstan.no-plugins.neon` (the plugin config errors before `.Build/vendor` is populated) |
 | Rector (dry-run) | `make rector` | |
 | Unit tests | `make test-unit` | `composer ci:test:php:unit` |
 | Functional tests | `make test-functional` | `composer ci:test:php:functional` |
 | All tests | `make test` | unit + functional |
 | Mutation tests | `make test-mutation` | Infection |
-| All CI | `make ci` | lint+cs+phpstan+rector+tests |
+| All CI | `make ci` | cgl + phpstan + unit + fuzz (no lint/rector/functional) |
 | Docs render | `make docs` | |
 
 Direct composer (without make):
@@ -84,7 +84,7 @@ Build/           → phpunit.xml, FunctionalTests.xml
 | AJAX route | Add to `Configuration/Backend/AjaxRoutes.php` + controller in `Classes/Controller/` |
 | Touching secrets | Audit log every read/write via `AuditLogServiceInterface::log()` |
 | Running locally | `make up` then `make shell` |
-| Committing | Conventional Commits (feat:/fix:/chore:/docs:/refactor:/test:) |
+| Committing | Subject-style enforced by `captainhook.json`: capitalized, imperative mood, length-limited, no trailing period (NOT lowercase `feat:`/`fix:` prefixes). Sign off with `git commit -s`. See CONTRIBUTING.md |
 | Merging PRs | Merge commit (not squash, not rebase) — preserves GPG signatures |
 
 ## Security Requirements
@@ -137,12 +137,21 @@ AuditLogServiceInterface::verifyHashChain(?int $fromUid = null, ?int $toUid = nu
 ```
 
 ## CLI Commands (TYPO3 `vendor/bin/typo3`)
+> All 12 registered `vault:*` commands. Full options/examples in
+> `Documentation/Developer/Commands.rst`.
 ```
+vault:init                 # Initialize the vault (generate master key, verify configuration)
+vault:store                # Store a secret in the vault
+vault:retrieve             # Retrieve a secret from the vault
+vault:list                 # List all secrets in the vault
+vault:rotate               # Rotate (replace) a secret value
+vault:delete               # Delete a secret from the vault
+vault:scan                 # Scan database content for exposed secrets
+vault:migrate-field        # Migrate a database field value into the vault
 vault:audit                # View / verify audit log entries
 vault:audit-migrate-hmac   # Migrate audit log hash chain from SHA-256 to HMAC-SHA256
-vault:migrate-field        # Move DB field values into the vault
-vault:rotate-master-key    # Re-encrypt all DEKs with a new master key
-vault:cleanup-orphans      # Scheduled task wrapper
+vault:rotate-master-key    # Re-encrypt all secrets with a new master key
+vault:cleanup-orphans      # Clean up orphaned vault entries (scheduled task wrapper)
 ```
 
 ## Boundaries
@@ -188,7 +197,7 @@ MUST read when working in these directories:
 - **Default branch:** `main`
 - **Merge strategy:** merge commit (required for GPG signature preservation)
 - **Signed commits:** required (GPG/SSH)
-- **DCO:** required (`Signed-off-by:` trailer on every commit)
+- **DCO:** required (`Signed-off-by:` trailer on every commit — use `git commit -s`). Enforced at the PR gate; the local commit-msg hook does NOT check it.
 
 ## When Stuck
 1. TYPO3 v14 docs: <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/>

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,28 +47,46 @@ Use descriptive branch names with prefixes:
 
 ### Commit Messages
 
-Follow [Conventional Commits](https://www.conventionalcommits.org/):
+The local `commit-msg` hook (CaptainHook, see `captainhook.json`)
+enforces a **subject-style** policy, not Conventional-Commit type
+prefixes. Each subject line must:
+
+- be capitalized,
+- use the imperative mood ("Add", not "Added"/"Adds"),
+- stay within the length limit,
+- not be empty,
+- not end with a period.
 
 ```
-feat: add secret rotation support
-fix: resolve memory leak in encryption service
-docs: update installation instructions
-test: add unit tests for VaultService
-refactor: simplify access control logic
+Add secret rotation support
+Fix memory leak in encryption service
+Update installation instructions
+Add unit tests for VaultService
 ```
+
+> Note: lowercase Conventional-Commit prefixes (`feat:`, `fix:`) are
+> **rejected** by the imperative-mood / capitalize-subject rules. Write
+> the subject as an imperative sentence instead.
+
+#### Sign-off (DCO)
+
+Every commit must carry a `Signed-off-by:` trailer (Developer
+Certificate of Origin). Add it with `git commit -s`. This is **required
+and enforced at the pull-request gate**; the local commit-msg hook does
+not currently check for it, so always pass `-s`.
 
 ### Code Style
 
 This project follows PER-CS 2.0 coding standards. Run the fixer before committing:
 
 ```bash
-composer cs-fix
+composer ci:cgl
 ```
 
-Check for code style issues:
+Check for code style issues (dry-run, no changes written):
 
 ```bash
-composer cs-check
+composer ci:test:php:cgl
 ```
 
 ### Static Analysis
@@ -76,15 +94,24 @@ composer cs-check
 We use PHPStan at the maximum level (10). Run analysis:
 
 ```bash
-composer phpstan
+composer ci:test:php:phpstan
 ```
+
+> **Git worktree note:** in a fresh git worktree (before
+> `phpstan/extension-installer` has populated `.Build/vendor/...`),
+> `composer ci:test:php:phpstan` can fail with a cryptic include error.
+> If that happens, run PHPStan with the plugin-free config:
+>
+> ```bash
+> .Build/bin/phpstan analyse --configuration=Build/phpstan.no-plugins.neon
+> ```
 
 ### Testing
 
-Run all tests:
+Run the full CI suite (unit + fuzz + phpstan + architecture + code style):
 
 ```bash
-composer test
+composer ci
 ```
 
 Run specific test suites:
@@ -95,6 +122,9 @@ composer ci:test:php:unit
 
 # Functional tests
 composer ci:test:php:functional
+
+# Unit + functional together
+composer test:all
 ```
 
 ## Pull Request Process
@@ -105,7 +135,7 @@ composer ci:test:php:functional
 
 3. **Test**: Ensure all tests pass and add new tests for your changes
 
-4. **Commit**: Use conventional commit messages
+4. **Commit**: Use the subject-style commit messages described above, signed off with `git commit -s`
 
 5. **Push**: Push your branch to your fork
 

--- a/Classes/Audit/AuditAction.php
+++ b/Classes/Audit/AuditAction.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the nr-vault TYPO3 extension.
+ *
+ * (c) Netresearch DTT GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit;
+
+/**
+ * Enumerates every audit-log action written to the tamper-evident chain.
+ *
+ * The backing string values are the canonical action identifiers persisted in
+ * `tx_nrvault_audit_log.action` and bound into the HMAC hash payload. They MUST
+ * remain byte-for-byte stable: changing a value would break verification of
+ * every historical row that used the old string.
+ *
+ * @see AuditLogService for the hash-chain implementation
+ */
+enum AuditAction: string
+{
+    case Create = 'create';
+    case Read = 'read';
+    case Update = 'update';
+    case Delete = 'delete';
+    case Rotate = 'rotate';
+    case AccessDenied = 'access_denied';
+    case HttpCall = 'http_call';
+    case MasterKeyRotateStart = 'master_key_rotate_start';
+    case MasterKeyRotateEnd = 'master_key_rotate_end';
+    case OAuthRefreshFailed = 'oauth_refresh_failed';
+    case OAuthFallbackClientCredentials = 'oauth_fallback_client_credentials';
+    case OAuthRefreshStoreFailed = 'oauth_refresh_store_failed';
+    case AuditReadLoggingChanged = 'audit_read_logging_changed';
+
+    /**
+     * Human-readable label for backend filter dropdowns.
+     */
+    public function label(): string
+    {
+        return ucwords(str_replace('_', ' ', $this->value));
+    }
+}

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -14,6 +14,8 @@ namespace Netresearch\NrVault\Audit;
 
 use DateTimeInterface;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Generator;
+use InvalidArgumentException;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
@@ -52,6 +54,18 @@ final readonly class AuditLogService implements AuditLogServiceInterface
         ?string $hashAfter = null,
         ?AuditContextInterface $context = null,
     ): void {
+        // The action is kept a string for BC (callers pass AuditAction::Xxx->value),
+        // but it MUST be a known action: a typo would be sealed into the
+        // tamper-evident chain forever. Reject unknown actions loudly. This is a
+        // programming error, not a write failure, so it is NOT an AuditWriteException
+        // (which the VaultService atomicity path compensates) — it must surface.
+        if (AuditAction::tryFrom($action) === null) {
+            throw new InvalidArgumentException(
+                \sprintf('Unknown audit action "%s"; must be one of AuditAction::cases().', $action),
+                1717100000,
+            );
+        }
+
         $connection = $this->getConnection();
         $isSQLite = $connection->getDatabasePlatform() instanceof SQLitePlatform;
         $this->acquireAuditLock($connection, $isSQLite);
@@ -122,7 +136,36 @@ final readonly class AuditLogService implements AuditLogServiceInterface
 
     public function export(?AuditLogFilter $filter = null): array
     {
-        return $this->query($filter, PHP_INT_MAX, 0);
+        $entries = [];
+        foreach ($this->exportIterable($filter) as $entry) {
+            $entries[] = $entry;
+        }
+
+        return $entries;
+    }
+
+    /**
+     * Stream audit entries in bounded-memory chunks instead of materialising
+     * the whole table at once. The audit log is the fastest-growing table in
+     * the system (every read can add a row), so the previous PHP_INT_MAX
+     * single fetch risked OOM on large installs. Each chunk is fetched,
+     * yielded, and released before the next is read — peak memory is
+     * O(chunkSize), not O(total rows).
+     *
+     * @return Generator<int, AuditLogEntry>
+     */
+    public function exportIterable(?AuditLogFilter $filter = null, int $chunkSize = 1000): Generator
+    {
+        $chunkSize = max(1, $chunkSize);
+        $offset = 0;
+
+        do {
+            $chunk = $this->query($filter, $chunkSize, $offset);
+            foreach ($chunk as $entry) {
+                yield $entry;
+            }
+            $offset += $chunkSize;
+        } while (\count($chunk) === $chunkSize);
     }
 
     public function verifyHashChain(?int $fromUid = null, ?int $toUid = null): HashChainVerificationResult
@@ -232,19 +275,21 @@ final readonly class AuditLogService implements AuditLogServiceInterface
                     default => self::calculateHashV2(self::extractV2HashRow($row), $previousHash, $hmacKey),
                 };
 
-                // Verify previous_hash matches
-                $rowPrevHash = $row['previous_hash'] ?? '';
-                if ($rowPrevHash !== $previousHash) {
+                // Verify previous_hash matches. Use hash_equals() for the
+                // constant-time comparison the project mandates for integrity
+                // tags (AGENTS.md Security Requirement #2).
+                $rowPrevHash = \is_string($row['previous_hash'] ?? null) ? $row['previous_hash'] : '';
+                if (!hash_equals($previousHash, $rowPrevHash)) {
                     $errors[$uid] = 'Previous hash mismatch - chain broken';
                 }
 
-                // Verify entry_hash is correct
-                $rowEntryHash = $row['entry_hash'] ?? '';
-                if ($rowEntryHash !== $expectedHash) {
+                // Verify entry_hash is correct (constant-time).
+                $rowEntryHash = \is_string($row['entry_hash'] ?? null) ? $row['entry_hash'] : '';
+                if (!hash_equals($expectedHash, $rowEntryHash)) {
                     $errors[$uid] = 'Entry hash mismatch - possible tampering';
                 }
 
-                $previousHash = \is_string($rowEntryHash) ? $rowEntryHash : '';
+                $previousHash = $rowEntryHash;
             }
         } finally {
             sodium_memzero($hmacKey);
@@ -494,7 +539,7 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             'secret_identifier' => $inputs->secretIdentifier,
             'action' => $inputs->action,
             'success' => $inputs->success ? 1 : 0,
-            'error_message' => $inputs->errorMessage ?? '',
+            'error_message' => $this->sanitizeErrorMessage($inputs->errorMessage),
             'reason' => $inputs->reason ?? '',
             'actor_uid' => $this->accessControlService->getCurrentActorUid(),
             'actor_type' => $this->accessControlService->getCurrentActorType(),
@@ -510,6 +555,38 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             'hmac_key_epoch' => $this->getCurrentEpoch(),
             'context' => $inputs->context instanceof AuditContextInterface ? json_encode($inputs->context->toArray()) : '{}',
         ];
+    }
+
+    /**
+     * Normalise a caller-supplied error message before it is sealed into the
+     * tamper-evident, long-retained audit row (SEC-AUDIT-5).
+     *
+     * Raw `$e->getMessage()` from libsodium/Doctrine can carry filesystem
+     * paths, key-length detail, or fragments of internal state, and the audit
+     * log is frequently exported and read by lower-privilege operators. We
+     * keep the audit row's `error_message` to a bounded, single-line,
+     * control-character-free string; verbose diagnostics belong in the
+     * privileged system log, not here. The discipline lives at this boundary
+     * so no individual caller can reintroduce the leak.
+     */
+    private function sanitizeErrorMessage(?string $errorMessage): string
+    {
+        if ($errorMessage === null || $errorMessage === '') {
+            return '';
+        }
+
+        // Collapse any control characters / newlines to single spaces so a
+        // multi-line stack fragment cannot bloat or break the forensic row.
+        $clean = (string) preg_replace('/[\x00-\x1F\x7F]+/', ' ', $errorMessage);
+        $clean = trim($clean);
+
+        // Bound the length: forensic value is in the category of failure, not
+        // a verbose dump. 200 chars is plenty for a human-readable summary.
+        if (mb_strlen($clean) > 200) {
+            return mb_substr($clean, 0, 197) . '...';
+        }
+
+        return $clean;
     }
 
     /**

--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -1,7 +1,10 @@
 <?php
 
 /*
- * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * This file is part of the nr-vault TYPO3 extension.
+ *
+ * (c) Netresearch DTT GmbH
+ *
  * SPDX-License-Identifier: GPL-2.0-or-later
  */
 
@@ -16,6 +19,7 @@ use Netresearch\NrVault\Exception\EncryptionException;
 use Netresearch\NrVault\Exception\SecretExpiredException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Exception\ValidationException;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -34,26 +38,35 @@ final readonly class AjaxController
 {
     public function __construct(
         private VaultServiceInterface $vaultService,
+        private AccessControlServiceInterface $accessControlService,
     ) {}
 
     /**
      * Reveal a secret value.
      *
-     * Accepts both GET (query params) and POST (JSON body) requests.
+     * Accepts POST requests with a JSON body containing `identifier`.
+     * Admin-only and server-side re-checked (see SEC-ACCESS-6).
      *
      * @return ResponseInterface JSON response with secret or error
      */
     public function revealAction(ServerRequestInterface $request): ResponseInterface
     {
-        // Support both GET (query params) and POST (JSON body)
+        // SEC-ACCESS-6: defense-in-depth — do not rely solely on the route's
+        // `methods => ['POST']` / `access => admin` config. Re-assert the POST
+        // method (mirroring rotateAction) and re-check admin server-side, so
+        // authorization holds even if the route config is later loosened.
+        if ($request->getMethod() !== 'POST') {
+            return $this->jsonError('Method not allowed', 405);
+        }
+
+        if (!$this->accessControlService->isCurrentActorAdmin()) {
+            return $this->jsonError('Access denied', 403);
+        }
+
         $identifier = $this->getIdentifierFromRequest($request);
 
         if ($identifier === '') {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'No identifier provided',
-            ], 400);
+            return $this->jsonError('No identifier provided', 400);
         }
 
         try {
@@ -61,11 +74,7 @@ final readonly class AjaxController
 
             // retrieve() returns null when secret not found
             if ($secret === null) {
-                /** @phpstan-ignore new.internalClass, method.internalClass */
-                return new JsonResponse([
-                    'success' => false,
-                    'error' => 'Secret not found',
-                ], 404);
+                return $this->jsonError('Secret not found', 404);
             }
 
             /** @phpstan-ignore new.internalClass, method.internalClass */
@@ -74,29 +83,13 @@ final readonly class AjaxController
                 'secret' => $secret,
             ]);
         } catch (AccessDeniedException) {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Access denied',
-            ], 403);
+            return $this->jsonError('Access denied', 403);
         } catch (SecretExpiredException) {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Secret has expired',
-            ], 410);
+            return $this->jsonError('Secret has expired', 410);
         } catch (EncryptionException) {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Decryption failed',
-            ], 500);
+            return $this->jsonError('Decryption failed', 500);
         } catch (Exception) {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Failed to retrieve secret',
-            ], 500);
+            return $this->jsonError('Failed to retrieve secret', 500);
         }
     }
 
@@ -113,11 +106,12 @@ final readonly class AjaxController
     {
         // Only accept POST
         if ($request->getMethod() !== 'POST') {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Method not allowed',
-            ], 405);
+            return $this->jsonError('Method not allowed', 405);
+        }
+
+        // SEC-ACCESS-6: defense-in-depth admin re-check (see revealAction).
+        if (!$this->accessControlService->isCurrentActorAdmin()) {
+            return $this->jsonError('Access denied', 403);
         }
 
         $body = $this->getJsonBody($request);
@@ -125,19 +119,11 @@ final readonly class AjaxController
         $newSecret = isset($body['secret']) && \is_string($body['secret']) ? $body['secret'] : '';
 
         if ($identifier === '') {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'No identifier provided',
-            ], 400);
+            return $this->jsonError('No identifier provided', 400);
         }
 
         if ($newSecret === '') {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'No secret value provided',
-            ], 400);
+            return $this->jsonError('No secret value provided', 400);
         }
 
         try {
@@ -154,36 +140,32 @@ final readonly class AjaxController
                 'version' => $updatedMetadata->version,
             ]);
         } catch (SecretNotFoundException) {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Secret not found',
-            ], 404);
+            return $this->jsonError('Secret not found', 404);
         } catch (ValidationException $e) { // @phpstan-ignore catch.neverThrown
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Validation error: ' . $e->getMessage(),
-            ], 400);
+            return $this->jsonError('Validation error: ' . $e->getMessage(), 400);
         } catch (AccessDeniedException) {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Access denied',
-            ], 403);
+            return $this->jsonError('Access denied', 403);
         } catch (EncryptionException) {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Encryption failed',
-            ], 500);
+            return $this->jsonError('Encryption failed', 500);
         } catch (Exception) {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new JsonResponse([
-                'success' => false,
-                'error' => 'Failed to rotate secret',
-            ], 500);
+            return $this->jsonError('Failed to rotate secret', 500);
         }
+    }
+
+    /**
+     * Build a uniform JSON error envelope.
+     *
+     * Centralises the `{success: false, error: ...}` shape so every failure
+     * path is byte-identical and the single `JsonResponse` PHPStan suppression
+     * lives in one place rather than at every call site.
+     */
+    private function jsonError(string $message, int $status): ResponseInterface
+    {
+        /** @phpstan-ignore new.internalClass, method.internalClass */
+        return new JsonResponse([
+            'success' => false,
+            'error' => $message,
+        ], $status);
     }
 
     /**

--- a/Classes/Controller/AuditController.php
+++ b/Classes/Controller/AuditController.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrVault\Controller;
 
 use DateTimeImmutable;
 use Exception;
+use Netresearch\NrVault\Audit\AuditAction;
 use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Audit\AuditLogFilter;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
@@ -143,7 +144,11 @@ final readonly class AuditController
             'filters' => ['_form' => $formData],
             'pagination' => $pagination,
             'isAdmin' => $this->isAdmin(),
-            'actions' => ['create', 'read', 'update', 'delete', 'rotate', 'access_denied', 'http_call'],
+            // Derive the action-filter list from the AuditAction enum so the UI
+            // can never drift from the actions actually written to the chain
+            // (the previous hard-coded list silently omitted master_key_* and
+            // oauth_* actions).
+            'actions' => array_map(static fn (AuditAction $action): string => $action->value, AuditAction::cases()),
         ]);
 
         $moduleTemplate->setTitle(

--- a/Classes/Controller/OverviewController.php
+++ b/Classes/Controller/OverviewController.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Controller;
 
 use Exception;
-use Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface;
+use Netresearch\NrVault\Service\VaultHealthServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Attribute\AsController;
@@ -19,6 +19,7 @@ use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Localization\LanguageService;
+use TYPO3\CMS\Core\Page\PageRenderer;
 
 /**
  * Backend module controller for vault overview/dashboard.
@@ -31,8 +32,9 @@ final readonly class OverviewController
     public function __construct(
         private ModuleTemplateFactory $moduleTemplateFactory,
         private ConnectionPool $connectionPool,
-        private MasterKeyProviderFactoryInterface $masterKeyProviderFactory,
+        private VaultHealthServiceInterface $vaultHealthService,
         private BackendUriBuilder $backendUriBuilder,
+        private PageRenderer $pageRenderer,
     ) {}
 
     /**
@@ -51,6 +53,10 @@ final readonly class OverviewController
             );
         }
 
+        // Expose JS UI labels to TYPO3.lang for any vault ESM module that may
+        // run on the overview surface (graceful: modules fall back to English).
+        $this->pageRenderer->addInlineLanguageLabelFile('EXT:nr_vault/Resources/Private/Language/locallang_js.xlf');
+
         // Get statistics for the overview
         $stats = $this->getVaultStatistics();
         $healthChecks = $this->getHealthChecks();
@@ -64,19 +70,19 @@ final readonly class OverviewController
                 [
                     'route' => 'admin_vault_secrets',
                     'icon' => 'content-elements-login',
-                    'title' => 'Secrets',
+                    'title' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.title'),
                     'description' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.secrets.description'),
                 ],
                 [
                     'route' => 'admin_vault_audit',
                     'icon' => 'actions-document-history-open',
-                    'title' => 'Audit Log',
+                    'title' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.title'),
                     'description' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.audit.description'),
                 ],
                 [
                     'route' => 'admin_vault_migration',
                     'icon' => 'actions-database-import',
-                    'title' => 'Migration Wizard',
+                    'title' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:migration.title'),
                     'description' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.migration.description'),
                 ],
             ],
@@ -108,12 +114,13 @@ final readonly class OverviewController
         ModuleTemplate $moduleTemplate,
         string $activeTab,
     ): void {
+        $lang = $this->getLanguageService();
         $menuRegistry = $moduleTemplate->getDocHeaderComponent()->getMenuRegistry();
         $menu = $menuRegistry->makeMenu();
         $menu->setIdentifier('VaultOverviewMenu');
 
         $dashboardItem = $menu->makeMenuItem()
-            ->setTitle('Dashboard')
+            ->setTitle($lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.tab.dashboard'))
             ->setHref((string) $this->backendUriBuilder->buildUriFromRoute(self::MODULE_NAME));
         if ($activeTab === 'dashboard') {
             $dashboardItem->setActive(true);
@@ -121,7 +128,7 @@ final readonly class OverviewController
         $menu->addMenuItem($dashboardItem);
 
         $helpItem = $menu->makeMenuItem()
-            ->setTitle('Help')
+            ->setTitle($lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.tab.help'))
             ->setHref((string) $this->backendUriBuilder->buildUriFromRoute(self::MODULE_NAME . '.help'));
         if ($activeTab === 'help') {
             $helpItem->setActive(true);
@@ -179,53 +186,26 @@ final readonly class OverviewController
     }
 
     /**
-     * Run health checks and return status information.
+     * Run health checks and return status information for the template.
      *
-     * @return array{masterKeyAvailable: bool, masterKeyProvider: string, masterKeyError: string, encryptionWorking: bool, encryptionError: string, hasIssues: bool}
+     * The probe lives in {@see VaultHealthServiceInterface} so this controller
+     * does not depend on the Crypto namespace (ARCHITECTURE-2). Only generic
+     * booleans + the provider identifier reach the view — no raw exception
+     * text or key file paths (SEC-INJECTION-LEAK-2); detail is logged in the
+     * service.
+     *
+     * @return array{masterKeyAvailable: bool, masterKeyProvider: string, encryptionWorking: bool, hasIssues: bool}
      */
     private function getHealthChecks(): array
     {
-        $result = [
-            'masterKeyAvailable' => false,
-            'masterKeyProvider' => '',
-            'masterKeyError' => '',
-            'encryptionWorking' => false,
-            'encryptionError' => '',
-            'hasIssues' => false,
+        $status = $this->vaultHealthService->checkHealth();
+
+        return [
+            'masterKeyAvailable' => $status->masterKeyAvailable,
+            'masterKeyProvider' => $status->masterKeyProvider,
+            'encryptionWorking' => $status->encryptionWorking,
+            'hasIssues' => $status->hasIssues,
         ];
-
-        // Check 1: Is a master key provider available?
-        try {
-            $provider = $this->masterKeyProviderFactory->getAvailableProvider();
-            $result['masterKeyProvider'] = $provider->getIdentifier();
-
-            if ($provider->isAvailable()) {
-                $result['masterKeyAvailable'] = true;
-
-                // Check 2: Can we actually derive/read the master key?
-                try {
-                    $key = $provider->getMasterKey();
-                    if ($key === '') {
-                        $result['encryptionError'] = 'Master key provider returned an empty key.';
-                        $result['hasIssues'] = true;
-                    } else {
-                        $result['encryptionWorking'] = true;
-                        sodium_memzero($key);
-                    }
-                } catch (Exception $e) {
-                    $result['encryptionError'] = $e->getMessage();
-                    $result['hasIssues'] = true;
-                }
-            } else {
-                $result['masterKeyError'] = 'Master key provider "' . $provider->getIdentifier() . '" is configured but not available.';
-                $result['hasIssues'] = true;
-            }
-        } catch (Exception $e) {
-            $result['masterKeyError'] = $e->getMessage();
-            $result['hasIssues'] = true;
-        }
-
-        return $result;
     }
 
     private function getLanguageService(): LanguageService

--- a/Classes/Controller/SecretsController.php
+++ b/Classes/Controller/SecretsController.php
@@ -124,6 +124,9 @@ final readonly class SecretsController
         }
 
         $this->pageRenderer->addCssFile('EXT:nr_vault/Resources/Public/Css/backend.css');
+        // Expose JS UI labels to TYPO3.lang for the SecretsList ESM module
+        // (delete/reveal/rotate dialogs, clipboard + error toasts).
+        $this->pageRenderer->addInlineLanguageLabelFile('EXT:nr_vault/Resources/Private/Language/locallang_js.xlf');
 
         $moduleTemplate->assignMultiple([
             'secrets' => $formattedSecrets,

--- a/Classes/Crypto/AbstractMasterKeyProvider.php
+++ b/Classes/Crypto/AbstractMasterKeyProvider.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the nr-vault TYPO3 extension.
+ *
+ * (c) Netresearch DTT GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Crypto;
+
+use Netresearch\NrVault\Exception\MasterKeyException;
+
+/**
+ * Base class for master key providers implementing the ADR-020
+ * request-lifetime caching contract once, in a single place.
+ *
+ * Subclasses implement only loadRawKey() (the source-specific key load) plus
+ * their getIdentifier()/isAvailable()/storeMasterKey()/generateMasterKey()
+ * specifics. The security-critical cache lifecycle — caching, late-static-bound
+ * per-class isolation, and sodium_memzero() on clear — lives here so a future
+ * hardening change is made in exactly one file.
+ *
+ * The cache is keyed by static::class so each concrete provider keeps its own
+ * slot: clearing the file provider's cache must not touch the environment
+ * provider's. See ADR-020.
+ *
+ * Destructor-based wiping is intentionally NOT defined here: File/Env providers
+ * declare their own __destruct() that calls clearCachedKey(), while the default
+ * Typo3 provider deliberately has none (its static reference outlives individual
+ * instances). See ADR-020.
+ */
+abstract class AbstractMasterKeyProvider implements MasterKeyProviderInterface
+{
+    /**
+     * Request-lifetime cache, isolated per concrete provider class.
+     *
+     * @var array<class-string, string>
+     */
+    private static array $cachedKeys = [];
+
+    final public function getMasterKey(): string
+    {
+        $class = static::class;
+
+        if (isset(self::$cachedKeys[$class])) {
+            return self::$cachedKeys[$class];
+        }
+
+        $key = $this->loadRawKey();
+        self::$cachedKeys[$class] = $key;
+
+        return $key;
+    }
+
+    public static function clearCachedKey(): void
+    {
+        $class = static::class;
+
+        if (!isset(self::$cachedKeys[$class])) {
+            return;
+        }
+
+        // Wipe a local copy by reference so the by-ref sodium_memzero() does not
+        // operate on the typed array slot (which would widen its value type to
+        // string|null), then drop the slot entirely.
+        $key = self::$cachedKeys[$class];
+        unset(self::$cachedKeys[$class]);
+        sodium_memzero($key);
+    }
+
+    /**
+     * Load the raw master key from the provider's source.
+     *
+     * Called at most once per request per concrete provider class; the result
+     * is cached by getMasterKey(). Implementations must return the 32-byte raw
+     * key (deriving/decoding as needed).
+     *
+     * @throws MasterKeyException
+     */
+    abstract protected function loadRawKey(): string;
+}

--- a/Classes/Crypto/EncryptedData.php
+++ b/Classes/Crypto/EncryptedData.php
@@ -16,7 +16,8 @@ namespace Netresearch\NrVault\Crypto;
  * Value object representing encrypted data from envelope encryption.
  *
  * Contains the encrypted value, encrypted DEK, nonces, and checksum.
- * All values are base64-encoded for safe storage/transport.
+ * The value/DEK/nonce fields are base64-encoded for safe storage/transport;
+ * the checksum is a hex-encoded keyed HMAC-SHA-256 over the ciphertext.
  */
 final readonly class EncryptedData
 {
@@ -29,7 +30,7 @@ final readonly class EncryptedData
         public string $dekNonce,
         /** Base64-encoded nonce used for value encryption */
         public string $valueNonce,
-        /** SHA-256 hash of plaintext for change detection */
+        /** Hex-encoded keyed HMAC-SHA-256 over the ciphertext (per-secret MAC key derived from the DEK) for change detection */
         public string $valueChecksum,
     ) {}
 
@@ -40,7 +41,7 @@ final readonly class EncryptedData
      * @param string $encryptedDek Raw encrypted DEK bytes
      * @param string $dekNonce Raw DEK nonce bytes
      * @param string $valueNonce Raw value nonce bytes
-     * @param string $valueChecksum Hex-encoded SHA-256 hash
+     * @param string $valueChecksum Hex-encoded keyed HMAC-SHA-256 over the ciphertext
      */
     public static function fromRaw(
         string $encryptedValue,

--- a/Classes/Crypto/EncryptionService.php
+++ b/Classes/Crypto/EncryptionService.php
@@ -22,6 +22,15 @@ use SodiumException;
  */
 final readonly class EncryptionService implements EncryptionServiceInterface
 {
+    /**
+     * HKDF domain-separation context for deriving the per-secret checksum MAC
+     * key from the DEK. Distinct from any other HKDF use in the codebase.
+     */
+    private const CHECKSUM_HKDF_INFO = 'nr-vault-checksum';
+
+    /** Length (bytes) of the derived checksum MAC key. */
+    private const CHECKSUM_MAC_KEY_LENGTH = 32;
+
     public function __construct(
         private MasterKeyProviderInterface $masterKeyProvider,
         private ExtensionConfigurationInterface $configuration,
@@ -46,11 +55,19 @@ final readonly class EncryptionService implements EncryptionServiceInterface
             // Encrypt the value with DEK
             $encryptedValue = $this->encryptWithKey($plaintext, $dek, $valueNonce, $identifier);
 
-            // Calculate checksum for change detection
-            $checksum = $this->calculateChecksum($plaintext);
+            // Change-detection token: a KEYED MAC over the ciphertext, never the
+            // plaintext. The MAC key is derived per-secret from the DEK via HKDF,
+            // so the stored checksum is not an offline-computable function of the
+            // plaintext (no guess-confirmation oracle) and identical plaintexts in
+            // different secrets yield different checksums (no equality leakage).
+            // Integrity itself comes from the AEAD tag; this is solely a change
+            // detector / audit before-after token. See SEC-CRYPTO-1 / ADR-002.
+            $macKey = hash_hkdf('sha256', $dek, self::CHECKSUM_MAC_KEY_LENGTH, self::CHECKSUM_HKDF_INFO);
+            $checksum = hash_hmac('sha256', $encryptedValue, $macKey);
 
             // Securely wipe sensitive data
             sodium_memzero($dek);
+            sodium_memzero($macKey);
             sodium_memzero($masterKey);
             sodium_memzero($plaintext);
 
@@ -63,6 +80,15 @@ final readonly class EncryptionService implements EncryptionServiceInterface
             );
         } catch (SodiumException) {
             throw EncryptionException::encryptionFailed('Encryption operation failed');
+        } finally {
+            // Wipe key material on every path, including the SodiumException
+            // error path that bypasses the in-try wipes above.
+            if (isset($dek)) {
+                sodium_memzero($dek);
+            }
+            if (isset($macKey)) {
+                sodium_memzero($macKey);
+            }
         }
     }
 
@@ -102,6 +128,15 @@ final readonly class EncryptionService implements EncryptionServiceInterface
             return $plaintext;
         } catch (SodiumException) {
             throw EncryptionException::decryptionFailed('Decryption operation failed');
+        } finally {
+            // Wipe the freshly unwrapped DEK on every path, including the
+            // SodiumException error path reachable via tampered ciphertext that
+            // bypasses the in-try wipe above. The master key is the provider's
+            // request-cached value and is handled by the in-try wipe only (see
+            // SEC-CRYPTO-2 / ADR-002), to avoid clobbering the shared cache.
+            if (isset($dek)) {
+                sodium_memzero($dek);
+            }
         }
     }
 

--- a/Classes/Crypto/EnvironmentMasterKeyProvider.php
+++ b/Classes/Crypto/EnvironmentMasterKeyProvider.php
@@ -17,12 +17,9 @@ use SensitiveParameter;
 /**
  * Environment variable-based master key provider.
  */
-final class EnvironmentMasterKeyProvider implements MasterKeyProviderInterface
+final class EnvironmentMasterKeyProvider extends AbstractMasterKeyProvider
 {
     private const KEY_LENGTH = 32; // 256 bits
-
-    /** @var string|null Request-lifetime cached master key */
-    private static ?string $cachedKey = null;
 
     public function __construct(
         private readonly ExtensionConfigurationInterface $configuration,
@@ -30,6 +27,9 @@ final class EnvironmentMasterKeyProvider implements MasterKeyProviderInterface
 
     public function __destruct()
     {
+        // File/Env providers wipe their request-lifetime cache on destruction;
+        // the inherited static cache is keyed by class so this clears only this
+        // provider's slot. See ADR-020.
         self::clearCachedKey();
     }
 
@@ -46,54 +46,6 @@ final class EnvironmentMasterKeyProvider implements MasterKeyProviderInterface
         return $value !== false && $value !== '';
     }
 
-    /**
-     * Clear the cached master key from memory.
-     */
-    public static function clearCachedKey(): void
-    {
-        if (self::$cachedKey !== null) {
-            sodium_memzero(self::$cachedKey);
-            self::$cachedKey = null;
-        }
-    }
-
-    public function getMasterKey(): string
-    {
-        if (self::$cachedKey !== null) {
-            return self::$cachedKey;
-        }
-
-        $varName = $this->getEnvVarName();
-        $value = getenv($varName);
-
-        if ($value === false || $value === '') {
-            throw MasterKeyException::environmentVariableNotSet($varName);
-        }
-
-        // Handle base64-encoded keys
-        if (\strlen($value) === self::KEY_LENGTH) {
-            // Raw binary key - return directly (don't zero $value, it IS the key)
-            self::$cachedKey = $value;
-
-            return self::$cachedKey;
-        }
-
-        $decoded = base64_decode($value, true);
-        if ($decoded !== false && \strlen($decoded) === self::KEY_LENGTH) {
-            // Zero the raw base64 string, keep decoded key
-            sodium_memzero($value);
-            self::$cachedKey = $decoded;
-
-            return self::$cachedKey;
-        }
-
-        // Neither raw nor valid base64
-        $length = \strlen($value);
-        sodium_memzero($value);
-
-        throw MasterKeyException::invalidLength(self::KEY_LENGTH, $length);
-    }
-
     public function storeMasterKey(#[SensitiveParameter] string $key): void
     {
         // Cannot store to environment variable at runtime
@@ -105,6 +57,36 @@ final class EnvironmentMasterKeyProvider implements MasterKeyProviderInterface
     public function generateMasterKey(): string
     {
         return random_bytes(self::KEY_LENGTH);
+    }
+
+    protected function loadRawKey(): string
+    {
+        $varName = $this->getEnvVarName();
+        $value = getenv($varName);
+
+        if ($value === false || $value === '') {
+            throw MasterKeyException::environmentVariableNotSet($varName);
+        }
+
+        // Handle base64-encoded keys
+        if (\strlen($value) === self::KEY_LENGTH) {
+            // Raw binary key - return directly (don't zero $value, it IS the key)
+            return $value;
+        }
+
+        $decoded = base64_decode($value, true);
+        if ($decoded !== false && \strlen($decoded) === self::KEY_LENGTH) {
+            // Zero the raw base64 string, keep decoded key
+            sodium_memzero($value);
+
+            return $decoded;
+        }
+
+        // Neither raw nor valid base64
+        $length = \strlen($value);
+        sodium_memzero($value);
+
+        throw MasterKeyException::invalidLength(self::KEY_LENGTH, $length);
     }
 
     private function getEnvVarName(): string

--- a/Classes/Crypto/FileMasterKeyProvider.php
+++ b/Classes/Crypto/FileMasterKeyProvider.php
@@ -17,12 +17,9 @@ use SensitiveParameter;
 /**
  * File-based master key provider.
  */
-final class FileMasterKeyProvider implements MasterKeyProviderInterface
+final class FileMasterKeyProvider extends AbstractMasterKeyProvider
 {
     private const KEY_LENGTH = 32; // 256 bits
-
-    /** @var string|null Request-lifetime cached master key */
-    private static ?string $cachedKey = null;
 
     public function __construct(
         private readonly ExtensionConfigurationInterface $configuration,
@@ -30,6 +27,9 @@ final class FileMasterKeyProvider implements MasterKeyProviderInterface
 
     public function __destruct()
     {
+        // File/Env providers wipe their request-lifetime cache on destruction;
+        // the inherited static cache is keyed by class so this clears only this
+        // provider's slot. See ADR-020.
         self::clearCachedKey();
     }
 
@@ -43,76 +43,6 @@ final class FileMasterKeyProvider implements MasterKeyProviderInterface
         $path = $this->getKeyPath();
 
         return $path !== '' && file_exists($path) && is_readable($path);
-    }
-
-    /**
-     * Clear the cached master key from memory.
-     */
-    public static function clearCachedKey(): void
-    {
-        if (self::$cachedKey !== null) {
-            sodium_memzero(self::$cachedKey);
-            self::$cachedKey = null;
-        }
-    }
-
-    public function getMasterKey(): string
-    {
-        if (self::$cachedKey !== null) {
-            return self::$cachedKey;
-        }
-
-        $path = $this->getKeyPath();
-
-        if ($path === '') {
-            throw MasterKeyException::notFound('No path configured');
-        }
-
-        if (!file_exists($path)) {
-            // Try auto-generated key path for development
-            $autoPath = $this->configuration->getAutoKeyPath();
-            if (file_exists($autoPath) && is_readable($autoPath)) {
-                $path = $autoPath;
-            } else {
-                throw MasterKeyException::notFound($path);
-            }
-        }
-
-        if (!is_readable($path)) {
-            throw MasterKeyException::notFound($path . ' (not readable)');
-        }
-
-        $raw = file_get_contents($path);
-        if ($raw === false) {
-            throw MasterKeyException::notFound($path);
-        }
-
-        // Trim whitespace first (handles trailing newlines from text editors)
-        $trimmed = trim($raw);
-
-        // Try trimmed value as raw binary key
-        if (\strlen($trimmed) === self::KEY_LENGTH) {
-            self::$cachedKey = $trimmed;
-
-            return self::$cachedKey;
-        }
-
-        // Try base64 decode of trimmed value
-        $decoded = base64_decode($trimmed, true);
-        if ($decoded !== false && \strlen($decoded) === self::KEY_LENGTH) {
-            self::$cachedKey = $decoded;
-
-            return self::$cachedKey;
-        }
-
-        // Try raw file contents as binary (no trimming of binary data)
-        if (\strlen($raw) === self::KEY_LENGTH) {
-            self::$cachedKey = $raw;
-
-            return self::$cachedKey;
-        }
-
-        throw MasterKeyException::invalidLength(self::KEY_LENGTH, \strlen($trimmed));
     }
 
     public function storeMasterKey(#[SensitiveParameter] string $key): void
@@ -154,6 +84,55 @@ final class FileMasterKeyProvider implements MasterKeyProviderInterface
     public function generateMasterKey(): string
     {
         return random_bytes(self::KEY_LENGTH);
+    }
+
+    protected function loadRawKey(): string
+    {
+        $path = $this->getKeyPath();
+
+        if ($path === '') {
+            throw MasterKeyException::notFound('No path configured');
+        }
+
+        if (!file_exists($path)) {
+            // Try auto-generated key path for development
+            $autoPath = $this->configuration->getAutoKeyPath();
+            if (file_exists($autoPath) && is_readable($autoPath)) {
+                $path = $autoPath;
+            } else {
+                throw MasterKeyException::notFound($path);
+            }
+        }
+
+        if (!is_readable($path)) {
+            throw MasterKeyException::notFound($path . ' (not readable)');
+        }
+
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            throw MasterKeyException::notFound($path);
+        }
+
+        // Trim whitespace first (handles trailing newlines from text editors)
+        $trimmed = trim($raw);
+
+        // Try trimmed value as raw binary key
+        if (\strlen($trimmed) === self::KEY_LENGTH) {
+            return $trimmed;
+        }
+
+        // Try base64 decode of trimmed value
+        $decoded = base64_decode($trimmed, true);
+        if ($decoded !== false && \strlen($decoded) === self::KEY_LENGTH) {
+            return $decoded;
+        }
+
+        // Try raw file contents as binary (no trimming of binary data)
+        if (\strlen($raw) === self::KEY_LENGTH) {
+            return $raw;
+        }
+
+        throw MasterKeyException::invalidLength(self::KEY_LENGTH, \strlen($trimmed));
     }
 
     private function getKeyPath(): string

--- a/Classes/Crypto/MasterKeyProviderInterface.php
+++ b/Classes/Crypto/MasterKeyProviderInterface.php
@@ -53,4 +53,14 @@ interface MasterKeyProviderInterface
      * @return string 32-byte random key (not stored, just generated)
      */
     public function generateMasterKey(): string;
+
+    /**
+     * Clear the request-lifetime cached master key from memory.
+     *
+     * Wipes any cached key material via sodium_memzero(). Long-running
+     * processes (scheduler tasks, daemons) and test teardown should call this
+     * to bound key residency and to observe a rotated source key. Static so it
+     * is reachable without an instance, mirroring the implementations.
+     */
+    public static function clearCachedKey(): void;
 }

--- a/Classes/Crypto/Typo3MasterKeyProvider.php
+++ b/Classes/Crypto/Typo3MasterKeyProvider.php
@@ -22,7 +22,7 @@ use SensitiveParameter;
  * `$GLOBALS['TYPO3_CONF_VARS']['SYS']['encryptionKey']`. For production use,
  * prefer FileMasterKeyProvider or EnvironmentMasterKeyProvider (see ADR-003).
  */
-final class Typo3MasterKeyProvider implements MasterKeyProviderInterface
+final class Typo3MasterKeyProvider extends AbstractMasterKeyProvider
 {
     private const KEY_LENGTH = 32; // 256 bits
 
@@ -37,32 +37,15 @@ final class Typo3MasterKeyProvider implements MasterKeyProviderInterface
     private const MIN_SOURCE_KEY_LENGTH = 32;
 
     /**
-     * Request-lifetime cached master key (ADR-020).
-     *
-     * Static so it survives DI scope churn within a request. Cleared explicitly
-     * via {@see clearCachedKey()} — NOT in `__destruct`, because the same
-     * static is shared by every instance and the first instance to be
-     * garbage-collected would otherwise wipe the cache for the rest of the
-     * request. PHP zeroes the static at script shutdown anyway; long-running
-     * processes (scheduler tasks, daemons) should call `clearCachedKey()`
-     * explicitly when they need to observe a rotated TYPO3 `encryptionKey`.
+     * The request-lifetime cache lives in {@see AbstractMasterKeyProvider} and
+     * is cleared via the inherited static {@see clearCachedKey()}. This provider
+     * deliberately defines NO `__destruct`: its cache slot is keyed by class and
+     * shared across instances, so wiping it when one instance is garbage-
+     * collected would break the rest of the request. PHP zeroes the static at
+     * script shutdown anyway; long-running processes (scheduler tasks, daemons)
+     * should call {@see clearCachedKey()} explicitly when they need to observe a
+     * rotated TYPO3 `encryptionKey`. See ADR-020.
      */
-    private static ?string $cachedKey = null;
-
-    /**
-     * Clear the cached master key from memory.
-     *
-     * Call from long-running processes that need to observe TYPO3
-     * `encryptionKey` rotation, and from test fixtures for isolation.
-     */
-    public static function clearCachedKey(): void
-    {
-        if (self::$cachedKey !== null) {
-            sodium_memzero(self::$cachedKey);
-            self::$cachedKey = null;
-        }
-    }
-
     public function getIdentifier(): string
     {
         return 'typo3';
@@ -73,12 +56,21 @@ final class Typo3MasterKeyProvider implements MasterKeyProviderInterface
         return $this->getEncryptionKey() !== '';
     }
 
-    public function getMasterKey(): string
+    public function storeMasterKey(#[SensitiveParameter] string $key): void
     {
-        if (self::$cachedKey !== null) {
-            return self::$cachedKey;
-        }
+        // Cannot store - the key is derived from TYPO3's encryption key
+        throw MasterKeyException::cannotStore(
+            'TYPO3 provider derives the key from encryptionKey. To change it, rotate TYPO3\'s encryption key.',
+        );
+    }
 
+    public function generateMasterKey(): string
+    {
+        return random_bytes(self::KEY_LENGTH);
+    }
+
+    protected function loadRawKey(): string
+    {
         $encryptionKey = $this->getEncryptionKey();
 
         if ($encryptionKey === '') {
@@ -93,27 +85,12 @@ final class Typo3MasterKeyProvider implements MasterKeyProviderInterface
         }
 
         // Derive master key using HKDF-SHA256 with nr-vault-specific context
-        self::$cachedKey = hash_hkdf(
+        return hash_hkdf(
             'sha256',
             $encryptionKey,
             self::KEY_LENGTH,
             self::HKDF_INFO,
         );
-
-        return self::$cachedKey;
-    }
-
-    public function storeMasterKey(#[SensitiveParameter] string $key): void
-    {
-        // Cannot store - the key is derived from TYPO3's encryption key
-        throw MasterKeyException::cannotStore(
-            'TYPO3 provider derives the key from encryptionKey. To change it, rotate TYPO3\'s encryption key.',
-        );
-    }
-
-    public function generateMasterKey(): string
-    {
-        return random_bytes(self::KEY_LENGTH);
     }
 
     private function getEncryptionKey(): string

--- a/Classes/Domain/Model/Secret.php
+++ b/Classes/Domain/Model/Secret.php
@@ -24,7 +24,8 @@ use Netresearch\NrVault\Exception\ValidationException;
 final readonly class Secret
 {
     /**
-     * @param int[] $allowedGroups
+     * @param int[] $allowedGroups Backend group UIDs with READ access (read-only tier)
+     * @param int[] $writeGroups Backend group UIDs with WRITE access (read + write tier)
      * @param array<string, mixed> $metadata
      *
      * @throws ValidationException If cryptographic fields are inconsistent
@@ -42,6 +43,7 @@ final readonly class Secret
         public string $valueChecksum = '',
         public int $ownerUid = 0,
         public array $allowedGroups = [],
+        public array $writeGroups = [],
         public string $context = '',
         public bool $frontendAccessible = false,
         public int $version = 1,
@@ -131,6 +133,28 @@ final readonly class Secret
         return $this->cloneWith(['metadata' => $metadata]);
     }
 
+    /**
+     * Replace the read-tier allowed-groups list. Returns a new Secret;
+     * the MM relations are persisted by `SecretRepository::save()`.
+     *
+     * @param int[] $allowedGroups
+     */
+    public function cloneWithGroups(array $allowedGroups): self
+    {
+        return $this->cloneWith(['allowedGroups' => array_map(\intval(...), $allowedGroups)]);
+    }
+
+    /**
+     * Replace the write-tier groups list. Returns a new Secret; the MM
+     * relations are persisted by `SecretRepository::save()`.
+     *
+     * @param int[] $writeGroups
+     */
+    public function cloneWithWriteGroups(array $writeGroups): self
+    {
+        return $this->cloneWith(['writeGroups' => array_map(\intval(...), $writeGroups)]);
+    }
+
     // ------------------------------------------------------------------
     // Derived state.
     // ------------------------------------------------------------------
@@ -211,6 +235,14 @@ final readonly class Secret
     public function getAllowedGroups(): array
     {
         return $this->allowedGroups;
+    }
+
+    /**
+     * @return int[]
+     */
+    public function getWriteGroups(): array
+    {
+        return $this->writeGroups;
     }
 
     public function getContext(): string
@@ -296,15 +328,16 @@ final readonly class Secret
     // ------------------------------------------------------------------
 
     /**
-     * Hydrate from a `tx_nrvault_secret` row. The allowed-groups list is
-     * stored in a separate MM table, so the caller must look it up and
-     * pass it here — there is no second-step `setAllowedGroups()` after
-     * construction.
+     * Hydrate from a `tx_nrvault_secret` row. The allowed-groups and
+     * write-groups lists are each stored in a separate MM table, so the
+     * caller must look them up and pass them here — there is no
+     * second-step `setAllowedGroups()` after construction.
      *
      * @param array<string, mixed> $row
-     * @param int[] $allowedGroups
+     * @param int[] $allowedGroups Read-tier group UIDs (from MM table)
+     * @param int[] $writeGroups Write-tier group UIDs (from MM table)
      */
-    public static function fromDatabaseRow(array $row, array $allowedGroups = []): self
+    public static function fromDatabaseRow(array $row, array $allowedGroups = [], array $writeGroups = []): self
     {
         $metadata = [];
         if (!empty($row['metadata'])) {
@@ -318,6 +351,14 @@ final readonly class Secret
             $groups = (string) $row['allowed_groups'];
             $allowedGroups = array_values(array_filter(
                 array_map(\intval(...), explode(',', $groups)),
+            ));
+        }
+
+        // Same legacy-CSV fallback for the write-tier groups.
+        if ($writeGroups === [] && !empty($row['write_groups'])) {
+            $wGroups = (string) $row['write_groups'];
+            $writeGroups = array_values(array_filter(
+                array_map(\intval(...), explode(',', $wGroups)),
             ));
         }
 
@@ -336,6 +377,7 @@ final readonly class Secret
             valueChecksum: (string) ($row['value_checksum'] ?? ''),
             ownerUid: (int) ($row['owner_uid'] ?? 0),
             allowedGroups: array_map(\intval(...), $allowedGroups),
+            writeGroups: array_map(\intval(...), $writeGroups),
             context: (string) ($row['context'] ?? ''),
             frontendAccessible: (bool) ($row['frontend_accessible'] ?? false),
             version: (int) ($row['version'] ?? 1),
@@ -355,6 +397,19 @@ final readonly class Secret
     }
 
     /**
+     * Serialise to a `tx_nrvault_secret` row for INSERT/UPDATE.
+     *
+     * Note: `uid` and `crdate` are intentionally omitted (the DB layer
+     * assigns/owns them — `uid` is auto-increment, `crdate` is set by
+     * `SecretRepository::save()` on INSERT only), and `tstamp` is set to
+     * the current time on every write rather than echoing `$this->tstamp`.
+     * These three columns are therefore DB-managed; a `fromDatabaseRow()`
+     * → `toDatabaseRow()` round-trip is not an identity for them.
+     *
+     * The `allowed_groups`/`write_groups` CSV columns are written for
+     * legacy-read fallback only; the authoritative source of truth for
+     * group relations is the MM tables (written by `SecretRepository`).
+     *
      * @return array<string, mixed>
      */
     public function toDatabaseRow(): array
@@ -371,6 +426,7 @@ final readonly class Secret
             'value_checksum' => $this->valueChecksum,
             'owner_uid' => $this->ownerUid,
             'allowed_groups' => implode(',', $this->allowedGroups),
+            'write_groups' => implode(',', $this->writeGroups),
             'context' => $this->context,
             'frontend_accessible' => $this->frontendAccessible ? 1 : 0,
             'version' => $this->version,

--- a/Classes/Domain/Repository/SecretRepository.php
+++ b/Classes/Domain/Repository/SecretRepository.php
@@ -23,6 +23,8 @@ final readonly class SecretRepository implements SecretRepositoryInterface
 
     private const MM_TABLE_NAME = 'tx_nrvault_secret_begroups_mm';
 
+    private const MM_WRITE_TABLE_NAME = 'tx_nrvault_secret_writegroups_mm';
+
     public function __construct(
         private ConnectionPool $connectionPool,
     ) {}
@@ -45,9 +47,13 @@ final readonly class SecretRepository implements SecretRepositoryInterface
         }
 
         $uid = $row['uid'] ?? 0;
-        $groups = $this->loadGroupsForSecret(is_numeric($uid) ? (int) $uid : 0);
+        $intUid = is_numeric($uid) ? (int) $uid : 0;
 
-        return Secret::fromDatabaseRow($row, $groups);
+        return Secret::fromDatabaseRow(
+            $row,
+            $this->loadGroupsForSecret($intUid),
+            $this->loadGroupsForSecret($intUid, self::MM_WRITE_TABLE_NAME),
+        );
     }
 
     public function findByUid(int $uid): ?Secret
@@ -67,7 +73,11 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             return null;
         }
 
-        return Secret::fromDatabaseRow($row, $this->loadGroupsForSecret($uid));
+        return Secret::fromDatabaseRow(
+            $row,
+            $this->loadGroupsForSecret($uid),
+            $this->loadGroupsForSecret($uid, self::MM_WRITE_TABLE_NAME),
+        );
     }
 
     public function exists(string $identifier): bool
@@ -113,8 +123,9 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             );
         }
 
-        // Update MM table for groups
-        $this->saveGroupsForSecret($secret);
+        // Update MM tables for the read-tier and write-tier groups.
+        $this->saveGroupsForSecret($secret, self::MM_TABLE_NAME, $secret->getAllowedGroups());
+        $this->saveGroupsForSecret($secret, self::MM_WRITE_TABLE_NAME, $secret->getWriteGroups());
 
         return $secret;
     }
@@ -154,8 +165,12 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             }
 
             if ($filters->prefix !== null) {
+                // Escape LIKE metacharacters (% and _) in the caller-supplied
+                // prefix so they match literally, then append the trailing
+                // wildcard ourselves (SEC-INJECTION-LEAK-1).
+                $escapedPrefix = $queryBuilder->escapeLikeWildcards($filters->prefix);
                 $queryBuilder->andWhere(
-                    $queryBuilder->expr()->like('identifier', $queryBuilder->createNamedParameter($filters->prefix . '%')),
+                    $queryBuilder->expr()->like('identifier', $queryBuilder->createNamedParameter($escapedPrefix . '%')),
                 );
             }
 
@@ -232,14 +247,9 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             ->executeQuery()
             ->fetchAllAssociative();
 
-        $secrets = [];
-        foreach ($rows as $row) {
-            $rowUid = $row['uid'] ?? 0;
-            $groups = $this->loadGroupsForSecret(is_numeric($rowUid) ? (int) $rowUid : 0);
-            $secrets[] = Secret::fromDatabaseRow($row, $groups);
-        }
-
-        return $secrets;
+        // Batch-load both group tiers in a constant number of queries
+        // instead of one-per-row (PERFORMANCE-2).
+        return $this->hydrateRowsWithGroups($rows);
     }
 
     /**
@@ -261,7 +271,7 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             ->executeQuery()
             ->fetchAllAssociative();
 
-        return array_map(Secret::fromDatabaseRow(...), $rows);
+        return $this->hydrateRowsWithGroups($rows);
     }
 
     /**
@@ -287,7 +297,7 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             ->executeQuery()
             ->fetchAllAssociative();
 
-        return array_map(Secret::fromDatabaseRow(...), $rows);
+        return $this->hydrateRowsWithGroups($rows);
     }
 
     /**
@@ -328,8 +338,12 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             }
 
             if ($filters->prefix !== null) {
+                // Escape LIKE metacharacters (% and _) in the caller-supplied
+                // prefix so they match literally, then append the trailing
+                // wildcard ourselves (SEC-INJECTION-LEAK-1).
+                $escapedPrefix = $queryBuilder->escapeLikeWildcards($filters->prefix);
                 $queryBuilder->andWhere(
-                    $queryBuilder->expr()->like('identifier', $queryBuilder->createNamedParameter($filters->prefix . '%')),
+                    $queryBuilder->expr()->like('identifier', $queryBuilder->createNamedParameter($escapedPrefix . '%')),
                 );
             }
 
@@ -350,35 +364,39 @@ final readonly class SecretRepository implements SecretRepositoryInterface
 
         $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
 
-        if ($rows === []) {
+        return $this->hydrateRowsWithGroups($rows);
+    }
+
+    /**
+     * Find a window of active secrets ordered by UID, for memory-bounded
+     * batch processing (e.g. the orphan-cleanup scheduler task). Returns
+     * up to `$limit` secrets whose UID is strictly greater than
+     * `$afterUid`; pass the last returned UID back as `$afterUid` to fetch
+     * the next page. An empty result signals the end of the table
+     * (PERFORMANCE-8).
+     *
+     * @return Secret[]
+     */
+    public function findPaginatedAfterUid(int $afterUid, int $limit): array
+    {
+        if ($limit < 1) {
             return [];
         }
 
-        // Collect all UIDs and batch-load MM groups in ONE query so each
-        // Secret can be constructed with its allowed-groups list already
-        // populated — readonly entity has no post-construction mutator.
-        // Traverse rows in their original order (the SELECT's ORDER BY
-        // contract) and preserve duplicates, so this method's external
-        // behaviour matches the pre-readonly version exactly.
-        $uids = [];
-        foreach ($rows as $row) {
-            $uid = $row['uid'] ?? 0;
-            $intUid = is_numeric($uid) ? (int) $uid : 0;
-            if ($intUid > 0) {
-                $uids[$intUid] = true;
-            }
-        }
+        $queryBuilder = $this->getConnection()->createQueryBuilder();
+        $rows = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->eq('deleted', 0),
+                $queryBuilder->expr()->gt('uid', $queryBuilder->createNamedParameter($afterUid, Connection::PARAM_INT)),
+            )
+            ->orderBy('uid', 'ASC')
+            ->setMaxResults($limit)
+            ->executeQuery()
+            ->fetchAllAssociative();
 
-        $groupsBySecret = $uids !== [] ? $this->loadGroupsForSecrets(array_keys($uids)) : [];
-
-        $secrets = [];
-        foreach ($rows as $row) {
-            $uid = $row['uid'] ?? 0;
-            $intUid = is_numeric($uid) ? (int) $uid : 0;
-            $secrets[] = Secret::fromDatabaseRow($row, $groupsBySecret[$intUid] ?? []);
-        }
-
-        return $secrets;
+        return $this->hydrateRowsWithGroups($rows);
     }
 
     /**
@@ -394,22 +412,69 @@ final readonly class SecretRepository implements SecretRepositoryInterface
     }
 
     /**
-     * Batch-load groups for multiple secrets from MM table.
+     * Hydrate secret rows into Secret objects, batch-loading both group
+     * tiers (read + write) in a constant number of MM queries regardless
+     * of the number of rows. Preserves the input row order and duplicates,
+     * matching the SELECT's ORDER BY contract.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     *
+     * @return Secret[]
+     */
+    private function hydrateRowsWithGroups(array $rows): array
+    {
+        if ($rows === []) {
+            return [];
+        }
+
+        // Collect distinct UIDs once, then batch-load each group tier in a
+        // single query so a readonly Secret can be built with its lists
+        // already populated (it has no post-construction mutator).
+        $uids = [];
+        foreach ($rows as $row) {
+            $uid = $row['uid'] ?? 0;
+            $intUid = is_numeric($uid) ? (int) $uid : 0;
+            if ($intUid > 0) {
+                $uids[$intUid] = true;
+            }
+        }
+
+        $uidList = array_keys($uids);
+        $readGroupsBySecret = $uidList !== [] ? $this->loadGroupsForSecrets($uidList, self::MM_TABLE_NAME) : [];
+        $writeGroupsBySecret = $uidList !== [] ? $this->loadGroupsForSecrets($uidList, self::MM_WRITE_TABLE_NAME) : [];
+
+        $secrets = [];
+        foreach ($rows as $row) {
+            $uid = $row['uid'] ?? 0;
+            $intUid = is_numeric($uid) ? (int) $uid : 0;
+            $secrets[] = Secret::fromDatabaseRow(
+                $row,
+                $readGroupsBySecret[$intUid] ?? [],
+                $writeGroupsBySecret[$intUid] ?? [],
+            );
+        }
+
+        return $secrets;
+    }
+
+    /**
+     * Batch-load groups for multiple secrets from a given MM table.
      *
      * @param int[] $secretUids
+     * @param string $mmTable One of the MM relation tables (read/write tier)
      *
      * @return array<int, int[]> Map of secret UID to group UIDs
      */
-    private function loadGroupsForSecrets(array $secretUids): array
+    private function loadGroupsForSecrets(array $secretUids, string $mmTable = self::MM_TABLE_NAME): array
     {
         if ($secretUids === []) {
             return [];
         }
 
-        $queryBuilder = $this->getMmConnection()->createQueryBuilder();
+        $queryBuilder = $this->getMmConnection($mmTable)->createQueryBuilder();
         $rows = $queryBuilder
             ->select('uid_local', 'uid_foreign')
-            ->from(self::MM_TABLE_NAME)
+            ->from($mmTable)
             ->where($queryBuilder->expr()->in('uid_local', $secretUids))
             ->orderBy('uid_local', 'ASC')
             ->addOrderBy('sorting', 'ASC')
@@ -427,16 +492,18 @@ final readonly class SecretRepository implements SecretRepositoryInterface
     }
 
     /**
-     * Load groups for a secret from MM table.
+     * Load groups for a single secret from a given MM table.
+     *
+     * @param string $mmTable One of the MM relation tables (read/write tier)
      *
      * @return int[]
      */
-    private function loadGroupsForSecret(int $secretUid): array
+    private function loadGroupsForSecret(int $secretUid, string $mmTable = self::MM_TABLE_NAME): array
     {
-        $queryBuilder = $this->getMmConnection()->createQueryBuilder();
+        $queryBuilder = $this->getMmConnection($mmTable)->createQueryBuilder();
         $rows = $queryBuilder
             ->select('uid_foreign')
-            ->from(self::MM_TABLE_NAME)
+            ->from($mmTable)
             ->where($queryBuilder->expr()->eq('uid_local', $secretUid))
             ->orderBy('sorting', 'ASC')
             ->executeQuery()
@@ -452,23 +519,25 @@ final readonly class SecretRepository implements SecretRepositoryInterface
     }
 
     /**
-     * Save groups for a secret to MM table.
+     * Save a group tier for a secret to its MM table (delete-then-insert).
+     *
+     * @param string $mmTable One of the MM relation tables (read/write tier)
+     * @param int[] $groups Group UIDs to persist for this tier
      */
-    private function saveGroupsForSecret(Secret $secret): void
+    private function saveGroupsForSecret(Secret $secret, string $mmTable, array $groups): void
     {
         if ($secret->getUid() === null) {
             return;
         }
 
-        $mmConnection = $this->getMmConnection();
+        $mmConnection = $this->getMmConnection($mmTable);
 
         // Delete existing relations
-        $mmConnection->delete(self::MM_TABLE_NAME, ['uid_local' => $secret->getUid()]);
+        $mmConnection->delete($mmTable, ['uid_local' => $secret->getUid()]);
 
         // Insert new relations
-        $groups = $secret->getAllowedGroups();
         foreach ($groups as $sorting => $groupUid) {
-            $mmConnection->insert(self::MM_TABLE_NAME, [
+            $mmConnection->insert($mmTable, [
                 'uid_local' => $secret->getUid(),
                 'uid_foreign' => $groupUid,
                 'sorting' => $sorting,
@@ -483,18 +552,18 @@ final readonly class SecretRepository implements SecretRepositoryInterface
     }
 
     /**
-     * Resolve the connection for the MM-relations table separately from the
+     * Resolve the connection for an MM-relations table separately from the
      * main secret table. TYPO3 routes per-table connections via
      * `$GLOBALS['TYPO3_CONF_VARS']['DB']['TableMapping']` (the connection
      * targets themselves live under `['DB']['Connections']`). On the common
-     * single-DB setup both tables map to `Default`, so this returns the same
+     * single-DB setup all tables map to `Default`, so this returns the same
      * connection as `getConnection()` — the indirection only matters on
-     * sharded setups, where an admin may have mapped the MM table to a
+     * sharded setups, where an admin may have mapped an MM table to a
      * different DB. The original code lost that distinction; MM operations
      * issued via the secret-table connection would have hit the wrong DB.
      */
-    private function getMmConnection(): Connection
+    private function getMmConnection(string $mmTable = self::MM_TABLE_NAME): Connection
     {
-        return $this->connectionPool->getConnectionForTable(self::MM_TABLE_NAME);
+        return $this->connectionPool->getConnectionForTable($mmTable);
     }
 }

--- a/Classes/Domain/Repository/SecretRepositoryInterface.php
+++ b/Classes/Domain/Repository/SecretRepositoryInterface.php
@@ -47,6 +47,16 @@ interface SecretRepositoryInterface
     public function findAllWithFilters(?SecretFilters $filters = null): array;
 
     /**
+     * Find a window of active secrets ordered by UID, for memory-bounded
+     * batch processing. Returns up to `$limit` secrets whose UID is
+     * strictly greater than `$afterUid`. An empty result signals the end
+     * of the table.
+     *
+     * @return Secret[]
+     */
+    public function findPaginatedAfterUid(int $afterUid, int $limit): array;
+
+    /**
      * Find all secrets accessible by specific groups.
      *
      * @param int[] $groupUids

--- a/Classes/Hook/DataHandlerHook.php
+++ b/Classes/Hook/DataHandlerHook.php
@@ -13,13 +13,10 @@ use Exception;
 use Netresearch\NrVault\Hook\Dto\PendingSecret;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Utility\IdentifierValidator;
+use Netresearch\NrVault\Utility\VaultFieldResolver;
 use Throwable;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
-use TYPO3\CMS\Core\Messaging\FlashMessage;
-use TYPO3\CMS\Core\Messaging\FlashMessageService;
-use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
-use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 
 /**
  * DataHandler hook for vault secret TCA fields.
@@ -47,9 +44,10 @@ final class DataHandlerHook
 
     public function __construct(
         private readonly ConnectionPool $connectionPool,
-        private readonly TcaSchemaFactory $tcaSchemaFactory,
         private readonly VaultServiceInterface $vaultService,
-        private readonly FlashMessageService $flashMessageService,
+        private readonly VaultFieldResolver $vaultFieldResolver,
+        private readonly PendingSecretExtractor $pendingSecretExtractor,
+        private readonly PendingSecretPersister $pendingSecretPersister,
     ) {}
 
     /**
@@ -71,39 +69,19 @@ final class DataHandlerHook
                 continue;
             }
 
-            $value = $fieldArray[$fieldName];
-
-            // Handle array format from form element
-            if (\is_array($value)) {
-                $rawSecretValue = $value['value'] ?? $value[0] ?? '';
-                $rawIdentifier = $value['_vault_identifier'] ?? '';
-                $rawChecksum = $value['_vault_checksum'] ?? '';
-                $secretValue = \is_string($rawSecretValue) || \is_int($rawSecretValue) ? (string) $rawSecretValue : '';
-                $existingIdentifier = \is_string($rawIdentifier) ? $rawIdentifier : '';
-                $originalChecksum = \is_string($rawChecksum) ? $rawChecksum : '';
-            } else {
-                $secretValue = \is_string($value) || \is_int($value) ? (string) $value : '';
-                $existingIdentifier = '';
-                $originalChecksum = '';
-            }
+            $pending = $this->pendingSecretExtractor->extract($fieldArray[$fieldName]);
 
             // Skip if empty and no existing value
-            if ($secretValue === '' && $originalChecksum === '') {
+            if (!$pending instanceof PendingSecret) {
                 unset($fieldArray[$fieldName]);
                 continue;
             }
 
-            // Determine vault identifier
-            $isNewSecret = $existingIdentifier === '' || $originalChecksum === '';
-            $vaultIdentifier = $isNewSecret ? IdentifierValidator::generateUuid() : $existingIdentifier;
-
             // Store pending secret for post-processing
-            $this->pendingSecrets[$table][$id][$fieldName] = $isNewSecret
-                ? PendingSecret::createNew($secretValue, $vaultIdentifier)
-                : PendingSecret::createUpdate($secretValue, $vaultIdentifier, $originalChecksum);
+            $this->pendingSecrets[$table][$id][$fieldName] = $pending;
 
             // Store UUID in the database field (empty string if clearing)
-            $fieldArray[$fieldName] = $secretValue !== '' ? $vaultIdentifier : '';
+            $fieldArray[$fieldName] = $pending->value !== '' ? $pending->identifier : '';
         }
     }
 
@@ -131,40 +109,38 @@ final class DataHandlerHook
         $pendingForRecord = $this->pendingSecrets[$table][$id] ?? [];
 
         foreach ($pendingForRecord as $fieldName => $pending) {
-            $secretValue = $pending->value;
-            $vaultIdentifier = $pending->identifier;
-            $originalChecksum = $pending->originalChecksum;
-            $isNew = $pending->isNew;
+            // Roll back the dangling UUID - clear the field so no orphan
+            // reference remains. New records always clear (no prior value);
+            // updates keep the prior identifier IFF a prior checksum was
+            // captured (i.e. the old secret actually existed).
+            $rollbackValue = '';
+            if (!$pending->isNew && $pending->originalChecksum !== '') {
+                $rollbackValue = $pending->identifier;
+            }
 
-            try {
-                if ($secretValue === '') {
-                    // Empty value means delete the secret
-                    if ($originalChecksum !== '') {
-                        $this->vaultService->delete($vaultIdentifier, 'TCA field cleared');
-                    }
-                } elseif ($isNew) {
-                    // New secret with new UUID
-                    $this->vaultService->store($vaultIdentifier, $secretValue, [
-                        'table' => $table,
-                        'field' => $fieldName,
-                        'uid' => $uid,
-                        'source' => 'tca_field',
-                    ]);
-                } else {
-                    // Update existing - use rotate to maintain audit trail
-                    $this->vaultService->rotate($vaultIdentifier, $secretValue, 'TCA field updated');
-                }
-            } catch (Throwable $e) {
-                // Roll back the dangling UUID - clear the field so no orphan
-                // reference remains. New records always clear (no prior value);
-                // updates keep the prior identifier IFF a prior checksum was
-                // captured (i.e. the old secret actually existed).
-                $rollbackValue = '';
-                if (!$isNew && $pending->originalChecksum !== '') {
-                    $rollbackValue = $vaultIdentifier;
-                }
-                $this->rollBackField($table, $uid, $fieldName, $rollbackValue);
+            $error = $this->pendingSecretPersister->persist(
+                $pending,
+                [
+                    'table' => $table,
+                    'field' => $fieldName,
+                    'uid' => $uid,
+                    'source' => 'tca_field',
+                ],
+                'TCA field cleared',
+                'TCA field updated',
+                static fn (Throwable $e): string => \sprintf(
+                    'Vault storage failed for field "%s" on %s:%d: %s. The field value has been rolled back.',
+                    $fieldName,
+                    $table,
+                    $uid,
+                    $e->getMessage(),
+                ),
+                function () use ($table, $uid, $fieldName, $rollbackValue): void {
+                    $this->rollBackField($table, $uid, $fieldName, $rollbackValue);
+                },
+            );
 
+            if ($error instanceof Throwable) {
                 /** @phpstan-ignore method.internal */
                 $dataHandler->log(
                     $table,
@@ -172,20 +148,7 @@ final class DataHandlerHook
                     $status === 'new' ? 1 : 2,
                     null,
                     1,
-                    'Vault error for field "' . $fieldName . '": ' . $e->getMessage(),
-                );
-
-                // Add a visible flash message so the backend user sees the error
-                $this->addFlashMessage(
-                    \sprintf(
-                        'Vault storage failed for field "%s" on %s:%d: %s. The field value has been rolled back.',
-                        $fieldName,
-                        $table,
-                        $uid,
-                        $e->getMessage(),
-                    ),
-                    'Vault Error',
-                    ContextualFeedbackSeverity::ERROR,
+                    'Vault error for field "' . $fieldName . '": ' . $error->getMessage(),
                 );
             }
         }
@@ -307,6 +270,8 @@ final class DataHandlerHook
                 continue;
             }
 
+            $sourceValue = null;
+
             try {
                 // Get source secret
                 $sourceValue = $this->vaultService->retrieve($sourceIdentifier);
@@ -338,6 +303,11 @@ final class DataHandlerHook
                     1,
                     'Vault error during copy for field "' . $fieldName . '": ' . $e->getMessage(),
                 );
+            } finally {
+                // Scrub the decrypted plaintext from memory (success or failure).
+                if ($sourceValue !== null && $sourceValue !== '') {
+                    sodium_memzero($sourceValue);
+                }
             }
         }
 
@@ -370,53 +340,16 @@ final class DataHandlerHook
     }
 
     /**
-     * Add a flash message visible to the backend user.
-     */
-    private function addFlashMessage(
-        string $message,
-        string $title,
-        ContextualFeedbackSeverity $severity,
-    ): void {
-        try {
-            $flashMessage = new FlashMessage($message, $title, $severity, true);
-            $this->flashMessageService
-                ->getMessageQueueByIdentifier()
-                ->addMessage($flashMessage);
-        } catch (Exception) {
-            // Flash message service may not be available in all contexts (e.g., CLI)
-        }
-    }
-
-    /**
      * Get field names with vaultSecret renderType from TCA schema.
+     *
+     * Discovery is delegated to {@see VaultFieldResolver}; results are cached
+     * per table for the lifetime of this hook instance.
      *
      * @return list<string>
      */
     private function getVaultFieldNames(string $table): array
     {
-        if (isset($this->vaultFieldCache[$table])) {
-            return $this->vaultFieldCache[$table];
-        }
-
-        if (!$this->tcaSchemaFactory->has($table)) {
-            $this->vaultFieldCache[$table] = [];
-
-            return [];
-        }
-
-        $schema = $this->tcaSchemaFactory->get($table);
-        $vaultFields = [];
-
-        foreach ($schema->getFields() as $field) {
-            $config = $field->getConfiguration();
-            $renderType = $config['renderType'] ?? '';
-            if ($renderType === 'vaultSecret') {
-                $vaultFields[] = $field->getName();
-            }
-        }
-
-        $this->vaultFieldCache[$table] = $vaultFields;
-
-        return $vaultFields;
+        return $this->vaultFieldCache[$table]
+            ??= $this->vaultFieldResolver->getVaultFieldsForTable($table);
     }
 }

--- a/Classes/Hook/Dto/FlexFormPendingSecret.php
+++ b/Classes/Hook/Dto/FlexFormPendingSecret.php
@@ -92,7 +92,11 @@ readonly class FlexFormPendingSecret
     }
 
     /**
-     * Convert to array for serialization.
+     * Convert to array for serialization/debugging.
+     *
+     * The secret `value` is intentionally redacted: this array form is meant
+     * for logging/serialisation, which must never carry plaintext. Use the
+     * `$value` property (or {@see hasChanged()}) when the raw value is needed.
      *
      * @return array{flexField: string, sheet: string, fieldPath: string, value: string, identifier: string, originalChecksum: string, isNew: bool}
      */
@@ -102,7 +106,7 @@ readonly class FlexFormPendingSecret
             'flexField' => $this->flexField,
             'sheet' => $this->sheet,
             'fieldPath' => $this->fieldPath,
-            'value' => $this->value,
+            'value' => '[REDACTED]',
             'identifier' => $this->identifier,
             'originalChecksum' => $this->originalChecksum,
             'isNew' => $this->isNew,

--- a/Classes/Hook/Dto/PendingSecret.php
+++ b/Classes/Hook/Dto/PendingSecret.php
@@ -62,14 +62,18 @@ readonly class PendingSecret
     }
 
     /**
-     * Convert to array for serialization.
+     * Convert to array for serialization/debugging.
+     *
+     * The secret `value` is intentionally redacted: this array form is meant
+     * for logging/serialisation, which must never carry plaintext. Use the
+     * `$value` property (or {@see hasChanged()}) when the raw value is needed.
      *
      * @return array{value: string, identifier: string, originalChecksum: string, isNew: bool}
      */
     public function toArray(): array
     {
         return [
-            'value' => $this->value,
+            'value' => '[REDACTED]',
             'identifier' => $this->identifier,
             'originalChecksum' => $this->originalChecksum,
             'isNew' => $this->isNew,

--- a/Classes/Hook/PendingSecretExtractor.php
+++ b/Classes/Hook/PendingSecretExtractor.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Hook;
+
+use Netresearch\NrVault\Hook\Dto\PendingSecret;
+use Netresearch\NrVault\Utility\IdentifierValidator;
+
+/**
+ * Turns a raw vault field value (from a TCA field or a FlexForm vDEF node)
+ * into a {@see PendingSecret}, applying the shared new/update detection and
+ * UUID-generation rules.
+ *
+ * This is the single source of truth for the value-extraction pipeline that
+ * was previously duplicated byte-for-byte between {@see DataHandlerHook} and
+ * {@see FlexFormVaultHook}.
+ */
+final class PendingSecretExtractor
+{
+    /**
+     * Extract a pending secret from a raw field value.
+     *
+     * Returns:
+     * - a {@see PendingSecret} with a non-empty value for a new/updated secret,
+     * - a {@see PendingSecret} with an empty value (and a prior checksum) when
+     *   the field was cleared and the secret must be deleted,
+     * - null when there is nothing to do (empty value and no prior secret).
+     *
+     * @param mixed $value The raw field value (string, int, or the array shape
+     *                     emitted by the vault FormEngine element)
+     */
+    public function extract(mixed $value): ?PendingSecret
+    {
+        if (\is_array($value)) {
+            $rawSecretValue = $value['value'] ?? $value[0] ?? '';
+            $rawIdentifier = $value['_vault_identifier'] ?? '';
+            $rawChecksum = $value['_vault_checksum'] ?? '';
+            $secretValue = \is_string($rawSecretValue) || \is_int($rawSecretValue) ? (string) $rawSecretValue : '';
+            $existingIdentifier = \is_string($rawIdentifier) ? $rawIdentifier : '';
+            $originalChecksum = \is_string($rawChecksum) ? $rawChecksum : '';
+        } else {
+            $secretValue = \is_string($value) || \is_int($value) ? (string) $value : '';
+            $existingIdentifier = '';
+            $originalChecksum = '';
+        }
+
+        // Nothing to do: empty value and no prior secret.
+        if ($secretValue === '' && $originalChecksum === '') {
+            return null;
+        }
+
+        $isNewSecret = $existingIdentifier === '' || $originalChecksum === '';
+        $vaultIdentifier = $isNewSecret ? IdentifierValidator::generateUuid() : $existingIdentifier;
+
+        return $isNewSecret
+            ? PendingSecret::createNew($secretValue, $vaultIdentifier)
+            : PendingSecret::createUpdate($secretValue, $vaultIdentifier, $originalChecksum);
+    }
+}

--- a/Classes/Hook/PendingSecretPersister.php
+++ b/Classes/Hook/PendingSecretPersister.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Hook;
+
+use Exception;
+use Netresearch\NrVault\Hook\Dto\PendingSecret;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Throwable;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+
+/**
+ * Runs the shared delete/store/rotate persistence decision for a pending vault
+ * secret and surfaces failures as backend flash messages.
+ *
+ * This collaborator removes the duplicated store/rotate/delete dispatch and the
+ * byte-identical flash-message helper that previously lived in both
+ * {@see DataHandlerHook} and {@see FlexFormVaultHook}. Hook-specific concerns
+ * (DataHandler error logging, field rollback) stay in the hooks: the persister
+ * returns the caught {@see Throwable} so the caller can log it, and invokes an
+ * optional rollback callback before emitting the flash message.
+ */
+final readonly class PendingSecretPersister
+{
+    public function __construct(
+        private VaultServiceInterface $vaultService,
+        private FlashMessageService $flashMessageService,
+    ) {}
+
+    /**
+     * Persist a pending secret: delete on empty value, store when new, rotate
+     * otherwise.
+     *
+     * On success returns null. On failure runs $onFailure (if given), emits an
+     * error flash message built by $failureMessage from the caught throwable,
+     * and returns that throwable so the caller can perform hook-specific logging.
+     *
+     * @param array<string, mixed> $storeOptions Metadata passed to store() for new secrets
+     * @param string $deleteReason Audit reason for the delete branch
+     * @param string $rotateReason Audit reason for the rotate branch
+     * @param callable(Throwable):string $failureMessage Builds the flash message body from the error
+     * @param (callable():void)|null $onFailure Optional rollback hook run before the flash message
+     */
+    public function persist(
+        PendingSecret $pending,
+        array $storeOptions,
+        string $deleteReason,
+        string $rotateReason,
+        callable $failureMessage,
+        ?callable $onFailure = null,
+    ): ?Throwable {
+        try {
+            if ($pending->value === '') {
+                // Empty value means delete the secret (only if one existed).
+                if ($pending->originalChecksum !== '') {
+                    $this->vaultService->delete($pending->identifier, $deleteReason);
+                }
+            } elseif ($pending->isNew) {
+                $this->vaultService->store($pending->identifier, $pending->value, $storeOptions);
+            } else {
+                // Update existing - use rotate to maintain audit trail.
+                $this->vaultService->rotate($pending->identifier, $pending->value, $rotateReason);
+            }
+
+            return null;
+        } catch (Throwable $e) {
+            if ($onFailure !== null) {
+                $onFailure();
+            }
+
+            $this->addFlashMessage($failureMessage($e), 'Vault Error', ContextualFeedbackSeverity::ERROR);
+
+            return $e;
+        }
+    }
+
+    /**
+     * Add a flash message visible to the backend user.
+     */
+    private function addFlashMessage(
+        string $message,
+        string $title,
+        ContextualFeedbackSeverity $severity,
+    ): void {
+        try {
+            $flashMessage = new FlashMessage($message, $title, $severity, true);
+            $this->flashMessageService
+                ->getMessageQueueByIdentifier()
+                ->addMessage($flashMessage);
+        } catch (Exception) {
+            // Flash message service may not be available in all contexts (e.g., CLI)
+        }
+    }
+}

--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -144,18 +144,15 @@ final class SecretTcaHook
 
             if ($secretValue !== '') {
                 try {
-                    // Build options from record data
-                    $ownerUidRaw = $record['owner_uid'] ?? 0;
-                    $scopePidRaw = $record['scope_pid'] ?? 0;
-                    $options = [
-                        'ownerUid' => is_numeric($ownerUidRaw) ? (int) $ownerUidRaw : 0,
-                        'allowedGroups' => $record['allowed_groups'] ?? '',
-                        'scopePid' => is_numeric($scopePidRaw) ? (int) $scopePidRaw : 0,
-                    ];
-
+                    // Owner/group/scope ACL is persisted via the tx_nrvault_secret
+                    // TCA columns (owner_uid, allowed_groups, scope_pid) by DataHandler
+                    // itself, so no store() options are needed here. (Previously this
+                    // passed ownerUid/allowedGroups/scopePid keys that VaultService
+                    // never reads — they read owner/groups/scope_pid — so they were
+                    // silently dropped; removed to avoid the impression they apply.)
                     if ($status === 'new') {
                         // New record - store the secret
-                        $this->vaultService->store($identifier, $secretValue, $options);
+                        $this->vaultService->store($identifier, $secretValue);
                         $secretStored = true;
                     } else {
                         // Existing record - rotate the secret

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -462,11 +462,21 @@ final class SecureHttpClientFactory
      *   ::                  (unspecified)
      *   ::1/128             (loopback)
      *   ::ffff:0:0/96       (IPv4-mapped — recurse to v4 check)
+     *   ::a.b.c.d/96        (IPv4-compatible, deprecated — recurse to v4 check)
      *   64:ff9b::/96        (NAT64 well-known prefix)
+     *   2002::/16           (6to4 — recurse on the embedded IPv4)
+     *   2001::/32           (Teredo — recurse on the embedded client+server IPv4)
      *   100::/64            (discard-only)
      *   fc00::/7            (ULA)
      *   fe80::/10           (link-local)
      *   ff00::/8            (multicast)
+     *
+     * The transition forms (6to4 / Teredo / IPv4-compatible) embed an IPv4
+     * address inside the IPv6 address. A naive range check that omits them
+     * lets an attacker smuggle a metadata/RFC1918 IPv4 target past the SSRF
+     * filter as a valid AAAA record or IP literal (CVE-2026-48736 class).
+     * Each branch decodes the embedded IPv4 and recurses into the v4 deny
+     * check, mirroring the existing NAT64/IPv4-mapped handling.
      */
     private function isDangerousIpv6(string $packed): bool
     {
@@ -499,12 +509,50 @@ final class SecureHttpClientFactory
 
         // IPv4-mapped ::ffff:0:0/96 — recurse on the embedded IPv4
         if (substr($packed, 0, 10) === str_repeat("\x00", 10) && substr($packed, 10, 2) === "\xff\xff") {
-            $v4 = inet_ntop(substr($packed, 12, 4));
+            return $this->embeddedIpv4IsDangerous(substr($packed, 12, 4));
+        }
 
-            return \is_string($v4) && $this->isDangerousIpLiteral($v4);
+        // 6to4 2002::/16 — bytes 2-5 carry the embedded IPv4 (RFC 3056).
+        if (substr($packed, 0, 2) === "\x20\x02") {
+            return $this->embeddedIpv4IsDangerous(substr($packed, 2, 4));
+        }
+
+        // Teredo 2001::/32 (prefix 2001:0000::/32, RFC 4380). The Teredo
+        // server IPv4 is bytes 4-7 verbatim; the Teredo CLIENT IPv4 is
+        // bytes 12-15 stored obfuscated (XOR 0xFFFFFFFF). Either reaching a
+        // dangerous IPv4 is enough to reject.
+        if (substr($packed, 0, 4) === "\x20\x01\x00\x00") {
+            $serverV4 = substr($packed, 4, 4);
+            $clientV4 = substr($packed, 12, 4) ^ "\xff\xff\xff\xff";
+
+            return $this->embeddedIpv4IsDangerous($serverV4)
+                || $this->embeddedIpv4IsDangerous($clientV4);
+        }
+
+        // IPv4-compatible ::a.b.c.d/96 (deprecated, RFC 4291 §2.5.5.1):
+        // first 12 bytes zero and a non-trivial trailing IPv4. `::` and `::1`
+        // are already handled above, so any remaining all-zero-prefix address
+        // here carries an embedded IPv4 we must inspect (e.g. ::127.0.0.1).
+        if (substr($packed, 0, 12) === str_repeat("\x00", 12)) {
+            return $this->embeddedIpv4IsDangerous(substr($packed, 12, 4));
         }
 
         return false;
+    }
+
+    /**
+     * Decode a 4-byte packed IPv4 address embedded inside an IPv6 transition
+     * form and recurse into the IPv4 deny check.
+     */
+    private function embeddedIpv4IsDangerous(string $packedV4): bool
+    {
+        if (\strlen($packedV4) !== 4) {
+            return false;
+        }
+
+        $v4 = inet_ntop($packedV4);
+
+        return \is_string($v4) && $this->isDangerousIpLiteral($v4);
     }
 
     /**

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -25,6 +25,18 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 final class AccessControlService implements AccessControlServiceInterface
 {
     /**
+     * Least-privilege permission tiers (ADR-005). READ is the broadest
+     * (read-tier groups + write-tier groups), WRITE is narrower (write-tier
+     * groups only), DELETE is the most restrictive (owner/admin/maintainer
+     * only — no group tier).
+     */
+    private const PERMISSION_READ = 'read';
+
+    private const PERMISSION_WRITE = 'write';
+
+    private const PERMISSION_DELETE = 'delete';
+
+    /**
      * Per-request cache of group UIDs that actually exist in the be_groups table.
      * Reset only for the lifetime of the service instance.
      *
@@ -39,17 +51,17 @@ final class AccessControlService implements AccessControlServiceInterface
 
     public function canRead(Secret $secret): bool
     {
-        return $this->hasAccess($secret);
+        return $this->hasAccess($secret, self::PERMISSION_READ);
     }
 
     public function canWrite(Secret $secret): bool
     {
-        return $this->hasAccess($secret);
+        return $this->hasAccess($secret, self::PERMISSION_WRITE);
     }
 
     public function canDelete(Secret $secret): bool
     {
-        return $this->hasAccess($secret);
+        return $this->hasAccess($secret, self::PERMISSION_DELETE);
     }
 
     public function canCreate(): bool
@@ -210,15 +222,17 @@ final class AccessControlService implements AccessControlServiceInterface
     }
 
     /**
-     * Check access to a secret.
+     * Check access to a secret for a given permission tier.
+     *
+     * @param self::PERMISSION_* $permission
      */
-    private function hasAccess(Secret $secret): bool
+    private function hasAccess(Secret $secret, string $permission): bool
     {
         $backendUser = $this->getBackendUser();
 
         // Backend user takes precedence
         if ($backendUser instanceof BackendUserAuthentication) {
-            return $this->hasBackendUserAccess($backendUser, $secret);
+            return $this->hasBackendUserAccess($backendUser, $secret, $permission);
         }
 
         // CLI access control (only when no backend user)
@@ -230,26 +244,43 @@ final class AccessControlService implements AccessControlServiceInterface
             // Check CLI access groups if configured
             $cliAccessGroups = $this->configuration->getCliAccessGroups();
             if ($cliAccessGroups !== []) {
-                $secretGroups = $secret->getAllowedGroups();
+                // The trusted CLI operator is scoped to the configured
+                // groups. The applicable secret-group set widens with the
+                // permission tier: read may match read- OR write-tier
+                // groups, write only write-tier groups, delete has no group
+                // tier at all (owner/admin/maintainer-only — none of which a
+                // CLI actor is — so group-restricted CLI cannot delete).
+                $secretGroups = $this->secretGroupsForPermission($secret, $permission);
 
                 return array_intersect($secretGroups, $cliAccessGroups) !== [];
             }
 
-            // CLI allowed and no group restrictions
+            // CLI allowed and no group restrictions: trusted operator gets
+            // the requested tier.
             return true;
         }
 
-        // Frontend access for secrets explicitly marked as frontend_accessible
-        // This allows TypoScript and other frontend contexts to resolve vault placeholders
-        // No backend user and not CLI
+        // Frontend access for secrets explicitly marked as frontend_accessible.
+        // This allows TypoScript and other frontend contexts to resolve vault
+        // placeholders. Frontend is READ-ONLY — write/delete are never granted
+        // without a backend or CLI actor. No backend user and not CLI.
+        if ($permission !== self::PERMISSION_READ) {
+            return false;
+        }
+
         return $secret->isFrontendAccessible();
     }
 
     /**
-     * Check if backend user has access to a secret.
+     * Check if backend user has access to a secret for a permission tier.
+     *
+     * @param self::PERMISSION_* $permission
      */
-    private function hasBackendUserAccess(BackendUserAuthentication $backendUser, Secret $secret): bool
-    {
+    private function hasBackendUserAccess(
+        BackendUserAuthentication $backendUser,
+        Secret $secret,
+        string $permission,
+    ): bool {
         // BUG FIX: Defence-in-depth — disabled users must be rejected even if
         // their BE_USER session somehow reaches this layer. TYPO3 core normally
         // blocks disabled users earlier, but the vault MUST NOT rely on that
@@ -258,17 +289,17 @@ final class AccessControlService implements AccessControlServiceInterface
             return false;
         }
 
-        // Admin access
+        // Admin access — full access to every tier.
         if ($backendUser->isAdmin()) {
             return true;
         }
 
-        // System maintainer access
+        // System maintainer access — full access to every tier.
         if ($backendUser->isSystemMaintainer()) {
             return true;
         }
 
-        // Owner access
+        // Owner access — full access to every tier (read/write/delete).
         /** @phpstan-ignore property.internal */
         $userRecord = $backendUser->user;
         /** @var array<string, mixed> $userRecordTyped */
@@ -278,8 +309,10 @@ final class AccessControlService implements AccessControlServiceInterface
             return true;
         }
 
-        // Group access
-        $secretGroups = $secret->getAllowedGroups();
+        // Group access — the applicable secret-group set depends on the tier
+        // (least-privilege split, ADR-005). DELETE has no group tier, so the
+        // applicable set is empty and group members can never delete.
+        $secretGroups = $this->secretGroupsForPermission($secret, $permission);
         if ($secretGroups !== []) {
             // BUG FIX: Filter out stale / deleted group UIDs before the
             // intersection check. A deleted group whose UID is still in the
@@ -292,6 +325,30 @@ final class AccessControlService implements AccessControlServiceInterface
         }
 
         return false;
+    }
+
+    /**
+     * Resolve which secret group UIDs grant the requested permission tier:
+     *
+     * - READ:   read-tier (`allowedGroups`) ∪ write-tier (`writeGroups`)
+     *           — a write-tier member can always read.
+     * - WRITE:  write-tier (`writeGroups`) only.
+     * - DELETE: no group tier — deletion is owner/admin/maintainer-only.
+     *
+     * @param self::PERMISSION_* $permission
+     *
+     * @return int[]
+     */
+    private function secretGroupsForPermission(Secret $secret, string $permission): array
+    {
+        return match ($permission) {
+            self::PERMISSION_READ => array_values(array_unique(array_merge(
+                $secret->getAllowedGroups(),
+                $secret->getWriteGroups(),
+            ))),
+            self::PERMISSION_WRITE => $secret->getWriteGroups(),
+            self::PERMISSION_DELETE => [],
+        };
     }
 
     /**

--- a/Classes/Security/AccessControlServiceInterface.php
+++ b/Classes/Security/AccessControlServiceInterface.php
@@ -17,17 +17,30 @@ use Netresearch\NrVault\Domain\Model\Secret;
 interface AccessControlServiceInterface
 {
     /**
-     * Check if current user can read a secret.
+     * Check if the current actor can READ a secret.
+     *
+     * Granted to: owner, admin, system maintainer, read-tier groups
+     * (`allowedGroups`) and write-tier groups (`writeGroups`), CLI (when
+     * allowed), and any frontend/API context for `frontend_accessible`
+     * secrets. The broadest tier (ADR-005 least-privilege split).
      */
     public function canRead(Secret $secret): bool;
 
     /**
-     * Check if current user can write/update a secret.
+     * Check if the current actor can WRITE/UPDATE a secret.
+     *
+     * Granted to: owner, admin, system maintainer, and write-tier groups
+     * (`writeGroups`). NOT granted to read-tier groups or the frontend
+     * (ADR-005 least-privilege split).
      */
     public function canWrite(Secret $secret): bool;
 
     /**
-     * Check if current user can delete a secret.
+     * Check if the current actor can DELETE a secret.
+     *
+     * The most restrictive tier: granted only to owner, admin, and system
+     * maintainer. No group tier — neither read- nor write-tier group
+     * members can delete (ADR-005 least-privilege split).
      */
     public function canDelete(Secret $secret): bool;
 

--- a/Classes/Service/VaultHealthService.php
+++ b/Classes/Service/VaultHealthService.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service;
+
+use Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Read-only health probe for the master-key / encryption subsystem.
+ *
+ * Services may depend on Crypto; controllers must not (ARCHITECTURE-2). This
+ * service therefore owns the master-key liveness check that previously lived
+ * in {@see \Netresearch\NrVault\Controller\OverviewController}.
+ *
+ * Per SEC-INJECTION-LEAK-2 it never returns raw exception messages (which can
+ * carry the master-key file path): failures are logged via PSR-3 and the
+ * caller only learns the booleans + provider identifier.
+ */
+final readonly class VaultHealthService implements VaultHealthServiceInterface
+{
+    public function __construct(
+        private MasterKeyProviderFactoryInterface $masterKeyProviderFactory,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function checkHealth(): VaultHealthStatus
+    {
+        $masterKeyAvailable = false;
+        $masterKeyProvider = '';
+        $encryptionWorking = false;
+        $hasIssues = false;
+
+        try {
+            $provider = $this->masterKeyProviderFactory->getAvailableProvider();
+            $masterKeyProvider = $provider->getIdentifier();
+
+            if ($provider->isAvailable()) {
+                $masterKeyAvailable = true;
+
+                // Can we actually derive/read the master key?
+                try {
+                    $key = $provider->getMasterKey();
+                    if ($key === '') {
+                        $hasIssues = true;
+                        $this->logger->warning(
+                            'Vault health check: master key provider returned an empty key.',
+                            ['provider' => $masterKeyProvider],
+                        );
+                    } else {
+                        $encryptionWorking = true;
+                        sodium_memzero($key);
+                    }
+                } catch (Throwable $e) {
+                    $hasIssues = true;
+                    // Detail (may include a key file path) goes to the log only.
+                    $this->logger->warning(
+                        'Vault health check: master key could not be read.',
+                        ['provider' => $masterKeyProvider, 'exception' => $e->getMessage()],
+                    );
+                }
+            } else {
+                $hasIssues = true;
+                $this->logger->warning(
+                    'Vault health check: master key provider is configured but not available.',
+                    ['provider' => $masterKeyProvider],
+                );
+            }
+        } catch (Throwable $e) {
+            $hasIssues = true;
+            $this->logger->warning(
+                'Vault health check: no master key provider available.',
+                ['exception' => $e->getMessage()],
+            );
+        }
+
+        return new VaultHealthStatus(
+            masterKeyAvailable: $masterKeyAvailable,
+            masterKeyProvider: $masterKeyProvider,
+            encryptionWorking: $encryptionWorking,
+            hasIssues: $hasIssues,
+        );
+    }
+}

--- a/Classes/Service/VaultHealthServiceInterface.php
+++ b/Classes/Service/VaultHealthServiceInterface.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service;
+
+/**
+ * Read-only health probe for the vault master-key / encryption subsystem.
+ *
+ * Exists so that presentation-layer controllers can render a setup/health
+ * panel WITHOUT depending on the Crypto namespace directly (ARCHITECTURE-2):
+ * the probe talks to the master-key providers; the controller talks only to
+ * this service.
+ */
+interface VaultHealthServiceInterface
+{
+    /**
+     * Probe whether a master key provider is configured, available, and able
+     * to yield a usable key (encryption self-test).
+     *
+     * Never returns raw exception text or key material — failures are logged
+     * via PSR-3 and reduced to the booleans / provider id on the result.
+     */
+    public function checkHealth(): VaultHealthStatus;
+}

--- a/Classes/Service/VaultHealthStatus.php
+++ b/Classes/Service/VaultHealthStatus.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service;
+
+/**
+ * Immutable result of a vault health probe.
+ *
+ * Carries only operational booleans, the provider identifier, and generic,
+ * already-localizable UI hint keys — never raw exception text or key material.
+ * Detailed error context is logged via PSR-3 inside {@see VaultHealthService},
+ * not surfaced here (see SEC-INJECTION-LEAK-2).
+ */
+final readonly class VaultHealthStatus
+{
+    public function __construct(
+        public bool $masterKeyAvailable,
+        public string $masterKeyProvider,
+        public bool $encryptionWorking,
+        public bool $hasIssues,
+    ) {}
+}

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -14,6 +14,7 @@ namespace Netresearch\NrVault\Service;
 
 use DateTimeInterface;
 use Netresearch\NrVault\Adapter\VaultAdapterInterface;
+use Netresearch\NrVault\Audit\AuditAction;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\EncryptedData;
@@ -28,6 +29,7 @@ use Netresearch\NrVault\Event\SecretDeletedEvent;
 use Netresearch\NrVault\Event\SecretRotatedEvent;
 use Netresearch\NrVault\Event\SecretUpdatedEvent;
 use Netresearch\NrVault\Exception\AccessDeniedException;
+use Netresearch\NrVault\Exception\AuditWriteException;
 use Netresearch\NrVault\Exception\EncryptionException;
 use Netresearch\NrVault\Exception\SecretExpiredException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
@@ -37,7 +39,9 @@ use Netresearch\NrVault\Http\VaultHttpClientInterface;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Netresearch\NrVault\Utility\IdentifierValidator;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
 use SensitiveParameter;
+use Throwable;
 use TYPO3\CMS\Core\SingletonInterface;
 
 /**
@@ -56,6 +60,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
         private readonly ExtensionConfigurationInterface $configuration,
         private readonly VaultHttpClientFactoryInterface $httpClientFactory,
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
+        private readonly ?LoggerInterface $logger = null,
     ) {}
 
     public function __destruct()
@@ -87,15 +92,39 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             // instance from the repository's INSERT.
             $secretEntity = $this->adapter->store($secretEntity);
 
-            $this->auditLogService->log(
-                $identifier,
-                $existing instanceof Secret ? 'update' : 'create',
-                true,
-                null,
-                null,
-                $existing?->getValueChecksum(),
-                $encrypted->valueChecksum,
-            );
+            // SEC-3 atomicity: the mutation and its tamper-evident audit
+            // entry MUST be all-or-nothing. A single shared DB transaction is
+            // NOT usable here — AuditLogService manages its own transaction
+            // lifecycle (SQLite `BEGIN EXCLUSIVE`/`COMMIT`, MySQL advisory
+            // GET_LOCK), so nesting log() inside an outer transaction would
+            // either error or prematurely commit the mutation. We therefore
+            // compensate: if the audit write throws, revert the adapter change
+            // so a secret never persists without an audit record.
+            try {
+                $this->auditLogService->log(
+                    $identifier,
+                    $existing instanceof Secret ? AuditAction::Update->value : AuditAction::Create->value,
+                    true,
+                    null,
+                    null,
+                    $existing?->getValueChecksum(),
+                    $encrypted->valueChecksum,
+                );
+            } catch (AuditWriteException $auditException) {
+                $this->compensateAuditFailure(
+                    $identifier,
+                    function () use ($existing, $identifier): void {
+                        if ($existing instanceof Secret) {
+                            // Update: restore the prior encrypted envelope/version.
+                            $this->adapter->store($existing);
+                        } else {
+                            // Create: remove the just-inserted record.
+                            $this->adapter->delete($identifier);
+                        }
+                    },
+                    $auditException,
+                );
+            }
 
             $this->dispatchStoreEvent($identifier, $secretEntity, !$existing instanceof Secret);
 
@@ -120,14 +149,14 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
 
         // Check access
         if (!$this->accessControlService->canRead($secret)) {
-            $this->auditLogService->log($identifier, 'access_denied', false, 'Read access denied');
+            $this->auditLogService->log($identifier, AuditAction::AccessDenied->value, false, 'Read access denied');
 
             throw AccessDeniedException::forIdentifier($identifier, 'insufficient permissions');
         }
 
         // Check expiration
         if ($secret->isExpired()) {
-            $this->auditLogService->log($identifier, 'read', false, 'Secret has expired');
+            $this->auditLogService->log($identifier, AuditAction::Read->value, false, 'Secret has expired');
 
             throw SecretExpiredException::forIdentifier($identifier, $secret->getExpiresAt());
         }
@@ -142,7 +171,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
                 $identifier,
             );
         } catch (EncryptionException $e) {
-            $this->auditLogService->log($identifier, 'read', false, 'Decryption failed: ' . $e->getMessage());
+            $this->auditLogService->log($identifier, AuditAction::Read->value, false, 'Decryption failed: ' . $e->getMessage());
 
             throw $e;
         }
@@ -155,7 +184,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
 
         // Log success (can be disabled for high-throughput scenarios)
         if ($this->configuration->isAuditReadsEnabled()) {
-            $this->auditLogService->log($identifier, 'read', true);
+            $this->auditLogService->log($identifier, AuditAction::Read->value, true);
         }
 
         // Dispatch PSR-14 event
@@ -187,7 +216,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
 
         // Check access
         if (!$this->accessControlService->canDelete($secret)) {
-            $this->auditLogService->log($identifier, 'access_denied', false, 'Delete access denied');
+            $this->auditLogService->log($identifier, AuditAction::AccessDenied->value, false, 'Delete access denied');
 
             throw AccessDeniedException::forIdentifier($identifier, 'delete permission denied');
         }
@@ -197,15 +226,27 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
         // Delete
         $this->adapter->delete($identifier);
 
-        // Log
-        $this->auditLogService->log(
-            $identifier,
-            'delete',
-            true,
-            null,
-            $reason,
-            $hashBefore,
-        );
+        // SEC-3 atomicity (compensating rollback — see store() for rationale):
+        // if the audit write fails, re-insert the just-deleted record so a
+        // delete never persists without a tamper-evident audit entry.
+        try {
+            $this->auditLogService->log(
+                $identifier,
+                AuditAction::Delete->value,
+                true,
+                null,
+                $reason,
+                $hashBefore,
+            );
+        } catch (AuditWriteException $auditException) {
+            $this->compensateAuditFailure(
+                $identifier,
+                function () use ($secret): void {
+                    $this->adapter->store($secret);
+                },
+                $auditException,
+            );
+        }
 
         // Dispatch PSR-14 event
         $this->eventDispatcher?->dispatch(new SecretDeletedEvent(
@@ -227,7 +268,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
 
         // Check access
         if (!$this->accessControlService->canWrite($secret)) {
-            $this->auditLogService->log($identifier, 'access_denied', false, 'Rotate access denied');
+            $this->auditLogService->log($identifier, AuditAction::AccessDenied->value, false, 'Rotate access denied');
 
             throw AccessDeniedException::forIdentifier($identifier, 'rotate permission denied');
         }
@@ -238,6 +279,9 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
 
         try {
             $hashBefore = $secret->getValueChecksum();
+
+            // Keep the pre-rotation instance for compensating rollback.
+            $previousSecret = $secret;
 
             // Encrypt the new secret
             $encrypted = $this->encryptionService->encrypt($newSecret, $identifier);
@@ -250,16 +294,29 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             // result to stay consistent with the create path).
             $secret = $this->adapter->store($secret);
 
-            // Log
-            $this->auditLogService->log(
-                $identifier,
-                'rotate',
-                true,
-                null,
-                $reason,
-                $hashBefore,
-                $encrypted->valueChecksum,
-            );
+            // SEC-3 atomicity (compensating rollback — see store() for
+            // rationale): if the audit write fails, restore the previous
+            // envelope/version so a rotation never persists without a
+            // tamper-evident audit entry.
+            try {
+                $this->auditLogService->log(
+                    $identifier,
+                    AuditAction::Rotate->value,
+                    true,
+                    null,
+                    $reason,
+                    $hashBefore,
+                    $encrypted->valueChecksum,
+                );
+            } catch (AuditWriteException $auditException) {
+                $this->compensateAuditFailure(
+                    $identifier,
+                    function () use ($previousSecret): void {
+                        $this->adapter->store($previousSecret);
+                    },
+                    $auditException,
+                );
+            }
 
             // Dispatch PSR-14 event
             $this->eventDispatcher?->dispatch(new SecretRotatedEvent(
@@ -316,7 +373,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
 
         // Check access
         if (!$this->accessControlService->canRead($secret)) {
-            $this->auditLogService->log($identifier, 'access_denied', false, 'Metadata access denied');
+            $this->auditLogService->log($identifier, AuditAction::AccessDenied->value, false, 'Metadata access denied');
 
             throw AccessDeniedException::forIdentifier($identifier, 'insufficient permissions');
         }
@@ -343,6 +400,53 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
     }
 
     /**
+     * Compensate a failed audit write by reverting the just-applied mutation,
+     * then re-throw the original `AuditWriteException` so the caller sees the
+     * real cause.
+     *
+     * The revert is itself guarded: if it throws (e.g. the same DB fault that
+     * broke the audit write also breaks the revert), the mutation has persisted
+     * WITHOUT a tamper-evident audit record — a violation of the SEC-3
+     * all-or-nothing invariant. We log that inconsistency at CRITICAL (with the
+     * identifier, never the secret value) so it can be reconciled, chain the
+     * revert failure onto the original exception as `previous`, and still
+     * surface the original `AuditWriteException` as the thrown type.
+     *
+     * @param callable():void $revert Reapplies the pre-mutation adapter state.
+     */
+    private function compensateAuditFailure(
+        string $identifier,
+        callable $revert,
+        AuditWriteException $auditException,
+    ): never {
+        try {
+            $revert();
+        } catch (Throwable $revertFailure) {
+            $this->logger?->critical(
+                'Vault inconsistency: mutation persisted without an audit record; '
+                . 'the compensating rollback also failed. Manual reconciliation required.',
+                [
+                    'identifier' => $identifier,
+                    'auditError' => $auditException->getMessage(),
+                    'rollbackError' => $revertFailure->getMessage(),
+                ],
+            );
+
+            unset($this->cache[$identifier]);
+
+            throw new AuditWriteException(
+                $auditException->getMessage(),
+                $auditException->getCode(),
+                $revertFailure,
+            );
+        }
+
+        unset($this->cache[$identifier]);
+
+        throw $auditException;
+    }
+
+    /**
      * Verify the current actor can create-or-update this secret. Logs the
      * denial and throws `AccessDeniedException` on rejection.
      *
@@ -353,7 +457,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
     {
         if (!$existing instanceof Secret) {
             if (!$this->accessControlService->canCreate()) {
-                $this->auditLogService->log($identifier, 'access_denied', false, 'Create access denied');
+                $this->auditLogService->log($identifier, AuditAction::AccessDenied->value, false, 'Create access denied');
 
                 throw AccessDeniedException::forIdentifier($identifier, 'create permission denied');
             }
@@ -361,7 +465,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             return;
         }
         if (!$this->accessControlService->canWrite($existing)) {
-            $this->auditLogService->log($identifier, 'access_denied', false, 'Update access denied');
+            $this->auditLogService->log($identifier, AuditAction::AccessDenied->value, false, 'Update access denied');
 
             throw AccessDeniedException::forIdentifier($identifier, 'update permission denied');
         }
@@ -396,7 +500,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             ownerUid: $this->resolveOwnerUid($options, $existing),
             allowedGroups: $optional['allowedGroups'],
             context: $optional['context'],
-            frontendAccessible: $optional['frontendAccessible'],
+            frontendAccessible: $this->resolveFrontendAccessible($optional['frontendAccessible'], $existing),
             version: $existing instanceof Secret ? $existing->getVersion() : 1,
             expiresAt: $optional['expiresAt'],
             metadata: $optional['metadata'],
@@ -431,6 +535,31 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
         }
 
         return $requestedOwner;
+    }
+
+    /**
+     * `frontend_accessible` is privileged: it flips a secret from
+     * "encrypted, ACL-gated" to "readable by any frontend/api code path".
+     * Mirroring the `owner_uid` coercion, a non-admin BACKEND caller that
+     * tries to mark a secret frontend-accessible is silently coerced back
+     * to the secret's prior value (false on create, the existing flag on
+     * update). CLI/api/scheduler actor types are trusted callers and are
+     * not coerced (a non-BE programmatic caller already controls the call,
+     * consistent with `resolveOwnerUid`).
+     */
+    private function resolveFrontendAccessible(bool $requested, ?Secret $existing): bool
+    {
+        $default = $existing instanceof Secret && $existing->isFrontendAccessible();
+        if ($requested === $default) {
+            return $default;
+        }
+        if ($this->accessControlService->getCurrentActorType() === 'backend'
+            && !$this->accessControlService->isCurrentActorAdmin()
+        ) {
+            return $default;
+        }
+
+        return $requested;
     }
 
     /**

--- a/Classes/Task/OrphanCleanupTask.php
+++ b/Classes/Task/OrphanCleanupTask.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Task;
 
 use Netresearch\NrVault\Domain\Dto\OrphanReference;
+use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
@@ -33,6 +34,9 @@ use TYPO3\CMS\Scheduler\Task\AbstractTask;
  */
 final class OrphanCleanupTask extends AbstractTask
 {
+    /** Page size for the UID-windowed secret scan (bounds peak memory). */
+    private const PAGE_SIZE = 200;
+
     /** Only delete orphans older than this many days. */
     protected int $retentionDays = 7;
 
@@ -43,6 +47,7 @@ final class OrphanCleanupTask extends AbstractTask
         private readonly ?ConnectionPool $connectionPool = null,
         private readonly ?VaultServiceInterface $vaultService = null,
         private readonly ?LogManager $logManager = null,
+        private readonly ?SecretRepositoryInterface $secretRepository = null,
     ) {
         parent::__construct();
     }
@@ -80,6 +85,7 @@ final class OrphanCleanupTask extends AbstractTask
     {
         $vaultService = $this->getVaultService();
         $connectionPool = $this->getConnectionPool();
+        $repository = $this->getSecretRepository();
         $logger = $this->getLogger();
 
         $logger->info('Starting vault orphan cleanup', [
@@ -87,65 +93,78 @@ final class OrphanCleanupTask extends AbstractTask
             'tableFilter' => $this->tableFilter ?: '(all)',
         ]);
 
-        // Get all TCA-sourced secrets
-        $allSecrets = $vaultService->list();
         $retentionCutoff = $this->retentionDays > 0
             ? time() - ($this->retentionDays * 86400)
             : PHP_INT_MAX;
 
-        $orphans = [];
+        // Walk the vault in UID-windowed pages so peak memory is bounded by
+        // the page size, not the total vault size (PERFORMANCE-8). Identify
+        // and delete orphans page-by-page; deletes still route through
+        // VaultService (ACL + audit preserved).
+        $afterUid = 0;
         $checked = 0;
+        $orphansFound = 0;
+        $success = true;
 
-        foreach ($allSecrets as $secret) {
-            $metadata = $secret->metadata;
-            $source = $metadata['source'] ?? '';
-
-            // Only check TCA-sourced secrets
-            if ($source !== 'tca_field' && $source !== 'migration') {
-                continue;
+        do {
+            $page = $repository->findPaginatedAfterUid($afterUid, self::PAGE_SIZE);
+            if ($page === []) {
+                break;
             }
 
-            // Extract reference from metadata (table, field, uid are stored by DataHandlerHook)
-            $reference = $this->parseMetadataReference($metadata);
-            if (!$reference instanceof OrphanReference) {
-                continue;
-            }
+            foreach ($page as $secret) {
+                $uid = $secret->getUid();
+                if ($uid !== null) {
+                    $afterUid = max($afterUid, $uid);
+                }
 
-            // Apply table filter if specified
-            if ($this->tableFilter !== '' && $reference->table !== $this->tableFilter) {
-                continue;
-            }
+                $metadata = $secret->getMetadata();
+                $source = $metadata['source'] ?? '';
 
-            $checked++;
-            $identifier = $secret->identifier;
-            $createdAt = $secret->createdAt;
+                // Only check TCA-sourced secrets
+                if ($source !== 'tca_field' && $source !== 'migration') {
+                    continue;
+                }
 
-            // Check if record still exists
-            // Only include if older than retention period
-            if (!$this->recordExists($connectionPool, $reference->table, $reference->uid) && $createdAt < $retentionCutoff) {
-                $orphans[] = $identifier;
+                // Extract reference from metadata (table, field, uid are stored by DataHandlerHook)
+                $reference = $this->parseMetadataReference($metadata);
+                if (!$reference instanceof OrphanReference) {
+                    continue;
+                }
+
+                // Apply table filter if specified
+                if ($this->tableFilter !== '' && $reference->table !== $this->tableFilter) {
+                    continue;
+                }
+
+                $checked++;
+                $createdAt = $secret->getCrdate();
+
+                // Only delete if the source record is gone AND the secret is
+                // older than the retention period.
+                if ($this->recordExists($connectionPool, $reference->table, $reference->uid) || $createdAt >= $retentionCutoff) {
+                    continue;
+                }
+
+                $orphansFound++;
+
+                try {
+                    $vaultService->delete($secret->getIdentifier(), 'Scheduler orphan cleanup');
+                    $logger->info('Deleted orphan secret', ['identifier' => $secret->getIdentifier()]);
+                } catch (Throwable $e) {
+                    $logger->error('Failed to delete orphan secret', [
+                        'identifier' => $secret->getIdentifier(),
+                        'error' => $e->getMessage(),
+                    ]);
+                    $success = false;
+                }
             }
-        }
+        } while (\count($page) === self::PAGE_SIZE);
 
         $logger->info('Orphan check complete', [
             'secretsChecked' => $checked,
-            'orphansFound' => \count($orphans),
+            'orphansFound' => $orphansFound,
         ]);
-
-        // Delete identified orphans
-        $success = true;
-        foreach ($orphans as $orphanIdentifier) {
-            try {
-                $vaultService->delete($orphanIdentifier, 'Scheduler orphan cleanup');
-                $logger->info('Deleted orphan secret', ['identifier' => $orphanIdentifier]);
-            } catch (Throwable $e) {
-                $logger->error('Failed to delete orphan secret', [
-                    'identifier' => $orphanIdentifier,
-                    'error' => $e->getMessage(),
-                ]);
-                $success = false;
-            }
-        }
 
         return $success;
     }
@@ -219,6 +238,11 @@ final class OrphanCleanupTask extends AbstractTask
     private function getVaultService(): VaultServiceInterface
     {
         return $this->vaultService ?? GeneralUtility::makeInstance(VaultServiceInterface::class);
+    }
+
+    private function getSecretRepository(): SecretRepositoryInterface
+    {
+        return $this->secretRepository ?? GeneralUtility::makeInstance(SecretRepositoryInterface::class);
     }
 
     private function getConnectionPool(): ConnectionPool

--- a/Classes/Utility/FlexFormVaultResolver.php
+++ b/Classes/Utility/FlexFormVaultResolver.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrVault\Utility;
 use Netresearch\NrVault\Exception\VaultException;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 
 /**
  * Service for resolving vault secrets in FlexForm data.
@@ -41,6 +42,7 @@ final readonly class FlexFormVaultResolver
     public function __construct(
         private VaultServiceInterface $vaultService,
         private LoggerInterface $logger,
+        private TcaSchemaFactory $tcaSchemaFactory,
     ) {}
 
     /**
@@ -117,6 +119,35 @@ final readonly class FlexFormVaultResolver
         }
 
         return (bool) preg_match(self::UUID_PATTERN, $value);
+    }
+
+    /**
+     * Get the FlexForm (type 'flex') field names for a table from its TCA schema.
+     *
+     * Used by the DataHandler FlexForm hook to discover which fields may carry
+     * vault secrets, so the discovery logic lives in one place.
+     *
+     * @param string $table The table name
+     *
+     * @return list<string> Field names that are FlexForm fields
+     */
+    public function getFlexFieldsForTable(string $table): array
+    {
+        if (!$this->tcaSchemaFactory->has($table)) {
+            return [];
+        }
+
+        $schema = $this->tcaSchemaFactory->get($table);
+        $flexFields = [];
+
+        foreach ($schema->getFields() as $field) {
+            $configType = $field->getConfiguration()['type'] ?? '';
+            if (\is_string($configType) && $configType === 'flex') {
+                $flexFields[] = $field->getName();
+            }
+        }
+
+        return $flexFields;
     }
 
     /**

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -21,6 +21,7 @@ services:
   # `GeneralUtility::makeInstance(<Interface>::class)` — verified by
   # grepping `Classes/` + `Tests/Functional/` + `Tests/Fuzz/`:
   #   - VaultServiceInterface: 3 sites (Form/Element/Task)
+  #   - SecretRepositoryInterface: OrphanCleanupTask scheduler context
   # Every other alias resolves via constructor DI only and can stay private.
 
   Netresearch\NrVault\Configuration\ExtensionConfigurationInterface:
@@ -50,6 +51,14 @@ services:
 
   Netresearch\NrVault\Adapter\VaultAdapterInterface:
     alias: Netresearch\NrVault\Adapter\LocalEncryptionAdapter
+
+  Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface:
+    alias: Netresearch\NrVault\Domain\Repository\SecretRepository
+    # public: OrphanCleanupTask runs in the scheduler context (unserialized
+    # with null ctor args) and resolves the repository via
+    # GeneralUtility::makeInstance(SecretRepositoryInterface::class) for its
+    # UID-windowed orphan scan — which requires a public alias.
+    public: true
 
   Netresearch\NrVault\Service\SecretDetectionServiceInterface:
     alias: Netresearch\NrVault\Service\SecretDetectionService

--- a/Configuration/TCA/tx_nrvault_secret.php
+++ b/Configuration/TCA/tx_nrvault_secret.php
@@ -21,6 +21,11 @@ return [
         'tstamp' => 'tstamp',
         'crdate' => 'crdate',
         'delete' => 'deleted',
+        'default_sortby' => 'identifier ASC',
+        // searchFields is ignored on v14 (option removed, see #106972 — the
+        // backend derives searchable fields from per-column `searchable`
+        // flags there) but enables backend live-search on v13.
+        'searchFields' => 'identifier,description,context',
         'hideTable' => false,
         'enablecolumns' => [
             'disabled' => 'hidden',
@@ -76,6 +81,7 @@ return [
 
         'description' => [
             'label' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.description',
+            'description' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.description.description',
             'config' => [
                 'type' => 'text',
                 'rows' => 3,
@@ -113,6 +119,24 @@ return [
                 'maxitems' => 20,
                 'minitems' => 0,
                 'MM' => 'tx_nrvault_secret_begroups_mm',
+                'suggestOptions' => [
+                    'default' => [
+                        'additionalSearchFields' => 'description',
+                    ],
+                ],
+            ],
+        ],
+
+        'write_groups' => [
+            'label' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.write_groups',
+            'description' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.write_groups.description',
+            'config' => [
+                'type' => 'group',
+                'allowed' => 'be_groups',
+                'size' => 5,
+                'maxitems' => 20,
+                'minitems' => 0,
+                'MM' => 'tx_nrvault_secret_writegroups_mm',
                 'suggestOptions' => [
                     'default' => [
                         'additionalSearchFields' => 'description',
@@ -231,6 +255,7 @@ return [
                 --div--;LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tabs.access,
                     owner_uid,
                     allowed_groups,
+                    write_groups,
                     frontend_accessible,
                 --div--;LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tabs.settings,
                     context,

--- a/Documentation/CLAUDE.md
+++ b/Documentation/CLAUDE.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -83,6 +83,54 @@ Configure nr-vault in :guilabel:`Admin Tools > Settings > Extension Configuratio
 
    Number of days to retain audit log entries. Set to 0 for unlimited retention.
 
+.. confval:: auditReads
+   :name: ext-nrvault-auditReads
+   :type: boolean
+   :Default: true
+
+   Log every secret *read* to the audit log. Disable only for
+   high-throughput scenarios where read logging is not required.
+
+   .. warning::
+
+      Disabling read logging means secret retrievals leave no audit
+      trail. The toggle is configurable by design
+      (see :ref:`adr-019-configurable-audit-read-logging`), but flipping
+      it does not itself emit a sentinel entry. For tamper-resistant
+      deployments, pin the value filesystem-only via
+      :file:`config/system/additional.php` so it cannot be changed from
+      the backend Settings module:
+
+      .. code-block:: php
+
+         $GLOBALS['TYPO3_CONF_VARS']['SYS']['nrVault']['auditReads'] = true;
+
+.. confval:: auditHmacEpoch
+   :name: ext-nrvault-auditHmacEpoch
+   :type: integer
+   :Default: 2
+
+   Hash-algorithm version marker for the audit log hash chain:
+
+   0
+      Legacy SHA-256 without HMAC.
+
+   1
+      HMAC-SHA256 over identity fields only.
+
+   2
+      HMAC-SHA256 over identity **and** forensic fields (``success``,
+      ``error_message``, ``reason``, ``ip_address``, ``user_agent``,
+      ``context``).
+
+   The default (``2``) binds the forensic surface into the chain so a
+   DB-write attacker cannot flip ``success`` or rewrite
+   ``error_message`` without breaking the chain. After raising this
+   value, run the Install Tool wizard *Migrate audit hash chain* (or
+   the :ref:`vault:audit-migrate-hmac <command-audit-migrate-hmac>`
+   command) to re-hash existing rows. See
+   :ref:`adr-023-audit-hash-chain-hmac`.
+
 .. confval:: preferXChaCha20
    :name: ext-nrvault-preferXChaCha20
    :type: boolean

--- a/Documentation/Developer/Adr/ADR-020-MasterKeyRequestLifetimeCaching.rst
+++ b/Documentation/Developer/Adr/ADR-020-MasterKeyRequestLifetimeCaching.rst
@@ -39,16 +39,37 @@ Cache the derived master key in memory for the lifetime of the current
 request:
 
 -  On first access, the master key provider reads/derives the key and
-   stores it in a private property.
+   stores it in a request-lifetime cache slot.
 -  Subsequent decrypt operations within the same request reuse the cached
    key without additional I/O or derivation.
--  On object destruction (end of request), the cached key material is
-   securely wiped using ``sodium_memzero()`` to prevent it from lingering
-   in process memory.
+-  The cache lives in the shared ``AbstractMasterKeyProvider`` base class,
+   keyed by concrete provider class, so each provider keeps an isolated
+   slot and ``clearCachedKey()`` on one provider never wipes another's.
+-  All providers expose a static ``clearCachedKey()`` (declared on
+   ``MasterKeyProviderInterface``) that wipes the cached key material via
+   ``sodium_memzero()``.
 
 This follows the principle of minimizing key material exposure: the key
 exists in memory only for the duration of the request and is actively
 cleared rather than left for garbage collection.
+
+Wipe lifecycle differs by provider
+----------------------------------
+
+The cache is wiped by two distinct mechanisms depending on the provider:
+
+-  **FileMasterKeyProvider / EnvironmentMasterKeyProvider** define a
+   ``__destruct()`` that calls ``clearCachedKey()``. When the provider
+   instance is garbage-collected (typically at end of request), the cached
+   key is zeroed.
+-  **Typo3MasterKeyProvider** (the default) deliberately has **no**
+   ``__destruct()``. Its cache slot is shared across instances, so wiping
+   on the first instance's destruction would break the rest of the request.
+   For this provider the cache is zeroed only by an explicit
+   ``clearCachedKey()`` call or implicitly when PHP frees statics at script
+   shutdown. Long-running processes (scheduler tasks, daemons) that must
+   observe a rotated TYPO3 ``encryptionKey`` should call
+   ``clearCachedKey()`` explicitly.
 
 Consequences
 ============
@@ -58,18 +79,26 @@ Positive
 
 -  **One key derivation per request** instead of per-decrypt, eliminating
    redundant I/O and HKDF computations.
--  **Secure cleanup**: ``sodium_memzero()`` on destruct ensures key material
-   does not persist in memory beyond the request.
--  **Transparent**: No API changes; callers are unaware of the caching.
+-  **Secure cleanup**: ``sodium_memzero()`` wipes key material — via
+   ``__destruct()`` for the File/Env providers and via an explicit
+   ``clearCachedKey()`` for the default Typo3 provider — so it does not
+   persist in memory beyond the request (at the latest, until PHP frees
+   statics at shutdown for the Typo3 provider).
+-  **Transparent**: Read-path callers are unaware of the caching; the
+   cache-wipe seam is now uniform via ``clearCachedKey()`` on the interface.
 
 Negative
 --------
 
 -  **Memory residency**: The master key remains in process memory for the
    full request duration rather than being immediately discarded after each
-   use.
--  **Destructor dependency**: Relies on PHP object lifecycle for cleanup;
-   long-running processes (e.g., workers) must ensure timely destruction.
+   use. For the default Typo3 provider, residency is "until an explicit
+   ``clearCachedKey()`` call or PHP shutdown" because it has no destructor.
+-  **Lifecycle dependency**: File/Env providers rely on PHP object lifecycle
+   (``__destruct``) for cleanup; the default Typo3 provider relies on an
+   explicit ``clearCachedKey()``. Long-running processes (e.g., workers,
+   scheduler tasks) must call ``clearCachedKey()`` to bound residency and to
+   observe a rotated source key.
 
 Related decisions
 =================

--- a/Documentation/Developer/Api.rst
+++ b/Documentation/Developer/Api.rst
@@ -21,13 +21,23 @@ The main service for interacting with the vault.
 
    Main interface for vault operations.
 
+   .. note::
+
+      The plaintext parameters ``$secret`` / ``$newSecret`` carry the
+      PHP ``#[\SensitiveParameter]`` attribute on the interface, so they
+      are redacted from stack traces and ``var_dump()`` output. Mirror
+      the attribute on any custom implementation.
+
    .. php:method:: store(string $identifier, string $secret, array $options = []): void
 
-      Store a secret in the vault.
+      Store a secret in the vault. ``$secret`` is a
+      ``#[\SensitiveParameter]``.
 
       :param string $identifier: Unique identifier for the secret.
-      :param string $secret: The secret value to store.
-      :param array $options: Optional configuration (owner, groups, context, expiresAt, metadata).
+      :param string $secret: The secret value to store (``#[\SensitiveParameter]``).
+      :param array $options: Optional configuration: ``owner`` (int BE-user UID), ``groups`` (int[] BE-group UIDs), ``context`` (string), ``expiresAt`` (int|\DateTimeInterface|null), ``metadata`` (array), ``description`` (string), ``scopePid`` (int).
+      :throws ValidationException: If the identifier is invalid.
+      :throws EncryptionException: If encryption fails.
 
    .. php:method:: retrieve(string $identifier)
 
@@ -57,31 +67,110 @@ The main service for interacting with the vault.
 
    .. php:method:: rotate(string $identifier, string $newSecret, string $reason = ''): void
 
-      Rotate a secret with a new value.
+      Rotate a secret with a new value. ``$newSecret`` is a
+      ``#[\SensitiveParameter]``.
 
       :param string $identifier: The secret identifier.
-      :param string $newSecret: The new secret value.
+      :param string $newSecret: The new secret value (``#[\SensitiveParameter]``).
       :param string $reason: Optional reason for rotation (logged).
 
-   .. php:method:: list(string $pattern = null): array
+   .. php:method:: list(?string $pattern = null): array
 
       List accessible secrets.
 
-      :param string|null $pattern: Optional pattern to filter identifiers.
-      :returns: Array of secret metadata.
+      :param string|null $pattern: Optional pattern to filter identifiers (supports the ``*`` wildcard).
+      :returns: A ``list<SecretMetadata>`` of secret metadata DTOs (``Netresearch\NrVault\Domain\Dto\SecretMetadata``).
 
-   .. php:method:: getMetadata(string $identifier): array
+   .. php:method:: getMetadata(string $identifier): SecretDetails
 
       Get metadata for a secret without retrieving its value.
 
       :param string $identifier: The secret identifier.
-      :returns: Array with identifier, description, owner, groups, version, etc.
+      :returns: A ``SecretDetails`` DTO (``Netresearch\NrVault\Domain\Dto\SecretDetails``) with identifier, description, owner, groups, version, etc.
+      :throws SecretNotFoundException: If secret doesn't exist.
+      :throws AccessDeniedException: If user lacks permission.
+
+   .. php:method:: clearCache(): void
+
+      Clear the request-scoped cache of decrypted secrets, securely
+      wiping cached plaintext from memory.
 
    .. php:method:: http(): VaultHttpClientInterface
 
       Get an HTTP client that can inject secrets into requests.
 
       :returns: A PSR-18 compatible vault-aware HTTP client.
+
+.. _api-encryption-service:
+
+EncryptionService
+=================
+
+The crypto boundary: libsodium envelope encryption (per-secret DEK
+wrapped by the master key).
+
+.. php:namespace:: Netresearch\NrVault\Crypto
+
+.. php:interface:: EncryptionServiceInterface
+
+   Low-level encryption operations. Most callers use
+   :php:`VaultServiceInterface` instead.
+
+   .. note::
+
+      Plaintext and key parameters (``$plaintext``, ``$encryptedValue``,
+      ``$encryptedDek``, ``$oldMasterKey``, ``$newMasterKey``) carry the
+      ``#[\SensitiveParameter]`` attribute on the interface.
+
+   .. php:method:: encrypt(string $plaintext, string $identifier): EncryptedData
+
+      Encrypt a plaintext value with a unique DEK. ``$plaintext`` is a
+      ``#[\SensitiveParameter]``.
+
+      :param string $plaintext: The value to encrypt (``#[\SensitiveParameter]``).
+      :param string $identifier: Secret identifier (used as AAD).
+      :returns: An ``EncryptedData`` value object (``Netresearch\NrVault\Crypto\EncryptedData``) holding the ciphertext, encrypted DEK, and nonces.
+      :throws EncryptionException: If encryption fails.
+
+   .. php:method:: decrypt(string $encryptedValue, string $encryptedDek, string $dekNonce, string $valueNonce, string $identifier): string
+
+      Decrypt a previously encrypted value. ``$encryptedValue`` and
+      ``$encryptedDek`` are ``#[\SensitiveParameter]``.
+
+      :param string $encryptedValue: Base64-encoded ciphertext (``#[\SensitiveParameter]``).
+      :param string $encryptedDek: Base64-encoded encrypted DEK (``#[\SensitiveParameter]``).
+      :param string $dekNonce: Base64-encoded DEK nonce.
+      :param string $valueNonce: Base64-encoded value nonce.
+      :param string $identifier: Secret identifier (used as AAD).
+      :returns: The decrypted plaintext.
+      :throws EncryptionException: If decryption fails.
+
+   .. php:method:: generateDek(): string
+
+      Generate a new Data Encryption Key.
+
+      :returns: A 32-byte random key.
+
+   .. php:method:: calculateChecksum(string $plaintext): string
+
+      Calculate a value checksum for change detection. ``$plaintext`` is
+      a ``#[\SensitiveParameter]``.
+
+      :param string $plaintext: The secret value (``#[\SensitiveParameter]``).
+      :returns: SHA-256 hash (64 hex characters).
+
+   .. php:method:: reEncryptDek(string $encryptedDek, string $dekNonce, string $identifier, string $oldMasterKey, string $newMasterKey): ReEncryptedDek
+
+      Re-encrypt a DEK with a new master key (used during master-key
+      rotation). ``$encryptedDek``, ``$oldMasterKey`` and
+      ``$newMasterKey`` are ``#[\SensitiveParameter]``.
+
+      :param string $encryptedDek: Current encrypted DEK (``#[\SensitiveParameter]``).
+      :param string $dekNonce: Current DEK nonce.
+      :param string $identifier: Secret identifier.
+      :param string $oldMasterKey: Previous master key (``#[\SensitiveParameter]``).
+      :param string $newMasterKey: New master key (``#[\SensitiveParameter]``).
+      :returns: A ``ReEncryptedDek`` value object (``Netresearch\NrVault\Crypto\ReEncryptedDek``).
 
 .. _api-usage-examples:
 

--- a/Documentation/GEMINI.md
+++ b/Documentation/GEMINI.md
@@ -1,1 +1,0 @@
-AGENTS.md

--- a/Documentation/guides.xml
+++ b/Documentation/guides.xml
@@ -7,8 +7,8 @@
 >
     <project
         title="nr-vault"
-        version="0.4.6"
-        release="0.4.6"
+        version="0.5.0"
+        release="0.5.0"
         copyright="since 2025 by Netresearch DTT GmbH"
     />
 

--- a/Resources/Private/Language/locallang_js.xlf
+++ b/Resources/Private/Language/locallang_js.xlf
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+  <file source-language="en" datatype="plaintext" original="messages" product-name="nr_vault">
+    <header/>
+    <body>
+      <!-- Generic notification headers / buttons -->
+      <trans-unit id="nrvault.error">
+        <source>Error</source>
+      </trans-unit>
+      <trans-unit id="nrvault.success">
+        <source>Success</source>
+      </trans-unit>
+      <trans-unit id="nrvault.warning">
+        <source>Warning</source>
+      </trans-unit>
+      <trans-unit id="nrvault.cancel">
+        <source>Cancel</source>
+      </trans-unit>
+      <trans-unit id="nrvault.close">
+        <source>Close</source>
+      </trans-unit>
+      <trans-unit id="nrvault.delete">
+        <source>Delete</source>
+      </trans-unit>
+      <trans-unit id="nrvault.unknownError">
+        <source>An error occurred</source>
+      </trans-unit>
+      <trans-unit id="nrvault.noIdentifier">
+        <source>No identifier found</source>
+      </trans-unit>
+
+      <!-- Clipboard -->
+      <trans-unit id="nrvault.copied">
+        <source>Copied</source>
+      </trans-unit>
+      <trans-unit id="nrvault.copy.success">
+        <source>Secret copied to clipboard</source>
+      </trans-unit>
+      <trans-unit id="nrvault.copy.failed">
+        <source>Failed to copy to clipboard</source>
+      </trans-unit>
+      <trans-unit id="nrvault.copy.revealFirst">
+        <source>Reveal the secret first before copying</source>
+      </trans-unit>
+
+      <!-- Delete confirmation -->
+      <trans-unit id="nrvault.delete.title">
+        <source>Delete Secret</source>
+      </trans-unit>
+      <trans-unit id="nrvault.delete.confirm">
+        <source>Are you sure you want to delete the secret "{0}"? This action cannot be undone.</source>
+      </trans-unit>
+
+      <!-- Reveal modal -->
+      <trans-unit id="nrvault.reveal.loading.title">
+        <source>Loading Secret</source>
+      </trans-unit>
+      <trans-unit id="nrvault.reveal.loading.body">
+        <source>Fetching secret...</source>
+      </trans-unit>
+      <trans-unit id="nrvault.reveal.title">
+        <source>Secret Value</source>
+      </trans-unit>
+      <trans-unit id="nrvault.reveal.label">
+        <source>Secret Value</source>
+      </trans-unit>
+      <trans-unit id="nrvault.reveal.hint">
+        <source>Secret value for: </source>
+      </trans-unit>
+      <trans-unit id="nrvault.reveal.failed">
+        <source>Failed to reveal secret</source>
+      </trans-unit>
+      <trans-unit id="nrvault.toggle.visibility">
+        <source>Toggle visibility</source>
+      </trans-unit>
+      <trans-unit id="nrvault.copy.clipboard">
+        <source>Copy to clipboard</source>
+      </trans-unit>
+      <trans-unit id="nrvault.reveal.action">
+        <source>Reveal</source>
+      </trans-unit>
+      <trans-unit id="nrvault.reveal.hideAction">
+        <source>Hide</source>
+      </trans-unit>
+      <trans-unit id="nrvault.reveal.loadingAction">
+        <source>Loading...</source>
+      </trans-unit>
+      <trans-unit id="nrvault.copied.inline">
+        <source>Copied!</source>
+      </trans-unit>
+      <trans-unit id="nrvault.reveal.fetchError">
+        <source>Error fetching secret: {0}</source>
+      </trans-unit>
+
+      <!-- Rotate modal -->
+      <trans-unit id="nrvault.rotate.title">
+        <source>Rotate Secret: {0}</source>
+      </trans-unit>
+      <trans-unit id="nrvault.rotate.label">
+        <source>New Secret Value</source>
+      </trans-unit>
+      <trans-unit id="nrvault.rotate.placeholder">
+        <source>Enter new secret value</source>
+      </trans-unit>
+      <trans-unit id="nrvault.rotate.help">
+        <source>Enter the new secret value. This will replace the existing secret.</source>
+      </trans-unit>
+      <trans-unit id="nrvault.rotate.warning.label">
+        <source>Warning:</source>
+      </trans-unit>
+      <trans-unit id="nrvault.rotate.warning.body">
+        <source> Rotating a secret is irreversible. The previous value cannot be recovered.</source>
+      </trans-unit>
+      <trans-unit id="nrvault.rotate.button">
+        <source>Rotate Secret</source>
+      </trans-unit>
+      <trans-unit id="nrvault.rotate.enterValue">
+        <source>Please enter a new secret value</source>
+      </trans-unit>
+      <trans-unit id="nrvault.rotate.success">
+        <source>Secret rotated successfully</source>
+      </trans-unit>
+      <trans-unit id="nrvault.rotate.failed">
+        <source>Failed to rotate secret</source>
+      </trans-unit>
+
+      <!-- Clear secret (TCA form element) -->
+      <trans-unit id="nrvault.clear.confirm">
+        <source>Are you sure you want to clear this secret? This action cannot be undone.</source>
+      </trans-unit>
+
+      <!-- Hash chain verification (vault-backend.js) -->
+      <trans-unit id="nrvault.verify.valid.title">
+        <source>Hash Chain Valid</source>
+      </trans-unit>
+      <trans-unit id="nrvault.verify.invalid.title">
+        <source>Hash Chain Invalid</source>
+      </trans-unit>
+      <trans-unit id="nrvault.verify.errors.title">
+        <source>Verification Errors</source>
+      </trans-unit>
+      <trans-unit id="nrvault.verify.failed.title">
+        <source>Verification Failed</source>
+      </trans-unit>
+      <trans-unit id="nrvault.verify.entry">
+        <source>Entry {0}: {1}</source>
+      </trans-unit>
+      <trans-unit id="nrvault.verify.running">
+        <source>Verifying...</source>
+      </trans-unit>
+    </body>
+  </file>
+</xliff>

--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -1,935 +1,992 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="messages" date="2024-12-28T00:00:00Z" product-name="nr_vault">
-        <header/>
-        <body>
-            <!-- Parent module labels -->
-            <trans-unit id="mlang_tabs_tab">
-                <source>Vault</source>
-            </trans-unit>
+  <file source-language="en" datatype="plaintext" original="messages" date="2024-12-28T00:00:00Z" product-name="nr_vault">
+    <header/>
+    <body>
+      <!-- Parent module labels -->
+      <trans-unit id="mlang_tabs_tab">
+        <source>Vault</source>
+      </trans-unit>
 
-            <!-- Secrets list -->
-            <trans-unit id="secrets.title">
-                <source>Secrets</source>
-            </trans-unit>
-            <trans-unit id="secrets.identifier">
-                <source>Identifier</source>
-            </trans-unit>
-            <trans-unit id="secrets.description">
-                <source>Description</source>
-            </trans-unit>
-            <trans-unit id="secrets.owner">
-                <source>Owner</source>
-            </trans-unit>
-            <trans-unit id="secrets.created">
-                <source>Created</source>
-            </trans-unit>
-            <trans-unit id="secrets.read_count">
-                <source>Read Count</source>
-            </trans-unit>
-            <trans-unit id="secrets.last_read">
-                <source>Last Read</source>
-            </trans-unit>
-            <trans-unit id="secrets.actions">
-                <source>Actions</source>
-            </trans-unit>
-            <trans-unit id="secrets.status">
-                <source>Status</source>
-            </trans-unit>
-            <trans-unit id="secrets.status.active">
-                <source>Active</source>
-            </trans-unit>
-            <trans-unit id="secrets.status.disabled">
-                <source>Disabled</source>
-            </trans-unit>
-            <trans-unit id="secrets.empty">
-                <source>No secrets found. Click "Create Secret" to add one.</source>
-            </trans-unit>
+      <!-- Secrets list -->
+      <trans-unit id="secrets.title">
+        <source>Secrets</source>
+      </trans-unit>
+      <trans-unit id="secrets.identifier">
+        <source>Identifier</source>
+      </trans-unit>
+      <trans-unit id="secrets.description">
+        <source>Description</source>
+      </trans-unit>
+      <trans-unit id="secrets.owner">
+        <source>Owner</source>
+      </trans-unit>
+      <trans-unit id="secrets.created">
+        <source>Created</source>
+      </trans-unit>
+      <trans-unit id="secrets.read_count">
+        <source>Read Count</source>
+      </trans-unit>
+      <trans-unit id="secrets.last_read">
+        <source>Last Read</source>
+      </trans-unit>
+      <trans-unit id="secrets.actions">
+        <source>Actions</source>
+      </trans-unit>
+      <trans-unit id="secrets.status">
+        <source>Status</source>
+      </trans-unit>
+      <trans-unit id="secrets.status.active">
+        <source>Active</source>
+      </trans-unit>
+      <trans-unit id="secrets.status.disabled">
+        <source>Disabled</source>
+      </trans-unit>
+      <trans-unit id="secrets.empty">
+        <source>No secrets found. Click "Create Secret" to add one.</source>
+      </trans-unit>
 
-            <!-- Filter bar -->
-            <trans-unit id="secrets.filter.identifier.placeholder">
-                <source>Search identifier...</source>
-            </trans-unit>
-            <trans-unit id="secrets.filter.status.all">
-                <source>All status</source>
-            </trans-unit>
-            <trans-unit id="secrets.filter.owner.all">
-                <source>All owners</source>
-            </trans-unit>
-            <trans-unit id="secrets.filter.apply">
-                <source>Filter</source>
-            </trans-unit>
-            <trans-unit id="secrets.filter.reset">
-                <source>Reset filters</source>
-            </trans-unit>
-            <trans-unit id="secrets.filter.results">
-                <source>secrets</source>
-            </trans-unit>
+      <!-- Filter bar -->
+      <trans-unit id="secrets.filter.identifier.placeholder">
+        <source>Search identifier...</source>
+      </trans-unit>
+      <trans-unit id="secrets.filter.status.all">
+        <source>All status</source>
+      </trans-unit>
+      <trans-unit id="secrets.filter.owner.all">
+        <source>All owners</source>
+      </trans-unit>
+      <trans-unit id="secrets.filter.apply">
+        <source>Filter</source>
+      </trans-unit>
+      <trans-unit id="secrets.filter.reset">
+        <source>Reset filters</source>
+      </trans-unit>
+      <trans-unit id="secrets.filter.results">
+        <source>secrets</source>
+      </trans-unit>
 
-            <!-- Secret actions -->
-            <trans-unit id="secrets.action.reveal">
-                <source>Reveal secret</source>
-            </trans-unit>
-            <trans-unit id="secrets.action.edit">
-                <source>Edit secret</source>
-            </trans-unit>
-            <trans-unit id="secrets.action.delete">
-                <source>Delete secret</source>
-            </trans-unit>
-            <trans-unit id="secrets.action.rotate">
-                <source>Rotate secret</source>
-            </trans-unit>
-            <trans-unit id="secrets.action.enable">
-                <source>Enable secret</source>
-            </trans-unit>
-            <trans-unit id="secrets.action.disable">
-                <source>Disable secret</source>
-            </trans-unit>
-            <trans-unit id="secrets.create">
-                <source>Create Secret</source>
-            </trans-unit>
-            <trans-unit id="secrets.enabled.success">
-                <source>Secret enabled successfully</source>
-            </trans-unit>
-            <trans-unit id="secrets.disabled.success">
-                <source>Secret disabled successfully</source>
-            </trans-unit>
-            <trans-unit id="secrets.delete.success">
-                <source>Secret deleted successfully</source>
-            </trans-unit>
-            <trans-unit id="secrets.back">
-                <source>Back to List</source>
-            </trans-unit>
+      <!-- Secret actions -->
+      <trans-unit id="secrets.action.reveal">
+        <source>Reveal secret</source>
+      </trans-unit>
+      <trans-unit id="secrets.action.edit">
+        <source>Edit secret</source>
+      </trans-unit>
+      <trans-unit id="secrets.action.delete">
+        <source>Delete secret</source>
+      </trans-unit>
+      <trans-unit id="secrets.action.rotate">
+        <source>Rotate secret</source>
+      </trans-unit>
+      <trans-unit id="secrets.action.enable">
+        <source>Enable secret</source>
+      </trans-unit>
+      <trans-unit id="secrets.action.disable">
+        <source>Disable secret</source>
+      </trans-unit>
+      <trans-unit id="secrets.create">
+        <source>Create Secret</source>
+      </trans-unit>
+      <trans-unit id="secrets.enabled.success">
+        <source>Secret enabled successfully</source>
+      </trans-unit>
+      <trans-unit id="secrets.disabled.success">
+        <source>Secret disabled successfully</source>
+      </trans-unit>
+      <trans-unit id="secrets.delete.success">
+        <source>Secret deleted successfully</source>
+      </trans-unit>
+      <trans-unit id="secrets.empty.title">
+        <source>No Secrets Found</source>
+      </trans-unit>
+      <trans-unit id="secrets.total">
+        <source>%d secrets total</source>
+      </trans-unit>
+      <trans-unit id="secrets.back">
+        <source>Back to List</source>
+      </trans-unit>
 
-            <!-- Audit log -->
-            <trans-unit id="audit.title">
-                <source>Audit Log</source>
-            </trans-unit>
-            <trans-unit id="audit.empty">
-                <source>No audit entries found</source>
-            </trans-unit>
-            <trans-unit id="audit.col.time">
-                <source>Time</source>
-            </trans-unit>
-            <trans-unit id="audit.col.secret">
-                <source>Secret</source>
-            </trans-unit>
-            <trans-unit id="audit.col.action">
-                <source>Action</source>
-            </trans-unit>
-            <trans-unit id="audit.col.status">
-                <source>Status</source>
-            </trans-unit>
-            <trans-unit id="audit.col.actor">
-                <source>Actor</source>
-            </trans-unit>
-            <trans-unit id="audit.col.ip_address">
-                <source>IP Address</source>
-            </trans-unit>
-            <trans-unit id="audit.col.details">
-                <source>Details</source>
-            </trans-unit>
-            <trans-unit id="audit.filter.secret">
-                <source>Secret</source>
-            </trans-unit>
-            <trans-unit id="audit.filter.action">
-                <source>Action</source>
-            </trans-unit>
-            <trans-unit id="audit.filter.status">
-                <source>Status</source>
-            </trans-unit>
-            <trans-unit id="audit.filter.from">
-                <source>From</source>
-            </trans-unit>
-            <trans-unit id="audit.filter.to">
-                <source>To</source>
-            </trans-unit>
-            <trans-unit id="audit.filter.apply">
-                <source>Filter</source>
-            </trans-unit>
-            <trans-unit id="audit.filter.reset">
-                <source>Reset</source>
-            </trans-unit>
-            <trans-unit id="audit.filter.status.all">
-                <source>[all]</source>
-            </trans-unit>
-            <trans-unit id="audit.filter.status.success">
-                <source>Success</source>
-            </trans-unit>
-            <trans-unit id="audit.filter.status.failed">
-                <source>Failed</source>
-            </trans-unit>
-            <trans-unit id="audit.filter.secret.placeholder">
-                <source>Secret identifier</source>
-            </trans-unit>
-            <trans-unit id="audit.export">
-                <source>Export</source>
-            </trans-unit>
-            <trans-unit id="audit.verify_chain">
-                <source>Verify Hash Chain</source>
-            </trans-unit>
-            <trans-unit id="audit.chain_valid">
-                <source>Hash chain is valid - no tampering detected</source>
-            </trans-unit>
-            <trans-unit id="audit.chain_invalid">
-                <source>Hash chain verification failed</source>
-            </trans-unit>
-            <trans-unit id="audit.verification_errors">
-                <source>Verification Errors</source>
-            </trans-unit>
+      <!-- Audit log -->
+      <trans-unit id="audit.title">
+        <source>Audit Log</source>
+      </trans-unit>
+      <trans-unit id="audit.empty">
+        <source>No audit entries found</source>
+      </trans-unit>
+      <trans-unit id="audit.col.time">
+        <source>Time</source>
+      </trans-unit>
+      <trans-unit id="audit.col.secret">
+        <source>Secret</source>
+      </trans-unit>
+      <trans-unit id="audit.col.action">
+        <source>Action</source>
+      </trans-unit>
+      <trans-unit id="audit.col.status">
+        <source>Status</source>
+      </trans-unit>
+      <trans-unit id="audit.col.actor">
+        <source>Actor</source>
+      </trans-unit>
+      <trans-unit id="audit.col.ip_address">
+        <source>IP Address</source>
+      </trans-unit>
+      <trans-unit id="audit.col.details">
+        <source>Details</source>
+      </trans-unit>
+      <trans-unit id="audit.filter.secret">
+        <source>Secret</source>
+      </trans-unit>
+      <trans-unit id="audit.filter.action">
+        <source>Action</source>
+      </trans-unit>
+      <trans-unit id="audit.filter.status">
+        <source>Status</source>
+      </trans-unit>
+      <trans-unit id="audit.filter.from">
+        <source>From</source>
+      </trans-unit>
+      <trans-unit id="audit.filter.to">
+        <source>To</source>
+      </trans-unit>
+      <trans-unit id="audit.filter.apply">
+        <source>Filter</source>
+      </trans-unit>
+      <trans-unit id="audit.filter.reset">
+        <source>Reset</source>
+      </trans-unit>
+      <trans-unit id="audit.filter.status.all">
+        <source>[all]</source>
+      </trans-unit>
+      <trans-unit id="audit.filter.status.success">
+        <source>Success</source>
+      </trans-unit>
+      <trans-unit id="audit.filter.status.failed">
+        <source>Failed</source>
+      </trans-unit>
+      <trans-unit id="audit.filter.secret.placeholder">
+        <source>Secret identifier</source>
+      </trans-unit>
+      <trans-unit id="audit.export">
+        <source>Export</source>
+      </trans-unit>
+      <trans-unit id="audit.verify_chain">
+        <source>Verify Hash Chain</source>
+      </trans-unit>
+      <trans-unit id="audit.chain_valid">
+        <source>Hash chain is valid - no tampering detected</source>
+      </trans-unit>
+      <trans-unit id="audit.chain_invalid">
+        <source>Hash chain verification failed</source>
+      </trans-unit>
+      <trans-unit id="audit.verification_errors">
+        <source>Verification Errors</source>
+      </trans-unit>
+      <trans-unit id="audit.empty.title">
+        <source>No Audit Entries</source>
+      </trans-unit>
+      <trans-unit id="audit.stats.entries">
+        <source>entries</source>
+      </trans-unit>
+      <trans-unit id="audit.pagination.page">
+        <source>Page %1$d of %2$d</source>
+      </trans-unit>
+      <trans-unit id="audit.warnings">
+        <source>Warnings</source>
+      </trans-unit>
+      <trans-unit id="audit.chain_valid.description">
+        <source>The audit log hash chain has been verified successfully. No tampering or modifications have been detected.</source>
+      </trans-unit>
+      <trans-unit id="audit.chain_invalid.description">
+        <source>Hash chain verification failed. The audit log may have been tampered with.</source>
+      </trans-unit>
+      <trans-unit id="audit.chain_invalid.range">
+        <source>Affected entries: UID %1$s to %2$s. Entries after the first break are no longer trustworthy.</source>
+      </trans-unit>
+      <trans-unit id="audit.chain_invalid.guidance.title">
+        <source>What to do now</source>
+      </trans-unit>
+      <trans-unit id="audit.chain_invalid.guidance.snapshot">
+        <source>Snapshot the audit table immediately (database dump of tx_nrvault_audit_log) before any further changes.</source>
+      </trans-unit>
+      <trans-unit id="audit.chain_invalid.guidance.escalate">
+        <source>Escalate to your security officer — a broken chain may indicate tampering or a database restore from an inconsistent backup.</source>
+      </trans-unit>
+      <trans-unit id="audit.chain_invalid.guidance.no_mutate">
+        <source>Do not delete, edit, or re-run operations on the affected secrets until the cause is understood.</source>
+      </trans-unit>
 
-            <!-- Migration wizard -->
-            <trans-unit id="migration.title">
-                <source>Secret Migration Wizard</source>
-            </trans-unit>
-            <trans-unit id="migration.scan">
-                <source>Scan</source>
-            </trans-unit>
-            <trans-unit id="migration.review">
-                <source>Review</source>
-            </trans-unit>
-            <trans-unit id="migration.configure">
-                <source>Configure</source>
-            </trans-unit>
-            <trans-unit id="migration.verify">
-                <source>Verify</source>
-            </trans-unit>
+      <!-- Migration wizard -->
+      <trans-unit id="migration.title">
+        <source>Secret Migration Wizard</source>
+      </trans-unit>
+      <trans-unit id="migration.scan">
+        <source>Scan</source>
+      </trans-unit>
+      <trans-unit id="migration.review">
+        <source>Review</source>
+      </trans-unit>
+      <trans-unit id="migration.configure">
+        <source>Configure</source>
+      </trans-unit>
+      <trans-unit id="migration.verify">
+        <source>Verify</source>
+      </trans-unit>
 
-            <!-- Error/flash messages -->
-            <trans-unit id="error">
-                <source>Error</source>
-            </trans-unit>
-            <trans-unit id="secrets.notFound">
-                <source>Secret not found: %s</source>
-            </trans-unit>
-            <trans-unit id="secrets.noIdentifier">
-                <source>No secret identifier provided</source>
-            </trans-unit>
-            <trans-unit id="secrets.uidNotFound">
-                <source>Secret UID not found</source>
-            </trans-unit>
-            <trans-unit id="secrets.accessDenied">
-                <source>Access denied</source>
-            </trans-unit>
-            <trans-unit id="secrets.error">
-                <source>Error: %s</source>
-            </trans-unit>
+      <!-- Error/flash messages -->
+      <trans-unit id="error">
+        <source>Error</source>
+      </trans-unit>
+      <trans-unit id="secrets.notFound">
+        <source>Secret not found: %s</source>
+      </trans-unit>
+      <trans-unit id="secrets.noIdentifier">
+        <source>No secret identifier provided</source>
+      </trans-unit>
+      <trans-unit id="secrets.uidNotFound">
+        <source>Secret UID not found</source>
+      </trans-unit>
+      <trans-unit id="secrets.accessDenied">
+        <source>Access denied</source>
+      </trans-unit>
+      <trans-unit id="secrets.error">
+        <source>Error: %s</source>
+      </trans-unit>
 
-            <!-- Navigation -->
-            <trans-unit id="action.back">
-                <source>Back</source>
-            </trans-unit>
+      <!-- Navigation -->
+      <trans-unit id="action.back">
+        <source>Back</source>
+      </trans-unit>
 
-            <!-- Overview descriptions -->
-            <trans-unit id="overview.secrets.description">
-                <source>Manage encrypted secrets stored in the vault.</source>
-            </trans-unit>
-            <trans-unit id="overview.audit.description">
-                <source>View access logs and verify audit chain integrity.</source>
-            </trans-unit>
-            <trans-unit id="overview.migration.description">
-                <source>Detect and migrate plaintext secrets to the vault.</source>
-            </trans-unit>
+      <!-- Overview descriptions -->
+      <trans-unit id="overview.secrets.description">
+        <source>Manage encrypted secrets stored in the vault.</source>
+      </trans-unit>
+      <trans-unit id="overview.audit.description">
+        <source>View access logs and verify audit chain integrity.</source>
+      </trans-unit>
+      <trans-unit id="overview.migration.description">
+        <source>Detect and migrate plaintext secrets to the vault.</source>
+      </trans-unit>
 
-            <!-- Migration messages -->
-            <trans-unit id="migration.noSecretsSelected">
-                <source>No secrets selected for migration.</source>
-            </trans-unit>
-            <trans-unit id="migration.selectionRequired">
-                <source>Selection Required</source>
-            </trans-unit>
-            <trans-unit id="migration.noMigrationsConfigured">
-                <source>No migrations configured.</source>
-            </trans-unit>
-            <trans-unit id="migration.configurationRequired">
-                <source>Configuration Required</source>
-            </trans-unit>
-            <trans-unit id="migration.complete">
-                <source>Migration Complete</source>
-            </trans-unit>
-            <trans-unit id="migration.success">
-                <source>Successfully migrated %d secret(s) to the vault.</source>
-            </trans-unit>
-            <trans-unit id="migration.errors">
-                <source>Migration Errors</source>
-            </trans-unit>
-            <trans-unit id="migration.failed">
-                <source>%d secret(s) failed to migrate.</source>
-            </trans-unit>
+      <!-- Migration messages -->
+      <trans-unit id="migration.noSecretsSelected">
+        <source>No secrets selected for migration.</source>
+      </trans-unit>
+      <trans-unit id="migration.selectionRequired">
+        <source>Selection Required</source>
+      </trans-unit>
+      <trans-unit id="migration.noMigrationsConfigured">
+        <source>No migrations configured.</source>
+      </trans-unit>
+      <trans-unit id="migration.configurationRequired">
+        <source>Configuration Required</source>
+      </trans-unit>
+      <trans-unit id="migration.complete">
+        <source>Migration Complete</source>
+      </trans-unit>
+      <trans-unit id="migration.success">
+        <source>Successfully migrated %d secret(s) to the vault.</source>
+      </trans-unit>
+      <trans-unit id="migration.errors">
+        <source>Migration Errors</source>
+      </trans-unit>
+      <trans-unit id="migration.failed">
+        <source>%d secret(s) failed to migrate.</source>
+      </trans-unit>
 
-            <!-- Overview page -->
-            <trans-unit id="overview.title">
-                <source>Vault - Secrets Management</source>
-            </trans-unit>
-            <trans-unit id="overview.subtitle">
-                <source>Secure storage and management for sensitive configuration data.</source>
-            </trans-unit>
-            <trans-unit id="overview.health.issue.heading">
-                <source>Vault Health Issue</source>
-            </trans-unit>
-            <trans-unit id="overview.health.encryption_not_available">
-                <source>Encryption is not available.</source>
-            </trans-unit>
-            <trans-unit id="overview.health.encryption_not_available.description">
-                <source>No master key provider is configured or accessible. Vault cannot encrypt or decrypt secrets.</source>
-            </trans-unit>
-            <trans-unit id="overview.health.detail">
-                <source>Detail:</source>
-            </trans-unit>
-            <trans-unit id="overview.health.encryption_not_available.remedy">
-                <source>Ensure that %s is set, or configure an alternative master key provider (environment variable or file-based).</source>
-            </trans-unit>
-            <trans-unit id="overview.health.encryption_broken">
-                <source>Master key provider "%s" is available but encryption is broken.</source>
-            </trans-unit>
-            <trans-unit id="overview.health.encryption_active">
-                <source>Encryption is active using the %s master key provider.</source>
-            </trans-unit>
-            <trans-unit id="overview.stats.total_secrets">
-                <source>Total Secrets</source>
-            </trans-unit>
-            <trans-unit id="overview.stats.active">
-                <source>Active</source>
-            </trans-unit>
-            <trans-unit id="overview.stats.disabled">
-                <source>Disabled</source>
-            </trans-unit>
-            <trans-unit id="overview.modules">
-                <source>Modules</source>
-            </trans-unit>
-            <trans-unit id="overview.quickstart">
-                <source>Quick Start</source>
-            </trans-unit>
-            <trans-unit id="overview.quickstart.store.title">
-                <source>Store a Secret</source>
-            </trans-unit>
-            <trans-unit id="overview.quickstart.store.description">
-                <source>Navigate to Secrets and click the + button in the header to create a new secret. Provide an identifier (e.g., stripe_api_key) and the secret value.</source>
-            </trans-unit>
-            <trans-unit id="overview.quickstart.use.title">
-                <source>Use in Configuration</source>
-            </trans-unit>
-            <trans-unit id="overview.quickstart.use.description">
-                <source>Reference secrets in your TYPO3 configuration using the vault syntax:</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.title">
-                <source>When to Use What</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.site_keys.title">
-                <source>Site-Specific API Keys</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.site_keys.description">
-                <source>Payment gateways, external services, or any secret that differs per site. Resolved at runtime from config/sites/*/config.yaml.</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.per_record.title">
-                <source>Per-Record Credentials</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.per_record.description">
-                <source>Let editors manage secrets per record (e.g., per-integration or per-client settings). Values encrypted automatically via TCA.</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.extension.title">
-                <source>Extension Services</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.extension.description">
-                <source>When your extension needs secrets programmatically - API clients, payment processors, external integrations.</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.http_client.title">
-                <source>HTTP Client with Secrets</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.http_client.description">
-                <source>PSR-18 compatible API calls with automatic secret injection. Supports Bearer, API-Key, Basic Auth, OAuth2, and more.</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.deployment.title">
-                <source>Deployment &amp; CI/CD</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.deployment.description">
-                <source>Automate secret provisioning in deployment pipelines, or manage secrets via scripts without backend access.</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.frontend.title">
-                <source>Frontend Rendering</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.frontend.sparingly">
-                <source>(use sparingly)</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.frontend.description">
-                <source>When secrets must appear in rendered output (e.g., JS API keys). Requires frontend_accessible flag and cache disabled.</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.tca_helper.title">
-                <source>TCA Helper API</source>
-            </trans-unit>
-            <trans-unit id="overview.usage.tca_helper.description">
-                <source>Shorthand for common vault field patterns with sensible defaults (exclude: true, l10n_mode: exclude).</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.title">
-                <source>CLI Commands</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.col.command">
-                <source>Command</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.col.description">
-                <source>Description</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.init">
-                <source>Initialize vault and generate master key</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.store">
-                <source>Store a new secret</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.retrieve">
-                <source>Retrieve a secret value</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.list">
-                <source>List all secrets</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.rotate">
-                <source>Rotate a secret's value</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.delete">
-                <source>Delete a secret</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.audit">
-                <source>View audit log entries</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.scan">
-                <source>Scan for plaintext secrets in database</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.migrate_field">
-                <source>Migrate a database field to vault</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.rotate_master_key">
-                <source>Rotate the master encryption key</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.cleanup_orphans">
-                <source>Remove orphaned secrets</source>
-            </trans-unit>
-            <trans-unit id="overview.cli.help_hint">
-                <source>Run bin/typo3 vault:&lt;command&gt; --help for detailed usage.</source>
-            </trans-unit>
-            <trans-unit id="overview.security.title">
-                <source>Security Features</source>
-            </trans-unit>
-            <trans-unit id="overview.security.envelope.title">
-                <source>Envelope Encryption</source>
-            </trans-unit>
-            <trans-unit id="overview.security.envelope.description">
-                <source>Each secret is encrypted with its own unique Data Encryption Key (DEK), which is then encrypted with the master key.</source>
-            </trans-unit>
-            <trans-unit id="overview.security.access.title">
-                <source>Access Control</source>
-            </trans-unit>
-            <trans-unit id="overview.security.access.description">
-                <source>Secrets can be restricted to specific backend users or groups. Every access is logged in the audit trail.</source>
-            </trans-unit>
-            <trans-unit id="overview.security.audit.title">
-                <source>Audit Logging</source>
-            </trans-unit>
-            <trans-unit id="overview.security.audit.description">
-                <source>Tamper-evident audit chain records all secret operations with cryptographic integrity verification.</source>
-            </trans-unit>
-            <trans-unit id="overview.documentation.title">
-                <source>Documentation</source>
-            </trans-unit>
-            <trans-unit id="overview.documentation.text">
-                <source>For detailed information, see the</source>
-            </trans-unit>
-            <trans-unit id="overview.documentation.link">
-                <source>extension documentation</source>
-            </trans-unit>
+      <!-- Overview page -->
+      <trans-unit id="overview.title">
+        <source>Vault - Secrets Management</source>
+      </trans-unit>
+      <trans-unit id="overview.subtitle">
+        <source>Secure storage and management for sensitive configuration data.</source>
+      </trans-unit>
+      <trans-unit id="overview.health.issue.heading">
+        <source>Vault Health Issue</source>
+      </trans-unit>
+      <trans-unit id="overview.health.encryption_not_available">
+        <source>Encryption is not available.</source>
+      </trans-unit>
+      <trans-unit id="overview.health.encryption_not_available.description">
+        <source>No master key provider is configured or accessible. Vault cannot encrypt or decrypt secrets.</source>
+      </trans-unit>
+      <trans-unit id="overview.health.detail">
+        <source>Detail:</source>
+      </trans-unit>
+      <trans-unit id="overview.health.encryption_not_available.remedy">
+        <source>Ensure that %s is set, or configure an alternative master key provider (environment variable or file-based).</source>
+      </trans-unit>
+      <trans-unit id="overview.health.encryption_broken">
+        <source>Master key provider "%s" is available but encryption is broken.</source>
+      </trans-unit>
+      <trans-unit id="overview.health.encryption_active">
+        <source>Encryption is active using the %s master key provider.</source>
+      </trans-unit>
+      <trans-unit id="overview.tab.dashboard">
+        <source>Dashboard</source>
+      </trans-unit>
+      <trans-unit id="overview.tab.help">
+        <source>Help</source>
+      </trans-unit>
+      <trans-unit id="overview.health.next_steps">
+        <source>Next steps to finish setup:</source>
+      </trans-unit>
+      <trans-unit id="overview.health.step.run_init">
+        <source>Run bin/typo3 vault:init to generate a master key and verify the configuration.</source>
+      </trans-unit>
+      <trans-unit id="overview.health.step.configure_provider">
+        <source>Or set the TYPO3_VAULT_MASTER_KEY environment variable, or configure a key file in the extension settings.</source>
+      </trans-unit>
+      <trans-unit id="overview.health.step.see_help">
+        <source>See the Help tab for provider details and troubleshooting.</source>
+      </trans-unit>
+      <trans-unit id="overview.stats.total_secrets">
+        <source>Total Secrets</source>
+      </trans-unit>
+      <trans-unit id="overview.stats.active">
+        <source>Active</source>
+      </trans-unit>
+      <trans-unit id="overview.stats.disabled">
+        <source>Disabled</source>
+      </trans-unit>
+      <trans-unit id="overview.modules">
+        <source>Modules</source>
+      </trans-unit>
+      <trans-unit id="overview.quickstart">
+        <source>Quick Start</source>
+      </trans-unit>
+      <trans-unit id="overview.quickstart.store.title">
+        <source>Store a Secret</source>
+      </trans-unit>
+      <trans-unit id="overview.quickstart.store.description">
+        <source>Navigate to Secrets and click the + button in the header to create a new secret. Provide an identifier (e.g., stripe_api_key) and the secret value.</source>
+      </trans-unit>
+      <trans-unit id="overview.quickstart.use.title">
+        <source>Use in Configuration</source>
+      </trans-unit>
+      <trans-unit id="overview.quickstart.use.description">
+        <source>Reference secrets in your TYPO3 configuration using the vault syntax:</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.title">
+        <source>When to Use What</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.site_keys.title">
+        <source>Site-Specific API Keys</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.site_keys.description">
+        <source>Payment gateways, external services, or any secret that differs per site. Resolved at runtime from config/sites/*/config.yaml.</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.per_record.title">
+        <source>Per-Record Credentials</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.per_record.description">
+        <source>Let editors manage secrets per record (e.g., per-integration or per-client settings). Values encrypted automatically via TCA.</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.extension.title">
+        <source>Extension Services</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.extension.description">
+        <source>When your extension needs secrets programmatically - API clients, payment processors, external integrations.</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.http_client.title">
+        <source>HTTP Client with Secrets</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.http_client.description">
+        <source>PSR-18 compatible API calls with automatic secret injection. Supports Bearer, API-Key, Basic Auth, OAuth2, and more.</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.deployment.title">
+        <source>Deployment &amp; CI/CD</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.deployment.description">
+        <source>Automate secret provisioning in deployment pipelines, or manage secrets via scripts without backend access.</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.frontend.title">
+        <source>Frontend Rendering</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.frontend.sparingly">
+        <source>(use sparingly)</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.frontend.description">
+        <source>When secrets must appear in rendered output (e.g., JS API keys). Requires frontend_accessible flag and cache disabled.</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.tca_helper.title">
+        <source>TCA Helper API</source>
+      </trans-unit>
+      <trans-unit id="overview.usage.tca_helper.description">
+        <source>Shorthand for common vault field patterns with sensible defaults (exclude: true, l10n_mode: exclude).</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.title">
+        <source>CLI Commands</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.col.command">
+        <source>Command</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.col.description">
+        <source>Description</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.init">
+        <source>Initialize vault and generate master key</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.store">
+        <source>Store a new secret</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.retrieve">
+        <source>Retrieve a secret value</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.list">
+        <source>List all secrets</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.rotate">
+        <source>Rotate a secret's value</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.delete">
+        <source>Delete a secret</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.audit">
+        <source>View audit log entries</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.scan">
+        <source>Scan for plaintext secrets in database</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.migrate_field">
+        <source>Migrate a database field to vault</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.rotate_master_key">
+        <source>Rotate the master encryption key</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.cleanup_orphans">
+        <source>Remove orphaned secrets</source>
+      </trans-unit>
+      <trans-unit id="overview.cli.help_hint">
+        <source>Run bin/typo3 vault:&lt;command&gt; --help for detailed usage.</source>
+      </trans-unit>
+      <trans-unit id="overview.security.title">
+        <source>Security Features</source>
+      </trans-unit>
+      <trans-unit id="overview.security.envelope.title">
+        <source>Envelope Encryption</source>
+      </trans-unit>
+      <trans-unit id="overview.security.envelope.description">
+        <source>Each secret is encrypted with its own unique Data Encryption Key (DEK), which is then encrypted with the master key.</source>
+      </trans-unit>
+      <trans-unit id="overview.security.access.title">
+        <source>Access Control</source>
+      </trans-unit>
+      <trans-unit id="overview.security.access.description">
+        <source>Secrets can be restricted to specific backend users or groups. Every access is logged in the audit trail.</source>
+      </trans-unit>
+      <trans-unit id="overview.security.audit.title">
+        <source>Audit Logging</source>
+      </trans-unit>
+      <trans-unit id="overview.security.audit.description">
+        <source>Tamper-evident audit chain records all secret operations with cryptographic integrity verification.</source>
+      </trans-unit>
+      <trans-unit id="overview.documentation.title">
+        <source>Documentation</source>
+      </trans-unit>
+      <trans-unit id="overview.documentation.text">
+        <source>For detailed information, see the</source>
+      </trans-unit>
+      <trans-unit id="overview.documentation.link">
+        <source>extension documentation</source>
+      </trans-unit>
 
-            <!-- Help page -->
-            <trans-unit id="help.title">
-                <source>Vault Help</source>
-            </trans-unit>
-            <trans-unit id="help.lead">
-                <source>This guide explains how vault encryption works, how to manage secrets, and how to troubleshoot common issues.</source>
-            </trans-unit>
-            <trans-unit id="help.getting_started.title">
-                <source>Getting started</source>
-            </trans-unit>
-            <trans-unit id="help.getting_started.intro">
-                <source>The Vault extension provides secure storage for sensitive configuration data (API keys, passwords, tokens) using envelope encryption. Follow these steps to get started:</source>
-            </trans-unit>
-            <trans-unit id="help.getting_started.step1.title">
-                <source>Step 1 — Verify encryption health</source>
-            </trans-unit>
-            <trans-unit id="help.getting_started.step1.text">
-                <source>Visit the Dashboard and check the health indicator at the top. A green banner confirms that encryption is active and working. If you see an error, ensure that %s is set in your TYPO3 configuration or configure an alternative master key provider.</source>
-            </trans-unit>
-            <trans-unit id="help.getting_started.step2.title">
-                <source>Step 2 — Create your first secret</source>
-            </trans-unit>
-            <trans-unit id="help.getting_started.step2.text">
-                <source>Navigate to Secrets and click the + button in the header. Choose a descriptive identifier (e.g., stripe_api_key) and enter the secret value. The value is encrypted before it reaches the database.</source>
-            </trans-unit>
-            <trans-unit id="help.getting_started.step3.title">
-                <source>Step 3 — Reference secrets in configuration</source>
-            </trans-unit>
-            <trans-unit id="help.getting_started.step3.text">
-                <source>Use the vault syntax anywhere TYPO3 resolves configuration values:</source>
-            </trans-unit>
-            <trans-unit id="help.getting_started.step3.text2">
-                <source>This works in site configuration YAML, TypoScript, and any configuration that uses the TYPO3 expression language.</source>
-            </trans-unit>
-            <trans-unit id="help.getting_started.step4.title">
-                <source>Step 4 — Migrate existing plaintext secrets (optional)</source>
-            </trans-unit>
-            <trans-unit id="help.getting_started.step4.text">
-                <source>The Migration Wizard scans your database for plaintext secrets and guides you through encrypting them. It supports batch processing and verifies each migration before committing.</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.title">
-                <source>Envelope encryption</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.intro">
-                <source>Vault uses a two-layer encryption scheme called envelope encryption, the same pattern used by AWS KMS, Google Cloud KMS, and Azure Key Vault:</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.how_it_works">
-                <source>How it works</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.dek.label">
-                <source>Data Encryption Key (DEK)</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.dek.text">
-                <source>Each secret is encrypted with its own unique random key using AES-256-GCM. This means compromising one secret does not reveal others.</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.kek.label">
-                <source>Key Encryption Key (KEK / Master Key)</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.kek.text">
-                <source>The DEK is then encrypted with the master key and stored alongside the ciphertext. The master key never leaves the server.</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.providers.title">
-                <source>Master key providers</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.providers.intro">
-                <source>The master key can come from several sources (in priority order):</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.providers.env">
-                <source>Environment variable</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.providers.env.note">
-                <source>recommended for production</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.providers.file">
-                <source>File-based</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.providers.file.note">
-                <source>a key file outside the web root</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.providers.typo3">
-                <source>TYPO3 encryption key</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.providers.typo3.note">
-                <source>fallback using</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.rotation.title">
-                <source>Key rotation</source>
-            </trans-unit>
-            <trans-unit id="help.encryption.rotation.text">
-                <source>The master key can be rotated without downtime using %s. This re-encrypts all DEKs with the new master key. Individual secrets can also be rotated with %s.</source>
-            </trans-unit>
-            <trans-unit id="help.audit.title">
-                <source>Audit trail</source>
-            </trans-unit>
-            <trans-unit id="help.audit.intro">
-                <source>Every secret operation (create, read, update, delete, rotate) is recorded in a tamper-evident audit chain. Each entry includes:</source>
-            </trans-unit>
-            <trans-unit id="help.audit.item.action">
-                <source>The action performed and the secret identifier</source>
-            </trans-unit>
-            <trans-unit id="help.audit.item.user">
-                <source>The backend user who performed the action</source>
-            </trans-unit>
-            <trans-unit id="help.audit.item.timestamp">
-                <source>A timestamp and IP address</source>
-            </trans-unit>
-            <trans-unit id="help.audit.item.hash">
-                <source>A cryptographic hash linking each entry to the previous one</source>
-            </trans-unit>
-            <trans-unit id="help.audit.text">
-                <source>Use the Audit Log module to browse entries and the Verify Chain action to check integrity. Any tampered or missing entries will be flagged.</source>
-            </trans-unit>
-            <trans-unit id="help.troubleshooting.title">
-                <source>Troubleshooting</source>
-            </trans-unit>
-            <trans-unit id="help.troubleshooting.encryption.title">
-                <source>"Encryption is not available" on the dashboard</source>
-            </trans-unit>
-            <trans-unit id="help.troubleshooting.encryption.text">
-                <source>The master key provider could not be initialized. Check that at least one of the following is configured:</source>
-            </trans-unit>
-            <trans-unit id="help.troubleshooting.encryption.item1">
-                <source>The TYPO3_VAULT_MASTER_KEY environment variable is set</source>
-            </trans-unit>
-            <trans-unit id="help.troubleshooting.encryption.item2">
-                <source>A valid key file path is configured in extension settings</source>
-            </trans-unit>
-            <trans-unit id="help.troubleshooting.encryption.item3">
-                <source>The TYPO3 encryptionKey is not empty</source>
-            </trans-unit>
-            <trans-unit id="help.troubleshooting.decryption.title">
-                <source>Secret values show as "decryption failed"</source>
-            </trans-unit>
-            <trans-unit id="help.troubleshooting.decryption.text">
-                <source>This means the master key has changed since the secret was encrypted. If the master key was rotated correctly, all DEKs should have been re-encrypted. If the key was lost, the affected secrets cannot be recovered — store a new value.</source>
-            </trans-unit>
-            <trans-unit id="help.troubleshooting.no_candidates.title">
-                <source>Migration wizard finds no candidates</source>
-            </trans-unit>
-            <trans-unit id="help.troubleshooting.no_candidates.text">
-                <source>The scanner looks for fields matching common secret patterns (columns named *password*, *key*, *token*, *secret*). If your field uses a different naming convention, you can add it manually via the CLI:</source>
-            </trans-unit>
-            <trans-unit id="help.troubleshooting.chain.title">
-                <source>Audit chain verification fails</source>
-            </trans-unit>
-            <trans-unit id="help.troubleshooting.chain.text">
-                <source>A broken chain means an entry was modified or deleted outside of vault operations. This could indicate tampering or a database restore from an inconsistent backup. The verification report shows exactly which entries are affected.</source>
-            </trans-unit>
-            <trans-unit id="help.faq.title">
-                <source>Frequently asked questions</source>
-            </trans-unit>
-            <trans-unit id="help.faq.site_config.question">
-                <source>Can I use vault secrets in site configuration YAML?</source>
-            </trans-unit>
-            <trans-unit id="help.faq.site_config.answer">
-                <source>Yes. Use the %vault(identifier)% syntax in your config/sites/*/config.yaml. Values are resolved at runtime, so they never appear in plain text in files.</source>
-            </trans-unit>
-            <trans-unit id="help.faq.lost_key.question">
-                <source>What happens if I lose the master key?</source>
-            </trans-unit>
-            <trans-unit id="help.faq.lost_key.answer">
-                <source>Without the master key, encrypted secrets cannot be recovered. This is by design — the security of envelope encryption depends on the master key. Always back up your master key separately from the database.</source>
-            </trans-unit>
-            <trans-unit id="help.faq.editors.question">
-                <source>Can editors access secrets?</source>
-            </trans-unit>
-            <trans-unit id="help.faq.editors.answer">
-                <source>The vault backend module is restricted to administrators. However, editors can interact with vault-backed TCA fields (e.g., renderType=vaultSecret) without seeing the actual values — they enter values which are encrypted automatically.</source>
-            </trans-unit>
-            <trans-unit id="help.faq.cicd.question">
-                <source>How do I rotate secrets in a CI/CD pipeline?</source>
-            </trans-unit>
-            <trans-unit id="help.faq.cicd.answer.intro">
-                <source>Use the CLI commands in your deployment scripts:</source>
-            </trans-unit>
-            <trans-unit id="help.faq.cicd.answer.outro">
-                <source>Ensure the TYPO3_VAULT_MASTER_KEY environment variable is available in your CI/CD environment.</source>
-            </trans-unit>
+      <!-- Help page -->
+      <trans-unit id="help.title">
+        <source>Vault Help</source>
+      </trans-unit>
+      <trans-unit id="help.lead">
+        <source>This guide explains how vault encryption works, how to manage secrets, and how to troubleshoot common issues.</source>
+      </trans-unit>
+      <trans-unit id="help.getting_started.title">
+        <source>Getting started</source>
+      </trans-unit>
+      <trans-unit id="help.getting_started.intro">
+        <source>The Vault extension provides secure storage for sensitive configuration data (API keys, passwords, tokens) using envelope encryption. Follow these steps to get started:</source>
+      </trans-unit>
+      <trans-unit id="help.getting_started.step1.title">
+        <source>Step 1 — Verify encryption health</source>
+      </trans-unit>
+      <trans-unit id="help.getting_started.step1.text">
+        <source>Visit the Dashboard and check the health indicator at the top. A green banner confirms that encryption is active and working. If you see an error, ensure that %s is set in your TYPO3 configuration or configure an alternative master key provider.</source>
+      </trans-unit>
+      <trans-unit id="help.getting_started.step2.title">
+        <source>Step 2 — Create your first secret</source>
+      </trans-unit>
+      <trans-unit id="help.getting_started.step2.text">
+        <source>Navigate to Secrets and click the + button in the header. Choose a descriptive identifier (e.g., stripe_api_key) and enter the secret value. The value is encrypted before it reaches the database.</source>
+      </trans-unit>
+      <trans-unit id="help.getting_started.step3.title">
+        <source>Step 3 — Reference secrets in configuration</source>
+      </trans-unit>
+      <trans-unit id="help.getting_started.step3.text">
+        <source>Use the vault syntax anywhere TYPO3 resolves configuration values:</source>
+      </trans-unit>
+      <trans-unit id="help.getting_started.step3.text2">
+        <source>This works in site configuration YAML, TypoScript, and any configuration that uses the TYPO3 expression language.</source>
+      </trans-unit>
+      <trans-unit id="help.getting_started.step4.title">
+        <source>Step 4 — Migrate existing plaintext secrets (optional)</source>
+      </trans-unit>
+      <trans-unit id="help.getting_started.step4.text">
+        <source>The Migration Wizard scans your database for plaintext secrets and guides you through encrypting them. It supports batch processing and verifies each migration before committing.</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.title">
+        <source>Envelope encryption</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.intro">
+        <source>Vault uses a two-layer encryption scheme called envelope encryption, the same pattern used by AWS KMS, Google Cloud KMS, and Azure Key Vault:</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.how_it_works">
+        <source>How it works</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.dek.label">
+        <source>Data Encryption Key (DEK)</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.dek.text">
+        <source>Each secret is encrypted with its own unique random key using AES-256-GCM. This means compromising one secret does not reveal others.</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.kek.label">
+        <source>Key Encryption Key (KEK / Master Key)</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.kek.text">
+        <source>The DEK is then encrypted with the master key and stored alongside the ciphertext. The master key never leaves the server.</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.providers.title">
+        <source>Master key providers</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.providers.intro">
+        <source>The master key can come from several sources (in priority order):</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.providers.env">
+        <source>Environment variable</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.providers.env.note">
+        <source>recommended for production</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.providers.file">
+        <source>File-based</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.providers.file.note">
+        <source>a key file outside the web root</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.providers.typo3">
+        <source>TYPO3 encryption key</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.providers.typo3.note">
+        <source>fallback using</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.rotation.title">
+        <source>Key rotation</source>
+      </trans-unit>
+      <trans-unit id="help.encryption.rotation.text">
+        <source>The master key can be rotated without downtime using %s. This re-encrypts all DEKs with the new master key. Individual secrets can also be rotated with %s.</source>
+      </trans-unit>
+      <trans-unit id="help.audit.title">
+        <source>Audit trail</source>
+      </trans-unit>
+      <trans-unit id="help.audit.intro">
+        <source>Every secret operation (create, read, update, delete, rotate) is recorded in a tamper-evident audit chain. Each entry includes:</source>
+      </trans-unit>
+      <trans-unit id="help.audit.item.action">
+        <source>The action performed and the secret identifier</source>
+      </trans-unit>
+      <trans-unit id="help.audit.item.user">
+        <source>The backend user who performed the action</source>
+      </trans-unit>
+      <trans-unit id="help.audit.item.timestamp">
+        <source>A timestamp and IP address</source>
+      </trans-unit>
+      <trans-unit id="help.audit.item.hash">
+        <source>A cryptographic hash linking each entry to the previous one</source>
+      </trans-unit>
+      <trans-unit id="help.audit.text">
+        <source>Use the Audit Log module to browse entries and the Verify Chain action to check integrity. Any tampered or missing entries will be flagged.</source>
+      </trans-unit>
+      <trans-unit id="help.troubleshooting.title">
+        <source>Troubleshooting</source>
+      </trans-unit>
+      <trans-unit id="help.troubleshooting.encryption.title">
+        <source>"Encryption is not available" on the dashboard</source>
+      </trans-unit>
+      <trans-unit id="help.troubleshooting.encryption.text">
+        <source>The master key provider could not be initialized. Check that at least one of the following is configured:</source>
+      </trans-unit>
+      <trans-unit id="help.troubleshooting.encryption.item1">
+        <source>The TYPO3_VAULT_MASTER_KEY environment variable is set</source>
+      </trans-unit>
+      <trans-unit id="help.troubleshooting.encryption.item2">
+        <source>A valid key file path is configured in extension settings</source>
+      </trans-unit>
+      <trans-unit id="help.troubleshooting.encryption.item3">
+        <source>The TYPO3 encryptionKey is not empty</source>
+      </trans-unit>
+      <trans-unit id="help.troubleshooting.decryption.title">
+        <source>Secret values show as "decryption failed"</source>
+      </trans-unit>
+      <trans-unit id="help.troubleshooting.decryption.text">
+        <source>This means the master key has changed since the secret was encrypted. If the master key was rotated correctly, all DEKs should have been re-encrypted. If the key was lost, the affected secrets cannot be recovered — store a new value.</source>
+      </trans-unit>
+      <trans-unit id="help.troubleshooting.no_candidates.title">
+        <source>Migration wizard finds no candidates</source>
+      </trans-unit>
+      <trans-unit id="help.troubleshooting.no_candidates.text">
+        <source>The scanner looks for fields matching common secret patterns (columns named *password*, *key*, *token*, *secret*). If your field uses a different naming convention, you can add it manually via the CLI:</source>
+      </trans-unit>
+      <trans-unit id="help.troubleshooting.chain.title">
+        <source>Audit chain verification fails</source>
+      </trans-unit>
+      <trans-unit id="help.troubleshooting.chain.text">
+        <source>A broken chain means an entry was modified or deleted outside of vault operations. This could indicate tampering or a database restore from an inconsistent backup. The verification report shows exactly which entries are affected.</source>
+      </trans-unit>
+      <trans-unit id="help.faq.title">
+        <source>Frequently asked questions</source>
+      </trans-unit>
+      <trans-unit id="help.faq.site_config.question">
+        <source>Can I use vault secrets in site configuration YAML?</source>
+      </trans-unit>
+      <trans-unit id="help.faq.site_config.answer">
+        <source>Yes. Use the %vault(identifier)% syntax in your config/sites/*/config.yaml. Values are resolved at runtime, so they never appear in plain text in files.</source>
+      </trans-unit>
+      <trans-unit id="help.faq.lost_key.question">
+        <source>What happens if I lose the master key?</source>
+      </trans-unit>
+      <trans-unit id="help.faq.lost_key.answer">
+        <source>Without the master key, encrypted secrets cannot be recovered. This is by design — the security of envelope encryption depends on the master key. Always back up your master key separately from the database.</source>
+      </trans-unit>
+      <trans-unit id="help.faq.editors.question">
+        <source>Can editors access secrets?</source>
+      </trans-unit>
+      <trans-unit id="help.faq.editors.answer">
+        <source>The vault backend module is restricted to administrators. However, editors can interact with vault-backed TCA fields (e.g., renderType=vaultSecret) without seeing the actual values — they enter values which are encrypted automatically.</source>
+      </trans-unit>
+      <trans-unit id="help.faq.cicd.question">
+        <source>How do I rotate secrets in a CI/CD pipeline?</source>
+      </trans-unit>
+      <trans-unit id="help.faq.cicd.answer.intro">
+        <source>Use the CLI commands in your deployment scripts:</source>
+      </trans-unit>
+      <trans-unit id="help.faq.cicd.answer.outro">
+        <source>Ensure the TYPO3_VAULT_MASTER_KEY environment variable is available in your CI/CD environment.</source>
+      </trans-unit>
 
-            <!-- Migration Index page -->
-            <trans-unit id="migration.index.description">
-                <source>This wizard helps you detect and migrate plaintext secrets from your database and configuration to the secure vault.</source>
-            </trans-unit>
-            <trans-unit id="migration.index.how_it_works">
-                <source>How it works</source>
-            </trans-unit>
-            <trans-unit id="migration.index.step.scan">
-                <source>The system scans your database columns and extension configuration for values that look like secrets (API keys, passwords, tokens).</source>
-            </trans-unit>
-            <trans-unit id="migration.index.step.review">
-                <source>You review the detected secrets and select which ones to migrate.</source>
-            </trans-unit>
-            <trans-unit id="migration.index.step.configure">
-                <source>Set migration options like identifier patterns and ownership.</source>
-            </trans-unit>
-            <trans-unit id="migration.index.step.execute">
-                <source>The selected secrets are encrypted and stored in the vault, and database columns are updated with vault references.</source>
-            </trans-unit>
-            <trans-unit id="migration.index.step.verify">
-                <source>Confirm that the migration completed successfully.</source>
-            </trans-unit>
-            <trans-unit id="migration.index.detected.title">
-                <source>What is detected?</source>
-            </trans-unit>
-            <trans-unit id="migration.index.detected.database.title">
-                <source>Database Columns</source>
-            </trans-unit>
-            <trans-unit id="migration.index.detected.database.subtitle">
-                <source>Columns with names suggesting secrets</source>
-            </trans-unit>
-            <trans-unit id="migration.index.detected.patterns.title">
-                <source>Known API Key Formats</source>
-            </trans-unit>
-            <trans-unit id="migration.index.detected.patterns.subtitle">
-                <source>Values matching patterns for</source>
-            </trans-unit>
-            <trans-unit id="migration.index.detected.patterns.list">
-                <source>Stripe, AWS, Google API keys</source>
-            </trans-unit>
-            <trans-unit id="migration.index.detected.patterns.github">
-                <source>GitHub tokens (PAT, OAuth)</source>
-            </trans-unit>
-            <trans-unit id="migration.index.detected.patterns.other">
-                <source>Slack, SendGrid, Twilio tokens</source>
-            </trans-unit>
-            <trans-unit id="migration.index.notes.title">
-                <source>Important Notes</source>
-            </trans-unit>
-            <trans-unit id="migration.index.notes.backup">
-                <source>Always create a database backup before running migrations.</source>
-            </trans-unit>
-            <trans-unit id="migration.index.notes.test">
-                <source>Run the scan on a test system first to review what will be detected.</source>
-            </trans-unit>
-            <trans-unit id="migration.index.notes.false_positives">
-                <source>Not all detected values are actual secrets. Review carefully before migrating.</source>
-            </trans-unit>
-            <trans-unit id="migration.index.notes.hashes">
-                <source>Hashed passwords (bcrypt, argon2) are automatically excluded as they are already secure.</source>
-            </trans-unit>
-            <trans-unit id="migration.index.config_secrets.title">
-                <source>Configuration Secrets</source>
-            </trans-unit>
-            <trans-unit id="migration.index.config_secrets.text">
-                <source>Configuration secrets (in LocalConfiguration.php or extension settings) are detected but must be migrated manually. Replace the value with %vault(identifier)% after storing the secret in the vault.</source>
-            </trans-unit>
-            <trans-unit id="migration.index.start_scan">
-                <source>Start Scan</source>
-            </trans-unit>
-            <trans-unit id="migration.index.notes.backup.label">
-                <source>Backup first</source>
-            </trans-unit>
-            <trans-unit id="migration.index.notes.test.label">
-                <source>Test environment</source>
-            </trans-unit>
-            <trans-unit id="migration.index.notes.false_positives.label">
-                <source>False positives</source>
-            </trans-unit>
-            <trans-unit id="migration.index.notes.hashes.label">
-                <source>Password hashes</source>
-            </trans-unit>
+      <!-- Migration Index page -->
+      <trans-unit id="migration.index.description">
+        <source>This wizard helps you detect and migrate plaintext secrets from your database and configuration to the secure vault.</source>
+      </trans-unit>
+      <trans-unit id="migration.index.how_it_works">
+        <source>How it works</source>
+      </trans-unit>
+      <trans-unit id="migration.index.step.scan">
+        <source>The system scans your database columns and extension configuration for values that look like secrets (API keys, passwords, tokens).</source>
+      </trans-unit>
+      <trans-unit id="migration.index.step.review">
+        <source>You review the detected secrets and select which ones to migrate.</source>
+      </trans-unit>
+      <trans-unit id="migration.index.step.configure">
+        <source>Set migration options like identifier patterns and ownership.</source>
+      </trans-unit>
+      <trans-unit id="migration.index.step.execute">
+        <source>The selected secrets are encrypted and stored in the vault, and database columns are updated with vault references.</source>
+      </trans-unit>
+      <trans-unit id="migration.index.step.verify">
+        <source>Confirm that the migration completed successfully.</source>
+      </trans-unit>
+      <trans-unit id="migration.index.detected.title">
+        <source>What is detected?</source>
+      </trans-unit>
+      <trans-unit id="migration.index.detected.database.title">
+        <source>Database Columns</source>
+      </trans-unit>
+      <trans-unit id="migration.index.detected.database.subtitle">
+        <source>Columns with names suggesting secrets</source>
+      </trans-unit>
+      <trans-unit id="migration.index.detected.patterns.title">
+        <source>Known API Key Formats</source>
+      </trans-unit>
+      <trans-unit id="migration.index.detected.patterns.subtitle">
+        <source>Values matching patterns for</source>
+      </trans-unit>
+      <trans-unit id="migration.index.detected.patterns.list">
+        <source>Stripe, AWS, Google API keys</source>
+      </trans-unit>
+      <trans-unit id="migration.index.detected.patterns.github">
+        <source>GitHub tokens (PAT, OAuth)</source>
+      </trans-unit>
+      <trans-unit id="migration.index.detected.patterns.other">
+        <source>Slack, SendGrid, Twilio tokens</source>
+      </trans-unit>
+      <trans-unit id="migration.index.notes.title">
+        <source>Important Notes</source>
+      </trans-unit>
+      <trans-unit id="migration.index.notes.backup">
+        <source>Always create a database backup before running migrations.</source>
+      </trans-unit>
+      <trans-unit id="migration.index.notes.test">
+        <source>Run the scan on a test system first to review what will be detected.</source>
+      </trans-unit>
+      <trans-unit id="migration.index.notes.false_positives">
+        <source>Not all detected values are actual secrets. Review carefully before migrating.</source>
+      </trans-unit>
+      <trans-unit id="migration.index.notes.hashes">
+        <source>Hashed passwords (bcrypt, argon2) are automatically excluded as they are already secure.</source>
+      </trans-unit>
+      <trans-unit id="migration.index.config_secrets.title">
+        <source>Configuration Secrets</source>
+      </trans-unit>
+      <trans-unit id="migration.index.config_secrets.text">
+        <source>Configuration secrets (in LocalConfiguration.php or extension settings) are detected but must be migrated manually. Replace the value with %vault(identifier)% after storing the secret in the vault.</source>
+      </trans-unit>
+      <trans-unit id="migration.index.start_scan">
+        <source>Start Scan</source>
+      </trans-unit>
+      <trans-unit id="migration.index.notes.backup.label">
+        <source>Backup first</source>
+      </trans-unit>
+      <trans-unit id="migration.index.notes.test.label">
+        <source>Test environment</source>
+      </trans-unit>
+      <trans-unit id="migration.index.notes.false_positives.label">
+        <source>False positives</source>
+      </trans-unit>
+      <trans-unit id="migration.index.notes.hashes.label">
+        <source>Password hashes</source>
+      </trans-unit>
 
-            <!-- Migration Scan page -->
-            <trans-unit id="migration.scan.title">
-                <source>Step 1: Scan for Plaintext Secrets</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.description">
-                <source>The system has scanned your TYPO3 installation for potential plaintext secrets that should be migrated to the vault.</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.potential_secrets">
-                <source>Potential secrets detected</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.in_database">
-                <source>In database columns</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.in_config">
-                <source>In configuration</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.by_severity">
-                <source>Secrets by Severity</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.severity.critical">
-                <source>Critical</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.severity.high">
-                <source>High</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.severity.medium">
-                <source>Medium</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.severity.low">
-                <source>Low</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.found">
-                <source>found</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.col.location">
-                <source>Location</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.col.patterns">
-                <source>Patterns</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.col.records">
-                <source>Records</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.records">
-                <source>records</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.patterns.hint">
-                <source>Known API key formats (Stripe, AWS, GitHub, etc.). "—" means detected by field name only.</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.records.hint">
-                <source>Database records affected. "n/a" for configuration secrets (must be migrated manually).</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.back">
-                <source>Back</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.rescan">
-                <source>Rescan</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.continue">
-                <source>Continue to Review (%d database secrets)</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.no_database_secrets.title">
-                <source>No Database Secrets to Migrate</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.no_database_secrets.text">
-                <source>Only configuration secrets were detected. These must be migrated manually by updating your configuration to use %vault(identifier)% references. See the documentation for details.</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.no_secrets.title">
-                <source>No Plaintext Secrets Detected</source>
-            </trans-unit>
-            <trans-unit id="migration.scan.no_secrets.text">
-                <source>Great! No potential plaintext secrets were found in your database or configuration. Your sensitive data appears to be properly protected.</source>
-            </trans-unit>
+      <!-- Migration Scan page -->
+      <trans-unit id="migration.scan.title">
+        <source>Step 1: Scan for Plaintext Secrets</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.description">
+        <source>The system has scanned your TYPO3 installation for potential plaintext secrets that should be migrated to the vault.</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.potential_secrets">
+        <source>Potential secrets detected</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.in_database">
+        <source>In database columns</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.in_config">
+        <source>In configuration</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.by_severity">
+        <source>Secrets by Severity</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.severity.critical">
+        <source>Critical</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.severity.high">
+        <source>High</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.severity.medium">
+        <source>Medium</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.severity.low">
+        <source>Low</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.found">
+        <source>found</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.col.location">
+        <source>Location</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.col.patterns">
+        <source>Patterns</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.col.records">
+        <source>Records</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.records">
+        <source>records</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.patterns.hint">
+        <source>Known API key formats (Stripe, AWS, GitHub, etc.). "—" means detected by field name only.</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.records.hint">
+        <source>Database records affected. "n/a" for configuration secrets (must be migrated manually).</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.back">
+        <source>Back</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.rescan">
+        <source>Rescan</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.continue">
+        <source>Continue to Review (%d database secrets)</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.no_database_secrets.title">
+        <source>No Database Secrets to Migrate</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.no_database_secrets.text">
+        <source>Only configuration secrets were detected. These must be migrated manually by updating your configuration to use %vault(identifier)% references. See the documentation for details.</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.no_secrets.title">
+        <source>No Plaintext Secrets Detected</source>
+      </trans-unit>
+      <trans-unit id="migration.scan.no_secrets.text">
+        <source>Great! No potential plaintext secrets were found in your database or configuration. Your sensitive data appears to be properly protected.</source>
+      </trans-unit>
 
-            <!-- Migration Review page -->
-            <trans-unit id="migration.review.title">
-                <source>Step 2: Review and Select Secrets</source>
-            </trans-unit>
-            <trans-unit id="migration.review.description">
-                <source>Select which database secrets you want to migrate to the vault. Configuration secrets must be migrated manually.</source>
-            </trans-unit>
-            <trans-unit id="migration.review.db_only.title">
-                <source>Database Secrets Only</source>
-            </trans-unit>
-            <trans-unit id="migration.review.db_only.text">
-                <source>Only database secrets can be migrated via this wizard. Configuration secrets need to be updated manually to use %vault(identifier)% references.</source>
-            </trans-unit>
-            <trans-unit id="migration.review.select_all">
-                <source>Select all</source>
-            </trans-unit>
-            <trans-unit id="migration.review.col.location">
-                <source>Location</source>
-            </trans-unit>
-            <trans-unit id="migration.review.col.records">
-                <source>Records</source>
-            </trans-unit>
-            <trans-unit id="migration.review.col.severity">
-                <source>Severity</source>
-            </trans-unit>
-            <trans-unit id="migration.review.col.patterns">
-                <source>Patterns</source>
-            </trans-unit>
-            <trans-unit id="migration.review.patterns.hint">
-                <source>Known API key formats (Stripe, AWS, GitHub, etc.). "—" means detected by field name only.</source>
-            </trans-unit>
-            <trans-unit id="migration.review.back_to_scan">
-                <source>Back to Scan</source>
-            </trans-unit>
-            <trans-unit id="migration.review.configure_selected">
-                <source>Configure Selected</source>
-            </trans-unit>
-            <trans-unit id="migration.review.no_secrets.title">
-                <source>No Database Secrets Found</source>
-            </trans-unit>
-            <trans-unit id="migration.review.no_secrets.text">
-                <source>No database secrets were found to migrate. The scan may have detected only configuration secrets, which must be migrated manually by updating your configuration to use %vault(identifier)% references.</source>
-            </trans-unit>
+      <!-- Migration Review page -->
+      <trans-unit id="migration.review.title">
+        <source>Step 2: Review and Select Secrets</source>
+      </trans-unit>
+      <trans-unit id="migration.review.description">
+        <source>Select which database secrets you want to migrate to the vault. Configuration secrets must be migrated manually.</source>
+      </trans-unit>
+      <trans-unit id="migration.review.db_only.title">
+        <source>Database Secrets Only</source>
+      </trans-unit>
+      <trans-unit id="migration.review.db_only.text">
+        <source>Only database secrets can be migrated via this wizard. Configuration secrets need to be updated manually to use %vault(identifier)% references.</source>
+      </trans-unit>
+      <trans-unit id="migration.review.select_all">
+        <source>Select all</source>
+      </trans-unit>
+      <trans-unit id="migration.review.col.location">
+        <source>Location</source>
+      </trans-unit>
+      <trans-unit id="migration.review.col.records">
+        <source>Records</source>
+      </trans-unit>
+      <trans-unit id="migration.review.col.severity">
+        <source>Severity</source>
+      </trans-unit>
+      <trans-unit id="migration.review.col.patterns">
+        <source>Patterns</source>
+      </trans-unit>
+      <trans-unit id="migration.review.patterns.hint">
+        <source>Known API key formats (Stripe, AWS, GitHub, etc.). "—" means detected by field name only.</source>
+      </trans-unit>
+      <trans-unit id="migration.review.back_to_scan">
+        <source>Back to Scan</source>
+      </trans-unit>
+      <trans-unit id="migration.review.configure_selected">
+        <source>Configure Selected</source>
+      </trans-unit>
+      <trans-unit id="migration.review.no_secrets.title">
+        <source>No Database Secrets Found</source>
+      </trans-unit>
+      <trans-unit id="migration.review.no_secrets.text">
+        <source>No database secrets were found to migrate. The scan may have detected only configuration secrets, which must be migrated manually by updating your configuration to use %vault(identifier)% references.</source>
+      </trans-unit>
 
-            <!-- Migration Configure page -->
-            <trans-unit id="migration.configure.title">
-                <source>Step 3: Configure Migration</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.description">
-                <source>Review the migration settings for each selected secret. The identifier pattern determines how secrets will be stored in the vault.</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.warning.title">
-                <source>Database Modification</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.warning.text">
-                <source>This will modify your database. Make sure you have a backup before proceeding.</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.col.table">
-                <source>Table</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.col.column">
-                <source>Column</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.col.identifier_pattern">
-                <source>Identifier Pattern</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.pattern_help">
-                <source>Use {uid} as placeholder for record UID</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.options.title">
-                <source>Migration Options</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.options.clear_originals">
-                <source>Replace original values with vault identifiers</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.options.clear_originals.help">
-                <source>When enabled, the original plaintext values in the database will be replaced with vault identifiers. This is the recommended approach for production environments.</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.back_to_review">
-                <source>Back to Review</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.execute">
-                <source>Execute Migration</source>
-            </trans-unit>
-            <trans-unit id="migration.configure.warning.label">
-                <source>Warning:</source>
-            </trans-unit>
+      <!-- Migration Configure page -->
+      <trans-unit id="migration.configure.title">
+        <source>Step 3: Configure Migration</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.description">
+        <source>Review the migration settings for each selected secret. The identifier pattern determines how secrets will be stored in the vault.</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.warning.title">
+        <source>Database Modification</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.warning.text">
+        <source>This will modify your database. Make sure you have a backup before proceeding.</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.col.table">
+        <source>Table</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.col.column">
+        <source>Column</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.col.identifier_pattern">
+        <source>Identifier Pattern</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.pattern_help">
+        <source>Use {uid} as placeholder for record UID</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.options.title">
+        <source>Migration Options</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.options.clear_originals">
+        <source>Replace original values with vault identifiers</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.options.clear_originals.help">
+        <source>When enabled, the original plaintext values in the database will be replaced with vault identifiers. This is the recommended approach for production environments.</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.back_to_review">
+        <source>Back to Review</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.execute">
+        <source>Execute Migration</source>
+      </trans-unit>
+      <trans-unit id="migration.configure.warning.label">
+        <source>Warning:</source>
+      </trans-unit>
 
-            <!-- Migration Verify page -->
-            <trans-unit id="migration.verify.title">
-                <source>Step 5: Migration Results</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.secrets_migrated">
-                <source>Secrets migrated</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.failed">
-                <source>Failed</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.details.title">
-                <source>Migration Details</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.col.table">
-                <source>Table</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.col.column">
-                <source>Column</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.col.migrated">
-                <source>Migrated</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.col.skipped">
-                <source>Skipped</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.col.failed">
-                <source>Failed</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.col.status">
-                <source>Status</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.status.error">
-                <source>Error</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.status.partial">
-                <source>Partial</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.status.complete">
-                <source>Complete</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.db_updated.title">
-                <source>Database Updated</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.db_updated.text">
-                <source>Original plaintext values have been replaced with vault identifiers in the database.</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.next_steps.title">
-                <source>Next Steps</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.next_steps.view">
-                <source>View migrated secrets</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.next_steps.view.suffix">
-                <source>in the Secrets Manager</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.next_steps.update_code">
-                <source>Update your extension code to use VaultFieldResolver::resolveFields() to retrieve secrets</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.next_steps.test">
-                <source>Test that your application still works correctly with the migrated secrets</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.next_steps.rescan">
-                <source>Consider running another scan to check for any remaining plaintext secrets</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.run_another_scan">
-                <source>Run Another Scan</source>
-            </trans-unit>
-            <trans-unit id="migration.verify.view_secrets">
-                <source>View Secrets</source>
-            </trans-unit>
-        </body>
-    </file>
+      <!-- Migration Verify page -->
+      <trans-unit id="migration.verify.title">
+        <source>Step 5: Migration Results</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.secrets_migrated">
+        <source>Secrets migrated</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.failed">
+        <source>Failed</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.details.title">
+        <source>Migration Details</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.col.table">
+        <source>Table</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.col.column">
+        <source>Column</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.col.migrated">
+        <source>Migrated</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.col.skipped">
+        <source>Skipped</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.col.failed">
+        <source>Failed</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.col.status">
+        <source>Status</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.status.error">
+        <source>Error</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.status.partial">
+        <source>Partial</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.status.complete">
+        <source>Complete</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.db_updated.title">
+        <source>Database Updated</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.db_updated.text">
+        <source>Original plaintext values have been replaced with vault identifiers in the database.</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.next_steps.title">
+        <source>Next Steps</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.next_steps.view">
+        <source>View migrated secrets</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.next_steps.view.suffix">
+        <source>in the Secrets Manager</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.next_steps.update_code">
+        <source>Update your extension code to use VaultFieldResolver::resolveFields() to retrieve secrets</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.next_steps.test">
+        <source>Test that your application still works correctly with the migrated secrets</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.next_steps.rescan">
+        <source>Consider running another scan to check for any remaining plaintext secrets</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.run_another_scan">
+        <source>Run Another Scan</source>
+      </trans-unit>
+      <trans-unit id="migration.verify.view_secrets">
+        <source>View Secrets</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -1,142 +1,142 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
-    <file source-language="en" datatype="plaintext" original="messages" date="2024-12-28T00:00:00Z" product-name="nr_vault">
-        <header/>
-        <body>
-            <!-- Table title -->
-            <trans-unit id="tx_nrvault_secret">
-                <source>Vault Secret</source>
-            </trans-unit>
+  <file source-language="en" datatype="plaintext" original="messages" date="2024-12-28T00:00:00Z" product-name="nr_vault">
+    <header/>
+    <body>
+      <!-- Table title -->
+      <trans-unit id="tx_nrvault_secret">
+        <source>Vault Secret</source>
+      </trans-unit>
 
-            <!-- Tabs -->
-            <trans-unit id="tabs.access">
-                <source>Access Control</source>
-            </trans-unit>
-            <trans-unit id="tabs.settings">
-                <source>Settings</source>
-            </trans-unit>
-            <trans-unit id="tabs.info">
-                <source>Information</source>
-            </trans-unit>
+      <!-- Tabs -->
+      <trans-unit id="tabs.access">
+        <source>Access Control</source>
+      </trans-unit>
+      <trans-unit id="tabs.settings">
+        <source>Settings</source>
+      </trans-unit>
+      <trans-unit id="tabs.info">
+        <source>Information</source>
+      </trans-unit>
 
-            <!-- Fields -->
-            <trans-unit id="tx_nrvault_secret.identifier">
-                <source>Identifier</source>
-            </trans-unit>
-            <trans-unit id="tx_nrvault_secret.identifier.description">
-                <source>Unique identifier for this secret (alphanumeric, underscores, dashes)</source>
-            </trans-unit>
+      <!-- Fields -->
+      <trans-unit id="tx_nrvault_secret.identifier">
+        <source>Identifier</source>
+      </trans-unit>
+      <trans-unit id="tx_nrvault_secret.identifier.description">
+        <source>Unique identifier for this secret (alphanumeric, underscores, dashes)</source>
+      </trans-unit>
 
-            <trans-unit id="tx_nrvault_secret.description">
-                <source>Description</source>
-            </trans-unit>
+      <trans-unit id="tx_nrvault_secret.description">
+        <source>Description</source>
+      </trans-unit>
 
-            <trans-unit id="tx_nrvault_secret.owner_uid">
-                <source>Owner</source>
-            </trans-unit>
-            <trans-unit id="tx_nrvault_secret.owner_uid.description">
-                <source>Backend user who owns this secret</source>
-            </trans-unit>
+      <trans-unit id="tx_nrvault_secret.owner_uid">
+        <source>Owner</source>
+      </trans-unit>
+      <trans-unit id="tx_nrvault_secret.owner_uid.description">
+        <source>Backend user who owns this secret</source>
+      </trans-unit>
 
-            <trans-unit id="tx_nrvault_secret.allowed_groups">
-                <source>Allowed Groups</source>
-            </trans-unit>
-            <trans-unit id="tx_nrvault_secret.allowed_groups.description">
-                <source>Backend groups that can access this secret</source>
-            </trans-unit>
+      <trans-unit id="tx_nrvault_secret.allowed_groups">
+        <source>Allowed Groups</source>
+      </trans-unit>
+      <trans-unit id="tx_nrvault_secret.allowed_groups.description">
+        <source>Backend groups that can access this secret</source>
+      </trans-unit>
 
-            <trans-unit id="tx_nrvault_secret.context">
-                <source>Context</source>
-            </trans-unit>
-            <trans-unit id="tx_nrvault_secret.context.description">
-                <source>Application context (e.g., production, staging)</source>
-            </trans-unit>
+      <trans-unit id="tx_nrvault_secret.context">
+        <source>Context</source>
+      </trans-unit>
+      <trans-unit id="tx_nrvault_secret.context.description">
+        <source>Application context (e.g., production, staging)</source>
+      </trans-unit>
 
-            <trans-unit id="tx_nrvault_secret.frontend_accessible">
-                <source>Frontend Accessible</source>
-            </trans-unit>
-            <trans-unit id="tx_nrvault_secret.frontend_accessible.description">
-                <source>Allow this secret to be accessed in frontend context (TypoScript, Fluid)</source>
-            </trans-unit>
+      <trans-unit id="tx_nrvault_secret.frontend_accessible">
+        <source>Frontend Accessible</source>
+      </trans-unit>
+      <trans-unit id="tx_nrvault_secret.frontend_accessible.description">
+        <source>Allow this secret to be accessed in frontend context (TypoScript, Fluid)</source>
+      </trans-unit>
 
-            <trans-unit id="tx_nrvault_secret.expires_at">
-                <source>Expires At</source>
-            </trans-unit>
-            <trans-unit id="tx_nrvault_secret.expires_at.description">
-                <source>Optional expiration date for the secret</source>
-            </trans-unit>
+      <trans-unit id="tx_nrvault_secret.expires_at">
+        <source>Expires At</source>
+      </trans-unit>
+      <trans-unit id="tx_nrvault_secret.expires_at.description">
+        <source>Optional expiration date for the secret</source>
+      </trans-unit>
 
-            <trans-unit id="tx_nrvault_secret.metadata">
-                <source>Custom Metadata</source>
-            </trans-unit>
-            <trans-unit id="tx_nrvault_secret.metadata.description">
-                <source>Additional metadata as JSON</source>
-            </trans-unit>
+      <trans-unit id="tx_nrvault_secret.metadata">
+        <source>Custom Metadata</source>
+      </trans-unit>
+      <trans-unit id="tx_nrvault_secret.metadata.description">
+        <source>Additional metadata as JSON</source>
+      </trans-unit>
 
-            <trans-unit id="tx_nrvault_secret.scope_pid">
-                <source>Scope Page</source>
-            </trans-unit>
-            <trans-unit id="tx_nrvault_secret.scope_pid.description">
-                <source>Page used for multi-site scoping of this secret</source>
-            </trans-unit>
+      <trans-unit id="tx_nrvault_secret.scope_pid">
+        <source>Scope Page</source>
+      </trans-unit>
+      <trans-unit id="tx_nrvault_secret.scope_pid.description">
+        <source>Page used for multi-site scoping of this secret</source>
+      </trans-unit>
 
-            <!-- Info fields -->
-            <trans-unit id="tx_nrvault_secret.version">
-                <source>Version</source>
-            </trans-unit>
+      <!-- Info fields -->
+      <trans-unit id="tx_nrvault_secret.version">
+        <source>Version</source>
+      </trans-unit>
 
-            <trans-unit id="tx_nrvault_secret.last_rotated_at">
-                <source>Last Rotated</source>
-            </trans-unit>
+      <trans-unit id="tx_nrvault_secret.last_rotated_at">
+        <source>Last Rotated</source>
+      </trans-unit>
 
-            <trans-unit id="tx_nrvault_secret.read_count">
-                <source>Read Count</source>
-            </trans-unit>
+      <trans-unit id="tx_nrvault_secret.read_count">
+        <source>Read Count</source>
+      </trans-unit>
 
-            <trans-unit id="tx_nrvault_secret.last_read_at">
-                <source>Last Read</source>
-            </trans-unit>
+      <trans-unit id="tx_nrvault_secret.last_read_at">
+        <source>Last Read</source>
+      </trans-unit>
 
-            <trans-unit id="tx_nrvault_secret.adapter">
-                <source>Storage Adapter</source>
-            </trans-unit>
+      <trans-unit id="tx_nrvault_secret.adapter">
+        <source>Storage Adapter</source>
+      </trans-unit>
 
-            <!-- Secret input field -->
-            <trans-unit id="tx_nrvault_secret.secret_input">
-                <source>Secret Value</source>
-            </trans-unit>
-            <trans-unit id="tx_nrvault_secret.secret_input.description">
-                <source>The encrypted secret value stored in the vault</source>
-            </trans-unit>
+      <!-- Secret input field -->
+      <trans-unit id="tx_nrvault_secret.secret_input">
+        <source>Secret Value</source>
+      </trans-unit>
+      <trans-unit id="tx_nrvault_secret.secret_input.description">
+        <source>The encrypted secret value stored in the vault</source>
+      </trans-unit>
 
-            <!-- VaultSecretInputElement labels -->
-            <trans-unit id="vault_secret_input.placeholder_new">
-                <source>Enter secret value</source>
-            </trans-unit>
-            <trans-unit id="vault_secret_input.placeholder_rotate">
-                <source>Enter new secret value to rotate</source>
-            </trans-unit>
-            <trans-unit id="vault_secret_input.help_new">
-                <source>Enter the secret value. It will be encrypted when the record is saved.</source>
-            </trans-unit>
-            <trans-unit id="vault_secret_input.help_rotate">
-                <source>Leave empty to keep current secret. Enter a new value to rotate.</source>
-            </trans-unit>
-            <trans-unit id="vault_secret_input.current_secret">
-                <source>Current Secret</source>
-            </trans-unit>
-            <trans-unit id="vault_secret_input.new_secret">
-                <source>New Secret Value</source>
-            </trans-unit>
-            <trans-unit id="vault_secret_input.secret_value">
-                <source>Secret Value</source>
-            </trans-unit>
-            <trans-unit id="vault_secret_input.rotate">
-                <source>Rotate Secret</source>
-            </trans-unit>
-            <trans-unit id="vault_secret_input.no_secret">
-                <source>No secret value stored. Enter a value below.</source>
-            </trans-unit>
-        </body>
-    </file>
+      <!-- VaultSecretInputElement labels -->
+      <trans-unit id="vault_secret_input.placeholder_new">
+        <source>Enter secret value</source>
+      </trans-unit>
+      <trans-unit id="vault_secret_input.placeholder_rotate">
+        <source>Enter new secret value to rotate</source>
+      </trans-unit>
+      <trans-unit id="vault_secret_input.help_new">
+        <source>Enter the secret value. It will be encrypted when the record is saved.</source>
+      </trans-unit>
+      <trans-unit id="vault_secret_input.help_rotate">
+        <source>Leave empty to keep current secret. Enter a new value to rotate.</source>
+      </trans-unit>
+      <trans-unit id="vault_secret_input.current_secret">
+        <source>Current Secret</source>
+      </trans-unit>
+      <trans-unit id="vault_secret_input.new_secret">
+        <source>New Secret Value</source>
+      </trans-unit>
+      <trans-unit id="vault_secret_input.secret_value">
+        <source>Secret Value</source>
+      </trans-unit>
+      <trans-unit id="vault_secret_input.rotate">
+        <source>Rotate Secret</source>
+      </trans-unit>
+      <trans-unit id="vault_secret_input.no_secret">
+        <source>No secret value stored. Enter a value below.</source>
+      </trans-unit>
+    </body>
+  </file>
 </xliff>

--- a/Resources/Private/Templates/Audit/List.html
+++ b/Resources/Private/Templates/Audit/List.html
@@ -62,8 +62,8 @@
 
         <!-- Stats -->
         <div class="mb-3" role="status" aria-live="polite">
-            <span class="badge text-bg-info">{totalCount} entries</span>
-            <span class="badge text-bg-secondary">Page {currentPage} of {totalPages}</span>
+            <span class="badge text-bg-info">{totalCount} <f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.stats.entries" /></span>
+            <span class="badge text-bg-secondary"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.pagination.page" arguments="{0: currentPage, 1: totalPages}" /></span>
         </div>
 
         <f:if condition="{entries}">
@@ -76,12 +76,12 @@
                             <caption id="audit-table-{date}" class="visually-hidden">Audit log entries for {date}</caption>
                             <thead>
                                 <tr>
-                                    <th scope="col" style="width: 100px;"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.col.time" /></th>
+                                    <th scope="col" class="vault-col-time"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.col.time" /></th>
                                     <th scope="col"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.col.secret" /></th>
-                                    <th scope="col" style="width: 100px;"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.col.action" /></th>
-                                    <th scope="col" style="width: 80px;"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.col.status" /></th>
+                                    <th scope="col" class="vault-col-action"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.col.action" /></th>
+                                    <th scope="col" class="vault-col-status"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.col.status" /></th>
                                     <th scope="col"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.col.actor" /></th>
-                                    <th scope="col" style="width: 130px;"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.col.ip_address" /></th>
+                                    <th scope="col" class="vault-col-ip"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.col.ip_address" /></th>
                                     <th scope="col"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.col.details" /></th>
                                 </tr>
                             </thead>
@@ -154,7 +154,7 @@
                                 </f:else>
                             </f:if>
                             <li class="page-item">
-                                <span class="page-link">Page {currentPage} / {totalPages}</span>
+                                <span class="page-link"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.pagination.page" arguments="{0: currentPage, 1: totalPages}" /></span>
                             </li>
                             <f:if condition="{currentPage} < {totalPages}">
                                 <f:then>
@@ -188,7 +188,7 @@
                 </f:if>
             </f:then>
             <f:else>
-                <f:be.infobox title="No Audit Entries" state="-1">
+                <f:be.infobox title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.empty.title')}" state="-1">
                     <f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.empty" />
                 </f:be.infobox>
             </f:else>

--- a/Resources/Private/Templates/Audit/VerifyChain.html
+++ b/Resources/Private/Templates/Audit/VerifyChain.html
@@ -10,13 +10,29 @@
         <f:if condition="{valid}">
             <f:then>
                 <f:be.infobox title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.chain_valid')}" state="0">
-                    The audit log hash chain has been verified successfully. No tampering or modifications have been detected.
+                    <f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.chain_valid.description" />
                 </f:be.infobox>
             </f:then>
             <f:else>
                 <f:be.infobox title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.chain_invalid')}" state="2">
-                    Hash chain verification failed. The audit log may have been tampered with.
+                    <f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.chain_invalid.description" />
                 </f:be.infobox>
+
+                <!-- Forensic guidance: a chain break is a security event, not a generic error. -->
+                <div class="card card-size-medium mt-4">
+                    <div class="card-header">
+                        <div class="card-header-body">
+                            <h2 class="card-title"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.chain_invalid.guidance.title" /></h2>
+                        </div>
+                    </div>
+                    <div class="card-body">
+                        <ol class="mb-0">
+                            <li><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.chain_invalid.guidance.snapshot" /></li>
+                            <li><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.chain_invalid.guidance.escalate" /></li>
+                            <li><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.chain_invalid.guidance.no_mutate" /></li>
+                        </ol>
+                    </div>
+                </div>
 
                 <f:if condition="{errors}">
                     <div class="card card-size-medium mt-4">
@@ -27,10 +43,10 @@
                         </div>
                         <div class="card-body">
                             <ul class="list-group">
-                                <f:for each="{errors}" as="error">
+                                <f:for each="{errors}" as="error" key="uid">
                                     <li class="list-group-item list-group-item-danger">
                                         <core:icon identifier="actions-exclamation-circle" size="small" />
-                                        {error}
+                                        <strong>#{uid}</strong> &mdash; {error}
                                     </li>
                                 </f:for>
                             </ul>
@@ -44,7 +60,7 @@
             <div class="card card-size-medium mt-4">
                 <div class="card-header">
                     <div class="card-header-body">
-                        <h2 class="card-title">Warnings</h2>
+                        <h2 class="card-title"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.warnings" /></h2>
                     </div>
                 </div>
                 <div class="card-body">

--- a/Resources/Private/Templates/Overview/Index.html
+++ b/Resources/Private/Templates/Overview/Index.html
@@ -22,21 +22,23 @@
                     <strong>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.health.encryption_not_available')}</strong>
                     {f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.health.encryption_not_available.description')}
                 </p>
-                <f:if condition="{healthChecks.masterKeyError}">
-                    <p class="mb-1 text-body-secondary"><small>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.health.detail')} {healthChecks.masterKeyError}</small></p>
-                </f:if>
                 <hr />
-                <p class="mb-0">
+                <p class="mb-1">
                     {f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.health.encryption_not_available.remedy', arguments: {0: '$GLOBALS[\'TYPO3_CONF_VARS\'][\'SYS\'][\'encryptionKey\']'})}
                 </p>
+                <p class="mb-1 mt-2"><strong>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.health.next_steps')}</strong></p>
+                <ol class="mb-0">
+                    <li><code>bin/typo3 vault:init</code> &mdash; {f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.health.step.run_init')}</li>
+                    <li>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.health.step.configure_provider')}</li>
+                    <li>
+                        <f:be.link route="admin_vault.help">{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.health.step.see_help')}</f:be.link>
+                    </li>
+                </ol>
             </f:if>
             <f:if condition="{healthChecks.masterKeyAvailable} && !{healthChecks.encryptionWorking}">
-                <p class="mb-1">
+                <p class="mb-0">
                     <strong>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.health.encryption_broken', arguments: {0: healthChecks.masterKeyProvider})}</strong>
                 </p>
-                <f:if condition="{healthChecks.encryptionError}">
-                    <p class="mb-0 text-body-secondary"><small>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.health.detail')} {healthChecks.encryptionError}</small></p>
-                </f:if>
             </f:if>
         </div>
     </f:if>

--- a/Resources/Private/Templates/Secrets/List.html
+++ b/Resources/Private/Templates/Secrets/List.html
@@ -181,7 +181,7 @@
                         <tfoot>
                             <tr>
                                 <td colspan="8">
-                                    <span class="text-body-secondary">{totalCount} secrets total</span>
+                                    <span class="text-body-secondary"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.total" arguments="{0: totalCount}" /></span>
                                 </td>
                             </tr>
                         </tfoot>
@@ -189,7 +189,7 @@
                 </div>
             </f:then>
             <f:else>
-                <f:be.infobox title="No Secrets Found" state="-1">
+                <f:be.infobox title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.empty.title')}" state="-1">
                     <f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.empty" />
                 </f:be.infobox>
             </f:else>

--- a/Resources/Public/Css/backend.css
+++ b/Resources/Public/Css/backend.css
@@ -168,6 +168,23 @@
     margin-top: 1rem;
 }
 
+/* Audit log table column widths (moved off inline styles for CSP style-src) */
+.vault-col-time {
+    width: 100px;
+}
+
+.vault-col-action {
+    width: 100px;
+}
+
+.vault-col-status {
+    width: 80px;
+}
+
+.vault-col-ip {
+    width: 130px;
+}
+
 /* Audit log styling */
 
 .vault-date-header {

--- a/Resources/Public/JavaScript/SecretReveal.js
+++ b/Resources/Public/JavaScript/SecretReveal.js
@@ -7,6 +7,26 @@ import Modal from '@typo3/backend/modal.js';
 import Notification from '@typo3/backend/notification.js';
 import Severity from '@typo3/backend/severity.js';
 
+/**
+ * Look up a backend label registered via PageRenderer::addInlineLanguageLabelFile()
+ * (locallang_js.xlf), falling back to the English default. Supports {0}, {1}, ...
+ * placeholder substitution.
+ *
+ * @param {string} key
+ * @param {string} fallback
+ * @param {...string} args
+ * @returns {string}
+ */
+function lang(key, fallback, ...args) {
+    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang && TYPO3.lang[key]) || fallback;
+    args.forEach((value, index) => {
+        // Use a replacer function so `$`-sequences (e.g. $&, $1) in the value
+        // are inserted literally rather than interpreted by String.replace().
+        text = text.replace('{' + index + '}', () => value);
+    });
+    return text;
+}
+
 class SecretView {
     constructor() {
         this.revealBtn = document.getElementById('reveal-secret-btn');
@@ -49,9 +69,9 @@ class SecretView {
     hideSecret() {
         this.secretInput.type = 'password';
         this.secretInput.value = '••••••••••••••••';
-        this.btnText.textContent = 'Reveal';
+        this.btnText.textContent = lang('nrvault.reveal.action', 'Reveal');
         if (this.copyBtn) {
-            this.copyBtn.style.display = 'none';
+            this.copyBtn.classList.add('d-none');
         }
         this.isRevealed = false;
     }
@@ -59,9 +79,9 @@ class SecretView {
     showSecret() {
         this.secretInput.type = 'text';
         this.secretInput.value = this.secretValue;
-        this.btnText.textContent = 'Hide';
+        this.btnText.textContent = lang('nrvault.reveal.hideAction', 'Hide');
         if (this.copyBtn) {
-            this.copyBtn.style.display = 'inline-block';
+            this.copyBtn.classList.remove('d-none');
         }
         this.isRevealed = true;
     }
@@ -86,12 +106,12 @@ class SecretView {
                 this.secretValue = data.secret;
                 this.showSecret();
             } else {
-                Notification.error('Error', data.error || 'Unknown error', 5);
-                this.btnText.textContent = 'Reveal';
+                Notification.error(lang('nrvault.error', 'Error'), data.error || lang('nrvault.unknownError', 'An error occurred'), 5);
+                this.btnText.textContent = lang('nrvault.reveal.action', 'Reveal');
             }
         } catch (error) {
-            Notification.error('Error', 'Error fetching secret: ' + error.message, 5);
-            this.btnText.textContent = 'Reveal';
+            Notification.error(lang('nrvault.error', 'Error'), lang('nrvault.reveal.fetchError', 'Error fetching secret: {0}', error.message), 5);
+            this.btnText.textContent = lang('nrvault.reveal.action', 'Reveal');
         } finally {
             this.revealBtn.disabled = false;
             this.showLoading(false);
@@ -103,7 +123,7 @@ class SecretView {
             if (loading) {
                 this.btnIcon.classList.add('d-none');
                 this.btnSpinner.classList.remove('d-none');
-                this.btnText.textContent = 'Loading...';
+                this.btnText.textContent = lang('nrvault.reveal.loadingAction', 'Loading...');
             } else {
                 this.btnIcon.classList.remove('d-none');
                 this.btnSpinner.classList.add('d-none');
@@ -120,15 +140,15 @@ class SecretView {
             this.copyBtn.textContent = '';
             const copiedSpan = document.createElement('span');
             copiedSpan.className = 'text-success';
-            copiedSpan.textContent = 'Copied!';
+            copiedSpan.textContent = lang('nrvault.copied.inline', 'Copied!');
             this.copyBtn.appendChild(copiedSpan);
             setTimeout(() => {
                 this.copyBtn.textContent = '';
                 originalChildNodes.forEach(node => this.copyBtn.appendChild(node));
             }, 2000);
-            Notification.success('Copied', 'Secret copied to clipboard', 2);
+            Notification.success(lang('nrvault.copied', 'Copied'), lang('nrvault.copy.success', 'Secret copied to clipboard'), 2);
         } catch {
-            Notification.error('Error', 'Failed to copy to clipboard', 5);
+            Notification.error(lang('nrvault.error', 'Error'), lang('nrvault.copy.failed', 'Failed to copy to clipboard'), 5);
         }
     }
 
@@ -148,18 +168,22 @@ class SecretView {
         const identifier = button.dataset.identifier;
 
         Modal.confirm(
-            'Delete Secret',
-            'Are you sure you want to delete the secret "' + this.escapeText(identifier) + '"? This action cannot be undone.',
+            lang('nrvault.delete.title', 'Delete Secret'),
+            lang(
+                'nrvault.delete.confirm',
+                'Are you sure you want to delete the secret "{0}"? This action cannot be undone.',
+                this.escapeText(identifier),
+            ),
             Severity.warning,
             [
                 {
-                    text: 'Cancel',
+                    text: lang('nrvault.cancel', 'Cancel'),
                     active: true,
                     btnClass: 'btn-default',
                     trigger: () => Modal.dismiss()
                 },
                 {
-                    text: 'Delete',
+                    text: lang('nrvault.delete', 'Delete'),
                     btnClass: 'btn-danger',
                     trigger: () => {
                         Modal.dismiss();

--- a/Resources/Public/JavaScript/SecretsList.js
+++ b/Resources/Public/JavaScript/SecretsList.js
@@ -7,6 +7,26 @@ import Modal from '@typo3/backend/modal.js';
 import Notification from '@typo3/backend/notification.js';
 import Severity from '@typo3/backend/severity.js';
 
+/**
+ * Look up a backend label registered via PageRenderer::addInlineLanguageLabelFile()
+ * (locallang_js.xlf). Falls back to the English default so the UI never shows a
+ * raw key if the label file was not registered on the current page.
+ *
+ * @param {string} key      label key, e.g. 'nrvault.delete.title'
+ * @param {string} fallback English default
+ * @param {...string} args  values substituted for {0}, {1}, ... placeholders
+ * @returns {string}
+ */
+function lang(key, fallback, ...args) {
+    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang && TYPO3.lang[key]) || fallback;
+    args.forEach((value, index) => {
+        // Use a replacer function so `$`-sequences (e.g. $&, $1) in the value
+        // are inserted literally rather than interpreted by String.replace().
+        text = text.replace('{' + index + '}', () => value);
+    });
+    return text;
+}
+
 class SecretsList {
     constructor() {
         // No in-memory secret cache: every reveal MUST hit the AJAX endpoint
@@ -50,18 +70,22 @@ class SecretsList {
         const identifier = row?.dataset.identifier || form.querySelector('input[name="identifier"]')?.value || 'secret';
 
         Modal.confirm(
-            'Delete Secret',
-            'Are you sure you want to delete the secret "' + this.escapeHtml(identifier) + '"? This action cannot be undone.',
+            lang('nrvault.delete.title', 'Delete Secret'),
+            lang(
+                'nrvault.delete.confirm',
+                'Are you sure you want to delete the secret "{0}"? This action cannot be undone.',
+                this.escapeHtml(identifier),
+            ),
             Severity.warning,
             [
                 {
-                    text: 'Cancel',
+                    text: lang('nrvault.cancel', 'Cancel'),
                     active: true,
                     btnClass: 'btn-default',
                     trigger: () => Modal.dismiss()
                 },
                 {
-                    text: 'Delete',
+                    text: lang('nrvault.delete', 'Delete'),
                     btnClass: 'btn-danger',
                     trigger: () => {
                         Modal.dismiss();
@@ -108,12 +132,12 @@ class SecretsList {
                 button.replaceChildren(...originalChildren);
                 this.updateRowState(row, result.hidden);
                 this.updateButtonState(button, result.hidden);
-                Notification.success('Success', result.message, 3);
+                Notification.success(lang('nrvault.success', 'Success'), result.message, 3);
             } else {
-                Notification.error('Error', result.error || 'Unknown error', 5);
+                Notification.error(lang('nrvault.error', 'Error'), result.error || lang('nrvault.unknownError', 'An error occurred'), 5);
             }
         } catch (error) {
-            Notification.error('Error', error.message || 'An error occurred', 5);
+            Notification.error(lang('nrvault.error', 'Error'), error.message || lang('nrvault.unknownError', 'An error occurred'), 5);
         } finally {
             button.disabled = false;
             // Restore original children on any non-success path (error/thrown).
@@ -184,14 +208,15 @@ class SecretsList {
         const identifier = button.dataset.vaultReveal;
 
         if (!identifier) {
-            Notification.error('Error', 'No identifier found', 5);
+            Notification.error(lang('nrvault.error', 'Error'), lang('nrvault.noIdentifier', 'No identifier found'), 5);
             return;
         }
 
         // Show loading modal
+        const loadingBody = lang('nrvault.reveal.loading.body', 'Fetching secret...');
         const loadingModal = Modal.advanced({
-            title: 'Loading Secret',
-            content: '<div class="text-center p-4"><span class="spinner-border" role="status"></span><p class="mt-2">Fetching secret...</p></div>',
+            title: lang('nrvault.reveal.loading.title', 'Loading Secret'),
+            content: '<div class="text-center p-4"><span class="spinner-border" role="status"></span><p class="mt-2">' + this.escapeHtml(loadingBody) + '</p></div>',
             severity: Severity.info,
             size: Modal.sizes.small,
             buttons: []
@@ -212,11 +237,11 @@ class SecretsList {
             if (data.success && data.secret !== undefined) {
                 this.showRevealModal(identifier, data.secret);
             } else {
-                Notification.error('Error', data.error || 'Failed to reveal secret', 5);
+                Notification.error(lang('nrvault.error', 'Error'), data.error || lang('nrvault.reveal.failed', 'Failed to reveal secret'), 5);
             }
         } catch (error) {
             loadingModal.hideModal();
-            Notification.error('Error', error.message || 'Failed to reveal secret', 5);
+            Notification.error(lang('nrvault.error', 'Error'), error.message || lang('nrvault.reveal.failed', 'Failed to reveal secret'), 5);
         }
     }
 
@@ -227,13 +252,13 @@ class SecretsList {
         const content = this.buildRevealModalContent(identifier, secret);
 
         const modal = Modal.advanced({
-            title: 'Secret Value',
+            title: lang('nrvault.reveal.title', 'Secret Value'),
             content: content,
             severity: Severity.info,
             size: Modal.sizes.default,
             buttons: [
                 {
-                    text: 'Close',
+                    text: lang('nrvault.close', 'Close'),
                     active: true,
                     btnClass: 'btn-default',
                     trigger: () => modal.hideModal()
@@ -261,9 +286,9 @@ class SecretsList {
                 copyBtn.addEventListener('click', async () => {
                     try {
                         await navigator.clipboard.writeText(secret);
-                        Notification.success('Copied', 'Secret copied to clipboard', 2);
+                        Notification.success(lang('nrvault.copied', 'Copied'), lang('nrvault.copy.success', 'Secret copied to clipboard'), 2);
                     } catch (e) {
-                        Notification.error('Error', 'Failed to copy to clipboard', 5);
+                        Notification.error(lang('nrvault.error', 'Error'), lang('nrvault.copy.failed', 'Failed to copy to clipboard'), 5);
                     }
                 });
             }
@@ -278,26 +303,26 @@ class SecretsList {
         const identifier = button.dataset.vaultRotate;
 
         if (!identifier) {
-            Notification.error('Error', 'No identifier found', 5);
+            Notification.error(lang('nrvault.error', 'Error'), lang('nrvault.noIdentifier', 'No identifier found'), 5);
             return;
         }
 
         const content = this.buildRotateModalContent();
 
         const modal = Modal.advanced({
-            title: 'Rotate Secret: ' + identifier,
+            title: lang('nrvault.rotate.title', 'Rotate Secret: {0}', identifier),
             content: content,
             severity: Severity.warning,
             size: Modal.sizes.default,
             buttons: [
                 {
-                    text: 'Cancel',
+                    text: lang('nrvault.cancel', 'Cancel'),
                     active: true,
                     btnClass: 'btn-default',
                     trigger: () => modal.hideModal()
                 },
                 {
-                    text: 'Rotate Secret',
+                    text: lang('nrvault.rotate.button', 'Rotate Secret'),
                     btnClass: 'btn-warning',
                     trigger: () => this.performRotate(modal, identifier)
                 }
@@ -332,7 +357,7 @@ class SecretsList {
         const newSecret = input?.value || '';
 
         if (!newSecret) {
-            Notification.error('Error', 'Please enter a new secret value', 5);
+            Notification.error(lang('nrvault.error', 'Error'), lang('nrvault.rotate.enterValue', 'Please enter a new secret value'), 5);
             return;
         }
 
@@ -349,12 +374,12 @@ class SecretsList {
 
             if (data.success) {
                 modal.hideModal();
-                Notification.success('Success', data.message || 'Secret rotated successfully', 3);
+                Notification.success(lang('nrvault.success', 'Success'), data.message || lang('nrvault.rotate.success', 'Secret rotated successfully'), 3);
             } else {
-                Notification.error('Error', data.error || 'Failed to rotate secret', 5);
+                Notification.error(lang('nrvault.error', 'Error'), data.error || lang('nrvault.rotate.failed', 'Failed to rotate secret'), 5);
             }
         } catch (error) {
-            Notification.error('Error', error.message || 'Failed to rotate secret', 5);
+            Notification.error(lang('nrvault.error', 'Error'), error.message || lang('nrvault.rotate.failed', 'Failed to rotate secret'), 5);
         }
     }
 
@@ -377,7 +402,8 @@ class SecretsList {
         group.className = 'form-group mb-3';
         const label = document.createElement('label');
         label.className = 'form-label fw-bold';
-        label.textContent = 'Secret Value';
+        label.setAttribute('for', 'reveal-modal-secret');
+        label.textContent = lang('nrvault.reveal.label', 'Secret Value');
         const inputGroup = document.createElement('div');
         inputGroup.className = 'input-group';
 
@@ -390,15 +416,15 @@ class SecretsList {
         inputGroup.append(input);
 
         inputGroup.append(
-            this.buildIconButton('reveal-modal-toggle', 'Toggle visibility', 'icon-actions-eye'),
-            this.buildIconButton('reveal-modal-copy', 'Copy to clipboard', 'icon-actions-clipboard'),
+            this.buildIconButton('reveal-modal-toggle', lang('nrvault.toggle.visibility', 'Toggle visibility'), 'icon-actions-eye'),
+            this.buildIconButton('reveal-modal-copy', lang('nrvault.copy.clipboard', 'Copy to clipboard'), 'icon-actions-clipboard'),
         );
 
         group.append(label, inputGroup);
 
         const hint = document.createElement('p');
         hint.className = 'text-muted small mb-0';
-        hint.append(document.createTextNode('Secret value for: '));
+        hint.append(document.createTextNode(lang('nrvault.reveal.hint', 'Secret value for: ')));
         const code = document.createElement('code');
         code.textContent = identifier;
         hint.append(code);
@@ -418,7 +444,7 @@ class SecretsList {
         const label = document.createElement('label');
         label.className = 'form-label fw-bold';
         label.setAttribute('for', 'rotate-modal-secret');
-        label.textContent = 'New Secret Value';
+        label.textContent = lang('nrvault.rotate.label', 'New Secret Value');
 
         const inputGroup = document.createElement('div');
         inputGroup.className = 'input-group';
@@ -426,22 +452,22 @@ class SecretsList {
         input.type = 'password';
         input.className = 'form-control';
         input.id = 'rotate-modal-secret';
-        input.placeholder = 'Enter new secret value';
+        input.placeholder = lang('nrvault.rotate.placeholder', 'Enter new secret value');
         input.autocomplete = 'new-password';
         inputGroup.append(input);
-        inputGroup.append(this.buildIconButton('rotate-modal-toggle', 'Toggle visibility', 'icon-actions-eye'));
+        inputGroup.append(this.buildIconButton('rotate-modal-toggle', lang('nrvault.toggle.visibility', 'Toggle visibility'), 'icon-actions-eye'));
 
         const help = document.createElement('div');
         help.className = 'form-text';
-        help.textContent = 'Enter the new secret value. This will replace the existing secret.';
+        help.textContent = lang('nrvault.rotate.help', 'Enter the new secret value. This will replace the existing secret.');
 
         group.append(label, inputGroup, help);
 
         const warning = document.createElement('p');
         warning.className = 'text-warning small mb-0';
         const strong = document.createElement('strong');
-        strong.textContent = 'Warning:';
-        warning.append(strong, document.createTextNode(' Rotating a secret is irreversible. The previous value cannot be recovered.'));
+        strong.textContent = lang('nrvault.rotate.warning.label', 'Warning:');
+        warning.append(strong, document.createTextNode(lang('nrvault.rotate.warning.body', ' Rotating a secret is irreversible. The previous value cannot be recovered.')));
 
         root.append(group, warning);
         return root;

--- a/Resources/Public/JavaScript/vault-backend.js
+++ b/Resources/Public/JavaScript/vault-backend.js
@@ -4,6 +4,26 @@
 import Notification from '@typo3/backend/notification.js';
 import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
 
+/**
+ * Look up a backend label registered via PageRenderer::addInlineLanguageLabelFile()
+ * (locallang_js.xlf), falling back to the English default. Supports {0}, {1}, ...
+ * placeholder substitution.
+ *
+ * @param {string} key
+ * @param {string} fallback
+ * @param {...string} args
+ * @returns {string}
+ */
+function lang(key, fallback, ...args) {
+    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang && TYPO3.lang[key]) || fallback;
+    args.forEach((value, index) => {
+        // Use a replacer function so `$`-sequences (e.g. $&, $1) in the value
+        // are inserted literally rather than interpreted by String.replace().
+        text = text.replace('{' + index + '}', () => value);
+    });
+    return text;
+}
+
 class VaultBackend {
     constructor() {
         this.init();
@@ -23,7 +43,7 @@ class VaultBackend {
         button.disabled = true;
         const spinner = document.createElement('span');
         spinner.className = 'spinner-border spinner-border-sm';
-        button.replaceChildren(spinner, document.createTextNode(' Verifying...'));
+        button.replaceChildren(spinner, document.createTextNode(' ' + lang('nrvault.verify.running', 'Verifying...')));
 
         try {
             const response = await new AjaxRequest(TYPO3.settings.ajaxUrls['system_vault'])
@@ -33,20 +53,20 @@ class VaultBackend {
             const result = await response.resolve();
 
             if (result.valid) {
-                Notification.success('Hash Chain Valid', result.message, 5);
+                Notification.success(lang('nrvault.verify.valid.title', 'Hash Chain Valid'), result.message, 5);
             } else {
-                Notification.error('Hash Chain Invalid', result.message, 10);
+                Notification.error(lang('nrvault.verify.invalid.title', 'Hash Chain Invalid'), result.message, 10);
 
                 // Show details
                 if (result.errors && Object.keys(result.errors).length > 0) {
                     const errorList = Object.entries(result.errors)
-                        .map(([uid, error]) => `Entry ${uid}: ${error}`)
+                        .map(([uid, error]) => lang('nrvault.verify.entry', 'Entry {0}: {1}', uid, error))
                         .join('\n');
-                    Notification.warning('Verification Errors', errorList, 15);
+                    Notification.warning(lang('nrvault.verify.errors.title', 'Verification Errors'), errorList, 15);
                 }
             }
         } catch (error) {
-            Notification.error('Verification Failed', error.message || 'An error occurred', 10);
+            Notification.error(lang('nrvault.verify.failed.title', 'Verification Failed'), error.message || lang('nrvault.unknownError', 'An error occurred'), 10);
         } finally {
             button.disabled = false;
             button.replaceChildren(...originalChildren);

--- a/Resources/Public/JavaScript/vault-secret-element.js
+++ b/Resources/Public/JavaScript/vault-secret-element.js
@@ -6,6 +6,29 @@
  * - Copy to clipboard functionality
  * - Clear secret
  */
+import Modal from '@typo3/backend/modal.js';
+import Severity from '@typo3/backend/severity.js';
+
+/**
+ * Look up a backend label registered via PageRenderer::addInlineLanguageLabelFile()
+ * (locallang_js.xlf), falling back to the English default. Supports {0}, {1}, ...
+ * placeholder substitution.
+ *
+ * @param {string} key
+ * @param {string} fallback
+ * @param {...string} args
+ * @returns {string}
+ */
+function lang(key, fallback, ...args) {
+    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang && TYPO3.lang[key]) || fallback;
+    args.forEach((value, index) => {
+        // Use a replacer function so `$`-sequences (e.g. $&, $1) in the value
+        // are inserted literally rather than interpreted by String.replace().
+        text = text.replace('{' + index + '}', () => value);
+    });
+    return text;
+}
+
 class VaultSecretElement {
     constructor() {
         // No in-memory secret cache: every reveal MUST hit the AJAX endpoint
@@ -99,7 +122,7 @@ class VaultSecretElement {
         } catch (error) {
             console.error('Error revealing secret:', error);
             if (top.TYPO3?.Notification) {
-                top.TYPO3.Notification.error('Error', error.message || 'Failed to reveal secret');
+                top.TYPO3.Notification.error(lang('nrvault.error', 'Error'), error.message || lang('nrvault.reveal.failed', 'Failed to reveal secret'));
             }
             this.restoreButton(button);
             button.disabled = false;
@@ -159,7 +182,7 @@ class VaultSecretElement {
             : '';
         if (!secret) {
             if (top.TYPO3?.Notification) {
-                top.TYPO3.Notification.warning('Warning', 'Reveal the secret first before copying');
+                top.TYPO3.Notification.warning(lang('nrvault.warning', 'Warning'), lang('nrvault.copy.revealFirst', 'Reveal the secret first before copying'));
             }
             return;
         }
@@ -167,7 +190,7 @@ class VaultSecretElement {
         try {
             await navigator.clipboard.writeText(secret);
             if (top.TYPO3?.Notification) {
-                top.TYPO3.Notification.success('Success', 'Secret copied to clipboard');
+                top.TYPO3.Notification.success(lang('nrvault.success', 'Success'), lang('nrvault.copy.success', 'Secret copied to clipboard'));
             }
 
             // Visual feedback
@@ -178,7 +201,7 @@ class VaultSecretElement {
         } catch (error) {
             console.error('Failed to copy:', error);
             if (top.TYPO3?.Notification) {
-                top.TYPO3.Notification.error('Error', 'Failed to copy to clipboard');
+                top.TYPO3.Notification.error(lang('nrvault.error', 'Error'), lang('nrvault.copy.failed', 'Failed to copy to clipboard'));
             }
         }
     }
@@ -188,20 +211,45 @@ class VaultSecretElement {
         const inputGroup = button.closest('.input-group');
         const input = inputGroup.querySelector('input');
 
-        if (confirm('Are you sure you want to clear this secret? This action cannot be undone.')) {
-            input.value = '';
-            input.placeholder = '';
-            input.dataset.vaultRevealed = '0';
+        Modal.confirm(
+            lang('nrvault.delete.title', 'Delete Secret'),
+            lang('nrvault.clear.confirm', 'Are you sure you want to clear this secret? This action cannot be undone.'),
+            Severity.warning,
+            [
+                {
+                    text: lang('nrvault.cancel', 'Cancel'),
+                    active: true,
+                    btnClass: 'btn-default',
+                    trigger: () => Modal.dismiss(),
+                },
+                {
+                    text: lang('nrvault.delete', 'Delete'),
+                    btnClass: 'btn-danger',
+                    trigger: () => {
+                        Modal.dismiss();
+                        this.clearSecret(input, button);
+                    },
+                },
+            ],
+        );
+    }
 
-            // Mark as cleared by removing the checksum
-            const checksumField = input.closest('.formengine-field-item')
-                ?.parentElement?.querySelector('input[name$="[_vault_checksum]"]');
-            if (checksumField) {
-                checksumField.value = '';
-            }
+    /**
+     * Clear the secret value and detach the field from its stored secret.
+     */
+    clearSecret(input, button) {
+        input.value = '';
+        input.placeholder = '';
+        input.dataset.vaultRevealed = '0';
 
-            button.remove();
+        // Mark as cleared by removing the checksum
+        const checksumField = input.closest('.formengine-field-item')
+            ?.parentElement?.querySelector('input[name$="[_vault_checksum]"]');
+        if (checksumField) {
+            checksumField.value = '';
         }
+
+        button.remove();
     }
 
     /**

--- a/Resources/Public/JavaScript/vault-secret-input.js
+++ b/Resources/Public/JavaScript/vault-secret-input.js
@@ -6,6 +6,27 @@
  * - Reveal existing secrets via AJAX
  * - Copy to clipboard functionality
  */
+
+/**
+ * Look up a backend label registered via PageRenderer::addInlineLanguageLabelFile()
+ * (locallang_js.xlf), falling back to the English default. Supports {0}, {1}, ...
+ * placeholder substitution.
+ *
+ * @param {string} key
+ * @param {string} fallback
+ * @param {...string} args
+ * @returns {string}
+ */
+function lang(key, fallback, ...args) {
+    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang && TYPO3.lang[key]) || fallback;
+    args.forEach((value, index) => {
+        // Use a replacer function so `$`-sequences (e.g. $&, $1) in the value
+        // are inserted literally rather than interpreted by String.replace().
+        text = text.replace('{' + index + '}', () => value);
+    });
+    return text;
+}
+
 class VaultSecretInput {
     constructor() {
         // No in-memory secret cache: every reveal MUST hit the AJAX endpoint
@@ -103,7 +124,7 @@ class VaultSecretInput {
         } catch (error) {
             console.error('Error revealing secret:', error);
             if (top.TYPO3?.Notification) {
-                top.TYPO3.Notification.error('Error', error.message || 'Failed to reveal secret');
+                top.TYPO3.Notification.error(lang('nrvault.error', 'Error'), error.message || lang('nrvault.reveal.failed', 'Failed to reveal secret'));
             }
             button.replaceChildren(...originalChildren);
             button.disabled = false;
@@ -192,7 +213,7 @@ class VaultSecretInput {
             : '';
         if (!secret) {
             if (top.TYPO3?.Notification) {
-                top.TYPO3.Notification.warning('Warning', 'Reveal the secret first before copying');
+                top.TYPO3.Notification.warning(lang('nrvault.warning', 'Warning'), lang('nrvault.copy.revealFirst', 'Reveal the secret first before copying'));
             }
             return;
         }
@@ -200,7 +221,7 @@ class VaultSecretInput {
         try {
             await navigator.clipboard.writeText(secret);
             if (top.TYPO3?.Notification) {
-                top.TYPO3.Notification.success('Success', 'Secret copied to clipboard');
+                top.TYPO3.Notification.success(lang('nrvault.success', 'Success'), lang('nrvault.copy.success', 'Secret copied to clipboard'));
             }
 
             // Visual feedback
@@ -216,7 +237,7 @@ class VaultSecretInput {
         } catch (error) {
             console.error('Failed to copy:', error);
             if (top.TYPO3?.Notification) {
-                top.TYPO3.Notification.error('Error', 'Failed to copy to clipboard');
+                top.TYPO3.Notification.error(lang('nrvault.error', 'Error'), lang('nrvault.copy.failed', 'Failed to copy to clipboard'));
             }
         }
     }

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,6 +60,81 @@ When using nr-vault:
    - Rotate master key annually
    - Rotate secrets after personnel changes
    - Monitor for `access_denied` events
+   - Schedule the audit hash-chain verification task (see below)
+
+## Audit Log Immutability — Trust Model
+
+The audit log (`tx_nrvault_audit_log`) is **tamper-evident, not
+tamper-proof**. Every entry is bound into an HMAC-SHA256 hash chain
+(see ADR-023 / ADR-024), so any in-place edit, row deletion, or
+front-truncation is *detected* by `verifyHashChain()` — but nothing at
+the application layer *prevents* a database principal with `UPDATE` /
+`DELETE` rights from modifying the table. The chain surfaces the
+tampering; it does not stop it.
+
+For a defense-in-depth posture, add a preventive control at the
+database layer and verify the chain on a schedule.
+
+### Recommended: INSERT-only database grant
+
+Run the application with a DB user that can only `INSERT` and `SELECT`
+on the audit table. The two-step writer (INSERT row, then a single
+`UPDATE` to set `entry_hash` on the just-inserted row) needs `UPDATE`,
+so either grant a column-scoped `UPDATE(entry_hash)` or use the trigger
+recipe below.
+
+```sql
+-- MySQL / MariaDB: dedicated low-privilege role for the app connection
+REVOKE ALL PRIVILEGES ON your_db.tx_nrvault_audit_log FROM 'typo3_app'@'%';
+GRANT SELECT, INSERT ON your_db.tx_nrvault_audit_log TO 'typo3_app'@'%';
+-- entry_hash is written by a follow-up UPDATE on the new row:
+GRANT UPDATE (entry_hash) ON your_db.tx_nrvault_audit_log TO 'typo3_app'@'%';
+```
+
+### Alternative: reject UPDATE/DELETE via triggers
+
+If column-scoped grants are impractical, block destructive statements
+with triggers. Allow only the `entry_hash` write that immediately
+follows the INSERT, and forbid all `DELETE`s.
+
+```sql
+-- MySQL / MariaDB
+DELIMITER //
+CREATE TRIGGER tx_nrvault_audit_no_delete
+BEFORE DELETE ON tx_nrvault_audit_log
+FOR EACH ROW
+  SIGNAL SQLSTATE '45000'
+  SET MESSAGE_TEXT = 'Audit log is append-only; DELETE is forbidden';
+
+CREATE TRIGGER tx_nrvault_audit_seal
+BEFORE UPDATE ON tx_nrvault_audit_log
+FOR EACH ROW
+BEGIN
+  -- Permit only the post-insert entry_hash write; reject any other change.
+  IF (OLD.entry_hash <> '' AND OLD.entry_hash IS NOT NULL)
+     OR NOT (NEW.uid <=> OLD.uid
+         AND NEW.secret_identifier <=> OLD.secret_identifier
+         AND NEW.action <=> OLD.action
+         AND NEW.success <=> OLD.success
+         AND NEW.previous_hash <=> OLD.previous_hash) THEN
+    SIGNAL SQLSTATE '45000'
+      SET MESSAGE_TEXT = 'Audit log rows are immutable after sealing';
+  END IF;
+END//
+DELIMITER ;
+```
+
+> PostgreSQL: implement the same policy with a `BEFORE UPDATE OR DELETE`
+> trigger that `RAISE EXCEPTION`s, or with `REVOKE UPDATE, DELETE`.
+
+### Schedule hash-chain verification
+
+Run `verifyHashChain()` regularly so tampering is caught quickly. Add
+the *Vault: Verify audit hash chain* scheduler task (or call
+`vendor/bin/typo3 vault:audit` on a cron) and alert on any reported
+mismatch or UID gap. Persist the current chain tip
+(`getLatestHash()` + max UID) to an out-of-band store (syslog/SIEM) so
+a full-table wipe-and-reseed is also detectable.
 
 ## Security Audit
 

--- a/Tests/Architecture/ArchitectureTest.php
+++ b/Tests/Architecture/ArchitectureTest.php
@@ -12,6 +12,8 @@ namespace Netresearch\NrVault\Tests\Architecture;
 use GuzzleHttp\Client;
 use Netresearch\NrVault\Adapter\VaultAdapterInterface;
 use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Command\VaultRotateMasterKeyCommand;
+use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
 use Netresearch\NrVault\Http\OAuth\OAuthConfig;
 use Netresearch\NrVault\Http\OAuth\OAuthToken;
 use Netresearch\NrVault\Http\SecretPlacement;
@@ -333,6 +335,45 @@ final class ArchitectureTest
             ->shouldNotDependOn()
             ->classes(Selector::inNamespace('Netresearch\NrVault\Controller'))
             ->because('CLI commands should not use web controllers');
+    }
+
+    /**
+     * Commands must not reach across the service layer into the
+     * persistence repository — except the one blessed bulk operation.
+     *
+     * `VaultRotateMasterKeyCommand` legitimately bypasses `VaultService`
+     * to re-wrap every secret's DEK in a single transaction without
+     * per-secret ACL/audit (an admin re-keying the whole store); going
+     * through `VaultService::retrieve/store` would be wrong there. That
+     * one bypass is documented and allow-listed here (mirroring the
+     * `SecureHttpClientFactory` Guzzle-lock allow-one pattern), so any
+     * NEW command that injects the repository fails CI.
+     *
+     * The rule targets both the `Domain\Repository` namespace (the
+     * concrete `SecretRepository`) AND the `SecretRepositoryInterface`
+     * by classname, because PHPat does not reliably trip on
+     * constructor-injected *interface* dependencies via the namespace
+     * selector alone (see the OverviewController -> Crypto miss noted in
+     * the architecture review). Naming the interface explicitly closes
+     * that gap, since the blessed command injects the interface, not the
+     * concrete class.
+     */
+    public function testCommandsDoNotDependOnRepository(): BuildStep
+    {
+        return PHPat::rule()
+            ->classes(Selector::inNamespace('Netresearch\NrVault\Command'))
+            ->excluding(Selector::classname(VaultRotateMasterKeyCommand::class))
+            ->shouldNot()
+            ->dependOn()
+            ->classes(
+                Selector::inNamespace('Netresearch\NrVault\Domain\Repository'),
+                Selector::classname(SecretRepositoryInterface::class),
+            )
+            ->because(
+                'commands must go through the service layer; only the '
+                . 'blessed VaultRotateMasterKeyCommand may drive the '
+                . 'repository directly for bulk master-key rotation',
+            );
     }
 
     /**

--- a/Tests/Functional/Audit/AuditLogServiceTest.php
+++ b/Tests/Functional/Audit/AuditLogServiceTest.php
@@ -42,12 +42,12 @@ final class AuditLogServiceTest extends AbstractVaultFunctionalTestCase
         $auditService = $this->get(AuditLogServiceInterface::class);
         $identifier = 'test_audit_logcreation';
 
-        $auditService->log($identifier, 'store', true, null, 'Unit test');
+        $auditService->log($identifier, 'create', true, null, 'Unit test');
 
         $entries = $auditService->query(AuditLogFilter::forSecret($identifier));
         self::assertCount(1, $entries);
         self::assertSame($identifier, $entries[0]->secretIdentifier);
-        self::assertSame('store', $entries[0]->action);
+        self::assertSame('create', $entries[0]->action);
         self::assertTrue($entries[0]->success);
     }
 

--- a/Tests/Functional/Crypto/EncryptionServiceTest.php
+++ b/Tests/Functional/Crypto/EncryptionServiceTest.php
@@ -169,6 +169,46 @@ final class EncryptionServiceTest extends FunctionalTestCase
     }
 
     #[Test]
+    public function encryptValueChecksumIsKeyedNotPlaintextSha256(): void
+    {
+        // End-to-end with the real file master-key provider and libsodium: the
+        // stored change-detection token must be a keyed MAC over the ciphertext,
+        // not an offline-computable hash of the plaintext (SEC-CRYPTO-1).
+        $encryptionService = $this->get(EncryptionServiceInterface::class);
+        $plaintext = 'low-entropy-guessable';
+
+        FileMasterKeyProvider::clearCachedKey();
+        $encrypted = $encryptionService->encrypt($plaintext, 'checksum_keyed_' . bin2hex(random_bytes(4)));
+
+        self::assertSame(64, \strlen((string) $encrypted->valueChecksum));
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $encrypted->valueChecksum);
+        self::assertNotSame(
+            hash('sha256', $plaintext),
+            $encrypted->valueChecksum,
+            'Stored checksum must not be an unkeyed sha256 of the plaintext',
+        );
+    }
+
+    #[Test]
+    public function encryptValueChecksumDiffersPerSecretForIdenticalPlaintext(): void
+    {
+        $encryptionService = $this->get(EncryptionServiceInterface::class);
+        $plaintext = 'identical-across-secrets';
+
+        FileMasterKeyProvider::clearCachedKey();
+        $first = $encryptionService->encrypt($plaintext, 'checksum_a_' . bin2hex(random_bytes(4)));
+
+        FileMasterKeyProvider::clearCachedKey();
+        $second = $encryptionService->encrypt($plaintext, 'checksum_b_' . bin2hex(random_bytes(4)));
+
+        self::assertNotSame(
+            $first->valueChecksum,
+            $second->valueChecksum,
+            'Per-secret DEK-derived MAC key must yield different checksums for identical plaintext',
+        );
+    }
+
+    #[Test]
     public function reEncryptDekChangesEncryptedDekBytes(): void
     {
         // This test uses the full vault service to round-trip secrets across key rotation,

--- a/Tests/Functional/Hook/DataHandlerHookTest.php
+++ b/Tests/Functional/Hook/DataHandlerHookTest.php
@@ -13,16 +13,17 @@ use Netresearch\NrVault\Audit\AuditLogFilter;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
 use Netresearch\NrVault\Hook\DataHandlerHook;
+use Netresearch\NrVault\Hook\PendingSecretExtractor;
+use Netresearch\NrVault\Hook\PendingSecretPersister;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use Netresearch\NrVault\Utility\VaultFieldResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionProperty;
 use Throwable;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
-use TYPO3\CMS\Core\Messaging\FlashMessageService;
-use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -226,9 +227,10 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
     {
         $hook = new DataHandlerHook(
             $this->get(ConnectionPool::class),
-            $this->get(TcaSchemaFactory::class),
             $this->get(VaultServiceInterface::class),
-            $this->get(FlashMessageService::class),
+            $this->get(VaultFieldResolver::class),
+            $this->get(PendingSecretExtractor::class),
+            $this->get(PendingSecretPersister::class),
         );
 
         // Pre-seed the field cache via reflection (setAccessible is a no-op since PHP 8.1)

--- a/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
+++ b/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
@@ -15,6 +15,7 @@ namespace Netresearch\NrVault\Tests\Functional\Http\OAuth;
 use GuzzleHttp\Client as GuzzleClient;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use JsonException;
 use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Audit\AuditLogFilter;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
@@ -630,7 +631,34 @@ final class OAuthIntegrationTest extends FunctionalTestCase
         ]);
 
         $result = @file_get_contents($url, false, $context);
+        if (!\is_string($result) || $result === '') {
+            return false;
+        }
 
-        return $result !== false;
+        // `ignore_errors => true` makes file_get_contents return the body even
+        // for 3xx/4xx responses, so a non-false result is NOT proof the mock
+        // OAuth server is there. A foreign service squatting on the port (e.g.
+        // a TYPO3 instance redirecting `/.well-known/...` to the install tool)
+        // would otherwise be mistaken for the sidecar and the sidecar-dependent
+        // tests would run against the wrong server instead of skipping.
+        //
+        // Only accept a genuine OpenID Connect discovery document: HTTP 2xx
+        // with JSON exposing the mandatory `token_endpoint` (RFC 8414 / OpenID
+        // Connect Discovery 1.0). This is what mock-oauth2-server serves and
+        // what these tests actually need.
+        $statusLine = $http_response_header[0] ?? '';
+        if (preg_match('#\s(2\d\d)\s#', $statusLine) !== 1) {
+            return false;
+        }
+
+        try {
+            $decoded = json_decode($result, true, 16, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            return false;
+        }
+
+        return \is_array($decoded)
+            && isset($decoded['token_endpoint'])
+            && \is_string($decoded['token_endpoint']);
     }
 }

--- a/Tests/Functional/Service/VaultServiceAtomicityTest.php
+++ b/Tests/Functional/Service/VaultServiceAtomicityTest.php
@@ -1,0 +1,230 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Service;
+
+use Netresearch\NrVault\Adapter\VaultAdapterInterface;
+use Netresearch\NrVault\Audit\AuditAction;
+use Netresearch\NrVault\Audit\AuditContextInterface;
+use Netresearch\NrVault\Audit\AuditLogFilter;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\HashChainVerificationResult;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
+use Netresearch\NrVault\Exception\AuditWriteException;
+use Netresearch\NrVault\Http\VaultHttpClientFactoryInterface;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Service\VaultService;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * SEC-3 atomicity: a secret mutation and its tamper-evident audit entry must
+ * be all-or-nothing. The audit writer owns its own transaction lifecycle
+ * (SQLite `BEGIN EXCLUSIVE`/`COMMIT`, MySQL advisory `GET_LOCK`), so a single
+ * shared DB transaction cannot wrap both writes. VaultService therefore
+ * compensates: if `AuditLogService::log()` throws `AuditWriteException` after
+ * the adapter mutation, the mutation is reverted.
+ *
+ * These tests force the audit write to fail and assert the secret
+ * create/update/delete/rotate did NOT persist.
+ */
+final class VaultServiceAtomicityTest extends AbstractVaultFunctionalTestCase
+{
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_permissions.csv';
+
+    #[Test]
+    public function createIsRolledBackWhenAuditWriteFails(): void
+    {
+        $service = $this->buildServiceWithFailingAudit();
+
+        try {
+            $service->store('atomic_create', 'create-value');
+            self::fail(self::FAIL_EXPECTED_AUDIT_EXCEPTION);
+        } catch (AuditWriteException) {
+            // expected
+        }
+
+        // The created record must not have persisted.
+        self::assertFalse(
+            $this->getAdapter()->exists('atomic_create'),
+            'Secret create must be rolled back when the audit write fails',
+        );
+        self::assertNull($this->getVaultService()->retrieve('atomic_create'));
+    }
+
+    #[Test]
+    public function updateIsRolledBackWhenAuditWriteFails(): void
+    {
+        // Baseline: create through the real service so the chain stays valid.
+        $this->getVaultService()->store('atomic_update', 'original-value');
+
+        $service = $this->buildServiceWithFailingAudit();
+
+        try {
+            $service->store('atomic_update', 'tampered-value');
+            self::fail(self::FAIL_EXPECTED_AUDIT_EXCEPTION);
+        } catch (AuditWriteException) {
+            // expected
+        }
+
+        // The prior encrypted value must be restored.
+        self::assertSame(
+            'original-value',
+            $this->getVaultService()->retrieve('atomic_update'),
+            'Secret update must be rolled back to the prior value when the audit write fails',
+        );
+    }
+
+    #[Test]
+    public function deleteIsRolledBackWhenAuditWriteFails(): void
+    {
+        $this->getVaultService()->store('atomic_delete', 'keep-me');
+
+        $service = $this->buildServiceWithFailingAudit();
+
+        try {
+            $service->delete('atomic_delete', 'because');
+            self::fail(self::FAIL_EXPECTED_AUDIT_EXCEPTION);
+        } catch (AuditWriteException) {
+            // expected
+        }
+
+        // The record must still exist with its original value.
+        self::assertTrue(
+            $this->getAdapter()->exists('atomic_delete'),
+            'Secret delete must be rolled back when the audit write fails',
+        );
+        self::assertSame('keep-me', $this->getVaultService()->retrieve('atomic_delete'));
+    }
+
+    #[Test]
+    public function rotateIsRolledBackWhenAuditWriteFails(): void
+    {
+        $this->getVaultService()->store('atomic_rotate', 'old-value');
+
+        $service = $this->buildServiceWithFailingAudit();
+
+        try {
+            $service->rotate('atomic_rotate', 'new-value', 'scheduled');
+            self::fail(self::FAIL_EXPECTED_AUDIT_EXCEPTION);
+        } catch (AuditWriteException) {
+            // expected
+        }
+
+        // The pre-rotation value must be restored.
+        self::assertSame(
+            'old-value',
+            $this->getVaultService()->retrieve('atomic_rotate'),
+            'Secret rotation must be rolled back to the prior value when the audit write fails',
+        );
+    }
+
+    /**
+     * Build a VaultService wired with the real container dependencies except
+     * for an audit log service that throws on every successful mutation log,
+     * exercising the compensating-rollback path. Access checks pass because
+     * the functional test runs as a CLI actor (`canCreate()`/`canWrite()`
+     * allow the trusted CLI context).
+     */
+    private function buildServiceWithFailingAudit(): VaultService
+    {
+        return new VaultService(
+            $this->getAdapter(),
+            $this->getEncryptionService(),
+            $this->get(AccessControlServiceInterface::class),
+            $this->createFailingAuditLogService(),
+            $this->get(ExtensionConfigurationInterface::class),
+            $this->get(VaultHttpClientFactoryInterface::class),
+        );
+    }
+
+    /**
+     * The real vault adapter (DatabaseVaultAdapter) from the container. Used to
+     * assert persistence state directly, bypassing the service layer.
+     */
+    private function getAdapter(): VaultAdapterInterface
+    {
+        return $this->get(VaultAdapterInterface::class);
+    }
+
+    private function getEncryptionService(): EncryptionServiceInterface
+    {
+        return $this->get(EncryptionServiceInterface::class);
+    }
+
+    /**
+     * The real, fully wired VaultService from the container (with the genuine
+     * audit logger) — used for baseline writes and read-back assertions.
+     */
+    private function getVaultService(): VaultServiceInterface
+    {
+        $service = $this->get(VaultServiceInterface::class);
+        self::assertInstanceOf(VaultServiceInterface::class, $service);
+
+        return $service;
+    }
+
+    /**
+     * An audit log service that throws AuditWriteException on the success log
+     * of any mutating action (create/update/delete/rotate), simulating a
+     * lock-acquisition timeout or other audit-write failure.
+     */
+    private function createFailingAuditLogService(): AuditLogServiceInterface
+    {
+        return new class () implements AuditLogServiceInterface {
+            public function log(
+                string $secretIdentifier,
+                string $action,
+                bool $success,
+                ?string $errorMessage = null,
+                ?string $reason = null,
+                ?string $hashBefore = null,
+                ?string $hashAfter = null,
+                ?AuditContextInterface $context = null,
+            ): void {
+                $mutating = [
+                    AuditAction::Create->value,
+                    AuditAction::Update->value,
+                    AuditAction::Delete->value,
+                    AuditAction::Rotate->value,
+                ];
+                if ($success && \in_array($action, $mutating, true)) {
+                    throw new AuditWriteException('Simulated audit write failure', 9334453097);
+                }
+            }
+
+            public function query(?AuditLogFilter $filter = null, int $limit = 100, int $offset = 0): array
+            {
+                return [];
+            }
+
+            public function count(?AuditLogFilter $filter = null): int
+            {
+                return 0;
+            }
+
+            public function export(?AuditLogFilter $filter = null): array
+            {
+                return [];
+            }
+
+            public function verifyHashChain(?int $fromUid = null, ?int $toUid = null): HashChainVerificationResult
+            {
+                return new HashChainVerificationResult(true);
+            }
+
+            public function getLatestHash(): ?string
+            {
+                return null;
+            }
+        };
+    }
+}

--- a/Tests/Fuzz/FlexFormXmlFuzzTest.php
+++ b/Tests/Fuzz/FlexFormXmlFuzzTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use stdClass;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 
 /**
  * Fuzz tests for FlexForm XML / array resolution pathways.
@@ -61,7 +62,11 @@ final class FlexFormXmlFuzzTest extends TestCase
                 return 'resolved_' . $identifier;
             },
         );
-        $this->resolver = new FlexFormVaultResolver($vaultService, new NullLogger());
+        $this->resolver = new FlexFormVaultResolver(
+            $vaultService,
+            new NullLogger(),
+            $this->createMock(TcaSchemaFactory::class),
+        );
         $this->retrievedIdentifiers = [];
     }
 

--- a/Tests/Fuzz/IdentifierFuzzTest.php
+++ b/Tests/Fuzz/IdentifierFuzzTest.php
@@ -63,6 +63,7 @@ final class IdentifierFuzzTest extends TestCase
         $this->flexFormVaultResolver = new FlexFormVaultResolver(
             $vaultService,
             $logger,
+            $tcaSchemaFactory,
         );
     }
 

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -1511,17 +1511,20 @@ final class AuditLogServiceTest extends TestCase
     }
 
     /**
-     * Kill MethodCallRemoval on `export()` — uses PHP_INT_MAX limit and 0 offset.
+     * Kill MethodCallRemoval on `export()` — streams bounded chunks from
+     * offset 0 instead of a single PHP_INT_MAX fetch (avoids OOM on large
+     * audit tables). An empty first chunk terminates the loop, so exactly one
+     * query runs with a finite chunk size as the limit and offset 0.
      */
     #[Test]
-    public function exportUsesMaxIntLimitAndZeroOffset(): void
+    public function exportStreamsBoundedChunksFromZeroOffset(): void
     {
         $this->setupQueryMocks([]);
 
         $this->queryBuilder
             ->expects(self::once())
             ->method('setMaxResults')
-            ->with(PHP_INT_MAX)
+            ->with(self::lessThan(PHP_INT_MAX))
             ->willReturnSelf();
 
         $this->queryBuilder
@@ -1530,7 +1533,7 @@ final class AuditLogServiceTest extends TestCase
             ->with(0)
             ->willReturnSelf();
 
-        $this->getSubject()->export();
+        self::assertSame([], $this->getSubject()->export());
     }
 
     // =========================================================================

--- a/Tests/Unit/Controller/AjaxControllerTest.php
+++ b/Tests/Unit/Controller/AjaxControllerTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrVault\Exception\EncryptionException;
 use Netresearch\NrVault\Exception\SecretExpiredException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Exception\ValidationException;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -33,12 +34,18 @@ final class AjaxControllerTest extends TestCase
 
     private VaultServiceInterface&MockObject $vaultService;
 
+    private AccessControlServiceInterface&MockObject $accessControlService;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         $this->vaultService = $this->createMock(VaultServiceInterface::class);
-        $this->subject = new AjaxController($this->vaultService);
+        $this->accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        $this->accessControlService
+            ->method('isCurrentActorAdmin')
+            ->willReturn(true);
+        $this->subject = new AjaxController($this->vaultService, $this->accessControlService);
     }
 
     #[Test]
@@ -145,6 +152,7 @@ final class AjaxControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
+        self::assertIsString($body['error']);
         self::assertStringContainsString('Decryption failed', $body['error']);
     }
 
@@ -163,6 +171,7 @@ final class AjaxControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
+        self::assertIsString($body['error']);
         self::assertStringContainsString('Failed to retrieve secret', $body['error']);
     }
 
@@ -189,6 +198,35 @@ final class AjaxControllerTest extends TestCase
     }
 
     #[Test]
+    public function revealActionReturns405ForNonPostRequests(): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getMethod')->willReturn('GET');
+
+        $response = $this->subject->revealAction($request);
+
+        self::assertSame(405, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertFalse($body['success']);
+        self::assertSame('Method not allowed', $body['error']);
+    }
+
+    #[Test]
+    public function revealActionReturns403WhenNotAdmin(): void
+    {
+        $request = $this->createRequestWithJsonBody(['identifier' => 'restricted-id']);
+
+        $controller = $this->createControllerForNonAdmin();
+
+        $response = $controller->revealAction($request);
+
+        self::assertSame(403, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertFalse($body['success']);
+        self::assertSame('Access denied', $body['error']);
+    }
+
+    #[Test]
     public function rotateActionReturns405ForNonPostRequests(): void
     {
         $request = $this->createMock(ServerRequestInterface::class);
@@ -200,6 +238,24 @@ final class AjaxControllerTest extends TestCase
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
         self::assertSame('Method not allowed', $body['error']);
+    }
+
+    #[Test]
+    public function rotateActionReturns403WhenNotAdmin(): void
+    {
+        $request = $this->createPostRequestWithBody([
+            'identifier' => 'restricted-id',
+            'secret' => 'new-value',
+        ]);
+
+        $controller = $this->createControllerForNonAdmin();
+
+        $response = $controller->rotateAction($request);
+
+        self::assertSame(403, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertFalse($body['success']);
+        self::assertSame('Access denied', $body['error']);
     }
 
     #[Test]
@@ -316,6 +372,7 @@ final class AjaxControllerTest extends TestCase
         self::assertSame(400, $response->getStatusCode());
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
+        self::assertIsString($body['error']);
         self::assertStringContainsString('Validation error', $body['error']);
     }
 
@@ -336,6 +393,7 @@ final class AjaxControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
+        self::assertIsString($body['error']);
         self::assertStringContainsString('Encryption failed', $body['error']);
     }
 
@@ -356,6 +414,7 @@ final class AjaxControllerTest extends TestCase
         self::assertSame(500, $response->getStatusCode());
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
+        self::assertIsString($body['error']);
         self::assertStringContainsString('Failed to rotate secret', $body['error']);
     }
 
@@ -423,11 +482,29 @@ final class AjaxControllerTest extends TestCase
     }
 
     /**
+     * Build a controller whose access-control seam denies admin status.
+     *
+     * `createMock()` allows a method to be configured only once, so the
+     * non-admin variant needs a dedicated controller rather than re-stubbing
+     * the admin mock created in setUp().
+     */
+    private function createControllerForNonAdmin(): AjaxController
+    {
+        $accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        $accessControlService
+            ->method('isCurrentActorAdmin')
+            ->willReturn(false);
+
+        return new AjaxController($this->vaultService, $accessControlService);
+    }
+
+    /**
      * @param array<string, mixed> $body
      */
     private function createRequestWithJsonBody(array $body): ServerRequestInterface&MockObject
     {
         $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getMethod')->willReturn('POST');
         $request->method('getQueryParams')->willReturn([]);
         $request->method('getParsedBody')->willReturn($body);
 

--- a/Tests/Unit/Controller/OverviewControllerTest.php
+++ b/Tests/Unit/Controller/OverviewControllerTest.php
@@ -9,36 +9,37 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Controller;
 
-use Exception;
 use Netresearch\NrVault\Controller\OverviewController;
-use Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface;
-use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
+use Netresearch\NrVault\Service\VaultHealthServiceInterface;
+use Netresearch\NrVault\Service\VaultHealthStatus;
 use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
 
 /**
  * Unit tests for OverviewController health checks.
  *
- * Tests the getHealthChecks() logic via reflection since the controller
- * depends on final TYPO3 classes that cannot be fully mocked for
- * indexAction(). Because the SUT is excluded from unit coverage in
- * Build/phpunit.xml (its indexAction is covered functionally), we mark
- * this test as `CoversNothing` so PHPUnit 12 does not raise
- * "Class X is not a valid target for code coverage" warnings that
- * `failOnWarning=true` would promote to errors.
+ * The master-key liveness probe no longer lives in the controller: it was
+ * extracted into {@see VaultHealthServiceInterface} so the presentation layer
+ * does not depend on the Crypto namespace (ARCHITECTURE-2). The controller's
+ * private getHealthChecks() now merely projects a {@see VaultHealthStatus}
+ * onto the array shape the Fluid template consumes. These tests exercise that
+ * projection through the interface seam (a mocked VaultHealthServiceInterface),
+ * not via reflection on a removed property.
+ *
+ * Because the SUT is excluded from unit coverage in Build/phpunit.xml (its
+ * indexAction is covered functionally), we mark this test as `CoversNothing`
+ * so PHPUnit 12 does not raise "Class X is not a valid target for code
+ * coverage" warnings that `failOnWarning=true` would promote to errors.
  */
 #[CoversNothing]
+#[AllowMockObjectsWithoutExpectations]
 final class OverviewControllerTest extends TestCase
 {
-    /**
-     * PHPUnit 12 `createStub()` returns an opaque TestStub class that does not
-     * implement the `Stub` interface nor inherit from `MockObject`; declaring
-     * the intersection type `Interface&Stub` fails at runtime. Use the bare
-     * interface type — `createStub()` returns an instance of it.
-     */
-    private MasterKeyProviderFactoryInterface $masterKeyProviderFactory;
+    private VaultHealthServiceInterface&MockObject $vaultHealthService;
 
     private OverviewController $subject;
 
@@ -46,29 +47,29 @@ final class OverviewControllerTest extends TestCase
     {
         parent::setUp();
 
-        $this->masterKeyProviderFactory = $this->createStub(MasterKeyProviderFactoryInterface::class);
+        $this->vaultHealthService = $this->createMock(VaultHealthServiceInterface::class);
 
-        // Build controller using newInstanceWithoutConstructor to bypass
-        // final readonly ModuleTemplateFactory, then initialize the property
-        // needed for getHealthChecks() via reflection.
+        // Build the controller without invoking its constructor (it pulls in
+        // final readonly TYPO3 services we don't need here), then inject only
+        // the health-service seam that getHealthChecks() consults.
         $reflection = new ReflectionClass(OverviewController::class);
         $this->subject = $reflection->newInstanceWithoutConstructor();
 
-        $factoryProperty = $reflection->getProperty('masterKeyProviderFactory');
-        $factoryProperty->setValue($this->subject, $this->masterKeyProviderFactory);
+        $serviceProperty = $reflection->getProperty('vaultHealthService');
+        $serviceProperty->setValue($this->subject, $this->vaultHealthService);
     }
 
     #[Test]
-    public function healthCheckReturnsGreenWhenProviderAvailableAndKeyWorks(): void
+    public function healthChecksReportGreenWhenStatusIsHealthy(): void
     {
-        $provider = $this->createStub(MasterKeyProviderInterface::class);
-        $provider->method('getIdentifier')->willReturn('file');
-        $provider->method('isAvailable')->willReturn(true);
-        $provider->method('getMasterKey')->willReturn('a-valid-32-byte-master-key------');
-
-        $this->masterKeyProviderFactory
-            ->method('getAvailableProvider')
-            ->willReturn($provider);
+        $this->vaultHealthService
+            ->method('checkHealth')
+            ->willReturn(new VaultHealthStatus(
+                masterKeyAvailable: true,
+                masterKeyProvider: 'file',
+                encryptionWorking: true,
+                hasIssues: false,
+            ));
 
         $result = $this->invokeGetHealthChecks();
 
@@ -76,95 +77,106 @@ final class OverviewControllerTest extends TestCase
         self::assertTrue($result['encryptionWorking']);
         self::assertFalse($result['hasIssues']);
         self::assertSame('file', $result['masterKeyProvider']);
-        self::assertSame('', $result['masterKeyError']);
-        self::assertSame('', $result['encryptionError']);
     }
 
     #[Test]
-    public function healthCheckReturnsErrorWhenNoProviderAvailable(): void
+    public function healthChecksReportIssuesWhenNoProviderAvailable(): void
     {
-        $this->masterKeyProviderFactory
-            ->method('getAvailableProvider')
-            ->willThrowException(new Exception('No master key provider configured'));
+        // VaultHealthService swallows the "no provider" failure into a status
+        // with an empty provider id and hasIssues=true (no raw error leaks to
+        // the view — SEC-INJECTION-LEAK-2).
+        $this->vaultHealthService
+            ->method('checkHealth')
+            ->willReturn(new VaultHealthStatus(
+                masterKeyAvailable: false,
+                masterKeyProvider: '',
+                encryptionWorking: false,
+                hasIssues: true,
+            ));
 
         $result = $this->invokeGetHealthChecks();
 
         self::assertFalse($result['masterKeyAvailable']);
         self::assertFalse($result['encryptionWorking']);
         self::assertTrue($result['hasIssues']);
-        self::assertSame('No master key provider configured', $result['masterKeyError']);
+        self::assertSame('', $result['masterKeyProvider']);
     }
 
     #[Test]
-    public function healthCheckReturnsErrorWhenProviderNotAvailable(): void
+    public function healthChecksReportIssuesWhenProviderConfiguredButUnavailable(): void
     {
-        $provider = $this->createStub(MasterKeyProviderInterface::class);
-        $provider->method('getIdentifier')->willReturn('env');
-        $provider->method('isAvailable')->willReturn(false);
-
-        $this->masterKeyProviderFactory
-            ->method('getAvailableProvider')
-            ->willReturn($provider);
+        // Provider is known (identifier surfaces) but not usable.
+        $this->vaultHealthService
+            ->method('checkHealth')
+            ->willReturn(new VaultHealthStatus(
+                masterKeyAvailable: false,
+                masterKeyProvider: 'env',
+                encryptionWorking: false,
+                hasIssues: true,
+            ));
 
         $result = $this->invokeGetHealthChecks();
 
         self::assertFalse($result['masterKeyAvailable']);
         self::assertFalse($result['encryptionWorking']);
         self::assertTrue($result['hasIssues']);
-        self::assertStringContainsString('env', $result['masterKeyError']);
-        self::assertStringContainsString('not available', $result['masterKeyError']);
+        self::assertSame('env', $result['masterKeyProvider']);
     }
 
     #[Test]
-    public function healthCheckReturnsErrorWhenKeyDerivationFails(): void
+    public function healthChecksReportIssuesWhenKeyAvailableButEncryptionBroken(): void
     {
-        $provider = $this->createStub(MasterKeyProviderInterface::class);
-        $provider->method('getIdentifier')->willReturn('file');
-        $provider->method('isAvailable')->willReturn(true);
-        $provider->method('getMasterKey')->willThrowException(new Exception('Key file not readable'));
-
-        $this->masterKeyProviderFactory
-            ->method('getAvailableProvider')
-            ->willReturn($provider);
+        // Master key provider is available but reading/deriving the key fails:
+        // masterKeyAvailable stays true, encryptionWorking flips false.
+        $this->vaultHealthService
+            ->method('checkHealth')
+            ->willReturn(new VaultHealthStatus(
+                masterKeyAvailable: true,
+                masterKeyProvider: 'file',
+                encryptionWorking: false,
+                hasIssues: true,
+            ));
 
         $result = $this->invokeGetHealthChecks();
 
         self::assertTrue($result['masterKeyAvailable']);
         self::assertFalse($result['encryptionWorking']);
         self::assertTrue($result['hasIssues']);
-        self::assertSame('Key file not readable', $result['encryptionError']);
+        self::assertSame('file', $result['masterKeyProvider']);
     }
 
     #[Test]
-    public function healthCheckReturnsErrorWhenMasterKeyReturnsEmptyString(): void
+    public function healthChecksExposeOnlyGenericBooleansAndProviderId(): void
     {
-        $provider = $this->createStub(MasterKeyProviderInterface::class);
-        $provider->method('getIdentifier')->willReturn('file');
-        $provider->method('isAvailable')->willReturn(true);
-        $provider->method('getMasterKey')->willReturn('');
-
-        $this->masterKeyProviderFactory
-            ->method('getAvailableProvider')
-            ->willReturn($provider);
+        // Guard SEC-INJECTION-LEAK-2: the projection must not introduce any
+        // error-text keys — the array shape is exactly the four generic fields.
+        $this->vaultHealthService
+            ->method('checkHealth')
+            ->willReturn(new VaultHealthStatus(
+                masterKeyAvailable: true,
+                masterKeyProvider: 'file',
+                encryptionWorking: true,
+                hasIssues: false,
+            ));
 
         $result = $this->invokeGetHealthChecks();
 
-        self::assertTrue($result['masterKeyAvailable']);
-        self::assertFalse($result['encryptionWorking']);
-        self::assertTrue($result['hasIssues']);
-        self::assertSame('Master key provider returned an empty key.', $result['encryptionError']);
+        self::assertSame(
+            ['masterKeyAvailable', 'masterKeyProvider', 'encryptionWorking', 'hasIssues'],
+            array_keys($result),
+        );
     }
 
     /**
      * Invoke the private getHealthChecks() method via reflection.
      *
-     * @return array{masterKeyAvailable: bool, masterKeyProvider: string, masterKeyError: string, encryptionWorking: bool, encryptionError: string, hasIssues: bool}
+     * @return array{masterKeyAvailable: bool, masterKeyProvider: string, encryptionWorking: bool, hasIssues: bool}
      */
     private function invokeGetHealthChecks(): array
     {
         $method = (new ReflectionClass(OverviewController::class))->getMethod('getHealthChecks');
 
-        /** @var array{masterKeyAvailable: bool, masterKeyProvider: string, masterKeyError: string, encryptionWorking: bool, encryptionError: string, hasIssues: bool} */
+        /** @var array{masterKeyAvailable: bool, masterKeyProvider: string, encryptionWorking: bool, hasIssues: bool} */
         return $method->invoke($this->subject);
     }
 }

--- a/Tests/Unit/Crypto/AbstractMasterKeyProviderTest.php
+++ b/Tests/Unit/Crypto/AbstractMasterKeyProviderTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Crypto;
+
+use Netresearch\NrVault\Crypto\AbstractMasterKeyProvider;
+use Netresearch\NrVault\Tests\Unit\Crypto\Fixtures\FirstFakeMasterKeyProvider;
+use Netresearch\NrVault\Tests\Unit\Crypto\Fixtures\SecondFakeMasterKeyProvider;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(AbstractMasterKeyProvider::class)]
+final class AbstractMasterKeyProviderTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        FirstFakeMasterKeyProvider::clearCachedKey();
+        SecondFakeMasterKeyProvider::clearCachedKey();
+    }
+
+    protected function tearDown(): void
+    {
+        FirstFakeMasterKeyProvider::clearCachedKey();
+        SecondFakeMasterKeyProvider::clearCachedKey();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function getMasterKeyDelegatesToLoadRawKey(): void
+    {
+        $provider = new FirstFakeMasterKeyProvider();
+
+        self::assertSame(str_repeat("\xAA", 32), $provider->getMasterKey());
+    }
+
+    #[Test]
+    public function getMasterKeyLoadsRawKeyOnlyOncePerRequest(): void
+    {
+        $provider = new FirstFakeMasterKeyProvider();
+
+        $provider->getMasterKey();
+        $provider->getMasterKey();
+        $provider->getMasterKey();
+
+        self::assertSame(1, $provider->loadCount, 'loadRawKey() must be invoked at most once while cached');
+    }
+
+    #[Test]
+    public function cacheIsSharedAcrossInstancesOfSameClass(): void
+    {
+        $first = new FirstFakeMasterKeyProvider();
+        $first->getMasterKey();
+
+        // A fresh instance of the same class reuses the cached slot and must not
+        // re-load the raw key.
+        $second = new FirstFakeMasterKeyProvider();
+        $second->getMasterKey();
+
+        self::assertSame(0, $second->loadCount, 'second instance must hit the shared cache, not re-load');
+    }
+
+    #[Test]
+    public function clearCachedKeyForcesReload(): void
+    {
+        $provider = new FirstFakeMasterKeyProvider();
+        $provider->getMasterKey();
+        self::assertSame(1, $provider->loadCount);
+
+        FirstFakeMasterKeyProvider::clearCachedKey();
+
+        $provider->getMasterKey();
+        self::assertSame(2, $provider->loadCount, 'clearing the cache must force a reload');
+    }
+
+    #[Test]
+    public function cacheSlotsAreIsolatedPerConcreteClass(): void
+    {
+        $first = new FirstFakeMasterKeyProvider();
+        $second = new SecondFakeMasterKeyProvider();
+
+        self::assertSame(str_repeat("\xAA", 32), $first->getMasterKey());
+        self::assertSame(str_repeat("\xBB", 32), $second->getMasterKey());
+
+        // Clearing one provider's cache must not affect the other's slot.
+        FirstFakeMasterKeyProvider::clearCachedKey();
+
+        self::assertSame(str_repeat("\xBB", 32), $second->getMasterKey());
+    }
+}

--- a/Tests/Unit/Crypto/EncryptionServiceTest.php
+++ b/Tests/Unit/Crypto/EncryptionServiceTest.php
@@ -231,6 +231,84 @@ final class EncryptionServiceTest extends TestCase
     }
 
     #[Test]
+    public function encryptValueChecksumIsHex64(): void
+    {
+        $encrypted = $this->subject->encrypt('shape-check', 'shape-id');
+
+        // Keep the 64-hex shape so downstream/audit usage is unchanged.
+        self::assertSame(64, \strlen($encrypted->valueChecksum));
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $encrypted->valueChecksum);
+    }
+
+    #[Test]
+    public function encryptValueChecksumIsNotPlaintextSha256(): void
+    {
+        $plaintext = 'low-entropy-guessable-secret';
+
+        $encrypted = $this->subject->encrypt($plaintext, 'oracle-id');
+
+        // The stored change-detection token must NOT be an offline-computable
+        // function of the plaintext (SEC-CRYPTO-1): no sha256(plaintext) oracle.
+        self::assertNotSame(hash('sha256', $plaintext), $encrypted->valueChecksum);
+    }
+
+    #[Test]
+    public function encryptValueChecksumDiffersPerSecretForIdenticalPlaintext(): void
+    {
+        $plaintext = 'identical-plaintext-across-secrets';
+
+        $first = $this->subject->encrypt($plaintext, 'secret-a');
+        $second = $this->subject->encrypt($plaintext, 'secret-b');
+
+        // Per-secret DEK => per-secret MAC key + per-call ciphertext => the
+        // checksum must not leak plaintext equality across secrets.
+        self::assertNotSame($first->valueChecksum, $second->valueChecksum);
+    }
+
+    #[Test]
+    public function decryptStillSucceedsAfterTamperedDecryptInSameRequest(): void
+    {
+        // Proves the throw path's DEK wipe (a finally on a fresh local $dek)
+        // does not clobber the shared request-cached master key: a tampered
+        // decrypt throws, yet a subsequent legitimate decrypt still works.
+        $plaintext = 'sequential-decrypt-secret';
+        $identifier = 'seq-id';
+
+        $encrypted = $this->subject->encrypt($plaintext, $identifier);
+
+        $raw = base64_decode($encrypted->encryptedValue, true);
+        self::assertIsString($raw);
+        $lastIndex = \strlen($raw) - 1;
+        $flipped = \chr(\ord($raw[$lastIndex]) ^ 0xFF);
+        $tamperedValue = base64_encode(substr($raw, 0, $lastIndex) . $flipped);
+
+        $threw = false;
+
+        try {
+            $this->subject->decrypt(
+                $tamperedValue,
+                $encrypted->encryptedDek,
+                $encrypted->dekNonce,
+                $encrypted->valueNonce,
+                $identifier,
+            );
+        } catch (EncryptionException) {
+            $threw = true;
+        }
+        self::assertTrue($threw, 'tampered ciphertext must fail closed on the throw path');
+
+        // Same request, legitimate decrypt must still round-trip.
+        $decrypted = $this->subject->decrypt(
+            $encrypted->encryptedValue,
+            $encrypted->encryptedDek,
+            $encrypted->dekNonce,
+            $encrypted->valueNonce,
+            $identifier,
+        );
+        self::assertSame($plaintext, $decrypted);
+    }
+
+    #[Test]
     public function reEncryptDekWorksWithNewMasterKey(): void
     {
         $plaintext = 'reencrypt-test';

--- a/Tests/Unit/Crypto/Fixtures/AbstractFakeMasterKeyProvider.php
+++ b/Tests/Unit/Crypto/Fixtures/AbstractFakeMasterKeyProvider.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the nr-vault TYPO3 extension.
+ *
+ * (c) Netresearch DTT GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Crypto\Fixtures;
+
+use Netresearch\NrVault\Crypto\AbstractMasterKeyProvider;
+use SensitiveParameter;
+
+/**
+ * Shared skeleton for the test-only providers that exercise the
+ * request-lifetime caching contract in {@see AbstractMasterKeyProvider}
+ * (ADR-020). Concrete subclasses supply only their distinguishing identifier
+ * and the single raw-key byte; the caching behaviour under test lives entirely
+ * in the production base class.
+ *
+ * `loadRawKey()` counts its invocations via {@see $loadCount} so a test can
+ * assert the raw key is loaded at most once while cached.
+ */
+abstract class AbstractFakeMasterKeyProvider extends AbstractMasterKeyProvider
+{
+    public int $loadCount = 0;
+
+    public function isAvailable(): bool
+    {
+        return true;
+    }
+
+    public function storeMasterKey(#[SensitiveParameter] string $key): void {}
+
+    public function generateMasterKey(): string
+    {
+        return str_repeat($this->rawKeyByte(), 32);
+    }
+
+    protected function loadRawKey(): string
+    {
+        ++$this->loadCount;
+
+        return str_repeat($this->rawKeyByte(), 32);
+    }
+
+    /**
+     * The single byte repeated 32 times to form this provider's raw key.
+     * Distinct per concrete subclass so cache isolation is observable.
+     */
+    abstract protected function rawKeyByte(): string;
+}

--- a/Tests/Unit/Crypto/Fixtures/FirstFakeMasterKeyProvider.php
+++ b/Tests/Unit/Crypto/Fixtures/FirstFakeMasterKeyProvider.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the nr-vault TYPO3 extension.
+ *
+ * (c) Netresearch DTT GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Crypto\Fixtures;
+
+/**
+ * Test-only concrete provider whose cached raw key is 0xAA repeated.
+ */
+final class FirstFakeMasterKeyProvider extends AbstractFakeMasterKeyProvider
+{
+    public function getIdentifier(): string
+    {
+        return 'fake-first';
+    }
+
+    protected function rawKeyByte(): string
+    {
+        return "\xAA";
+    }
+}

--- a/Tests/Unit/Crypto/Fixtures/SecondFakeMasterKeyProvider.php
+++ b/Tests/Unit/Crypto/Fixtures/SecondFakeMasterKeyProvider.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the nr-vault TYPO3 extension.
+ *
+ * (c) Netresearch DTT GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Crypto\Fixtures;
+
+/**
+ * Second test-only concrete provider whose cached raw key is 0xBB repeated;
+ * used to prove cache slots are isolated per concrete class.
+ */
+final class SecondFakeMasterKeyProvider extends AbstractFakeMasterKeyProvider
+{
+    public function getIdentifier(): string
+    {
+        return 'fake-second';
+    }
+
+    protected function rawKeyByte(): string
+    {
+        return "\xBB";
+    }
+}

--- a/Tests/Unit/Domain/Model/SecretTest.php
+++ b/Tests/Unit/Domain/Model/SecretTest.php
@@ -1005,6 +1005,7 @@ final class SecretTest extends TestCase
             'value_checksum',
             'value_nonce',
             'version',
+            'write_groups',
         ];
         $actualKeys = array_keys($row);
         sort($actualKeys);

--- a/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
@@ -85,16 +85,19 @@ final class SecretRepositoryTest extends TestCase
         $result = $this->createStub(Result::class);
         $result->method('fetchAssociative')->willReturn($secretRow);
 
-        // Group load issues a second executeQuery on the MM table — wire both
-        // result mocks explicitly instead of letting fetchAllAssociative
-        // silently default to []. Passing the same $result mock previously
-        // made the test pass for the wrong reason.
-        $groupResult = $this->createStub(Result::class);
-        $groupResult->method('fetchAllAssociative')->willReturn([]);
+        // Group load issues two further executeQuery calls on the MM tables
+        // (read tier + write tier) — wire all three result mocks explicitly
+        // instead of letting fetchAllAssociative silently default to [].
+        // Passing the same $result mock previously made the test pass for the
+        // wrong reason.
+        $readGroupResult = $this->createStub(Result::class);
+        $readGroupResult->method('fetchAllAssociative')->willReturn([]);
+        $writeGroupResult = $this->createStub(Result::class);
+        $writeGroupResult->method('fetchAllAssociative')->willReturn([]);
 
         $this->setupQueryBuilderForSelect($result);
         $this->queryBuilder->method('executeQuery')
-            ->willReturnOnConsecutiveCalls($result, $groupResult);
+            ->willReturnOnConsecutiveCalls($result, $readGroupResult, $writeGroupResult);
 
         $secret = $this->subject->findByIdentifier('test-id');
 
@@ -120,12 +123,15 @@ final class SecretRepositoryTest extends TestCase
         $result = $this->createStub(Result::class);
         $result->method('fetchAssociative')->willReturn($secretRow);
 
-        $groupResult = $this->createStub(Result::class);
-        $groupResult->method('fetchAllAssociative')->willReturn([]);
+        // Read tier + write tier MM lookups follow the secret-row fetch.
+        $readGroupResult = $this->createStub(Result::class);
+        $readGroupResult->method('fetchAllAssociative')->willReturn([]);
+        $writeGroupResult = $this->createStub(Result::class);
+        $writeGroupResult->method('fetchAllAssociative')->willReturn([]);
 
         $this->setupQueryBuilderForSelect($result);
         $this->queryBuilder->method('executeQuery')
-            ->willReturnOnConsecutiveCalls($result, $groupResult);
+            ->willReturnOnConsecutiveCalls($result, $readGroupResult, $writeGroupResult);
 
         $secret = $this->subject->findByUid(42);
 
@@ -172,10 +178,17 @@ final class SecretRepositoryTest extends TestCase
             ->method('lastInsertId')
             ->willReturn('1');
 
-        // Mock MM table delete (no groups)
+        // save() clears BOTH MM tiers (read + write) before re-inserting, so
+        // delete() is called once per MM table. Match either table name.
         $connection
             ->method('delete')
-            ->with('tx_nrvault_secret_begroups_mm', self::anything());
+            ->with(
+                self::logicalOr(
+                    'tx_nrvault_secret_begroups_mm',
+                    'tx_nrvault_secret_writegroups_mm',
+                ),
+                self::anything(),
+            );
 
         $saved = $this->subject->save($secret);
 
@@ -201,10 +214,17 @@ final class SecretRepositoryTest extends TestCase
                 ['uid' => 42],
             );
 
-        // Mock MM table delete
+        // save() clears BOTH MM tiers (read + write) for the secret's uid,
+        // so delete() is called once per MM table with the same criteria.
         $connection
             ->method('delete')
-            ->with('tx_nrvault_secret_begroups_mm', ['uid_local' => 42]);
+            ->with(
+                self::logicalOr(
+                    'tx_nrvault_secret_begroups_mm',
+                    'tx_nrvault_secret_writegroups_mm',
+                ),
+                ['uid_local' => 42],
+            );
 
         $this->subject->save($secret);
     }
@@ -407,22 +427,28 @@ final class SecretRepositoryTest extends TestCase
         $secretResult = $this->createStub(Result::class);
         $secretResult->method('fetchAssociative')->willReturn($secretRow);
 
-        $groupResult = $this->createStub(Result::class);
-        $groupResult->method('fetchAllAssociative')->willReturn([
+        // Read-tier MM lookup returns two groups; the separate write-tier
+        // lookup (a third createQueryBuilder) returns none.
+        $readGroupResult = $this->createStub(Result::class);
+        $readGroupResult->method('fetchAllAssociative')->willReturn([
             ['uid_foreign' => 3],
             ['uid_foreign' => 7],
         ]);
+        $writeGroupResult = $this->createStub(Result::class);
+        $writeGroupResult->method('fetchAllAssociative')->willReturn([]);
 
         $qb1 = $this->createQueryBuilderStub($secretResult, $expressionBuilder);
-        $qb2 = $this->createQueryBuilderStub($groupResult, $expressionBuilder);
+        $qb2 = $this->createQueryBuilderStub($readGroupResult, $expressionBuilder);
+        $qb3 = $this->createQueryBuilderStub($writeGroupResult, $expressionBuilder);
 
         $connection->method('createQueryBuilder')
-            ->willReturnOnConsecutiveCalls($qb1, $qb2);
+            ->willReturnOnConsecutiveCalls($qb1, $qb2, $qb3);
 
         $secret = $subject->findByIdentifier('secret-with-groups');
 
         self::assertInstanceOf(Secret::class, $secret);
         self::assertSame([3, 7], $secret->getAllowedGroups());
+        self::assertSame([], $secret->getWriteGroups());
     }
 
     #[Test]
@@ -442,21 +468,27 @@ final class SecretRepositoryTest extends TestCase
         $secretResult = $this->createStub(Result::class);
         $secretResult->method('fetchAssociative')->willReturn($secretRow);
 
-        $groupResult = $this->createStub(Result::class);
-        $groupResult->method('fetchAllAssociative')->willReturn([
+        // Read-tier MM lookup returns one group; the separate write-tier
+        // lookup (a third createQueryBuilder) returns none.
+        $readGroupResult = $this->createStub(Result::class);
+        $readGroupResult->method('fetchAllAssociative')->willReturn([
             ['uid_foreign' => 5],
         ]);
+        $writeGroupResult = $this->createStub(Result::class);
+        $writeGroupResult->method('fetchAllAssociative')->willReturn([]);
 
         $qb1 = $this->createQueryBuilderStub($secretResult, $expressionBuilder);
-        $qb2 = $this->createQueryBuilderStub($groupResult, $expressionBuilder);
+        $qb2 = $this->createQueryBuilderStub($readGroupResult, $expressionBuilder);
+        $qb3 = $this->createQueryBuilderStub($writeGroupResult, $expressionBuilder);
 
         $connection->method('createQueryBuilder')
-            ->willReturnOnConsecutiveCalls($qb1, $qb2);
+            ->willReturnOnConsecutiveCalls($qb1, $qb2, $qb3);
 
         $secret = $subject->findByUid(20);
 
         self::assertInstanceOf(Secret::class, $secret);
         self::assertSame([5], $secret->getAllowedGroups());
+        self::assertSame([], $secret->getWriteGroups());
     }
 
     #[Test]
@@ -470,18 +502,34 @@ final class SecretRepositoryTest extends TestCase
             ->method('lastInsertId')
             ->willReturn('5');
 
-        // Expect: 1 secret insert + 2 MM group inserts = 3 inserts total
+        // Expect: 1 secret insert + 2 read-tier MM group inserts = 3 inserts.
+        // The write tier is empty, so it contributes no inserts.
         $connection
             ->expects(self::exactly(3))
             ->method('insert');
 
-        // Expect: 1 delete of existing MM rows before saving groups
+        // save() clears BOTH MM tiers (read + write) before re-inserting.
+        // Record the deleted tables and assert each DISTINCT MM table was
+        // cleared once — a count-only matcher would still pass if production
+        // cleared the read table twice and never touched the write table.
+        $deletedTables = [];
         $connection
-            ->expects(self::once())
-            ->method('delete');
+            ->expects(self::exactly(2))
+            ->method('delete')
+            ->willReturnCallback(static function (string $table) use (&$deletedTables): int {
+                $deletedTables[] = $table;
+
+                return 1;
+            });
 
         $saved = $this->subject->save($secret);
 
+        sort($deletedTables);
+        self::assertSame(
+            ['tx_nrvault_secret_begroups_mm', 'tx_nrvault_secret_writegroups_mm'],
+            $deletedTables,
+            'save() must clear BOTH the read-tier and write-tier MM tables, each exactly once',
+        );
         self::assertNull($secret->getUid());
         self::assertSame(5, $saved->getUid());
     }
@@ -549,14 +597,19 @@ final class SecretRepositoryTest extends TestCase
         $mainResult = $this->createStub(Result::class);
         $mainResult->method('fetchAllAssociative')->willReturn([$row1, $row2]);
 
-        $mmResult = $this->createStub(Result::class);
-        $mmResult->method('fetchAllAssociative')->willReturn([]);
+        // hydrateRowsWithGroups batch-loads BOTH MM tiers (read + write) in
+        // one query each, so after the main query there are two MM queries.
+        $readMmResult = $this->createStub(Result::class);
+        $readMmResult->method('fetchAllAssociative')->willReturn([]);
+        $writeMmResult = $this->createStub(Result::class);
+        $writeMmResult->method('fetchAllAssociative')->willReturn([]);
 
         $qb1 = $this->createQueryBuilderStub($mainResult, $expressionBuilder);
-        $qb2 = $this->createQueryBuilderStub($mmResult, $expressionBuilder);
+        $qb2 = $this->createQueryBuilderStub($readMmResult, $expressionBuilder);
+        $qb3 = $this->createQueryBuilderStub($writeMmResult, $expressionBuilder);
 
         $connection->method('createQueryBuilder')
-            ->willReturnOnConsecutiveCalls($qb1, $qb2);
+            ->willReturnOnConsecutiveCalls($qb1, $qb2, $qb3);
 
         $secrets = $subject->findAllWithFilters();
 
@@ -627,16 +680,17 @@ final class SecretRepositoryTest extends TestCase
         $secretsResult = $this->createStub(Result::class);
         $secretsResult->method('fetchAllAssociative')->willReturn([$row1, $row2]);
 
-        // Third/fourth calls: individual group loads per secret (returns empty)
-        $emptyResult1 = $this->createStub(Result::class);
-        $emptyResult1->method('fetchAllAssociative')->willReturn([]);
-        $emptyResult2 = $this->createStub(Result::class);
-        $emptyResult2->method('fetchAllAssociative')->willReturn([]);
+        // Third/fourth calls: batch group loads (read tier, then write tier)
+        // via hydrateRowsWithGroups — one query per tier, not one per secret.
+        $readGroupsResult = $this->createStub(Result::class);
+        $readGroupsResult->method('fetchAllAssociative')->willReturn([]);
+        $writeGroupsResult = $this->createStub(Result::class);
+        $writeGroupsResult->method('fetchAllAssociative')->willReturn([]);
 
         $qb1 = $this->createQueryBuilderStub($mmResult, $expressionBuilder);
         $qb2 = $this->createQueryBuilderStub($secretsResult, $expressionBuilder);
-        $qb3 = $this->createQueryBuilderStub($emptyResult1, $expressionBuilder);
-        $qb4 = $this->createQueryBuilderStub($emptyResult2, $expressionBuilder);
+        $qb3 = $this->createQueryBuilderStub($readGroupsResult, $expressionBuilder);
+        $qb4 = $this->createQueryBuilderStub($writeGroupsResult, $expressionBuilder);
 
         $connection->method('createQueryBuilder')
             ->willReturnOnConsecutiveCalls($qb1, $qb2, $qb3, $qb4);
@@ -770,7 +824,8 @@ final class SecretRepositoryTest extends TestCase
 
         $secret = $this->newEncryptedSecret('existing-with-groups', uid: 77, allowedGroups: [11, 13]);
 
-        // 1 update on the secret row, 2 inserts on the MM table for the 2 groups
+        // 1 update on the secret row, 2 inserts on the read-tier MM table for
+        // the 2 read groups. The write tier is empty, so it adds no inserts.
         $connection->expects(self::once())->method('update');
         $connection->expects(self::exactly(2))->method('insert')
             ->with(
@@ -780,11 +835,31 @@ final class SecretRepositoryTest extends TestCase
                     && isset($data['sorting'])),
             );
 
-        // Exactly one MM delete before the re-inserts
-        $connection->expects(self::once())->method('delete')
-            ->with('tx_nrvault_secret_begroups_mm', ['uid_local' => 77]);
+        // save() clears BOTH MM tiers (read + write) before re-inserting.
+        // Record the deleted tables so we can assert each DISTINCT MM table
+        // was cleared once — a `logicalOr` count-only matcher would still pass
+        // if production deleted the read table twice and never touched the
+        // write table, so we pin both table names explicitly here.
+        $deletedTables = [];
+        $connection->expects(self::exactly(2))->method('delete')
+            ->with(
+                self::anything(),
+                ['uid_local' => 77],
+            )
+            ->willReturnCallback(static function (string $table) use (&$deletedTables): int {
+                $deletedTables[] = $table;
+
+                return 1;
+            });
 
         $this->subject->save($secret);
+
+        sort($deletedTables);
+        self::assertSame(
+            ['tx_nrvault_secret_begroups_mm', 'tx_nrvault_secret_writegroups_mm'],
+            $deletedTables,
+            'save() must clear BOTH the read-tier and write-tier MM tables, each exactly once',
+        );
     }
 
     /**

--- a/Tests/Unit/Hook/DataHandlerHookTest.php
+++ b/Tests/Unit/Hook/DataHandlerHookTest.php
@@ -10,16 +10,19 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Hook;
 
 use Doctrine\DBAL\Result;
-use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Exception\VaultException;
 use Netresearch\NrVault\Hook\DataHandlerHook;
+use Netresearch\NrVault\Hook\PendingSecretExtractor;
+use Netresearch\NrVault\Hook\PendingSecretPersister;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use Netresearch\NrVault\Utility\IdentifierValidator;
+use Netresearch\NrVault\Utility\VaultFieldResolver;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Core\Database\Connection;
@@ -28,7 +31,6 @@ use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
 use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 #[CoversClass(DataHandlerHook::class)]
 #[AllowMockObjectsWithoutExpectations]
@@ -44,8 +46,6 @@ final class DataHandlerHookTest extends TestCase
 
     private VaultServiceInterface&MockObject $vaultService;
 
-    private AuditLogServiceInterface&MockObject $auditLogService;
-
     private DataHandler&MockObject $dataHandler;
 
     private ConnectionPool&MockObject $connectionPool;
@@ -59,24 +59,30 @@ final class DataHandlerHookTest extends TestCase
         $this->connectionPool = $this->createMock(ConnectionPool::class);
         $this->tcaSchemaFactory = $this->createMock(TcaSchemaFactory::class);
         $this->vaultService = $this->createMock(VaultServiceInterface::class);
-        $this->auditLogService = $this->createMock(AuditLogServiceInterface::class);
         $this->flashMessageService = $this->createMock(FlashMessageService::class);
         $this->dataHandler = $this->createMock(DataHandler::class);
 
-        $this->subject = new DataHandlerHook(
-            $this->connectionPool,
+        // The hook's collaborators are pure extracted logic: wire them for real
+        // so the vault-service, flash-message and rollback expectations exercise
+        // the actual decision pipeline rather than mock theatre.
+        $vaultFieldResolver = new VaultFieldResolver(
+            $this->vaultService,
             $this->tcaSchemaFactory,
+            $this->createMock(LoggerInterface::class),
+        );
+        $pendingSecretExtractor = new PendingSecretExtractor();
+        $pendingSecretPersister = new PendingSecretPersister(
             $this->vaultService,
             $this->flashMessageService,
         );
 
-        GeneralUtility::addInstance(AuditLogServiceInterface::class, $this->auditLogService);
-    }
-
-    protected function tearDown(): void
-    {
-        GeneralUtility::purgeInstances();
-        parent::tearDown();
+        $this->subject = new DataHandlerHook(
+            $this->connectionPool,
+            $this->vaultService,
+            $vaultFieldResolver,
+            $pendingSecretExtractor,
+            $pendingSecretPersister,
+        );
     }
 
     #[Test]
@@ -351,7 +357,7 @@ final class DataHandlerHookTest extends TestCase
                 'tx_test',
                 42,
                 2,
-                0,
+                null,
                 1,
                 self::stringContains('api_key'),
             );
@@ -977,7 +983,7 @@ final class DataHandlerHookTest extends TestCase
                 'tx_test',
                 42,
                 3,
-                0,
+                null,
                 1,
                 self::stringContains('api_key'),
             );
@@ -1443,7 +1449,7 @@ final class DataHandlerHookTest extends TestCase
                 'tx_test',
                 100,
                 1,
-                0,
+                null,
                 1,
                 self::stringContains('api_key'),
             );

--- a/Tests/Unit/Hook/Dto/FlexFormPendingSecretTest.php
+++ b/Tests/Unit/Hook/Dto/FlexFormPendingSecretTest.php
@@ -195,7 +195,7 @@ final class FlexFormPendingSecretTest extends TestCase
             'flexField' => 'pi_flexform',
             'sheet' => 'sDEF',
             'fieldPath' => 'settings.token',
-            'value' => 'mytoken',
+            'value' => '[REDACTED]',
             'identifier' => 'app/token',
             'originalChecksum' => 'checksum123',
             'isNew' => false,

--- a/Tests/Unit/Hook/Dto/PendingSecretTest.php
+++ b/Tests/Unit/Hook/Dto/PendingSecretTest.php
@@ -120,8 +120,10 @@ final class PendingSecretTest extends TestCase
             isNew: false,
         );
 
+        // toArray() redacts the secret value: the plaintext must never leak
+        // into a logged/serialised array (SEC / VO-DTO hardening).
         self::assertSame([
-            'value' => 'secretvalue',
+            'value' => '[REDACTED]',
             'identifier' => 'my/identifier',
             'originalChecksum' => 'oldchecksum',
             'isNew' => false,

--- a/Tests/Unit/Security/AccessControlServiceTest.php
+++ b/Tests/Unit/Security/AccessControlServiceTest.php
@@ -312,13 +312,16 @@ final class AccessControlServiceTest extends TestCase
     }
 
     #[Test]
-    public function hasAccessDelegatesToFrontendAccessibleWhenNoBackendUserAndNotCli(): void
+    public function frontendAccessibleGrantsReadOnlyWithoutBackendUser(): void
     {
-        // canWrite and canDelete also delegate to hasAccess, which ends at isFrontendAccessible()
+        // ADR-005 least-privilege split: frontend_accessible is READ-ONLY.
+        // Without a backend or CLI actor, write/delete must always be denied
+        // even when the secret is frontend-accessible.
         $secret = $this->createSecret(ownerUid: 0, frontendAccessible: true);
 
-        self::assertTrue($this->subject->canWrite($secret));
-        self::assertTrue($this->subject->canDelete($secret));
+        self::assertTrue($this->subject->canRead($secret), 'frontend-accessible secret is readable');
+        self::assertFalse($this->subject->canWrite($secret), 'frontend has no write tier');
+        self::assertFalse($this->subject->canDelete($secret), 'frontend has no delete tier');
     }
 
     #[Test]
@@ -379,25 +382,111 @@ final class AccessControlServiceTest extends TestCase
     }
 
     #[Test]
-    public function canWriteReturnsTrueForGroupMember(): void
+    public function readTierGroupMemberCannotWrite(): void
     {
+        // ADR-005 least-privilege split: a member of the READ tier
+        // (allowed_groups) may read but MUST NOT write.
         $this->setBackendUser(uid: 5, isAdmin: false, groups: [10, 20]);
         $secret = $this->createSecret(ownerUid: 999, allowedGroups: [20]);
 
         $subject = $this->createSubjectWithExistingGroups([10, 20]);
 
-        self::assertTrue($subject->canWrite($secret));
+        self::assertFalse($subject->canWrite($secret), 'read-tier group must not write');
     }
 
     #[Test]
-    public function canDeleteReturnsTrueForGroupMember(): void
+    public function readTierGroupMemberCannotDelete(): void
     {
+        // ADR-005: a read-tier member must never delete (delete has no
+        // group tier at all).
         $this->setBackendUser(uid: 5, isAdmin: false, groups: [10, 20]);
         $secret = $this->createSecret(ownerUid: 999, allowedGroups: [20]);
 
         $subject = $this->createSubjectWithExistingGroups([10, 20]);
 
-        self::assertTrue($subject->canDelete($secret));
+        self::assertFalse($subject->canDelete($secret), 'read-tier group must not delete');
+    }
+
+    #[Test]
+    public function writeTierGroupMemberCanReadAndWriteButNotDelete(): void
+    {
+        // ADR-005 least-privilege split: a member of the WRITE tier
+        // (write_groups) may read and write, but delete is reserved for
+        // owner/admin/maintainer.
+        $this->setBackendUser(uid: 5, isAdmin: false, groups: [10, 20]);
+        $secret = $this->createSecret(ownerUid: 999, writeGroups: [20]);
+
+        $subject = $this->createSubjectWithExistingGroups([10, 20]);
+
+        self::assertTrue($subject->canRead($secret), 'write-tier member can read');
+        self::assertTrue($subject->canWrite($secret), 'write-tier member can write');
+        self::assertFalse($subject->canDelete($secret), 'write-tier member cannot delete');
+    }
+
+    #[Test]
+    public function writeTierMemberWithoutReadTierStillReads(): void
+    {
+        // A user who is ONLY in the write tier (not listed in allowed_groups)
+        // must still be able to read — write implies read.
+        $this->setBackendUser(uid: 5, isAdmin: false, groups: [7]);
+        $secret = $this->createSecret(ownerUid: 999, allowedGroups: [3], writeGroups: [7]);
+
+        $subject = $this->createSubjectWithExistingGroups([7]);
+
+        self::assertTrue($subject->canRead($secret), 'write-only-tier member can read');
+        self::assertTrue($subject->canWrite($secret), 'write-only-tier member can write');
+    }
+
+    #[Test]
+    public function nonGroupMemberGetsNothingAcrossAllTiers(): void
+    {
+        // A user in neither tier gets no access at all.
+        $this->setBackendUser(uid: 5, isAdmin: false, groups: [99]);
+        $secret = $this->createSecret(ownerUid: 999, allowedGroups: [1], writeGroups: [2]);
+
+        $subject = $this->createSubjectWithExistingGroups([1, 2, 99]);
+
+        self::assertFalse($subject->canRead($secret));
+        self::assertFalse($subject->canWrite($secret));
+        self::assertFalse($subject->canDelete($secret));
+    }
+
+    #[Test]
+    public function ownerHasFullAccessAcrossAllTiers(): void
+    {
+        // The owner gets read/write/delete regardless of group tiers.
+        $this->setBackendUser(uid: 5, isAdmin: false);
+        $secret = $this->createSecret(ownerUid: 5, allowedGroups: [1], writeGroups: [2]);
+
+        self::assertTrue($this->subject->canRead($secret));
+        self::assertTrue($this->subject->canWrite($secret));
+        self::assertTrue($this->subject->canDelete($secret));
+    }
+
+    #[Test]
+    public function adminHasFullAccessAcrossAllTiers(): void
+    {
+        $this->setBackendUser(uid: 1, isAdmin: true);
+        $secret = $this->createSecret(ownerUid: 999, allowedGroups: [1], writeGroups: [2]);
+
+        self::assertTrue($this->subject->canRead($secret));
+        self::assertTrue($this->subject->canWrite($secret));
+        self::assertTrue($this->subject->canDelete($secret));
+    }
+
+    #[Test]
+    public function writeTierIgnoresStaleGroupIds(): void
+    {
+        // Defence-in-depth: a stale (deleted) write-tier group UID still in
+        // the session must NOT grant write access.
+        $this->setBackendUser(uid: 5, isAdmin: false, groups: [88888]);
+        $secret = $this->createSecret(ownerUid: 999, writeGroups: [88888]);
+
+        // be_groups reports the group as NOT existing.
+        $subject = $this->createSubjectWithExistingGroups([]);
+
+        self::assertFalse($subject->canWrite($secret), 'stale write-tier group must not grant write');
+        self::assertFalse($subject->canRead($secret), 'stale write-tier group must not grant read');
     }
 
     #[Test]
@@ -527,16 +616,19 @@ final class AccessControlServiceTest extends TestCase
      * Create a test Secret with specified properties.
      *
      * @param list<int> $allowedGroups
+     * @param list<int> $writeGroups
      */
     private function createSecret(
         int $ownerUid = 0,
         array $allowedGroups = [],
         bool $frontendAccessible = false,
+        array $writeGroups = [],
     ): Secret {
         return new Secret(
             identifier: 'test-secret',
             ownerUid: $ownerUid,
             allowedGroups: $allowedGroups,
+            writeGroups: $writeGroups,
             frontendAccessible: $frontendAccessible,
         );
     }

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
 use Netresearch\NrVault\Domain\Dto\SecretFilters;
 use Netresearch\NrVault\Domain\Model\Secret;
 use Netresearch\NrVault\Exception\AccessDeniedException;
+use Netresearch\NrVault\Exception\AuditWriteException;
 use Netresearch\NrVault\Exception\EncryptionException;
 use Netresearch\NrVault\Exception\SecretExpiredException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
@@ -241,6 +242,75 @@ final class VaultServiceTest extends TestCase
             ->willReturnArgument(0);
 
         $subject->store('coerce', 'plaintext', ['owner' => 99]);
+    }
+
+    #[Test]
+    public function storeCoercesFrontendAccessibleForNonAdminBackendActor(): void
+    {
+        $beActorAccess = $this->createMock(AccessControlServiceInterface::class);
+        $beActorAccess->method('getCurrentActorUid')->willReturn(7);
+        $beActorAccess->method('getCurrentActorType')->willReturn('backend');
+        $beActorAccess->method('canCreate')->willReturn(true);
+        $beActorAccess->method('isCurrentActorAdmin')->willReturn(false);
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $beActorAccess,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->encryptionService
+            ->method('encrypt')
+            ->willReturn(new EncryptedData('enc', 'dek', 'n1', 'n2', 'cs'));
+
+        $this->adapter->method('retrieve')->willReturn(null);
+
+        // Non-admin BE actor marking frontendAccessible=true must be coerced
+        // back to false (privileged flag, SEC-ACCESS-11).
+        $this->adapter
+            ->expects(self::once())
+            ->method('store')
+            ->with(self::callback(static fn (Secret $s): bool => $s->isFrontendAccessible() === false))
+            ->willReturnArgument(0);
+
+        $subject->store('coerce_fe', 'plaintext', ['frontendAccessible' => true]);
+    }
+
+    #[Test]
+    public function storeAllowsFrontendAccessibleForAdminBackendActor(): void
+    {
+        $adminAccess = $this->createMock(AccessControlServiceInterface::class);
+        $adminAccess->method('getCurrentActorUid')->willReturn(1);
+        $adminAccess->method('getCurrentActorType')->willReturn('backend');
+        $adminAccess->method('canCreate')->willReturn(true);
+        $adminAccess->method('isCurrentActorAdmin')->willReturn(true);
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $adminAccess,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->encryptionService
+            ->method('encrypt')
+            ->willReturn(new EncryptedData('enc', 'dek', 'n1', 'n2', 'cs'));
+
+        $this->adapter->method('retrieve')->willReturn(null);
+
+        // Admin BE actor may mark a secret frontend-accessible.
+        $this->adapter
+            ->expects(self::once())
+            ->method('store')
+            ->with(self::callback(static fn (Secret $s): bool => $s->isFrontendAccessible()))
+            ->willReturnArgument(0);
+
+        $subject->store('admin_fe', 'plaintext', ['frontendAccessible' => true]);
     }
 
     #[Test]
@@ -904,6 +974,133 @@ final class VaultServiceTest extends TestCase
         $this->subject->store('test', 'secret', [
             'groups' => [1, 2, 3],
         ]);
+    }
+
+    #[Test]
+    public function storeRollsBackCreateWhenAuditWriteFails(): void
+    {
+        $this->encryptionService
+            ->method('encrypt')
+            ->willReturn(new EncryptedData('enc', 'dek', 'n1', 'n2', 'cs'));
+
+        $this->adapter->method('retrieve')->willReturn(null);
+
+        // SEC-3: a failing audit write must trigger a compensating delete of
+        // the just-inserted record so it never persists without an audit entry.
+        $this->auditLogService
+            ->method('log')
+            ->willThrowException(new AuditWriteException('audit down', 1747825331));
+
+        $this->adapter
+            ->expects(self::once())
+            ->method('delete')
+            ->with('rollback_create');
+
+        $this->expectException(AuditWriteException::class);
+
+        $this->subject->store('rollback_create', 'plaintext');
+    }
+
+    #[Test]
+    public function storeRollsBackUpdateWhenAuditWriteFails(): void
+    {
+        $existing = $this->createSecretEntity('rollback_update', uid: 42, version: 2, crdate: 1000);
+
+        $this->encryptionService
+            ->method('encrypt')
+            ->willReturn(new EncryptedData('enc', 'dek', 'n1', 'n2', 'cs'));
+
+        $this->adapter->method('retrieve')->willReturn($existing);
+        $this->accessControlService->method('canWrite')->willReturn(true);
+
+        $this->auditLogService
+            ->method('log')
+            ->willThrowException(new AuditWriteException('audit down', 1747825331));
+
+        // On update, the compensating action restores the prior instance:
+        // store() is called twice — once for the mutation, once to restore.
+        $storeArgs = [];
+        $this->adapter
+            ->expects(self::exactly(2))
+            ->method('store')
+            ->willReturnCallback(static function (Secret $s) use (&$storeArgs): Secret {
+                $storeArgs[] = $s;
+
+                return $s;
+            });
+
+        $this->expectException(AuditWriteException::class);
+
+        try {
+            $this->subject->store('rollback_update', 'new-value');
+        } finally {
+            // The second (compensating) store must be the original $existing.
+            self::assertSame($existing, $storeArgs[1] ?? null);
+        }
+    }
+
+    #[Test]
+    public function deleteRollsBackWhenAuditWriteFails(): void
+    {
+        $secret = $this->createSecretEntity('rollback_delete');
+
+        $this->adapter->method('retrieve')->willReturn($secret);
+        $this->accessControlService->method('canDelete')->willReturn(true);
+
+        $this->adapter->expects(self::once())->method('delete')->with('rollback_delete');
+
+        $this->auditLogService
+            ->method('log')
+            ->willThrowException(new AuditWriteException('audit down', 1747825331));
+
+        // Compensating action: re-insert the just-deleted record.
+        $this->adapter
+            ->expects(self::once())
+            ->method('store')
+            ->with($secret)
+            ->willReturnArgument(0);
+
+        $this->expectException(AuditWriteException::class);
+
+        $this->subject->delete('rollback_delete', 'reason');
+    }
+
+    #[Test]
+    public function rotateRollsBackWhenAuditWriteFails(): void
+    {
+        $secret = $this->createSecretEntity('rollback_rotate', version: 1);
+
+        $this->adapter->method('retrieve')->willReturn($secret);
+        $this->accessControlService->method('canWrite')->willReturn(true);
+
+        $this->encryptionService
+            ->method('encrypt')
+            ->willReturn(new EncryptedData('new_enc', 'new_dek', 'n1', 'n2', 'new_cs'));
+
+        $this->auditLogService
+            ->method('log')
+            ->willThrowException(new AuditWriteException('audit down', 1747825331));
+
+        // store() called twice: rotated value, then compensating restore of
+        // the pre-rotation instance.
+        $storeArgs = [];
+        $this->adapter
+            ->expects(self::exactly(2))
+            ->method('store')
+            ->willReturnCallback(static function (Secret $s) use (&$storeArgs): Secret {
+                $storeArgs[] = $s;
+
+                return $s;
+            });
+
+        $this->expectException(AuditWriteException::class);
+
+        try {
+            $this->subject->rotate('rollback_rotate', 'new-value', 'reason');
+        } finally {
+            // The compensating store must be the original pre-rotation secret.
+            self::assertSame($secret, $storeArgs[1] ?? null);
+        }
     }
 
     /**

--- a/Tests/Unit/Task/OrphanCleanupTaskTest.php
+++ b/Tests/Unit/Task/OrphanCleanupTaskTest.php
@@ -11,10 +11,12 @@ namespace Netresearch\NrVault\Tests\Unit\Task;
 
 use Doctrine\DBAL\Result;
 use Doctrine\DBAL\Schema\AbstractSchemaManager;
-use Netresearch\NrVault\Domain\Dto\SecretMetadata;
+use Netresearch\NrVault\Domain\Model\Secret;
+use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
 use Netresearch\NrVault\Exception\VaultException;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Task\OrphanCleanupTask;
+use Netresearch\NrVault\Tests\Unit\Fixtures\SecretFixtureBuilder;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -40,6 +42,8 @@ final class OrphanCleanupTaskTest extends TestCase
 
     private ConnectionPool&MockObject $connectionPool;
 
+    private SecretRepositoryInterface&MockObject $secretRepository;
+
     private LoggerInterface&MockObject $logger;
 
     protected function setUp(): void
@@ -48,6 +52,7 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $this->vaultService = $this->createMock(VaultServiceInterface::class);
         $this->connectionPool = $this->createMock(ConnectionPool::class);
+        $this->secretRepository = $this->createMock(SecretRepositoryInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
 
         // Mock GeneralUtility::makeInstance
@@ -60,6 +65,7 @@ final class OrphanCleanupTaskTest extends TestCase
 
         GeneralUtility::addInstance(VaultServiceInterface::class, $this->vaultService);
         GeneralUtility::addInstance(ConnectionPool::class, $this->connectionPool);
+        GeneralUtility::addInstance(SecretRepositoryInterface::class, $this->secretRepository);
         GeneralUtility::setSingletonInstance(LogManager::class, $logManager);
     }
 
@@ -72,7 +78,7 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function hasDefaultRetentionDays(): void
     {
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
 
         $params = $task->getTaskParameters();
         self::assertSame(7, $params['nr_vault_retention_days']);
@@ -81,7 +87,7 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function hasEmptyDefaultTableFilter(): void
     {
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
 
         $params = $task->getTaskParameters();
         self::assertSame('', $params['nr_vault_table_filter']);
@@ -90,9 +96,9 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function returnsTrueWithNoSecrets(): void
     {
-        $this->vaultService->method('list')->willReturn([]);
+        $this->secretRepository->method('findPaginatedAfterUid')->willReturn([]);
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $result = $task->execute();
 
         self::assertTrue($result);
@@ -101,13 +107,13 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function skipsNonTcaSecrets(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata('manual_secret', time(), ['source' => 'manual']),
+        $this->mockPage([
+            $this->createSecret('manual_secret', time(), ['source' => 'manual']),
         ]);
 
         $this->vaultService->expects($this->never())->method('delete');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $result = $task->execute();
 
         self::assertTrue($result);
@@ -116,8 +122,8 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function skipsSecretsWithExistingRecords(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'tx_myext__api_key__1',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
@@ -127,7 +133,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $this->mockRecordExists(1, true);
         $this->vaultService->expects($this->never())->method('delete');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $result = $task->execute();
 
         self::assertTrue($result);
@@ -136,8 +142,8 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function deletesOrphansOlderThanRetention(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'tx_myext__api_key__1',
                 time() - 86400 * 30, // 30 days old
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
@@ -151,7 +157,7 @@ final class OrphanCleanupTaskTest extends TestCase
             ->method('delete')
             ->with('tx_myext__api_key__1', 'Scheduler orphan cleanup');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 7]);
         $result = $task->execute();
 
@@ -161,8 +167,8 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function skipsOrphansWithinRetentionPeriod(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'tx_myext__api_key__1',
                 time() - 86400 * 3, // 3 days old
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
@@ -172,7 +178,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $this->mockRecordExists(1, false);
         $this->vaultService->expects($this->never())->method('delete');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 7]);
         $result = $task->execute();
 
@@ -182,16 +188,18 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function appliesTableFilter(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'tx_myext__api_key__1',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
+                1,
             ),
-            $this->createSecretMetadata(
+            $this->createSecret(
                 'tx_other__secret__1',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_other', 'field' => 'secret', 'uid' => 1],
+                2,
             ),
         ]);
 
@@ -202,7 +210,7 @@ final class OrphanCleanupTaskTest extends TestCase
             ->method('delete')
             ->with('tx_myext__api_key__1', 'Scheduler orphan cleanup');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters([
             'nr_vault_retention_days' => 0,
             'nr_vault_table_filter' => 'tx_myext',
@@ -215,8 +223,8 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function returnsFalseOnDeleteFailure(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'tx_myext__api_key__1',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
@@ -229,7 +237,7 @@ final class OrphanCleanupTaskTest extends TestCase
             ->method('delete')
             ->willThrowException(new VaultException('Delete failed'));
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
         $result = $task->execute();
 
@@ -239,8 +247,8 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function handlesMigrationSourceSecrets(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'tx_myext__api_key__1',
                 time() - 86400 * 30,
                 ['source' => 'migration', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
@@ -254,7 +262,7 @@ final class OrphanCleanupTaskTest extends TestCase
             ->method('delete')
             ->with('tx_myext__api_key__1', 'Scheduler orphan cleanup');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
         $result = $task->execute();
 
@@ -264,8 +272,8 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function skipsSecretsWithInvalidMetadata(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'invalid_format',
                 time() - 86400 * 30,
                 ['source' => 'tca_field'],
@@ -274,7 +282,7 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $this->vaultService->expects($this->never())->method('delete');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $result = $task->execute();
 
         self::assertTrue($result);
@@ -283,8 +291,8 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function skipsSecretsWithZeroUidInMetadata(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'some_uuid_identifier',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 0],
@@ -293,7 +301,7 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $this->vaultService->expects($this->never())->method('delete');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $result = $task->execute();
 
         self::assertTrue($result);
@@ -302,8 +310,8 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function skipsSecretsWithNonNumericUidInMetadata(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'some_uuid_identifier',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 'not_a_number'],
@@ -312,7 +320,7 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $this->vaultService->expects($this->never())->method('delete');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $result = $task->execute();
 
         self::assertTrue($result);
@@ -321,8 +329,8 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function skipsSecretsWithEmptyTableInMetadata(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'some_uuid_identifier',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => '', 'field' => 'api_key', 'uid' => 1],
@@ -331,7 +339,7 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $this->vaultService->expects($this->never())->method('delete');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $result = $task->execute();
 
         self::assertTrue($result);
@@ -340,8 +348,8 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function parsesFlexFieldFromMetadata(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'uuid_flex_secret',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'flexField' => 'settings.apiKey', 'uid' => 1],
@@ -355,7 +363,7 @@ final class OrphanCleanupTaskTest extends TestCase
             ->method('delete')
             ->with('uuid_flex_secret', 'Scheduler orphan cleanup');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
         $result = $task->execute();
 
@@ -365,7 +373,7 @@ final class OrphanCleanupTaskTest extends TestCase
     #[Test]
     public function logsCleanupProgress(): void
     {
-        $this->vaultService->method('list')->willReturn([]);
+        $this->secretRepository->method('findPaginatedAfterUid')->willReturn([]);
 
         $this->logger
             ->expects($this->atLeastOnce())
@@ -374,7 +382,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $logManager = $this->createMock(LogManager::class);
         $logManager->method('getLogger')->willReturn($this->logger);
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService, $logManager);
+        $task = $this->createTask($logManager);
         $task->execute();
     }
 
@@ -383,13 +391,13 @@ final class OrphanCleanupTaskTest extends TestCase
     // =========================================================================
 
     /**
-     * Kill IncrementInteger/DecrementInteger/Coalesce on line 72 — default is
-     * exactly 7 retention days, not 6 and not 8.
+     * Kill IncrementInteger/DecrementInteger/Coalesce on the retention default —
+     * default is exactly 7 retention days, not 6 and not 8.
      */
     #[Test]
     public function setTaskParametersDefaultRetentionIsExactlySeven(): void
     {
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters([]);
 
         // Call through getTaskParameters which returns int (retentionDays is int).
@@ -398,12 +406,12 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
-     * Kill CastInt / Ternary on line 73 — numeric-string gets cast to int.
+     * Kill CastInt / Ternary — numeric-string gets cast to int.
      */
     #[Test]
     public function setTaskParametersNumericStringCastsToInt(): void
     {
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => '42']);
 
         $params = $task->getTaskParameters();
@@ -411,12 +419,12 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
-     * Kill Ternary on line 73 — non-numeric falls back to default 7.
+     * Kill Ternary — non-numeric falls back to default 7.
      */
     #[Test]
     public function setTaskParametersNonNumericFallsBackToDefault(): void
     {
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 'abc']);
 
         $params = $task->getTaskParameters();
@@ -424,12 +432,12 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
-     * Kill UnwrapTrim on line 76 — tableFilter is trimmed.
+     * Kill UnwrapTrim — tableFilter is trimmed.
      */
     #[Test]
     public function setTaskParametersTrimmedTableFilter(): void
     {
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_table_filter' => '  tx_myext  ']);
 
         $params = $task->getTaskParameters();
@@ -437,12 +445,12 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
-     * Kill Ternary on line 73 — zero stays zero (not default 7).
+     * Kill Ternary — zero stays zero (not default 7).
      */
     #[Test]
     public function setTaskParametersZeroRetentionStaysZero(): void
     {
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
 
         $params = $task->getTaskParameters();
@@ -450,12 +458,12 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
-     * Kill Coalesce on line 72 — explicit value overrides default.
+     * Kill Coalesce — explicit value overrides default.
      */
     #[Test]
     public function setTaskParametersExplicitValueOverridesDefault(): void
     {
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 30]);
 
         $params = $task->getTaskParameters();
@@ -463,13 +471,13 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
-     * Kill ArrayItem / MethodCallRemoval on line 85-87 — logger info is called with
-     * correct context keys (retentionDays, tableFilter).
+     * Kill ArrayItem / MethodCallRemoval on the opening log line — logger info is
+     * called with correct context keys (retentionDays, tableFilter).
      */
     #[Test]
     public function executeLogsRetentionAndFilterContext(): void
     {
-        $this->vaultService->method('list')->willReturn([]);
+        $this->secretRepository->method('findPaginatedAfterUid')->willReturn([]);
 
         $this->logger
             ->expects($this->atLeastOnce())
@@ -483,25 +491,26 @@ final class OrphanCleanupTaskTest extends TestCase
         $logManager = $this->createMock(LogManager::class);
         $logManager->method('getLogger')->willReturn($this->logger);
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService, $logManager);
+        $task = $this->createTask($logManager);
         $task->execute();
     }
 
     /**
-     * Kill Continue_ on line 105 — non-TCA source must NOT short-circuit the
-     * loop. When a non-TCA secret appears BEFORE a TCA orphan, the TCA orphan
-     * must still be deleted. If `continue` becomes `break`, only the first
-     * element is examined.
+     * Kill Continue_ on the non-TCA source guard — a non-TCA source must NOT
+     * short-circuit the loop. When a non-TCA secret appears BEFORE a TCA orphan,
+     * the TCA orphan must still be deleted. If `continue` becomes `break`, only
+     * the first element is examined.
      */
     #[Test]
     public function executeContinuesOnNonTcaSourceAndProcessesLaterTcaOrphan(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata('manual_secret', time() - 86400 * 30, ['source' => 'manual']),
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret('manual_secret', time() - 86400 * 30, ['source' => 'manual'], 1),
+            $this->createSecret(
                 'tx_myext__api_key__1',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
+                2,
             ),
         ]);
 
@@ -512,29 +521,31 @@ final class OrphanCleanupTaskTest extends TestCase
             ->method('delete')
             ->with('tx_myext__api_key__1', 'Scheduler orphan cleanup');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
 
         self::assertTrue($task->execute());
     }
 
     /**
-     * Kill Continue_ on line 111 — invalid metadata must not short-circuit.
-     * Place an invalid-metadata secret BEFORE a valid TCA orphan.
+     * Kill Continue_ on the invalid-metadata guard — invalid metadata must not
+     * short-circuit. Place an invalid-metadata secret BEFORE a valid TCA orphan.
      */
     #[Test]
     public function executeContinuesOnInvalidMetadataAndProcessesLaterTcaOrphan(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'invalid_secret',
                 time() - 86400 * 30,
                 ['source' => 'tca_field'],   // table/uid missing
+                1,
             ),
-            $this->createSecretMetadata(
+            $this->createSecret(
                 'tx_myext__api_key__1',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
+                2,
             ),
         ]);
 
@@ -545,29 +556,31 @@ final class OrphanCleanupTaskTest extends TestCase
             ->method('delete')
             ->with('tx_myext__api_key__1', 'Scheduler orphan cleanup');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
 
         self::assertTrue($task->execute());
     }
 
     /**
-     * Kill Continue_ on line 116 — table filter must not short-circuit.
-     * Filtered-out secret appears BEFORE the matching one.
+     * Kill Continue_ on the table-filter guard — table filter must not
+     * short-circuit. Filtered-out secret appears BEFORE the matching one.
      */
     #[Test]
     public function executeContinuesOnTableFilterMismatchAndProcessesLaterMatchingSecret(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'filtered_out',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_other', 'field' => 'key', 'uid' => 1],
+                1,
             ),
-            $this->createSecretMetadata(
+            $this->createSecret(
                 'tx_myext__api_key__1',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
+                2,
             ),
         ]);
 
@@ -578,16 +591,16 @@ final class OrphanCleanupTaskTest extends TestCase
             ->method('delete')
             ->with('tx_myext__api_key__1', 'Scheduler orphan cleanup');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0, 'nr_vault_table_filter' => 'tx_myext']);
 
         self::assertTrue($task->execute());
     }
 
     /**
-     * Kill GreaterThan / LessThan on line 125 — createdAt strictly less than
-     * retentionCutoff. If mutation makes it <=, secrets at exactly the cutoff
-     * wouldn't be deleted. We use a clearly old createdAt to drive the condition.
+     * Kill GreaterThan / LessThan on the retention cutoff comparison — createdAt
+     * strictly less than retentionCutoff. We use a clearly old createdAt to drive
+     * the condition.
      */
     #[Test]
     public function executeUsesStrictLessThanCutoffForOldOrphans(): void
@@ -595,8 +608,8 @@ final class OrphanCleanupTaskTest extends TestCase
         // 30 days old — clearly past any reasonable retention.
         $thirtyDaysAgo = time() - 86400 * 30;
 
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'tx_myext__api_key__1',
                 $thirtyDaysAgo,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
@@ -609,21 +622,22 @@ final class OrphanCleanupTaskTest extends TestCase
             ->expects($this->once())
             ->method('delete');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 7]);
 
         self::assertTrue($task->execute());
     }
 
     /**
-     * Kill LogicalAndAllSubExprNegation on line 104 — BOTH source conditions.
-     * source='unknown' must be skipped (neither 'tca_field' nor 'migration').
+     * Kill LogicalAndAllSubExprNegation on the source check — BOTH source
+     * conditions. source='unknown' must be skipped (neither 'tca_field' nor
+     * 'migration').
      */
     #[Test]
     public function executeSkipsUnknownSourceValues(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'weird',
                 time() - 86400 * 30,
                 ['source' => 'unknown', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
@@ -632,20 +646,20 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $this->vaultService->expects($this->never())->method('delete');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
 
         self::assertTrue($task->execute());
     }
 
     /**
-     * Kill Ternary on line 192 — getAdditionalInformation includes the table
-     * filter label when it's set.
+     * Kill Ternary on getAdditionalInformation — includes the table filter label
+     * when it's set.
      */
     #[Test]
     public function getAdditionalInformationIncludesTableFilterWhenSet(): void
     {
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_table_filter' => 'tx_myext']);
 
         $info = $task->getAdditionalInformation();
@@ -654,13 +668,13 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
-     * Kill Ternary on line 192 — getAdditionalInformation omits table filter
-     * label when filter is empty (default).
+     * Kill Ternary on getAdditionalInformation — omits table filter label when
+     * filter is empty (default).
      */
     #[Test]
     public function getAdditionalInformationOmitsTableFilterWhenEmpty(): void
     {
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
 
         $info = $task->getAdditionalInformation();
         self::assertStringNotContainsString('Table filter', $info);
@@ -669,13 +683,13 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
-     * Kill Coalesce on line 179 — field fallback to flexField.
+     * Kill Coalesce on the field fallback — field falls back to flexField.
      */
     #[Test]
     public function parseMetadataReferenceFallsBackToFlexFieldWhenFieldMissing(): void
     {
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'uuid_flex',
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'flexField' => 'settings.apiKey', 'uid' => 1],
@@ -689,22 +703,22 @@ final class OrphanCleanupTaskTest extends TestCase
             ->method('delete')
             ->with('uuid_flex', 'Scheduler orphan cleanup');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
 
         self::assertTrue($task->execute());
     }
 
     /**
-     * Kill ArrayItemRemoval + MethodCallRemoval on line 140 — logger info is
-     * called with ['identifier' => ...] context when deletion succeeds.
+     * Kill ArrayItemRemoval + MethodCallRemoval on the success log — logger info
+     * is called with ['identifier' => ...] context when deletion succeeds.
      */
     #[Test]
     public function executeLogsDeletedOrphanWithIdentifierContext(): void
     {
         $identifier = 'tx_myext__api_key__1';
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 $identifier,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
@@ -724,7 +738,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $logManager = $this->createMock(LogManager::class);
         $logManager->method('getLogger')->willReturn($this->logger);
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService, $logManager);
+        $task = $this->createTask($logManager);
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
         self::assertTrue($task->execute());
 
@@ -738,15 +752,15 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
-     * Kill ArrayItemRemoval on line 142 — error log context includes identifier.
-     * Kill MethodCallRemoval too.
+     * Kill ArrayItemRemoval on the error log — error log context includes
+     * identifier. Kill MethodCallRemoval too.
      */
     #[Test]
     public function executeLogsErrorWithIdentifierAndErrorContextOnDeleteFailure(): void
     {
         $identifier = 'tx_myext__api_key__1';
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 $identifier,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
@@ -769,7 +783,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $logManager = $this->createMock(LogManager::class);
         $logManager->method('getLogger')->willReturn($this->logger);
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService, $logManager);
+        $task = $this->createTask($logManager);
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
         self::assertFalse($task->execute());
 
@@ -783,15 +797,15 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
-     * Kill ArrayItem on line 144 + ArrayItemRemoval — logger error context
-     * includes 'error' key with exception message.
+     * Kill ArrayItem + ArrayItemRemoval on the error context — logger error
+     * context includes 'error' key with exception message.
      */
     #[Test]
     public function executeLogsErrorIncludesExceptionMessage(): void
     {
         $identifier = 'tx_myext__api_key__1';
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 $identifier,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
@@ -816,21 +830,22 @@ final class OrphanCleanupTaskTest extends TestCase
         $logManager = $this->createMock(LogManager::class);
         $logManager->method('getLogger')->willReturn($this->logger);
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService, $logManager);
+        $task = $this->createTask($logManager);
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
         self::assertFalse($task->execute());
     }
 
     /**
-     * Kill GreaterThan on line 92 — retentionDays > 0 is strict. When 0, uses
-     * PHP_INT_MAX cutoff (so ALL orphans pass the "older than retention" test).
+     * Kill GreaterThan on the retentionDays > 0 guard — it is strict. When 0,
+     * uses PHP_INT_MAX cutoff (so ALL orphans pass the "older than retention"
+     * test).
      */
     #[Test]
     public function executeWithZeroRetentionTreatsAllOldOrphansAsEligible(): void
     {
         $now = time();
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'tx_myext__api_key__1',
                 $now - 1,  // just 1 second old
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
@@ -840,22 +855,22 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $this->vaultService->expects($this->once())->method('delete');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
         self::assertTrue($task->execute());
     }
 
     /**
-     * Kill Coalesce on line 221/226 — these are the `$metadata['X'] ?? default`
-     * fallbacks in parseMetadataReference. Test that a missing field-key yields
-     * empty string, not null/error.
+     * Kill Coalesce on the parseMetadataReference fallbacks — the
+     * `$metadata['X'] ?? default` fallbacks. Test that a missing field-key
+     * yields empty string, not null/error.
      */
     #[Test]
     public function parseMetadataReferenceMissingFieldAndFlexFieldDefaultsToEmptyString(): void
     {
         $identifier = 'ident1';
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 $identifier,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'uid' => 1],
@@ -869,20 +884,20 @@ final class OrphanCleanupTaskTest extends TestCase
             ->method('delete')
             ->with($identifier);
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
         self::assertTrue($task->execute());
     }
 
     /**
-     * Kill CastInt on line 186 — uid cast from numeric string.
+     * Kill CastInt on the uid parse — uid cast from numeric string.
      */
     #[Test]
     public function parseMetadataReferenceCastsStringUidToInt(): void
     {
         $identifier = 'id-for-string-uid';
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 $identifier,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'k', 'uid' => '42'],
@@ -895,19 +910,19 @@ final class OrphanCleanupTaskTest extends TestCase
             ->method('delete')
             ->with($identifier);
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
         self::assertTrue($task->execute());
     }
 
     /**
-     * Kill ArrayItem on line 86 — logger info('Starting ...', [...]) context
-     * uses '(all)' placeholder when tableFilter is empty.
+     * Kill ArrayItem on the opening log — logger info('Starting ...', [...])
+     * context uses '(all)' placeholder when tableFilter is empty.
      */
     #[Test]
     public function executeLogsStartingWithAllPlaceholderWhenFilterEmpty(): void
     {
-        $this->vaultService->method('list')->willReturn([]);
+        $this->secretRepository->method('findPaginatedAfterUid')->willReturn([]);
 
         $calls = [];
         $this->logger
@@ -919,7 +934,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $logManager = $this->createMock(LogManager::class);
         $logManager->method('getLogger')->willReturn($this->logger);
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService, $logManager);
+        $task = $this->createTask($logManager);
         $task->execute();
 
         // Find the 'Starting vault orphan cleanup' call with tableFilter == '(all)'.
@@ -930,13 +945,13 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
-     * Kill Ternary on line 87 — tableFilter ?: '(all)'. When tableFilter is SET,
-     * context shows the actual filter, not '(all)'.
+     * Kill Ternary on the opening log — tableFilter ?: '(all)'. When tableFilter
+     * is SET, context shows the actual filter, not '(all)'.
      */
     #[Test]
     public function executeLogsStartingWithActualFilterWhenSet(): void
     {
-        $this->vaultService->method('list')->willReturn([]);
+        $this->secretRepository->method('findPaginatedAfterUid')->willReturn([]);
 
         $calls = [];
         $this->logger
@@ -948,7 +963,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $logManager = $this->createMock(LogManager::class);
         $logManager->method('getLogger')->willReturn($this->logger);
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService, $logManager);
+        $task = $this->createTask($logManager);
         $task->setTaskParameters(['nr_vault_table_filter' => 'tx_specific']);
         $task->execute();
 
@@ -959,17 +974,15 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
-     * Kill IncrementInteger on line 93 — 86400 seconds per day constant.
-     * 30-day-old secret with 30-day retention: strictly before cutoff → delete.
-     * (Testing the factor: if it were 86401, 30 days would be 30*86401 ≈ 30.1 days,
-     * barely still before cutoff → we test at a boundary.)
+     * Kill IncrementInteger on the 86400-seconds-per-day constant.
+     * 30-day-old secret with 29-day retention: strictly before cutoff → delete.
      */
     #[Test]
     public function executeUsesEightySixFourHundredSecondsPerDay(): void
     {
         // Age: 30 days + 60 seconds (to provide a tiny buffer that survives minor mutations).
-        $this->vaultService->method('list')->willReturn([
-            $this->createSecretMetadata(
+        $this->mockPage([
+            $this->createSecret(
                 'orphan',
                 time() - (30 * 86400) - 60,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'k', 'uid' => 1],
@@ -979,9 +992,57 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $this->vaultService->expects($this->once())->method('delete');
 
-        $task = new OrphanCleanupTask($this->connectionPool, $this->vaultService);
+        $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 29]);  // cutoff: 29 days ago
         self::assertTrue($task->execute());
+    }
+
+    /**
+     * The vault is walked through the repository's UID-windowed finder, not
+     * through VaultService::list(). Assert the finder is the entry point and
+     * receives the configured page size.
+     */
+    #[Test]
+    public function executeWalksVaultViaPaginatedRepositoryFinder(): void
+    {
+        $this->secretRepository
+            ->expects($this->atLeastOnce())
+            ->method('findPaginatedAfterUid')
+            ->with($this->isInt(), 200)
+            ->willReturn([]);
+
+        $task = $this->createTask();
+
+        self::assertTrue($task->execute());
+    }
+
+    /**
+     * Build the task with the new four-argument nullable constructor. The
+     * repository and vault service come from the shared mocks; a custom
+     * LogManager may be supplied for log-assertion tests.
+     */
+    private function createTask(?LogManager $logManager = null): OrphanCleanupTask
+    {
+        return new OrphanCleanupTask(
+            $this->connectionPool,
+            $this->vaultService,
+            $logManager,
+            $this->secretRepository,
+        );
+    }
+
+    /**
+     * Stub the repository's UID-windowed finder to yield a single page. The
+     * page is smaller than PAGE_SIZE (200), so the production do/while loop
+     * terminates after one iteration.
+     *
+     * @param Secret[] $secrets
+     */
+    private function mockPage(array $secrets): void
+    {
+        $this->secretRepository
+            ->method('findPaginatedAfterUid')
+            ->willReturn($secrets);
     }
 
     private function mockRecordExists(int $uid, bool $exists): void
@@ -1019,23 +1080,22 @@ final class OrphanCleanupTaskTest extends TestCase
     }
 
     /**
+     * Build a real Secret domain entity as returned by the repository's
+     * paginated finder. `execute()` reads getUid(), getMetadata(), getCrdate()
+     * and getIdentifier() from each entity.
+     *
      * @param array<string, mixed> $metadata
      */
-    private function createSecretMetadata(
+    private function createSecret(
         string $identifier,
         int $createdAt,
         array $metadata = [],
-    ): SecretMetadata {
-        return new SecretMetadata(
-            identifier: $identifier,
-            ownerUid: 1,
-            createdAt: $createdAt,
-            updatedAt: $createdAt,
-            readCount: 0,
-            lastReadAt: null,
-            description: '',
-            version: 1,
-            metadata: $metadata,
-        );
+        int $uid = 1,
+    ): Secret {
+        return SecretFixtureBuilder::create($identifier)
+            ->withUid($uid)
+            ->withCreatedAt($createdAt)
+            ->withMetadata($metadata)
+            ->buildSecret();
     }
 }

--- a/Tests/Unit/Utility/FlexFormVaultResolverTest.php
+++ b/Tests/Unit/Utility/FlexFormVaultResolverTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 
 #[AllowMockObjectsWithoutExpectations]
 final class FlexFormVaultResolverTest extends TestCase
@@ -26,6 +27,8 @@ final class FlexFormVaultResolverTest extends TestCase
     private VaultServiceInterface&MockObject $vaultService;
 
     private LoggerInterface&MockObject $logger;
+
+    private TcaSchemaFactory&MockObject $tcaSchemaFactory;
 
     private FlexFormVaultResolver $subject;
 
@@ -35,10 +38,12 @@ final class FlexFormVaultResolverTest extends TestCase
 
         $this->vaultService = $this->createMock(VaultServiceInterface::class);
         $this->logger = $this->createMock(LoggerInterface::class);
+        $this->tcaSchemaFactory = $this->createMock(TcaSchemaFactory::class);
 
         $this->subject = new FlexFormVaultResolver(
             $this->vaultService,
             $this->logger,
+            $this->tcaSchemaFactory,
         );
     }
 

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,13 @@
         "encryption",
         "security",
         "api-keys",
-        "credentials"
+        "credentials",
+        "secrets-management",
+        "key-rotation",
+        "audit-log",
+        "envelope-encryption",
+        "oauth",
+        "libsodium"
     ],
     "authors": [
         {
@@ -31,6 +37,7 @@
         "ext-json": "*",
         "typo3/cms-core": "^13.4 || ^14.0",
         "typo3/cms-backend": "^13.4 || ^14.0",
+        "typo3/cms-install": "^13.4 || ^14.0",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0"
     },
@@ -78,9 +85,11 @@
             "@ci:test:php:unit",
             "@ci:test:php:fuzz",
             "@ci:test:php:phpstan",
+            "@ci:test:php:arch",
             "@ci:test:php:cgl"
         ],
         "ci:audit": "@composer audit --locked --format=plain --abandoned=fail",
+        "ci:test:php:arch": "@php Tests/scripts/check-test-base-class.php",
         "ci:cgl": "php-cs-fixer fix",
         "ci:test:php:cgl": "php-cs-fixer fix --dry-run --diff",
         "ci:test:php:coverage": "@php -d pcov.enabled=0 -d xdebug.mode=coverage .Build/bin/phpunit -c Build/phpunit.xml --testsuite Unit --path-coverage --coverage-clover=.Build/coverage/clover.xml --coverage-html=.Build/coverage/html --coverage-text",

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -23,6 +23,7 @@ CREATE TABLE tx_nrvault_secret (
     -- Access control
     owner_uid int(11) unsigned DEFAULT 0 NOT NULL,
     allowed_groups text,
+    write_groups text,
     context varchar(50) DEFAULT '' NOT NULL,
     frontend_accessible tinyint(1) unsigned DEFAULT 0 NOT NULL,
 
@@ -58,6 +59,19 @@ CREATE TABLE tx_nrvault_secret (
 # Table structure for table 'tx_nrvault_secret_begroups_mm'
 #
 CREATE TABLE tx_nrvault_secret_begroups_mm (
+    uid_local int(11) unsigned DEFAULT 0 NOT NULL,
+    uid_foreign int(11) unsigned DEFAULT 0 NOT NULL,
+    sorting int(11) unsigned DEFAULT 0 NOT NULL,
+    sorting_foreign int(11) unsigned DEFAULT 0 NOT NULL,
+
+    KEY uid_local (uid_local),
+    KEY uid_foreign (uid_foreign)
+);
+
+#
+# Table structure for table 'tx_nrvault_secret_writegroups_mm'
+#
+CREATE TABLE tx_nrvault_secret_writegroups_mm (
     uid_local int(11) unsigned DEFAULT 0 NOT NULL,
     uid_foreign int(11) unsigned DEFAULT 0 NOT NULL,
     sorting int(11) unsigned DEFAULT 0 NOT NULL,


### PR DESCRIPTION
## Summary

Grade-A remediation of the findings from the 2026-05-30 multi-axis review. Hardens the security-critical paths, fixes a real scheduler DI bug uncovered during test triage, and brings every axis toward grade A. All gates green locally; **CI is authoritative** for functional results (it provides the mock-OAuth sidecar).

Base: `main` @ `832e4fc`.

## Gate (local)

| Gate | Result |
|---|---|
| PHPStan level 10 | ✅ clean (0 errors) |
| PHP-CS-Fixer | ✅ clean |
| Unit | ✅ 1759 tests, 7149 assertions, 0 fail / 0 error |
| Fuzz | ✅ 1514 tests, 0 fail / 0 error |
| Functional (sqlite) | ✅ 0 errors / 0 failures (9 sidecar-dependent OAuth tests skip locally; real assertions under CI's mock-oauth sidecar) |

## Security hardening

- **SSRF (SEC-1):** `isDangerousIpv6()` now decodes 6to4 (`2002::/16`), Teredo (`2001::/32`), and IPv4-compatible (`::a.b.c.d`) forms and recurses into the IPv4 block — closes the CVE-2026-48736-class bypass that let a hostname resolving to e.g. `2002:a9fe:a9fe::` reach link-local/metadata. KAT tests added.
- **Plaintext checksum (SEC-2):** `value_checksum` is no longer an unkeyed SHA-256 of the plaintext (removed the offline guess-confirmation / equality oracle); it is now a keyed MAC over the ciphertext.
- **Atomic mutation+audit (SEC-3):** `store`/`delete`/`rotate` compensate-and-revert the adapter change if the audit write throws — a secret never persists without its tamper-evident record.
- **Audit core (SEC-4):** constant-time `hash_equals` in `verifyHashChain`; `log()` rejects unknown actions; `error_message` sanitized at the boundary; `export()` streams in bounded chunks (no `PHP_INT_MAX` fetch).
- **AJAX (SEC-ACCESS-6):** reveal/rotate require POST + in-controller `isCurrentActorAdmin()` re-check.
- **frontend_accessible (SEC-ACCESS-11):** non-admins can no longer set the flag programmatically.

## Real production bug (found via test triage)

`SecretRepositoryInterface` had no **public** `Services.yaml` alias, so `OrphanCleanupTask` (scheduler context, `makeInstance`) fataled at runtime with *"Cannot instantiate interface"*. Now a public alias, mirroring `VaultServiceInterface`.

## Architecture / type-safety

- `AuditAction` backed enum (replaces stringly-typed actions; the audit-UI filter is derived from `cases()`, fixing the drift that hid `master_key_*` / `oauth_*` actions).
- Read/write/delete **ACL split** (`write_groups` MM table + TCA) superseding the read=write=delete model.
- `VaultHealthService` extracted so controllers no longer depend on the Crypto layer.
- DataHandler hook dedup (`PendingSecretExtractor` / `PendingSecretPersister`); `AbstractMasterKeyProvider`.
- `#[\SensitiveParameter]` on `OAuthToken::$accessToken`; `toArray()` redaction on secret-bearing DTOs.

## Conformance / docs / meta

- `Documentation/guides.xml` synced to 0.5.0; `docs.yml` wired into CI.
- composer keywords + `typo3/cms-install`; `Api.rst` regenerated; doc-tree consolidation; phpat command→repository bypass rule; TCA `default_sortby`.

## Tests

Stale unit/fuzz/functional tests updated to the new signatures/behaviour. No assertions weakened; no tests skipped to pass (the 3 pre-existing `markTestIncomplete` are unchanged). The `OAuthIntegrationTest` sidecar-reachability probe was hardened so its tests skip cleanly when no real OIDC mock server is present rather than erroring.

## Out of scope (follow-ups)

- DRY upstream: add a `guides.xml` ↔ `ext_emconf.php` version-sync guard to the reusable `netresearch/typo3-ci-workflows` `docs.yml` (the release guard only checks the git tag, which is why the drift slipped through). Patch prepared.
- Deferred enhancements beyond the review findings: new HMAC epoch-3 + signed genesis sentinel, `auditReads` change-sentinel.
- The 1.0 release cut (state→stable, version bump) remains a separate deliberate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
