### PR TITLE
Resolve /assess findings: findIdentifiers fix, CLI-doc guard, packaging conventions

### DIFF
--- a/.ddev/.gitignore
+++ b/.ddev/.gitignore
@@ -1,0 +1,13 @@
+# DDEV-local working artifacts — not committed.
+# The tracked DDEV config (config.yaml, commands/, web-build/, docker-compose.*,
+# mock-oauth/, apache/, addon-metadata/) stays versioned; everything below is
+# generated or developer-machine-specific.
+/.v14-data/
+/db_snapshots/
+/import.yaml
+/import-db/
+/sequelace.yaml
+/.dbimageBuild/
+/.ddev-docker-compose-*.yaml
+/.global_commands/
+/.homeadditions/

--- a/.ddev/commands/web/setup
+++ b/.ddev/commands/web/setup
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+## Description: One-shot project setup (canonical entry point — delegates to install-v14)
+## Usage: setup
+## Example: ddev setup
+
+set -e
+
+# Canonical Netresearch convention: `ddev setup` is the single entry point that
+# Makefile targets and aliases delegate to. For nr-vault that is the TYPO3 v14
+# install + extension wiring implemented in `install-v14`.
+exec "$(dirname "$0")/install-v14" "$@"

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,36 @@
+# Normalize line endings.
+* text=auto
+
+# Exclude development-only paths from `git archive` (composer dist / TER packages),
+# keeping published artifacts small. Runtime code (Classes, Configuration,
+# Resources, Documentation, ext_* , composer.json, LICENSE) is intentionally NOT
+# listed here so it stays in the package.
+/.ddev/                export-ignore
+/.github/              export-ignore
+/.review-notes/        export-ignore
+/Build/                export-ignore
+/Tests/                export-ignore
+/docs/                 export-ignore
+/claudedocs/           export-ignore
+/.editorconfig         export-ignore
+/.gitattributes        export-ignore
+/.gitignore            export-ignore
+/.gitleaks.toml        export-ignore
+/.php-cs-fixer.dist.php export-ignore
+/.semgrepignore        export-ignore
+/AGENTS.md             export-ignore
+/CLAUDE.md             export-ignore
+/GEMINI.md             export-ignore
+/captainhook.json      export-ignore
+/codecov.yml           export-ignore
+/fractor.php           export-ignore
+/infection.json5       export-ignore
+/package.json          export-ignore
+/package-lock.json     export-ignore
+/phpat.neon            export-ignore
+/phpstan.neon          export-ignore
+/phpstan-baseline.neon export-ignore
+/playwright.config.ts  export-ignore
+/rector.php            export-ignore
+/renovate.json         export-ignore
+/semgrep.yml           export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`SecretRepository::findIdentifiers()` now skips non-string identifier
+  rows** instead of coercing them to an empty string. A driver/schema
+  anomaly that returned a non-string `identifier` previously injected a
+  bogus empty identifier into list views and rotation loops; such rows are
+  now dropped (an empty identifier is unreachable for valid data).
+
+### Added
+- **CLI documentation drift guard** (`Tests/scripts/check-cli-docs.php`,
+  wired into `composer ci` as `ci:test:php:doc-cli`). It verifies every
+  documented `vault:*` example across `README.md` and the whole
+  `Documentation/` tree against the command classes — unknown commands,
+  unknown options, and excess positional arguments fail the build. Backslash
+  line-continuations are joined so options on continuation lines are checked,
+  and both `#[AsCommand(name: …)]` and positional `#[AsCommand(…)]` forms are
+  recognised.
+- `.gitattributes` (`export-ignore` dev-only paths for smaller composer/TER
+  packages), `.ddev/.gitignore`, and a canonical `.ddev/commands/web/setup`
+  entry point.
+
+### Documentation
+- README CLI reference expanded from 5 to all 12 `vault:*` commands with
+  corrected argument signatures (`vault:store --value=…`, `vault:audit
+  --since=…`).
+- Corrected `vault:*` examples across the documentation that drifted from the
+  actual command signatures: `vault:store` value via `--value`/`--metadata`
+  (not `--description`/`--context`/`--expires` or a positional), `vault:audit`
+  `--since`/`--until` (not `--days`), `vault:migrate-field` positional
+  `<table> <field>` (not `--table`/`--field`), `vault:rotate-master-key`
+  `--confirm`/`--new-key`, the full `vault:audit` option reference, and
+  `tx_vault_secret` → `tx_nrvault_secret`.
+
 ## [0.6.1] - 2026-05-31
 
 ### Fixed

--- a/Classes/Domain/Repository/SecretRepository.php
+++ b/Classes/Domain/Repository/SecretRepository.php
@@ -193,8 +193,18 @@ final readonly class SecretRepository implements SecretRepositoryInterface
         $identifiers = [];
 
         while ($row = $result->fetchAssociative()) {
-            $identifier = $row['identifier'] ?? '';
-            $identifiers[] = \is_string($identifier) ? $identifier : '';
+            $identifier = $row['identifier'] ?? null;
+            // Skip rows whose identifier is not a non-empty string (driver/schema
+            // anomaly). Emitting '' here would inject a bogus empty identifier
+            // into callers (list views, rotation loops), so drop it instead.
+            if (!\is_string($identifier)) {
+                continue;
+            }
+            if ($identifier === '') {
+                continue;
+            }
+
+            $identifiers[] = $identifier;
         }
 
         return $identifiers;

--- a/Documentation/Developer/Adr/ADR-009-ExtensionConfigurationSecrets.rst
+++ b/Documentation/Developer/Adr/ADR-009-ExtensionConfigurationSecrets.rst
@@ -138,7 +138,7 @@ Example: Translation service integration
 .. code-block:: bash
    :caption: Store secret via CLI
 
-   ./vendor/bin/typo3 vault:store acme_translate_api_key "your-actual-api-key"
+   ./vendor/bin/typo3 vault:store acme_translate_api_key --value="your-actual-api-key"
 
 Why this is safe
 ----------------

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -107,12 +107,11 @@ Example
    # Interactive (prompts for secret)
    vendor/bin/typo3 vault:store stripe_api_key
 
-   # With options
+   # With options (arbitrary metadata via repeatable --metadata key=value)
    vendor/bin/typo3 vault:store payment_key \
      --value="sk_live_..." \
-     --description="Stripe production key" \
-     --context="payment" \
-     --expires="+90 days" \
+     --metadata="description=Stripe production key" \
+     --metadata="context=payment" \
      --groups="1,2"
 
 .. _command-retrieve:
@@ -275,20 +274,35 @@ View the audit log.
 Options
 -------
 
---identifier=ID
+--identifier, -i =ID
    Filter by secret identifier.
 
---action=ACTION
-   Filter by action (create, read, update, delete, rotate).
+--action, -a =ACTION
+   Filter by action (create, read, update, delete, rotate, access_denied).
 
---days=N
-   Show entries from last N days (default: 30).
+--actor=UID
+   Filter by actor (backend user UID).
 
---limit=N
-   Maximum entries to show (default: 100).
+--since=DATE
+   Show entries since the given date (``Y-m-d`` or ``Y-m-d H:i:s``).
 
---format=FORMAT
-   Output format: table (default), json.
+--until=DATE
+   Show entries up to the given date (``Y-m-d`` or ``Y-m-d H:i:s``).
+
+--success=BOOL
+   Filter by success status (``true``/``false``).
+
+--limit, -l =N
+   Maximum number of results (default: 50).
+
+--format, -f =FORMAT
+   Output format: ``table`` (default), ``json``, ``csv``.
+
+--verify
+   Verify hash chain integrity instead of listing entries.
+
+--export, -e =FILE
+   Export results to a file (format taken from ``--format``).
 
 .. _command-audit-example:
 
@@ -298,8 +312,8 @@ Example
 .. code-block:: bash
    :caption: vault:audit examples
 
-   # View recent audit log
-   vendor/bin/typo3 vault:audit --days=7
+   # View audit log since a given date
+   vendor/bin/typo3 vault:audit --since=2026-05-01
 
    # Filter by secret
    vendor/bin/typo3 vault:audit --identifier=stripe_api_key

--- a/Documentation/Troubleshooting/Index.rst
+++ b/Documentation/Troubleshooting/Index.rst
@@ -97,7 +97,7 @@ causes:
 
 1. Verify that the active master key matches the one used during
    encryption.
-2. Check database integrity for the ``tx_vault_secret`` table.
+2. Check database integrity for the ``tx_nrvault_secret`` table.
 3. If the data is corrupt, restore from a database backup and ensure
    the matching master key is in place.
 
@@ -150,7 +150,7 @@ If you manage a large number of secrets, consider these optimizations:
    implications).
 
 **Database indexing**
-   The ``tx_vault_secret`` table includes indexes on commonly queried
+   The ``tx_nrvault_secret`` table includes indexes on commonly queried
    columns. Ensure these indexes exist after migrations.
 
 .. _troubleshooting-rotate-master-key:
@@ -163,20 +163,28 @@ new master key without changing the actual secret values.
 
 1. **Create a backup** of the current master key and database.
 
-2. **Generate a new master key:**
+2. **Generate a new master key.** The file master-key provider accepts either
+   32 raw bytes or a base64-encoded 32-byte key. A base64 key file is easy to
+   create with:
 
    .. code-block:: bash
 
-      vendor/bin/typo3 vault:generate-key > /secure/path/new-master-key
+      openssl rand -base64 32 > /secure/path/new-master-key
 
-3. **Run the rotation command:**
+   (``vault:init`` itself writes a raw 32-byte key file by default, or a
+   base64 value with ``--env``; the file provider reads both.)
+
+3. **Run the rotation command** with ``--confirm`` (without it the command
+   prints an opt-in warning and exits without rotating):
 
    .. code-block:: bash
 
-      vendor/bin/typo3 vault:rotate-master-key
+      vendor/bin/typo3 vault:rotate-master-key \
+          --new-key=/secure/path/new-master-key \
+          --confirm
 
-   The command will prompt for or auto-detect the old and new keys
-   depending on your provider configuration.
+   Use ``--dry-run`` first to simulate, and ``--old-key`` if the current key
+   cannot be auto-detected from your provider configuration.
 
 4. **Update your configuration** to point to the new master key.
 
@@ -209,8 +217,8 @@ vault-managed secrets:
    .. code-block:: bash
 
       vendor/bin/typo3 vault:migrate-field \
-          --table=tx_myext_domain_model_connection \
-          --field=api_key
+          tx_myext_domain_model_connection \
+          api_key
 
    This reads the current plaintext value, encrypts it into the vault,
    and replaces the field value with a vault reference identifier.

--- a/Documentation/Usage/ExtensionSettings.rst
+++ b/Documentation/Usage/ExtensionSettings.rst
@@ -84,7 +84,7 @@ validation. See :ref:`adr-009-extension-configuration-secrets` for the design ra
    .. code-block:: bash
       :caption: Store API key via command line
 
-      ./vendor/bin/typo3 vault:store deepl_api_key "your-deepl-api-key-here"
+      ./vendor/bin/typo3 vault:store deepl_api_key --value="your-deepl-api-key-here"
 
 2. Configure extension setting with vault reference:
 

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -170,12 +170,11 @@ Create or update a secret:
    # Interactive (prompts for value)
    vendor/bin/typo3 vault:store stripe_api_key
 
-   # With all options
+   # With options (arbitrary metadata via repeatable --metadata key=value)
    vendor/bin/typo3 vault:store payment_key \
      --value="sk_live_..." \
-     --description="Stripe production key" \
-     --context="payment" \
-     --expires="+90 days" \
+     --metadata="description=Stripe production key" \
+     --metadata="context=payment" \
      --groups="1,2"
 
 .. _usage-cli-vault-retrieve:
@@ -248,8 +247,8 @@ View the audit log:
 .. code-block:: bash
    :caption: View audit log
 
-   # View recent entries
-   vendor/bin/typo3 vault:audit --days=7
+   # View entries since a given date
+   vendor/bin/typo3 vault:audit --since=2026-05-01
 
    # Filter by secret
    vendor/bin/typo3 vault:audit --identifier=stripe_api_key

--- a/README.md
+++ b/README.md
@@ -192,21 +192,43 @@ Secret placement options: `Bearer`, `BasicAuth`, `Header`, `QueryParam`, `BodyFi
 
 ## CLI Commands
 
+All 12 `vault:*` commands (full options and examples in
+[`Documentation/Developer/Commands.rst`](Documentation/Developer/Commands.rst)):
+
 ```bash
-# Initialize vault (create master key)
+# --- Setup ---
+# Initialize the vault by generating a master key
 vendor/bin/typo3 vault:init
 
-# List secrets (respects access control)
+# --- Secret CRUD ---
+# Store a secret in the vault (value via --value, --stdin, --file, or interactive prompt)
+vendor/bin/typo3 vault:store my_secret_id --value="s3cr3t-value"
+# Retrieve a secret from the vault
+vendor/bin/typo3 vault:retrieve my_secret_id
+# List secrets in the vault (respects access control)
 vendor/bin/typo3 vault:list
-
-# Rotate a secret
+# Rotate (update) a secret
 vendor/bin/typo3 vault:rotate my_secret_id --reason="Scheduled rotation"
+# Delete a secret from the vault
+vendor/bin/typo3 vault:delete my_secret_id
 
-# Rotate master key (re-encrypts all DEKs)
+# --- Master key ---
+# Rotate the master encryption key (re-encrypts all DEKs)
 vendor/bin/typo3 vault:rotate-master-key --new-key=/path/to/new.key --confirm
 
-# View audit log
-vendor/bin/typo3 vault:audit --identifier=my_secret_id --days=30
+# --- Migration & hardening ---
+# Migrate an existing plaintext DB field value into the vault
+vendor/bin/typo3 vault:migrate-field tx_myext_settings api_key
+# Scan database and configuration for potential plaintext secrets
+vendor/bin/typo3 vault:scan
+# Clean up orphaned vault secrets from deleted TCA records
+vendor/bin/typo3 vault:cleanup-orphans
+
+# --- Audit ---
+# Query and export vault audit logs (filter by --since / --until, Y-m-d)
+vendor/bin/typo3 vault:audit --identifier=my_secret_id --since=2026-05-01
+# Migrate the audit log hash chain from SHA-256 to HMAC-SHA256
+vendor/bin/typo3 vault:audit-migrate-hmac
 ```
 
 ## Requirements

--- a/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
@@ -701,27 +701,15 @@ final class SecretRepositoryTest extends TestCase
     }
 
     /**
-     * Characterisation test + documented gap.
+     * A non-string identifier row (driver/schema anomaly) must be skipped,
+     * not coerced to an empty string. Emitting '' would inject a bogus empty
+     * identifier into downstream consumers (list views, rotation loops) that
+     * cannot distinguish it from a real value.
      *
-     * `SecretRepository::findIdentifiers()` silently coerces a non-string
-     * identifier row to an empty string and appends it to the result array.
-     * This is BUG-MASKING behaviour — downstream consumers cannot
-     * distinguish a real (but empty) identifier from a data-integrity
-     * problem.
-     *
-     * Correct behaviour would be either:
-     *   (a) log a warning and skip the row, OR
-     *   (b) throw a domain exception.
-     *
-     * We mark this test INCOMPLETE so it is visible in every CI run as a
-     * pending quality debt, without blocking unrelated merges. When the
-     * production code is fixed to (a) or (b), the `markTestIncomplete()`
-     * call must be removed and the assertions below re-enabled.
-     *
-     * @see SecretRepository::findIdentifiers() lines 183-190
+     * @see SecretRepository::findIdentifiers()
      */
     #[Test]
-    public function findIdentifiersDoesNotSilentlyReturnEmptyStringForNonStringRow(): void
+    public function findIdentifiersSkipsNonStringRow(): void
     {
         $result = $this->createStub(Result::class);
         $result->method('fetchAssociative')
@@ -732,18 +720,8 @@ final class SecretRepositoryTest extends TestCase
 
         $this->setupQueryBuilderForSelect($result);
 
-        // Pin the current buggy behaviour so a regression to "worse" (e.g.
-        // returning a bogus non-empty string) is caught.
         $identifiers = $this->subject->findIdentifiers();
-        self::assertSame([''], $identifiers, 'current (buggy) behaviour pinned');
-
-        self::markTestIncomplete(
-            'BUG: SecretRepository::findIdentifiers() silently returns [""] for '
-            . 'a non-string identifier row. It should either skip the row with '
-            . 'a logged warning or throw. Fix the production code, then remove '
-            . 'this markTestIncomplete() call and change the assertion to '
-            . '`assertNotSame([""], $identifiers)`.',
-        );
+        self::assertSame([], $identifiers, 'non-string identifier row is skipped, not coerced to ""');
     }
 
     // ------------------------------------------------------------------

--- a/Tests/scripts/check-cli-docs.php
+++ b/Tests/scripts/check-cli-docs.php
@@ -1,0 +1,280 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+/*
+ * Documentation drift guard for the `vault:*` CLI.
+ *
+ * Every `vendor/bin/typo3 vault:<cmd> ...` example in README.md and the
+ * Developer/Commands.rst reference is checked against the authoritative
+ * command definitions in Classes/Command/*Command.php:
+ *
+ *   - the command name must exist (`#[AsCommand(name: 'vault:...')]`)
+ *   - every `--option` used must be a real option of THAT command
+ *     (or a known global Symfony/TYPO3 option)
+ *   - the number of positional arguments must not exceed the command's
+ *     declared `addArgument()` count
+ *
+ * Like check-test-base-class.php this is a lightweight static scan (regex,
+ * no autoloader) so it runs before the test suite, in pre-commit hooks, and
+ * on fresh checkouts where `.Build/` may be empty.
+ *
+ * Exit codes:
+ *   0 — every documented example matches a real command signature
+ *   1 — at least one example references an unknown command/option or passes
+ *       too many positional arguments
+ */
+
+$projectRoot = dirname(__DIR__, 2);
+$commandDir = $projectRoot . '/Classes/Command';
+
+if (!is_dir($commandDir)) {
+    fwrite(STDERR, "Command directory not found: {$commandDir}\n");
+    exit(1);
+}
+
+/*
+ * Options Symfony's Application and TYPO3's CommandApplication add to every
+ * command. Examples may legitimately use these even though no command class
+ * declares them.
+ */
+$globalOptions = [
+    'help', 'quiet', 'verbose', 'version', 'ansi', 'no-ansi',
+    'no-interaction', 'env', 'no-debug',
+];
+
+/**
+ * @return array{0: array<string, array{options: array<string,true>, args: int}>, 1: list<string>}
+ */
+$parseCommands = static function (string $commandDir): array {
+    /** @var array<string, array{options: array<string,true>, args: int}> $commands */
+    $commands = [];
+    /** @var list<string> $errors */
+    $errors = [];
+
+    /** @var SplFileInfo $file */
+    foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($commandDir, RecursiveDirectoryIterator::SKIP_DOTS)) as $file) {
+        if (!$file->isFile()) {
+            continue;
+        }
+        if ($file->getExtension() !== 'php') {
+            continue;
+        }
+        $contents = file_get_contents($file->getPathname());
+        if ($contents === false) {
+            continue;
+        }
+
+        // Only command classes carry an #[AsCommand(...)] attribute. Accept
+        // both the named-argument form #[AsCommand(name: 'vault:x')] and the
+        // positional form #[AsCommand('vault:x')].
+        if (!preg_match('/#\[AsCommand\(\s*(?:name:\s*)?[\'"]([^\'"]+)[\'"]/', $contents, $nameMatch)) {
+            continue;
+        }
+        $name = $nameMatch[1];
+
+        // Option names: first string literal argument of each addOption() call.
+        /** @var array<string,true> $options */
+        $options = [];
+        if (preg_match_all('/->addOption\(\s*[\'"]([a-zA-Z0-9][a-zA-Z0-9-]*)[\'"]/', $contents, $optMatches)) {
+            foreach ($optMatches[1] as $opt) {
+                $options[$opt] = true;
+            }
+        }
+
+        // Positional argument count: number of addArgument() calls.
+        $argCount = preg_match_all('/->addArgument\(/', $contents);
+
+        $commands[$name] = ['options' => $options, 'args' => (int) $argCount];
+    }
+
+    if ($commands === []) {
+        $errors[] = "No #[AsCommand] classes parsed from {$commandDir}";
+    }
+
+    return [$commands, $errors];
+};
+
+/**
+ * Extract `vendor/bin/typo3 vault:* ...` example invocations from a doc file.
+ * Returns a list of [lineNumber, rawCommandLine].
+ *
+ * @return list<array{int, string}>
+ */
+$extractExamples = static function (string $path): array {
+    /** @var list<array{int, string}> $examples */
+    $examples = [];
+    $lines = file($path, FILE_IGNORE_NEW_LINES);
+    if ($lines === false) {
+        return $examples;
+    }
+
+    $count = count($lines);
+    for ($i = 0; $i < $count; ++$i) {
+        $line = $lines[$i];
+        // Match a vault:* invocation anywhere on the line (code blocks, prose).
+        if (!preg_match('/(?:vendor\/bin\/typo3|bin\/typo3|typo3)\s+(vault:[a-z-]+)(.*)$/', $line, $m)) {
+            continue;
+        }
+
+        $startLine = $i + 1;
+        $rest = $m[2];
+
+        // Join shell line continuations: a trailing backslash means the
+        // options continue on the next line(s). Without this the guard would
+        // only validate the first line and miss drift on continuation lines.
+        while (rtrim($rest) !== '' && str_ends_with(rtrim($rest), '\\') && $i + 1 < $count) {
+            $rest = rtrim($rest);
+            $rest = substr($rest, 0, -1); // drop trailing backslash
+            ++$i;
+            $rest .= ' ' . trim($lines[$i]);
+        }
+
+        $examples[] = [$startLine, trim($m[1] . ' ' . $rest)];
+    }
+
+    return $examples;
+};
+
+/**
+ * Parse a single example command line into [command, options[], positionalCount].
+ * Strips trailing shell noise (redirects, pipes, line continuations, comments).
+ *
+ * @return array{string, list<string>, int}
+ */
+$parseExample = static function (string $cmdLine): array {
+    // Cut shell trailers: redirects, pipes, backgrounding, comments, continuations.
+    $cmdLine = preg_replace('/\s*(?:[|>&#].*|\\\\)$/', '', $cmdLine) ?? $cmdLine;
+
+    // Tokenize respecting single/double quotes so a quoted value containing a
+    // space stays in ONE token — including when the quote follows `=`
+    // (e.g. --reason="Scheduled rotation") or stands alone ("foo bar").
+    // A token is a run of non-space/non-quote chars, each optionally followed
+    // by a quoted span, repeated (so --reason="a b" is one token).
+    preg_match_all('/(?:[^\s"\']+(?:"[^"]*"|\'[^\']*\')?|"[^"]*"|\'[^\']*\')+/', trim($cmdLine), $tokMatch);
+    $tokens = $tokMatch[0] ?? [];
+    $command = array_shift($tokens) ?? '';
+
+    /** @var list<string> $options */
+    $options = [];
+    $positional = 0;
+
+    foreach ($tokens as $tok) {
+        if ($tok === '') {
+            continue;
+        }
+        if (str_starts_with($tok, '--')) {
+            // Strip a value: --opt=value  OR  bare --opt.
+            $opt = substr($tok, 2);
+            $eq = strpos($opt, '=');
+            if ($eq !== false) {
+                $opt = substr($opt, 0, $eq);
+            }
+            if ($opt !== '') {
+                $options[] = $opt;
+            }
+
+            continue;
+        }
+        if (str_starts_with($tok, '-') && strlen($tok) > 1) {
+            // Short option (e.g. -r, -f) — not validated against long names here.
+            continue;
+        }
+        // Synopsis grammar, not a real argument: [options], <identifier>,
+        // [<arg>], [--], {a|b}. These describe the signature, they don't pass a value.
+        if (preg_match('/^[\[<{].*[\]>}]$/', $tok)) {
+            continue;
+        }
+        if ($tok === '[--]') {
+            continue;
+        }
+        if ($tok === '--') {
+            continue;
+        }
+        // A positional argument (placeholder or literal value).
+        ++$positional;
+    }
+
+    return [$command, $options, $positional];
+};
+
+[$commands, $parseErrors] = $parseCommands($commandDir);
+$violations = $parseErrors;
+
+// Scan README plus every doc under Documentation/ so a vault:* example
+// anywhere in the docs is validated — not just the two reference files.
+/** @var array<string,string> $docFiles label => absolute path */
+$docFiles = [];
+if (is_file($projectRoot . '/README.md')) {
+    $docFiles['README.md'] = $projectRoot . '/README.md';
+}
+$docDir = $projectRoot . '/Documentation';
+if (is_dir($docDir)) {
+    /** @var SplFileInfo $file */
+    foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($docDir, RecursiveDirectoryIterator::SKIP_DOTS)) as $file) {
+        if (!$file->isFile()) {
+            continue;
+        }
+        if (!in_array($file->getExtension(), ['rst', 'md'], true)) {
+            continue;
+        }
+        $label = ltrim(str_replace($projectRoot, '', $file->getPathname()), '/');
+        $docFiles[$label] = $file->getPathname();
+    }
+    ksort($docFiles);
+}
+
+$checked = 0;
+foreach ($docFiles as $label => $path) {
+    if (!is_file($path)) {
+        continue;
+    }
+
+    foreach ($extractExamples($path) as [$lineNo, $cmdLine]) {
+        [$command, $options, $positional] = $parseExample($cmdLine);
+
+        if (!isset($commands[$command])) {
+            $violations[] = "{$label}:{$lineNo}: unknown command '{$command}'";
+
+            continue;
+        }
+        ++$checked;
+
+        $def = $commands[$command];
+        foreach ($options as $opt) {
+            if (isset($def['options'][$opt])) {
+                continue;
+            }
+            if (in_array($opt, $globalOptions, true)) {
+                continue;
+            }
+            $known = array_keys($def['options']);
+            sort($known);
+            $hint = $known === [] ? '(command has no options)' : '(have: --' . implode(', --', $known) . ')';
+            $violations[] = "{$label}:{$lineNo}: '{$command}' has no option '--{$opt}' {$hint}";
+        }
+
+        if ($positional > $def['args']) {
+            $violations[] = "{$label}:{$lineNo}: '{$command}' takes {$def['args']} positional argument(s), example passes {$positional}";
+        }
+    }
+}
+
+if ($violations !== []) {
+    sort($violations);
+    fwrite(STDERR, "ERROR: CLI documentation drift detected:\n");
+    foreach ($violations as $v) {
+        fwrite(STDERR, "  - {$v}\n");
+    }
+    fwrite(STDERR, "\nFix the documented example(s) to match the command signature in\n");
+    fwrite(STDERR, "Classes/Command/*Command.php, or update the command definition.\n");
+    exit(1);
+}
+
+echo 'OK: ' . $checked . ' documented vault:* example(s) match their command signatures (' . count($commands) . " commands).\n";
+exit(0);

--- a/composer.json
+++ b/composer.json
@@ -86,10 +86,12 @@
             "@ci:test:php:fuzz",
             "@ci:test:php:phpstan",
             "@ci:test:php:arch",
+            "@ci:test:php:doc-cli",
             "@ci:test:php:cgl"
         ],
         "ci:audit": "@composer audit --locked --format=plain --abandoned=fail",
         "ci:test:php:arch": "@php Tests/scripts/check-test-base-class.php",
+        "ci:test:php:doc-cli": "@php Tests/scripts/check-cli-docs.php",
         "ci:cgl": "php-cs-fixer fix",
         "ci:test:php:cgl": "php-cs-fixer fix --dry-run --diff",
         "ci:test:php:coverage": "@php -d pcov.enabled=0 -d xdebug.mode=coverage .Build/bin/phpunit -c Build/phpunit.xml --testsuite Unit --path-coverage --coverage-clover=.Build/coverage/clover.xml --coverage-html=.Build/coverage/html --coverage-text",


### PR DESCRIPTION
## Summary

Follow-up to an automated `/assess` review of the extension. Every finding was **resolved** — a code fix where there was a real defect, a documented disposition where the finding was a false positive / not applicable / a checkpoint-calibration issue. No correct code was changed to satisfy a check, and a new CI guard prevents the one recurring defect class (CLI-doc drift).

## Changes

**Fix — product bug**
- `SecretRepository::findIdentifiers()` now **skips** non-string identifier rows (driver/schema anomaly) instead of coercing them to `''`, which injected a bogus empty identifier into list views and rotation loops. The characterisation test that pinned the buggy `['']` behaviour is un-skipped and now asserts the corrected `[]`.

**Docs — accuracy + drift guard**
- README CLI reference expanded from 5 → all **12** `vault:*` commands, with argument signatures verified against the command classes (`vault:store --value=…`, `vault:audit --since=…`).
- Fixed `tx_vault_secret` → `tx_nrvault_secret`, replaced the nonexistent `vault:generate-key` with `openssl rand -base64 32`, and dropped the nonexistent `vault:audit --days` option (documented the real `--since`/`--until`).
- **New CI guard** `Tests/scripts/check-cli-docs.php` (pure PHP, no autoloader — same pattern as `check-test-base-class.php`) parses `Classes/Command/*Command.php` and fails the build if any documented example uses an unknown command/option or passes too many positional arguments. Wired into `composer ci` as `ci:test:php:doc-cli`. It already caught a third drift (`--days` in `Commands.rst`) that manual review had missed.

**Packaging / DDEV conventions**
- `.gitattributes` (`export-ignore` dev-only paths for smaller composer/TER packages), `.ddev/.gitignore`, and a canonical `.ddev/commands/web/setup` entry point delegating to `install-v14`.

**Repo settings (applied out-of-band, not in this diff)**
- Branch protection on `main` now requires the two stable security checks and enables `enforce_admins` (the assessment flagged both as gaps). `required_signatures` and conversation-resolution were preserved.

## Not included (deliberately)

- **`captainhook.json` → `Build/`** (assessment suggested it): attempted, but captainhook cannot install hooks reliably in this bare+worktree layout (it wrote them to a bogus nested path). Reverted in full; better done with a worktree-aware `core.hooksPath` in a dedicated change.
- False positives left as-is (would break working code): e.g. testsuite-name case checks (`name="Unit"` is correct and wired to `composer ci:test:php:unit`), the secret-detection scanner's own `AKIA`/`secret =` patterns.

## Checklist

- [x] Tests pass locally (`runTests.sh -p 8.4 -s unit` → **1763 tests, 7155 assertions, SUCCESS**)
- [x] PHPStan passes (changed file via `Build/phpstan.no-plugins.neon` → `[OK] No errors`; project config's `ergebnis` registration issue is pre-existing)
- [x] Code style is correct (`php-cs-fixer --dry-run` → `"files":[]`)
- [x] Documentation updated (render → 44 docs, 0 errors; CLI examples machine-verified)
- [x] CHANGELOG.md updated

## Test Plan

- `composer ci:test:php:doc-cli` → `OK: 54 documented vault:* example(s) match their command signatures (12 commands)`; proven to fail on injected bad examples (unknown command, unknown option, excess positional).
- `composer ci:test:php:arch` → `0 new violations`.
- The bug fix is covered by `SecretRepositoryTest::findIdentifiersSkipsNonStringRow` (asserts `[]` for a non-string row).
