### PR TITLE
Require TYPO3 v14.3 LTS instead of v14.0

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -11,7 +11,7 @@ body:
     id: typo3-version
     attributes:
       label: TYPO3 Version
-      placeholder: "14.0.0"
+      placeholder: "14.3.0"
     validations:
       required: true
   - type: input

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
       contents: read
     with:
         php-versions: '["8.2","8.3","8.4","8.5"]'
-        typo3-versions: '["^13.4","^14.0"]'
+        typo3-versions: '["^13.4","^14.3"]'
         run-functional-tests: true
         upload-coverage: true
         # Coverage driver trade-off:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@
 
 ## Project Overview
 
-- **Stack:** PHP 8.2+, TYPO3 ^13.4 || ^14.0, libsodium (XChaCha20-Poly1305 / AES-256-GCM envelope encryption)
+- **Stack:** PHP 8.2+, TYPO3 ^13.4 || ^14.3, libsodium (XChaCha20-Poly1305 / AES-256-GCM envelope encryption)
 - **Environment:** DDEV for local development
 - **License:** GPL-2.0-or-later
 - **Namespace:** `Netresearch\NrVault\` (PSR-4 from `Classes/`)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Require TYPO3 v14.3 LTS instead of v14.0** for the v14 line
+  (`typo3/cms-* : ^13.4 || ^14.3`). 14.0/14.1/14.2 were unsupported sprint
+  releases; 14.3 is the LTS. The CI matrix, README, and bug-report template
+  are aligned to the same constraint. (`ext_emconf.php` keeps its coarse
+  `13.4.0-14.99.99` range — a single continuous range cannot express the
+  `^13.4 || ^14.3` gap. Because nr-vault requires a composer-based TYPO3
+  installation, `composer.json` is the authoritative version constraint.)
+
 ### Fixed
 - **`SecretRepository::findIdentifiers()` now skips non-string identifier
   rows** instead of coercing them to an empty string. A driver/schema

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -39,7 +39,7 @@ Strict types, final classes, readonly properties, constructor promotion. DI via 
 ## Setup
 - `make up` — DDEV + TYPO3 v14 install
 - `make shell` — container shell
-- PHP `^8.2`, TYPO3 `^13.4 || ^14.0`
+- PHP `^8.2`, TYPO3 `^13.4 || ^14.3`
 
 ## Directory Structure
 ```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/netresearch/t3x-nr-vault/graph/badge.svg)](https://codecov.io/gh/netresearch/t3x-nr-vault)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/netresearch/t3x-nr-vault/badge)](https://securityscorecards.dev/viewer/?uri=github.com/netresearch/t3x-nr-vault)
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/11695/badge)](https://www.bestpractices.dev/projects/11695)
-[![TYPO3](https://img.shields.io/badge/TYPO3-13.4%20|%2014-orange.svg)](https://typo3.org/)
+[![TYPO3](https://img.shields.io/badge/TYPO3-13.4%20|%2014.3-orange.svg)](https://typo3.org/)
 [![PHP](https://img.shields.io/badge/PHP-8.2+-blue.svg)](https://www.php.net/)
 [![PHPStan](https://img.shields.io/badge/PHPStan-level%2010-brightgreen.svg)](https://phpstan.org/)
 [![License](https://img.shields.io/badge/License-GPL--2.0--or--later-blue.svg)](LICENSE)
@@ -233,7 +233,7 @@ vendor/bin/typo3 vault:audit-migrate-hmac
 
 ## Requirements
 
-- **TYPO3**: v13.4 / v14.0+
+- **TYPO3**: v13.4 LTS / v14.3 LTS+
 - **PHP**: ^8.2
 - **Extensions**: `ext-sodium` (bundled with PHP)
 - **CPU**: AES-NI support recommended (XChaCha20-Poly1305 fallback available)

--- a/composer.json
+++ b/composer.json
@@ -35,9 +35,9 @@
         "php": "^8.2",
         "ext-sodium": "*",
         "ext-json": "*",
-        "typo3/cms-core": "^13.4 || ^14.0",
-        "typo3/cms-backend": "^13.4 || ^14.0",
-        "typo3/cms-install": "^13.4 || ^14.0",
+        "typo3/cms-core": "^13.4 || ^14.3",
+        "typo3/cms-backend": "^13.4 || ^14.3",
+        "typo3/cms-install": "^13.4 || ^14.3",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0"
     },
@@ -45,7 +45,7 @@
         "mikey179/vfsstream": "^1.6",
         "netresearch/typo3-ci-workflows": "^1.0",
         "roave/security-advisories": "dev-latest",
-        "typo3/cms-scheduler": "^13.4 || ^14.0"
+        "typo3/cms-scheduler": "^13.4 || ^14.3"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary

The v14 constraint was `^14.0`, which allows the unsupported sprint releases 14.0/14.1/14.2. **14.3 is the v14 LTS** (released 2026-04-21). This tightens the requirement to `^13.4 || ^14.3` and aligns every other version reference so composer, CI, and docs agree.

## Changes

- **composer.json** — `typo3/cms-core`, `cms-backend`, `cms-install`, and dev `cms-scheduler` → `^13.4 || ^14.3`.
- **.github/workflows/ci.yml** — test matrix `typo3-versions` → `["^13.4","^14.3"]` (so CI tests what composer requires).
- **README.md** — TYPO3 badge and the Requirements line → v14.3 LTS.
- **.github/ISSUE_TEMPLATE/bug-report.yml** — version placeholder `14.0.0` → `14.3.0`.
- **AGENTS.md / Classes/AGENTS.md** — stack notes → `^13.4 || ^14.3`.
- **CHANGELOG.md** — `[Unreleased] → Changed` entry.

## Deliberately NOT changed

- **`ext_emconf.php`** keeps `13.4.0-14.99.99`. The em-conf `'typo3' => 'min-max'` form is a *single continuous range* and cannot express the disjoint `^13.4 || ^14.3` (it can't carve out 14.0–14.2). The floor stays `13.4.0` because 13.4 is still supported — raising it would drop 13.4. Because nr-vault requires a composer-based TYPO3 installation, `composer.json` is the authoritative version constraint (this does not affect TER distribution).

## Test Plan

- `composer validate` (JSON valid; constraints resolve — 14.3 is released).
- CI matrix now resolves `^14.3`; let the pipeline confirm install + tests on 13.4 and 14.3.
- No code changed — no runtime behaviour change; this is a dependency-constraint tightening.

