### PR TITLE
Resolve mechanical SonarCloud findings in backend JavaScript

### DIFF
--- a/Resources/Public/JavaScript/SecretForm.js
+++ b/Resources/Public/JavaScript/SecretForm.js
@@ -8,8 +8,9 @@ import Modal from '@typo3/backend/modal.js';
 import Severity from '@typo3/backend/severity.js';
 
 class SecretForm {
+    pidInput = null;
+
     constructor() {
-        this.pidInput = null;
         this.init();
     }
 

--- a/Resources/Public/JavaScript/SecretReveal.js
+++ b/Resources/Public/JavaScript/SecretReveal.js
@@ -18,7 +18,7 @@ import Severity from '@typo3/backend/severity.js';
  * @returns {string}
  */
 function lang(key, fallback, ...args) {
-    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang && TYPO3.lang[key]) || fallback;
+    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang?.[key]) || fallback;
     args.forEach((value, index) => {
         // Use a replacer function so `$`-sequences (e.g. $&, $1) in the value
         // are inserted literally rather than interpreted by String.replace().
@@ -59,10 +59,10 @@ class SecretView {
     handleReveal() {
         if (this.isRevealed) {
             this.hideSecret();
-        } else if (this.secretValue !== null) {
-            this.showSecret();
-        } else {
+        } else if (this.secretValue === null) {
             this.fetchAndReveal();
+        } else {
+            this.showSecret();
         }
     }
 

--- a/Resources/Public/JavaScript/SecretsList.js
+++ b/Resources/Public/JavaScript/SecretsList.js
@@ -18,7 +18,7 @@ import Severity from '@typo3/backend/severity.js';
  * @returns {string}
  */
 function lang(key, fallback, ...args) {
-    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang && TYPO3.lang[key]) || fallback;
+    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang?.[key]) || fallback;
     args.forEach((value, index) => {
         // Use a replacer function so `$`-sequences (e.g. $&, $1) in the value
         // are inserted literally rather than interpreted by String.replace().
@@ -46,7 +46,7 @@ class SecretsList {
         // Delete confirmation with TYPO3 Modal
         document.querySelectorAll('.btn-danger[type="submit"]').forEach(button => {
             const form = button.closest('form');
-            if (form && form.action.includes('delete')) {
+            if (form?.action.includes('delete')) {
                 button.addEventListener('click', this.handleDelete.bind(this));
             }
         });
@@ -100,7 +100,6 @@ class SecretsList {
         event.preventDefault();
         const button = event.currentTarget;
         const form = button.closest('form');
-        const identifier = form.querySelector('input[name="identifier"]').value;
         const row = button.closest('tr');
         const url = form.action;
 
@@ -287,7 +286,7 @@ class SecretsList {
                     try {
                         await navigator.clipboard.writeText(secret);
                         Notification.success(lang('nrvault.copied', 'Copied'), lang('nrvault.copy.success', 'Secret copied to clipboard'), 2);
-                    } catch (e) {
+                    } catch {
                         Notification.error(lang('nrvault.error', 'Error'), lang('nrvault.copy.failed', 'Failed to copy to clipboard'), 5);
                     }
                 });

--- a/Resources/Public/JavaScript/vault-backend.js
+++ b/Resources/Public/JavaScript/vault-backend.js
@@ -15,7 +15,7 @@ import AjaxRequest from '@typo3/core/ajax/ajax-request.js';
  * @returns {string}
  */
 function lang(key, fallback, ...args) {
-    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang && TYPO3.lang[key]) || fallback;
+    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang?.[key]) || fallback;
     args.forEach((value, index) => {
         // Use a replacer function so `$`-sequences (e.g. $&, $1) in the value
         // are inserted literally rather than interpreted by String.replace().

--- a/Resources/Public/JavaScript/vault-secret-element.js
+++ b/Resources/Public/JavaScript/vault-secret-element.js
@@ -20,7 +20,7 @@ import Severity from '@typo3/backend/severity.js';
  * @returns {string}
  */
 function lang(key, fallback, ...args) {
-    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang && TYPO3.lang[key]) || fallback;
+    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang?.[key]) || fallback;
     args.forEach((value, index) => {
         // Use a replacer function so `$`-sequences (e.g. $&, $1) in the value
         // are inserted literally rather than interpreted by String.replace().
@@ -177,7 +177,7 @@ class VaultSecretElement {
         // Source of truth = the visible DOM input. When revealed, its value
         // holds the plaintext; when hidden, the value is empty (cleared by
         // handleToggleVisibility) so copy refuses.
-        const secret = (input && input.type === 'text' && input.dataset.vaultRevealed === '1')
+        const secret = (input?.type === 'text' && input.dataset.vaultRevealed === '1')
             ? input.value
             : '';
         if (!secret) {

--- a/Resources/Public/JavaScript/vault-secret-input.js
+++ b/Resources/Public/JavaScript/vault-secret-input.js
@@ -18,7 +18,7 @@
  * @returns {string}
  */
 function lang(key, fallback, ...args) {
-    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang && TYPO3.lang[key]) || fallback;
+    let text = (typeof TYPO3 !== 'undefined' && TYPO3.lang?.[key]) || fallback;
     args.forEach((value, index) => {
         // Use a replacer function so `$`-sequences (e.g. $&, $1) in the value
         // are inserted literally rather than interpreted by String.replace().
@@ -208,7 +208,7 @@ class VaultSecretInput {
         // Source of truth = the visible DOM input. When revealed, its value
         // holds the plaintext; when hidden (input.type === 'password'), it
         // holds the placeholder dots.
-        const secret = (displayInput && displayInput.type === 'text')
+        const secret = (displayInput?.type === 'text')
             ? displayInput.value
             : '';
         if (!secret) {


### PR DESCRIPTION
First wave of the SonarCloud issue cleanup (project-wide triage: 245 fix / 80 keep / 21 FP).

**This PR — Resources/ JavaScript (12 mechanical edits, 14 findings):**
- `S6582` prefer optional chaining ×8
- `S2486` optional catch binding (drop unused `e`)
- `S7757` class-field init for `pidInput`
- `S7735` lead with the positive condition
- `S1481`/`S1854` remove an unused dead-store local

All behavior-preserving; ESM syntax verified on all six modules.

**Intentionally kept** (documented in triage): 6× `S1848` DOM-ready `new X()` bootstraps (the constructor side-effect *is* the purpose; any rewrite just trades it for an unused-var finding) and 1× `S7764` `window.addEventListener` (browser idiom, adjacent `window.location.origin` stays). The 2× `S3776` cognitive-complexity refactors will come in the judgment wave.