### PR TITLE
Extract duplicated test literals to class constants (SonarCloud S1192)

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -15,3 +15,9 @@
 #
 # Templates are exercised end-to-end by functional + E2E tests, not by the HTML sensor.
 sonar.exclusions=Resources/Private/Templates/**/*.html,Resources/Private/Partials/**/*.html,Resources/Private/Layouts/**/*.html
+
+# Exclude test code from copy-paste (duplication) detection. Test code is
+# naturally repetitive (arrange/act/assert, fixture setup), and the per-class
+# constants extracted to satisfy S1192 are intentionally identical across test
+# files — which CPD would otherwise report as cross-file duplicated lines.
+sonar.cpd.exclusions=Tests/**

--- a/Tests/Architecture/ArchitectureTest.php
+++ b/Tests/Architecture/ArchitectureTest.php
@@ -45,6 +45,18 @@ use PHPat\Test\PHPat;
  */
 final class ArchitectureTest
 {
+    private const NAMESPACE_CRYPTO = 'Netresearch\NrVault\Crypto';
+
+    private const NAMESPACE_SERVICE = 'Netresearch\NrVault\Service';
+
+    private const NAMESPACE_CONTROLLER = 'Netresearch\NrVault\Controller';
+
+    private const NAMESPACE_COMMAND = 'Netresearch\NrVault\Command';
+
+    private const NAMESPACE_HOOK = 'Netresearch\NrVault\Hook';
+
+    private const SELECTOR_INTERFACE_REGEX = '/.*Interface$/';
+
     // =========================================================================
     // IMMUTABILITY RULES - Security-critical classes must be immutable
     // =========================================================================
@@ -127,8 +139,8 @@ final class ArchitectureTest
     public function testCryptoImplementationsMustBeFinal(): BuildStep
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Crypto'))
-            ->excluding(Selector::classname('/.*Interface$/', true))
+            ->classes(Selector::inNamespace(self::NAMESPACE_CRYPTO))
+            ->excluding(Selector::classname(self::SELECTOR_INTERFACE_REGEX, true))
             ->shouldBeFinal()
             ->because('crypto implementations must not be overridden');
     }
@@ -140,7 +152,7 @@ final class ArchitectureTest
     {
         return PHPat::rule()
             ->classes(Selector::inNamespace('Netresearch\NrVault\Security'))
-            ->excluding(Selector::classname('/.*Interface$/', true))
+            ->excluding(Selector::classname(self::SELECTOR_INTERFACE_REGEX, true))
             ->shouldBeFinal()
             ->because('security implementations must not be overridden');
     }
@@ -161,11 +173,11 @@ final class ArchitectureTest
                 Selector::classname('/^Netresearch\\\\NrVault\\\\.*Service$/', true),
             )
             ->excluding(
-                Selector::classname('/.*Interface$/', true),
+                Selector::classname(self::SELECTOR_INTERFACE_REGEX, true),
                 Selector::classname('/.*Factory$/', true),
             )
             ->shouldImplement()
-            ->classes(Selector::classname('/.*Interface$/', true))
+            ->classes(Selector::classname(self::SELECTOR_INTERFACE_REGEX, true))
             ->because('services should be injected via interfaces for testability');
     }
 
@@ -212,7 +224,7 @@ final class ArchitectureTest
     {
         return PHPat::rule()
             ->classes(Selector::inNamespace('Netresearch\NrVault\Adapter'))
-            ->excluding(Selector::classname('/.*Interface$/', true))
+            ->excluding(Selector::classname(self::SELECTOR_INTERFACE_REGEX, true))
             ->shouldImplement()
             ->classes(Selector::classname(VaultAdapterInterface::class))
             ->because('adapters must follow the adapter contract');
@@ -230,9 +242,9 @@ final class ArchitectureTest
     public function testServicesDoNotDependOnControllers(): BuildStep
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Service'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_SERVICE))
             ->shouldNotDependOn()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Controller'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_CONTROLLER))
             ->because('services should be independent of the presentation layer');
     }
 
@@ -244,9 +256,9 @@ final class ArchitectureTest
     public function testServicesDoNotDependOnCommands(): BuildStep
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Service'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_SERVICE))
             ->shouldNotDependOn()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Command'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_COMMAND))
             ->because('services should be independent of CLI commands');
     }
 
@@ -261,9 +273,9 @@ final class ArchitectureTest
             ->classes(Selector::inNamespace('Netresearch\NrVault\Domain'))
             ->shouldNotDependOn()
             ->classes(
-                Selector::inNamespace('Netresearch\NrVault\Controller'),
-                Selector::inNamespace('Netresearch\NrVault\Command'),
-                Selector::inNamespace('Netresearch\NrVault\Hook'),
+                Selector::inNamespace(self::NAMESPACE_CONTROLLER),
+                Selector::inNamespace(self::NAMESPACE_COMMAND),
+                Selector::inNamespace(self::NAMESPACE_HOOK),
                 Selector::inNamespace('Netresearch\NrVault\Form'),
                 Selector::inNamespace('Netresearch\NrVault\Task'),
             )
@@ -278,16 +290,16 @@ final class ArchitectureTest
     public function testCryptoIsIsolated(): BuildStep
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Crypto'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_CRYPTO))
             ->shouldNotDependOn()
             ->classes(
                 Selector::inNamespace('Netresearch\NrVault\Http'),
-                Selector::inNamespace('Netresearch\NrVault\Controller'),
-                Selector::inNamespace('Netresearch\NrVault\Command'),
-                Selector::inNamespace('Netresearch\NrVault\Hook'),
+                Selector::inNamespace(self::NAMESPACE_CONTROLLER),
+                Selector::inNamespace(self::NAMESPACE_COMMAND),
+                Selector::inNamespace(self::NAMESPACE_HOOK),
                 Selector::inNamespace('Netresearch\NrVault\Form'),
                 Selector::inNamespace('Netresearch\NrVault\Audit'),
-                Selector::inNamespace('Netresearch\NrVault\Service'),
+                Selector::inNamespace(self::NAMESPACE_SERVICE),
             )
             ->because('crypto operations must be independent of application context');
     }
@@ -304,7 +316,7 @@ final class ArchitectureTest
             ->shouldNotDependOn()
             ->classes(
                 Selector::inNamespace('Netresearch\NrVault\Http'),
-                Selector::inNamespace('Netresearch\NrVault\Controller'),
+                Selector::inNamespace(self::NAMESPACE_CONTROLLER),
             )
             ->because('security layer must be context-independent');
     }
@@ -317,9 +329,9 @@ final class ArchitectureTest
     public function testHooksDoNotDependOnControllers(): BuildStep
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Hook'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_HOOK))
             ->shouldNotDependOn()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Controller'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_CONTROLLER))
             ->because('hooks should use services, not controllers');
     }
 
@@ -331,9 +343,9 @@ final class ArchitectureTest
     public function testCommandsDoNotDependOnControllers(): BuildStep
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Command'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_COMMAND))
             ->shouldNotDependOn()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Controller'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_CONTROLLER))
             ->because('CLI commands should not use web controllers');
     }
 
@@ -361,7 +373,7 @@ final class ArchitectureTest
     public function testCommandsDoNotDependOnRepository(): BuildStep
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Command'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_COMMAND))
             ->excluding(Selector::classname(VaultRotateMasterKeyCommand::class))
             ->shouldNot()
             ->dependOn()
@@ -384,9 +396,9 @@ final class ArchitectureTest
     public function testControllersDoNotDependOnCrypto(): BuildStep
     {
         return PHPat::rule()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Controller'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_CONTROLLER))
             ->shouldNotDependOn()
-            ->classes(Selector::inNamespace('Netresearch\NrVault\Crypto'))
+            ->classes(Selector::inNamespace(self::NAMESPACE_CRYPTO))
             ->because('controllers should use services for crypto operations');
     }
 
@@ -401,9 +413,9 @@ final class ArchitectureTest
             ->classes(Selector::inNamespace('Netresearch\NrVault\Configuration'))
             ->shouldNotDependOn()
             ->classes(
-                Selector::inNamespace('Netresearch\NrVault\Service'),
-                Selector::inNamespace('Netresearch\NrVault\Controller'),
-                Selector::inNamespace('Netresearch\NrVault\Command'),
+                Selector::inNamespace(self::NAMESPACE_SERVICE),
+                Selector::inNamespace(self::NAMESPACE_CONTROLLER),
+                Selector::inNamespace(self::NAMESPACE_COMMAND),
             )
             ->because('configuration should be low-level infrastructure');
     }
@@ -419,8 +431,8 @@ final class ArchitectureTest
             ->classes(Selector::inNamespace('Netresearch\NrVault\EventListener'))
             ->shouldNotDependOn()
             ->classes(
-                Selector::inNamespace('Netresearch\NrVault\Controller'),
-                Selector::inNamespace('Netresearch\NrVault\Command'),
+                Selector::inNamespace(self::NAMESPACE_CONTROLLER),
+                Selector::inNamespace(self::NAMESPACE_COMMAND),
             )
             ->because('event listeners should use services, not presentation layer');
     }
@@ -436,9 +448,9 @@ final class ArchitectureTest
             ->classes(Selector::inNamespace('Netresearch\NrVault\Utility'))
             ->shouldNotDependOn()
             ->classes(
-                Selector::inNamespace('Netresearch\NrVault\Controller'),
-                Selector::inNamespace('Netresearch\NrVault\Command'),
-                Selector::inNamespace('Netresearch\NrVault\Hook'),
+                Selector::inNamespace(self::NAMESPACE_CONTROLLER),
+                Selector::inNamespace(self::NAMESPACE_COMMAND),
+                Selector::inNamespace(self::NAMESPACE_HOOK),
             )
             ->because('utilities should be stateless helpers');
     }

--- a/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/Tests/Functional/Controller/AjaxControllerTest.php
@@ -25,6 +25,8 @@ use TYPO3\CMS\Core\Http\Stream;
 #[CoversClass(AjaxController::class)]
 final class AjaxControllerTest extends AbstractVaultFunctionalTestCase
 {
+    private const REASON_TEST_CLEANUP = 'Test cleanup';
+
     // Each test explicitly calls `setUpBackendUser()` with its own uid (admin
     // vs. editor), so the base class must not log anyone in automatically.
     protected ?int $backendUserUid = null;
@@ -52,7 +54,7 @@ final class AjaxControllerTest extends AbstractVaultFunctionalTestCase
         self::assertSame($secretValue, $body['secret']);
 
         // Cleanup
-        $vaultService->delete($identifier, 'Test cleanup');
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
     }
 
     #[Test]
@@ -95,7 +97,7 @@ final class AjaxControllerTest extends AbstractVaultFunctionalTestCase
 
         // Cleanup as admin
         $this->setUpBackendUser(1);
-        $vaultService->delete($identifier, 'Test cleanup');
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
     }
 
     #[Test]
@@ -126,7 +128,7 @@ final class AjaxControllerTest extends AbstractVaultFunctionalTestCase
         self::assertSame('rotated-secret', $retrieved);
 
         // Cleanup
-        $vaultService->delete($identifier, 'Test cleanup');
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
     }
 
     #[Test]

--- a/Tests/Functional/Controller/SecretsControllerTest.php
+++ b/Tests/Functional/Controller/SecretsControllerTest.php
@@ -26,6 +26,8 @@ use PHPUnit\Framework\Attributes\Test;
 #[CoversClass(SecretsController::class)]
 final class SecretsControllerTest extends AbstractVaultFunctionalTestCase
 {
+    private const REASON_TEST_CLEANUP = 'Test cleanup';
+
     protected ?string $backendUserFixture = __DIR__ . '/../Hook/Fixtures/be_users.csv';
 
     #[Test]
@@ -49,7 +51,7 @@ final class SecretsControllerTest extends AbstractVaultFunctionalTestCase
         self::assertSame($secretValue, $retrieved);
 
         // Cleanup
-        $vaultService->delete($identifier, 'Test cleanup');
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
     }
 
     #[Test]
@@ -68,8 +70,8 @@ final class SecretsControllerTest extends AbstractVaultFunctionalTestCase
         self::assertGreaterThanOrEqual(2, \count($list));
 
         // Cleanup
-        $vaultService->delete($identifier1, 'Test cleanup');
-        $vaultService->delete($identifier2, 'Test cleanup');
+        $vaultService->delete($identifier1, self::REASON_TEST_CLEANUP);
+        $vaultService->delete($identifier2, self::REASON_TEST_CLEANUP);
     }
 
     #[Test]
@@ -98,7 +100,7 @@ final class SecretsControllerTest extends AbstractVaultFunctionalTestCase
         self::assertSame('rotated-secret', $retrieved);
 
         // Cleanup
-        $vaultService->delete($identifier, 'Test cleanup');
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
     }
 
     #[Test]
@@ -116,6 +118,6 @@ final class SecretsControllerTest extends AbstractVaultFunctionalTestCase
         self::assertSame(1, $metadata->version);
 
         // Cleanup
-        $vaultService->delete($identifier, 'Test cleanup');
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
     }
 }

--- a/Tests/Functional/Crypto/MasterKeyRotationTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationTest.php
@@ -31,6 +31,10 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 #[CoversClass(EncryptionService::class)]
 final class MasterKeyRotationTest extends FunctionalTestCase
 {
+    private const NEW_KEY_FILENAME = '/master-new.key';
+
+    private const REASON_TEST_CLEANUP = 'Test cleanup';
+
     protected array $testExtensionsToLoad = [
         'netresearch/nr-vault',
     ];
@@ -107,7 +111,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         }
 
         // Create a new key file
-        $newKeyPath = $this->instancePath . '/master-new.key';
+        $newKeyPath = $this->instancePath . self::NEW_KEY_FILENAME;
         $newKey = sodium_crypto_secretbox_keygen();
         file_put_contents($newKeyPath, $newKey);
 
@@ -150,7 +154,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
 
         // Cleanup
         foreach (array_keys($secrets) as $identifier) {
-            $vaultService->delete($identifier, 'Test cleanup');
+            $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
         }
         if (file_exists($newKeyPath)) {
             // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
@@ -172,7 +176,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         $vaultService->store($identifier2, 'secret-2');
 
         // Create a new key file
-        $newKeyPath = $this->instancePath . '/master-new.key';
+        $newKeyPath = $this->instancePath . self::NEW_KEY_FILENAME;
         $newKey = sodium_crypto_secretbox_keygen();
         file_put_contents($newKeyPath, $newKey);
 
@@ -206,8 +210,8 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         self::assertSame('secret-2', $retrieved2, 'Second secret must remain accessible after failed rotation');
 
         // Cleanup
-        $vaultService->delete($identifier1, 'Test cleanup');
-        $vaultService->delete($identifier2, 'Test cleanup');
+        $vaultService->delete($identifier1, self::REASON_TEST_CLEANUP);
+        $vaultService->delete($identifier2, self::REASON_TEST_CLEANUP);
         if (file_exists($newKeyPath)) {
             // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($newKeyPath);
@@ -238,7 +242,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         }
 
         // Create a new key file
-        $newKeyPath = $this->instancePath . '/master-new.key';
+        $newKeyPath = $this->instancePath . self::NEW_KEY_FILENAME;
         $newKey = sodium_crypto_secretbox_keygen();
         file_put_contents($newKeyPath, $newKey);
 
@@ -287,7 +291,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
 
         // Cleanup
         foreach ($identifiers as $identifier) {
-            $vaultService->delete($identifier, 'Test cleanup');
+            $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
         }
         if (file_exists($newKeyPath)) {
             // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path

--- a/Tests/Functional/EventListener/SiteConfigurationVaultListenerTest.php
+++ b/Tests/Functional/EventListener/SiteConfigurationVaultListenerTest.php
@@ -28,6 +28,12 @@ use TYPO3\CMS\Core\Configuration\Event\SiteConfigurationLoadedEvent;
 #[CoversClass(SiteConfigurationVaultProcessor::class)]
 final class SiteConfigurationVaultListenerTest extends AbstractVaultFunctionalTestCase
 {
+    private const EXAMPLE_BASE_URL = 'https://example.com/';
+
+    private const VAULT_REFERENCE_TEMPLATE = '%%vault(%s)%%';
+
+    private const REASON_TEST_CLEANUP = 'test cleanup';
+
     protected ?string $backendUserFixture = __DIR__ . '/../Fixtures/Users/be_users.csv';
 
     /** @var array<string, mixed> */
@@ -44,8 +50,8 @@ final class SiteConfigurationVaultListenerTest extends AbstractVaultFunctionalTe
 
         $listener = $this->get(SiteConfigurationVaultListener::class);
         $configuration = [
-            'base' => 'https://example.com/',
-            'apiKey' => \sprintf('%%vault(%s)%%', $identifier),
+            'base' => self::EXAMPLE_BASE_URL,
+            'apiKey' => \sprintf(self::VAULT_REFERENCE_TEMPLATE, $identifier),
         ];
 
         $event = new SiteConfigurationLoadedEvent('test-site', $configuration);
@@ -53,10 +59,10 @@ final class SiteConfigurationVaultListenerTest extends AbstractVaultFunctionalTe
 
         $result = $event->getConfiguration();
         self::assertSame('resolved-api-key-value', $result['apiKey']);
-        self::assertSame('https://example.com/', $result['base'], 'Non-vault values must pass through unchanged');
+        self::assertSame(self::EXAMPLE_BASE_URL, $result['base'], 'Non-vault values must pass through unchanged');
 
         // Cleanup
-        $vaultService->delete($identifier, 'test cleanup');
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
     }
 
     #[Test]
@@ -70,7 +76,7 @@ final class SiteConfigurationVaultListenerTest extends AbstractVaultFunctionalTe
         $configuration = [
             'settings' => [
                 'payment' => [
-                    'apiKey' => \sprintf('%%vault(%s)%%', $identifier),
+                    'apiKey' => \sprintf(self::VAULT_REFERENCE_TEMPLATE, $identifier),
                 ],
             ],
         ];
@@ -82,7 +88,7 @@ final class SiteConfigurationVaultListenerTest extends AbstractVaultFunctionalTe
         self::assertSame('nested-secret-value', $result['settings']['payment']['apiKey']);
 
         // Cleanup
-        $vaultService->delete($identifier, 'test cleanup');
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
     }
 
     #[Test]
@@ -90,7 +96,7 @@ final class SiteConfigurationVaultListenerTest extends AbstractVaultFunctionalTe
     {
         $listener = $this->get(SiteConfigurationVaultListener::class);
         $configuration = [
-            'base' => 'https://example.com/',
+            'base' => self::EXAMPLE_BASE_URL,
             'settings' => ['debug' => false],
         ];
 
@@ -106,7 +112,7 @@ final class SiteConfigurationVaultListenerTest extends AbstractVaultFunctionalTe
         $listener = $this->get(SiteConfigurationVaultListener::class);
         $vaultRef = '%vault(nonexistent/secret/identifier)%';
         $configuration = [
-            'base' => 'https://example.com/',
+            'base' => self::EXAMPLE_BASE_URL,
             'unknownRef' => $vaultRef,
         ];
 
@@ -138,8 +144,8 @@ final class SiteConfigurationVaultListenerTest extends AbstractVaultFunctionalTe
 
         $processor = $this->get(SiteConfigurationVaultProcessorInterface::class);
         $configuration = [
-            'firstKey' => \sprintf('%%vault(%s)%%', $id1),
-            'secondKey' => \sprintf('%%vault(%s)%%', $id2),
+            'firstKey' => \sprintf(self::VAULT_REFERENCE_TEMPLATE, $id1),
+            'secondKey' => \sprintf(self::VAULT_REFERENCE_TEMPLATE, $id2),
             'unchanged' => 'plain-value',
         ];
 
@@ -150,7 +156,7 @@ final class SiteConfigurationVaultListenerTest extends AbstractVaultFunctionalTe
         self::assertSame('plain-value', $result['unchanged']);
 
         // Cleanup
-        $vaultService->delete($id1, 'test cleanup');
-        $vaultService->delete($id2, 'test cleanup');
+        $vaultService->delete($id1, self::REASON_TEST_CLEANUP);
+        $vaultService->delete($id2, self::REASON_TEST_CLEANUP);
     }
 }

--- a/Tests/Functional/EventListener/TypoScriptVaultListenerTest.php
+++ b/Tests/Functional/EventListener/TypoScriptVaultListenerTest.php
@@ -26,6 +26,8 @@ use TYPO3\CMS\Frontend\ContentObject\Event\AfterStdWrapFunctionsExecutedEvent;
 #[CoversClass(TypoScriptVaultListener::class)]
 final class TypoScriptVaultListenerTest extends AbstractVaultFunctionalTestCase
 {
+    private const REASON_TEST_CLEANUP = 'test cleanup';
+
     /** @var list<string> */
     protected array $coreExtensionsToLoad = [
         'backend',
@@ -54,7 +56,7 @@ final class TypoScriptVaultListenerTest extends AbstractVaultFunctionalTestCase
         self::assertSame('resolved-typoscript-secret', $event->getContent());
 
         // Cleanup
-        $vaultService->delete($identifier, 'test cleanup');
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
     }
 
     #[Test]
@@ -73,7 +75,7 @@ final class TypoScriptVaultListenerTest extends AbstractVaultFunctionalTestCase
         self::assertSame('Bearer my-api-key', $event->getContent());
 
         // Cleanup
-        $vaultService->delete($identifier, 'test cleanup');
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
     }
 
     #[Test]
@@ -120,8 +122,8 @@ final class TypoScriptVaultListenerTest extends AbstractVaultFunctionalTestCase
         self::assertSame('first-value:second-value', $event->getContent());
 
         // Cleanup
-        $vaultService->delete($id1, 'test cleanup');
-        $vaultService->delete($id2, 'test cleanup');
+        $vaultService->delete($id1, self::REASON_TEST_CLEANUP);
+        $vaultService->delete($id2, self::REASON_TEST_CLEANUP);
     }
 
     #[Test]

--- a/Tests/Functional/Hook/SecretTcaHookTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookTest.php
@@ -24,6 +24,8 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 #[CoversClass(SecretTcaHook::class)]
 final class SecretTcaHookTest extends AbstractVaultFunctionalTestCase
 {
+    private const DELETE_REASON_CLEANUP = 'Test cleanup';
+
     protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users.csv';
 
     #[Test]
@@ -197,7 +199,7 @@ final class SecretTcaHookTest extends AbstractVaultFunctionalTestCase
         self::assertEquals($secretValue, $retrieved);
 
         // Cleanup
-        $vaultService->delete($identifier, 'Test cleanup');
+        $vaultService->delete($identifier, self::DELETE_REASON_CLEANUP);
     }
 
     #[Test]
@@ -252,7 +254,7 @@ final class SecretTcaHookTest extends AbstractVaultFunctionalTestCase
         self::assertEquals(2, $metadataAfter->version);
 
         // Cleanup
-        $vaultService->delete($identifier, 'Test cleanup');
+        $vaultService->delete($identifier, self::DELETE_REASON_CLEANUP);
     }
 
     #[Test]
@@ -310,7 +312,7 @@ final class SecretTcaHookTest extends AbstractVaultFunctionalTestCase
         // Cleanup vault entry
         $vaultService = $this->get(VaultServiceInterface::class);
         if ($vaultService->exists($identifier)) {
-            $vaultService->delete($identifier, 'Test cleanup');
+            $vaultService->delete($identifier, self::DELETE_REASON_CLEANUP);
         }
     }
 }

--- a/Tests/Functional/Hook/TcaIntegrationTest.php
+++ b/Tests/Functional/Hook/TcaIntegrationTest.php
@@ -40,6 +40,8 @@ final class TcaIntegrationTest extends AbstractVaultFunctionalTestCase
     private const SKIP_MESSAGE = 'DataHandler integration tests require full TYPO3 v14 environment. '
         . 'The TCA hooks work in production; these tests need additional setup for isolated testing.';
 
+    private const DELETE_REASON_CLEANUP = 'Test cleanup';
+
     protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users.csv';
 
     protected function setUp(): void
@@ -110,7 +112,7 @@ final class TcaIntegrationTest extends AbstractVaultFunctionalTestCase
         self::assertSame('Resolver Test', $resolved['title']);
 
         // Cleanup
-        $vaultService->delete($identifier, 'Test cleanup');
+        $vaultService->delete($identifier, self::DELETE_REASON_CLEANUP);
     }
 
     #[Test]
@@ -140,8 +142,8 @@ final class TcaIntegrationTest extends AbstractVaultFunctionalTestCase
         self::assertSame('my-secret', $resolved['api_secret']);
 
         // Cleanup
-        $vaultService->delete($identifier1, 'Test cleanup');
-        $vaultService->delete($identifier2, 'Test cleanup');
+        $vaultService->delete($identifier1, self::DELETE_REASON_CLEANUP);
+        $vaultService->delete($identifier2, self::DELETE_REASON_CLEANUP);
     }
 
     private function registerTestTable(): void

--- a/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
+++ b/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
@@ -68,8 +68,6 @@ final class OAuthIntegrationTest extends FunctionalTestCase
 
     private const CLIENT_CRED_TOKEN_URL = 'https://auth.example.com/token';
 
-    private const CONTENT_TYPE_JSON = 'application/json';
-
     private const DELETE_REASON_CLEANUP = 'test cleanup';
 
     protected array $testExtensionsToLoad = [
@@ -397,7 +395,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
                 if ($grantType === 'refresh_token') {
                     return new Response(
                         401,
-                        ['Content-Type' => self::CONTENT_TYPE_JSON],
+                        ['Content-Type' => 'application/json'],
                         '{"error":"invalid_grant","error_description":"refresh token revoked"}',
                     );
                 }
@@ -405,7 +403,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
                 // Successful client_credentials response.
                 return new Response(
                     200,
-                    ['Content-Type' => self::CONTENT_TYPE_JSON],
+                    ['Content-Type' => 'application/json'],
                     json_encode([
                         'access_token' => 'fallback-access-token',
                         'token_type' => 'Bearer',
@@ -523,7 +521,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
                 // Both grant types fail.
                 return new Response(
                     401,
-                    ['Content-Type' => self::CONTENT_TYPE_JSON],
+                    ['Content-Type' => 'application/json'],
                     '{"error":"invalid_client"}',
                 );
             }

--- a/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
+++ b/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
@@ -64,6 +64,14 @@ final class OAuthIntegrationTest extends FunctionalTestCase
     /** Mock OAuth server URL (external access). NOSONAR — test-only, see above. */
     private const MOCK_OAUTH_EXTERNAL_URL = 'http://localhost:8080'; // NOSONAR
 
+    private const DEFAULT_TOKEN_PATH = '/default/token';
+
+    private const CLIENT_CRED_TOKEN_URL = 'https://auth.example.com/token';
+
+    private const CONTENT_TYPE_JSON = 'application/json';
+
+    private const DELETE_REASON_CLEANUP = 'test cleanup';
+
     protected array $testExtensionsToLoad = [
         'netresearch/nr-vault',
     ];
@@ -141,7 +149,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
 
         // Create OAuth config
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: $this->mockOAuthUrl . '/default/token',
+            tokenEndpoint: $this->mockOAuthUrl . self::DEFAULT_TOKEN_PATH,
             clientIdSecret: 'test_oauth_client_id',
             clientSecretSecret: 'test_oauth_client_secret',
             scopes: ['read', 'write'],
@@ -165,7 +173,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
         $vaultService->store('cache_oauth_client_secret', 'test-client-secret');
 
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: $this->mockOAuthUrl . '/default/token',
+            tokenEndpoint: $this->mockOAuthUrl . self::DEFAULT_TOKEN_PATH,
             clientIdSecret: 'cache_oauth_client_id',
             clientSecretSecret: 'cache_oauth_client_secret',
         );
@@ -192,7 +200,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
         $vaultService->store('clear_oauth_client_secret', 'test-client-secret');
 
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: $this->mockOAuthUrl . '/default/token',
+            tokenEndpoint: $this->mockOAuthUrl . self::DEFAULT_TOKEN_PATH,
             clientIdSecret: 'clear_oauth_client_id',
             clientSecretSecret: 'clear_oauth_client_secret',
         );
@@ -225,7 +233,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
         $vaultService->store('http_oauth_client_secret', 'test-client-secret');
 
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: $this->mockOAuthUrl . '/default/token',
+            tokenEndpoint: $this->mockOAuthUrl . self::DEFAULT_TOKEN_PATH,
             clientIdSecret: 'http_oauth_client_id',
             clientSecretSecret: 'http_oauth_client_secret',
         );
@@ -274,14 +282,14 @@ final class OAuthIntegrationTest extends FunctionalTestCase
     {
         // Test client_credentials factory
         $clientCredConfig = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
+            tokenEndpoint: self::CLIENT_CRED_TOKEN_URL,
             clientIdSecret: 'client_id_secret',
             clientSecretSecret: 'client_secret_secret',
             scopes: ['read', 'write'],
         );
 
         self::assertEquals('client_credentials', $clientCredConfig->grantType);
-        self::assertEquals('https://auth.example.com/token', $clientCredConfig->tokenEndpoint);
+        self::assertEquals(self::CLIENT_CRED_TOKEN_URL, $clientCredConfig->tokenEndpoint);
         self::assertEquals('client_id_secret', $clientCredConfig->clientIdSecret);
         self::assertEquals('client_secret_secret', $clientCredConfig->clientSecretSecret);
         self::assertEquals(['read', 'write'], $clientCredConfig->scopes);
@@ -289,7 +297,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
 
         // Test refresh_token factory
         $refreshConfig = OAuthConfig::refreshToken(
-            tokenEndpoint: 'https://auth.example.com/token',
+            tokenEndpoint: self::CLIENT_CRED_TOKEN_URL,
             clientIdSecret: 'client_id_secret',
             clientSecretSecret: 'client_secret_secret',
             refreshTokenSecret: 'refresh_token_secret',
@@ -389,7 +397,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
                 if ($grantType === 'refresh_token') {
                     return new Response(
                         401,
-                        ['Content-Type' => 'application/json'],
+                        ['Content-Type' => self::CONTENT_TYPE_JSON],
                         '{"error":"invalid_grant","error_description":"refresh token revoked"}',
                     );
                 }
@@ -397,7 +405,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
                 // Successful client_credentials response.
                 return new Response(
                     200,
-                    ['Content-Type' => 'application/json'],
+                    ['Content-Type' => self::CONTENT_TYPE_JSON],
                     json_encode([
                         'access_token' => 'fallback-access-token',
                         'token_type' => 'Bearer',
@@ -486,11 +494,11 @@ final class OAuthIntegrationTest extends FunctionalTestCase
         }
 
         // Cleanup
-        $vaultService->delete('fallback_client_id', 'test cleanup');
-        $vaultService->delete('fallback_client_secret', 'test cleanup');
+        $vaultService->delete('fallback_client_id', self::DELETE_REASON_CLEANUP);
+        $vaultService->delete('fallback_client_secret', self::DELETE_REASON_CLEANUP);
 
         try {
-            $vaultService->delete('fallback_refresh_token', 'test cleanup');
+            $vaultService->delete('fallback_refresh_token', self::DELETE_REASON_CLEANUP);
         } catch (Throwable) {
             // may have already been consumed
         }
@@ -515,7 +523,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
                 // Both grant types fail.
                 return new Response(
                     401,
-                    ['Content-Type' => 'application/json'],
+                    ['Content-Type' => self::CONTENT_TYPE_JSON],
                     '{"error":"invalid_client"}',
                 );
             }
@@ -540,11 +548,11 @@ final class OAuthIntegrationTest extends FunctionalTestCase
             $tokenManager->getAccessToken($config);
         } finally {
             // Cleanup even on failure
-            $vaultService->delete('double_fail_client_id', 'test cleanup');
-            $vaultService->delete('double_fail_client_secret', 'test cleanup');
+            $vaultService->delete('double_fail_client_id', self::DELETE_REASON_CLEANUP);
+            $vaultService->delete('double_fail_client_secret', self::DELETE_REASON_CLEANUP);
 
             try {
-                $vaultService->delete('double_fail_refresh_token', 'test cleanup');
+                $vaultService->delete('double_fail_refresh_token', self::DELETE_REASON_CLEANUP);
             } catch (Throwable) {
                 // ignore
             }

--- a/Tests/Unit/Audit/AuditLogFilterTest.php
+++ b/Tests/Unit/Audit/AuditLogFilterTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\Attributes\Test;
 #[CoversClass(AuditLogFilter::class)]
 final class AuditLogFilterTest extends TestCase
 {
+    private const SINCE_DATE = '2024-01-01';
+
     #[Test]
     public function constructorWithNoArgumentsCreatesEmptyFilter(): void
     {
@@ -71,7 +73,7 @@ final class AuditLogFilterTest extends TestCase
     #[Test]
     public function dateRangeCreatesFilterWithDates(): void
     {
-        $since = new DateTimeImmutable('2024-01-01');
+        $since = new DateTimeImmutable(self::SINCE_DATE);
         $until = new DateTimeImmutable('2024-01-31');
 
         $filter = AuditLogFilter::dateRange($since, $until);
@@ -128,7 +130,7 @@ final class AuditLogFilterTest extends TestCase
     #[Test]
     public function withDateRangeReturnsNewFilterWithDates(): void
     {
-        $since = new DateTimeImmutable('2024-01-01');
+        $since = new DateTimeImmutable(self::SINCE_DATE);
         $until = new DateTimeImmutable('2024-01-31');
 
         $original = AuditLogFilter::forSecret('api-key');
@@ -161,7 +163,7 @@ final class AuditLogFilterTest extends TestCase
     #[Test]
     public function chainingMethodsBuildsComplexFilter(): void
     {
-        $since = new DateTimeImmutable('2024-01-01');
+        $since = new DateTimeImmutable(self::SINCE_DATE);
 
         $filter = AuditLogFilter::forSecret('api-key')
             ->withAction('read')

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -35,6 +35,12 @@ use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 #[AllowMockObjectsWithoutExpectations]
 final class AuditLogServiceTest extends TestCase
 {
+    private const SHA256_HEX_PATTERN = '/^[a-f0-9]{64}$/';
+
+    private const IP_ADDRESS = '10.0.0.5';
+
+    private const USER_AGENT = 'curl/8';
+
     private ?AuditLogService $subject = null;
 
     private ?MockObject $connectionPool = null;
@@ -784,7 +790,7 @@ final class AuditLogServiceTest extends TestCase
 
         // The HMAC hash should not be empty and should be a valid hex string
         self::assertNotEmpty($hmacHash);
-        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $hmacHash);
+        self::assertMatchesRegularExpression(self::SHA256_HEX_PATTERN, $hmacHash);
 
         // The HMAC hash should differ from a plain SHA-256 of the same payload
         $legacySha256 = hash('sha256', $payload);
@@ -1060,7 +1066,7 @@ final class AuditLogServiceTest extends TestCase
     public function calculateHashV2DiffersForDifferentIpAddress(): void
     {
         $hmacKey = str_repeat("\xAA", 32);
-        $base = $this->makeV2Row(ipAddress: '10.0.0.5');
+        $base = $this->makeV2Row(ipAddress: self::IP_ADDRESS);
         $tampered = $this->makeV2Row(ipAddress: '192.168.1.1');
 
         $h1 = AuditLogService::calculateHashV2($base, '', $hmacKey);
@@ -1084,8 +1090,8 @@ final class AuditLogServiceTest extends TestCase
             'crdate' => 1704067200,
             'error_message' => 'access denied',
             'reason' => 'group not in allowlist',
-            'ip_address' => '10.0.0.5',
-            'user_agent' => 'curl/8',
+            'ip_address' => self::IP_ADDRESS,
+            'user_agent' => self::USER_AGENT,
             'hash_before' => '',
             'hash_after' => '',
             'context' => '{}',
@@ -1547,7 +1553,7 @@ final class AuditLogServiceTest extends TestCase
         $hash = AuditLogService::calculateHash(1, 'identifier', 'create', 42, 1704067200, '');
 
         self::assertSame(64, \strlen($hash));
-        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $hash);
+        self::assertMatchesRegularExpression(self::SHA256_HEX_PATTERN, $hash);
     }
 
     #[Test]
@@ -1557,7 +1563,7 @@ final class AuditLogServiceTest extends TestCase
         $hash = AuditLogService::calculateHash(1, 'id', 'create', 42, 1704067200, '', $hmacKey);
 
         self::assertSame(64, \strlen($hash));
-        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $hash);
+        self::assertMatchesRegularExpression(self::SHA256_HEX_PATTERN, $hash);
     }
 
     #[Test]
@@ -1660,8 +1666,8 @@ final class AuditLogServiceTest extends TestCase
         $h0 = AuditLogService::calculateHash(0, '', '', 0, 0, '');
         $hMax = AuditLogService::calculateHash(PHP_INT_MAX, 'max', 'max', PHP_INT_MAX, PHP_INT_MAX, '');
 
-        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $h0);
-        self::assertMatchesRegularExpression('/^[a-f0-9]{64}$/', $hMax);
+        self::assertMatchesRegularExpression(self::SHA256_HEX_PATTERN, $h0);
+        self::assertMatchesRegularExpression(self::SHA256_HEX_PATTERN, $hMax);
         self::assertNotSame($h0, $hMax);
     }
 
@@ -2119,8 +2125,8 @@ final class AuditLogServiceTest extends TestCase
             'crdate' => 1704067200,
             'error_message' => '',
             'reason' => '',
-            'ip_address' => '10.0.0.5',
-            'user_agent' => 'curl/8',
+            'ip_address' => self::IP_ADDRESS,
+            'user_agent' => self::USER_AGENT,
             'hash_before' => '',
             'hash_after' => '',
             'context' => '{}',
@@ -2147,8 +2153,8 @@ final class AuditLogServiceTest extends TestCase
         int $crdate = 1704067200,
         string $errorMessage = '',
         string $reason = '',
-        string $ipAddress = '10.0.0.5',
-        string $userAgent = 'curl/8',
+        string $ipAddress = self::IP_ADDRESS,
+        string $userAgent = self::USER_AGENT,
         string $hashBefore = '',
         string $hashAfter = '',
         string $context = '{}',

--- a/Tests/Unit/Command/VaultAuditCommandTest.php
+++ b/Tests/Unit/Command/VaultAuditCommandTest.php
@@ -27,6 +27,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[AllowMockObjectsWithoutExpectations]
 final class VaultAuditCommandTest extends TestCase
 {
+    private const IP_ADDRESS = '127.0.0.1';
+
     private AuditLogServiceInterface&MockObject $auditLogService;
 
     private CommandTester $commandTester;
@@ -78,7 +80,7 @@ final class VaultAuditCommandTest extends TestCase
             'actor_uid' => 1,
             'actor_username' => 'admin',
             'actor_type' => 'be_user',
-            'ip_address' => '127.0.0.1',
+            'ip_address' => self::IP_ADDRESS,
             'entry_hash' => 'abc123def456',
             'previous_hash' => 'prev123',
             'context' => '{}',
@@ -281,7 +283,7 @@ final class VaultAuditCommandTest extends TestCase
             'actor_uid' => 1,
             'actor_username' => 'admin',
             'actor_type' => 'be_user',
-            'ip_address' => '127.0.0.1',
+            'ip_address' => self::IP_ADDRESS,
             'entry_hash' => 'exporthash',
             'previous_hash' => '',
             'context' => '{}',
@@ -428,7 +430,7 @@ final class VaultAuditCommandTest extends TestCase
                 'actor_uid' => 1,
                 'actor_username' => 'admin',
                 'actor_type' => 'be_user',
-                'ip_address' => '127.0.0.1',
+                'ip_address' => self::IP_ADDRESS,
                 'entry_hash' => 'hash1',
                 'previous_hash' => '',
                 'context' => '{}',
@@ -516,7 +518,7 @@ final class VaultAuditCommandTest extends TestCase
             'actor_uid' => 1,
             'actor_username' => 'admin',
             'actor_type' => 'be_user',
-            'ip_address' => '127.0.0.1',
+            'ip_address' => self::IP_ADDRESS,
             'entry_hash' => 'csvhash',
             'previous_hash' => '',
             'context' => '{}',

--- a/Tests/Unit/Command/VaultCleanupOrphansCommandTest.php
+++ b/Tests/Unit/Command/VaultCleanupOrphansCommandTest.php
@@ -33,6 +33,16 @@ use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface
 #[AllowMockObjectsWithoutExpectations]
 final class VaultCleanupOrphansCommandTest extends TestCase
 {
+    private const MSG_NO_TCA_SECRETS = 'No TCA-sourced secrets found';
+
+    private const MSG_NO_ORPHANS = 'No orphaned secrets found';
+
+    private const IDENTIFIER = '01937b6e-4b6c-7abc-8def-0123456789ab';
+
+    private const IDENTIFIER_1 = '01937b6e-4b6c-7abc-8def-0123456789a1';
+
+    private const IDENTIFIER_2 = '01937b6e-4b6c-7abc-8def-0123456789a2';
+
     private VaultServiceInterface&MockObject $vaultService;
 
     private ConnectionPool&MockObject $connectionPool;
@@ -76,7 +86,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
         $exitCode = $this->commandTester->execute([]);
 
         self::assertSame(0, $exitCode);
-        self::assertStringContainsString('No TCA-sourced secrets found', $this->commandTester->getDisplay());
+        self::assertStringContainsString(self::MSG_NO_TCA_SECRETS, $this->commandTester->getDisplay());
     }
 
     #[Test]
@@ -89,7 +99,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
         $exitCode = $this->commandTester->execute([]);
 
         self::assertSame(0, $exitCode);
-        self::assertStringContainsString('No TCA-sourced secrets found', $this->commandTester->getDisplay());
+        self::assertStringContainsString(self::MSG_NO_TCA_SECRETS, $this->commandTester->getDisplay());
     }
 
     #[Test]
@@ -98,7 +108,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
         // Metadata must include table, field, and uid for orphan detection
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
             ),
@@ -109,7 +119,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
         $exitCode = $this->commandTester->execute([]);
 
         self::assertSame(0, $exitCode);
-        self::assertStringContainsString('No orphaned secrets found', $this->commandTester->getDisplay());
+        self::assertStringContainsString(self::MSG_NO_ORPHANS, $this->commandTester->getDisplay());
     }
 
     #[Test]
@@ -117,7 +127,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
             ),
@@ -143,12 +153,12 @@ final class VaultCleanupOrphansCommandTest extends TestCase
 
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789a1',
+                self::IDENTIFIER_1,
                 $recentOrphan,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
             ),
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789a2',
+                self::IDENTIFIER_2,
                 $oldOrphan,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 2],
             ),
@@ -172,12 +182,12 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789a1',
+                self::IDENTIFIER_1,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
             ),
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789a2',
+                self::IDENTIFIER_2,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_other', 'field' => 'secret', 'uid' => 1],
             ),
@@ -201,7 +211,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
             ),
@@ -212,7 +222,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
         $this->vaultService
             ->expects($this->once())
             ->method('delete')
-            ->with('01937b6e-4b6c-7abc-8def-0123456789ab', 'Orphan cleanup');
+            ->with(self::IDENTIFIER, 'Orphan cleanup');
 
         $this->commandTester->setInputs(['yes']);
         $exitCode = $this->commandTester->execute([]);
@@ -226,7 +236,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
             ),
@@ -250,7 +260,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
             ),
@@ -272,7 +282,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'migration', 'table' => 'tx_myext', 'field' => 'api_key', 'uid' => 1],
             ),
@@ -440,7 +450,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'key', 'uid' => 1],
             ),
@@ -450,7 +460,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
         $exitCode = $this->commandTester->execute([]);
 
         self::assertSame(0, $exitCode);
-        self::assertStringContainsString('No orphaned secrets found', $this->commandTester->getDisplay());
+        self::assertStringContainsString(self::MSG_NO_ORPHANS, $this->commandTester->getDisplay());
     }
 
     #[Test]
@@ -458,7 +468,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'key', 'uid' => 1],
             ),
@@ -506,7 +516,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
 
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 $createdAt,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'key', 'uid' => 1],
             ),
@@ -522,7 +532,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
         $display = $this->commandTester->getDisplay();
 
         if ($expectedOrphanCount === 0) {
-            self::assertStringContainsString('No orphaned secrets found', $display);
+            self::assertStringContainsString(self::MSG_NO_ORPHANS, $display);
         } else {
             self::assertStringContainsString(
                 \sprintf('Found %d orphaned secrets', $expectedOrphanCount),
@@ -554,7 +564,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => $source, 'table' => 'tx_myext', 'field' => 'key', 'uid' => 1],
             ),
@@ -568,7 +578,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
         if ($expectProcessed) {
             self::assertStringContainsString('Found 1 TCA-sourced', $display);
         } else {
-            self::assertStringContainsString('No TCA-sourced secrets found', $display);
+            self::assertStringContainsString(self::MSG_NO_TCA_SECRETS, $display);
         }
     }
 
@@ -581,7 +591,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'uid' => 1], // no 'table' key
             ),
@@ -592,7 +602,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
         $this->commandTester->setInputs(['yes']);
         $this->commandTester->execute([]);
 
-        self::assertStringContainsString('No orphaned secrets found', $this->commandTester->getDisplay());
+        self::assertStringContainsString(self::MSG_NO_ORPHANS, $this->commandTester->getDisplay());
     }
 
     /**
@@ -603,7 +613,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'key', 'uid' => 0],
             ),
@@ -614,7 +624,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
         $this->commandTester->setInputs(['yes']);
         $this->commandTester->execute([]);
 
-        self::assertStringContainsString('No orphaned secrets found', $this->commandTester->getDisplay());
+        self::assertStringContainsString(self::MSG_NO_ORPHANS, $this->commandTester->getDisplay());
     }
 
     /**
@@ -625,7 +635,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'flexform_field', 'table' => 'tt_content', 'flexField' => 'pi_flexform', 'uid' => 1],
             ),
@@ -646,7 +656,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     #[Test]
     public function dryRunListsExactIdentifierForOrphan(): void
     {
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::IDENTIFIER;
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
                 $uuid,
@@ -670,7 +680,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     #[Test]
     public function deleteFailureErrorContainsIdentifierAndMessage(): void
     {
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::IDENTIFIER;
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
                 $uuid,
@@ -701,7 +711,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     #[Test]
     public function deletePassesOrphanCleanupReasonExactly(): void
     {
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::IDENTIFIER;
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
                 $uuid,
@@ -743,7 +753,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'key', 'uid' => 1],
             ),
@@ -767,7 +777,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'key', 'uid' => 1],
             ),
@@ -792,7 +802,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     {
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
-                '01937b6e-4b6c-7abc-8def-0123456789ab',
+                self::IDENTIFIER,
                 time() - 86400 * 30,
                 ['source' => 'tca_field', 'table' => 'tx_myext', 'field' => 'key', 'uid' => 1],
             ),
@@ -810,8 +820,8 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     #[Test]
     public function summaryShowsExactDeletedAndFailedCountsOnMixedOutcome(): void
     {
-        $uuid1 = '01937b6e-4b6c-7abc-8def-0123456789a1';
-        $uuid2 = '01937b6e-4b6c-7abc-8def-0123456789a2';
+        $uuid1 = self::IDENTIFIER_1;
+        $uuid2 = self::IDENTIFIER_2;
 
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
@@ -857,7 +867,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     #[Test]
     public function liveModeDisplaysSuccessMessageAfterDeletion(): void
     {
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::IDENTIFIER;
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
                 $uuid,
@@ -1047,7 +1057,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     #[Test]
     public function displaysDeletingSectionOnLiveRun(): void
     {
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::IDENTIFIER;
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
                 $uuid,
@@ -1069,7 +1079,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     #[Test]
     public function displaysCancelledMessageOnNoConfirmation(): void
     {
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::IDENTIFIER;
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
                 $uuid,
@@ -1096,7 +1106,7 @@ final class VaultCleanupOrphansCommandTest extends TestCase
     #[Test]
     public function dryRunDisplaysWouldBeDeletedSection(): void
     {
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::IDENTIFIER;
         $this->vaultService->method('list')->willReturn([
             $this->createSecretMetadata(
                 $uuid,

--- a/Tests/Unit/Command/VaultInitCommandTest.php
+++ b/Tests/Unit/Command/VaultInitCommandTest.php
@@ -24,6 +24,8 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[AllowMockObjectsWithoutExpectations]
 final class VaultInitCommandTest extends TestCase
 {
+    private const MASTER_KEY_PATH = 'vault/master.key';
+
     private ExtensionConfigurationInterface&MockObject $configuration;
 
     private CommandTester $commandTester;
@@ -95,7 +97,7 @@ final class VaultInitCommandTest extends TestCase
             ->method('getMasterKeySource')
             ->willReturn('');
 
-        $outputFile = vfsStream::url('vault/master.key');
+        $outputFile = vfsStream::url(self::MASTER_KEY_PATH);
 
         $exitCode = $this->commandTester->execute([
             '--output' => $outputFile,
@@ -120,7 +122,7 @@ final class VaultInitCommandTest extends TestCase
             ->method('getMasterKeyProvider')
             ->willReturn('file');
 
-        $outputFile = vfsStream::url('vault/master.key');
+        $outputFile = vfsStream::url(self::MASTER_KEY_PATH);
 
         $exitCode = $this->commandTester->execute([
             '--output' => $outputFile,
@@ -144,7 +146,7 @@ final class VaultInitCommandTest extends TestCase
             ->method('getMasterKeyProvider')
             ->willReturn('file');
 
-        $outputFile = vfsStream::url('vault/master.key');
+        $outputFile = vfsStream::url(self::MASTER_KEY_PATH);
 
         $exitCode = $this->commandTester->execute([
             '--output' => $outputFile,
@@ -204,7 +206,7 @@ final class VaultInitCommandTest extends TestCase
             ->willReturn('file');
 
         $exitCode = $this->commandTester->execute([
-            '--output' => vfsStream::url('vault/master.key'),
+            '--output' => vfsStream::url(self::MASTER_KEY_PATH),
         ]);
 
         self::assertSame(0, $exitCode);

--- a/Tests/Unit/Command/VaultMigrateFieldCommandTest.php
+++ b/Tests/Unit/Command/VaultMigrateFieldCommandTest.php
@@ -41,6 +41,8 @@ use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 #[CoversClass(VaultMigrateFieldCommand::class)]
 final class VaultMigrateFieldCommandTest extends TestCase
 {
+    private const MSG_SUCCESSFULLY_MIGRATED = 'Successfully migrated';
+
     private VaultServiceInterface $vaultService;
 
     private ConnectionPool $connectionPool;
@@ -183,7 +185,7 @@ final class VaultMigrateFieldCommandTest extends TestCase
         ]);
 
         self::assertSame(0, $exitCode);
-        self::assertStringContainsString('Successfully migrated', $this->commandTester->getDisplay());
+        self::assertStringContainsString(self::MSG_SUCCESSFULLY_MIGRATED, $this->commandTester->getDisplay());
         // Use the canonical validator instead of an ad-hoc regex so the test
         // stays aligned with production's definition of "valid UUID v7".
         self::assertIsString($capturedIdentifier);
@@ -284,7 +286,7 @@ final class VaultMigrateFieldCommandTest extends TestCase
         ]);
 
         self::assertSame(0, $exitCode);
-        self::assertStringContainsString('Successfully migrated', $this->commandTester->getDisplay());
+        self::assertStringContainsString(self::MSG_SUCCESSFULLY_MIGRATED, $this->commandTester->getDisplay());
     }
 
     #[Test]
@@ -410,7 +412,7 @@ final class VaultMigrateFieldCommandTest extends TestCase
         ]);
 
         self::assertSame(0, $exitCode);
-        self::assertStringContainsString('Successfully migrated', $this->commandTester->getDisplay());
+        self::assertStringContainsString(self::MSG_SUCCESSFULLY_MIGRATED, $this->commandTester->getDisplay());
     }
 
     #[Test]
@@ -432,7 +434,7 @@ final class VaultMigrateFieldCommandTest extends TestCase
         ]);
 
         self::assertSame(0, $exitCode);
-        self::assertStringContainsString('Successfully migrated', $this->commandTester->getDisplay());
+        self::assertStringContainsString(self::MSG_SUCCESSFULLY_MIGRATED, $this->commandTester->getDisplay());
     }
 
     #[Test]

--- a/Tests/Unit/Configuration/Dto/VaultServerConfigTest.php
+++ b/Tests/Unit/Configuration/Dto/VaultServerConfigTest.php
@@ -18,6 +18,16 @@ use PHPUnit\Framework\Attributes\Test;
 #[CoversClass(VaultServerConfig::class)]
 final class VaultServerConfigTest extends TestCase
 {
+    private const ADDRESS_EXAMPLE = 'https://vault.example.com';
+
+    private const ADDRESS_INTERNAL = 'https://vault.internal';
+
+    private const ADDRESS_VAULT = 'https://vault.com';
+
+    private const PATH_SECRET_DATA = 'secret/data';
+
+    private const PATH_KV_MYAPP = 'kv/myapp';
+
     #[Test]
     public function constructorDefaultsAllPropertiesToEmptyString(): void
     {
@@ -33,14 +43,14 @@ final class VaultServerConfigTest extends TestCase
     public function constructorSetsProvidedValues(): void
     {
         $subject = new VaultServerConfig(
-            address: 'https://vault.example.com',
-            path: 'secret/data',
+            address: self::ADDRESS_EXAMPLE,
+            path: self::PATH_SECRET_DATA,
             authMethod: 'token',
             token: 's.mytoken123',
         );
 
-        self::assertSame('https://vault.example.com', $subject->address);
-        self::assertSame('secret/data', $subject->path);
+        self::assertSame(self::ADDRESS_EXAMPLE, $subject->address);
+        self::assertSame(self::PATH_SECRET_DATA, $subject->path);
         self::assertSame('token', $subject->authMethod);
         self::assertSame('s.mytoken123', $subject->token);
     }
@@ -49,14 +59,14 @@ final class VaultServerConfigTest extends TestCase
     public function fromArrayCreatesObjectWithAllFields(): void
     {
         $subject = VaultServerConfig::fromArray([
-            'address' => 'https://vault.internal',
-            'path' => 'kv/myapp',
+            'address' => self::ADDRESS_INTERNAL,
+            'path' => self::PATH_KV_MYAPP,
             'authMethod' => 'token',
             'token' => 's.abc123',
         ]);
 
-        self::assertSame('https://vault.internal', $subject->address);
-        self::assertSame('kv/myapp', $subject->path);
+        self::assertSame(self::ADDRESS_INTERNAL, $subject->address);
+        self::assertSame(self::PATH_KV_MYAPP, $subject->path);
         self::assertSame('token', $subject->authMethod);
         self::assertSame('s.abc123', $subject->token);
     }
@@ -76,11 +86,11 @@ final class VaultServerConfigTest extends TestCase
     public function fromArrayIgnoresMissingOptionalFields(): void
     {
         $subject = VaultServerConfig::fromArray([
-            'address' => 'https://vault.example.com',
+            'address' => self::ADDRESS_EXAMPLE,
             'path' => 'secret',
         ]);
 
-        self::assertSame('https://vault.example.com', $subject->address);
+        self::assertSame(self::ADDRESS_EXAMPLE, $subject->address);
         self::assertSame('secret', $subject->path);
         self::assertSame('', $subject->authMethod);
         self::assertSame('', $subject->token);
@@ -100,9 +110,9 @@ final class VaultServerConfigTest extends TestCase
 
     public static function isValidProvider(): iterable
     {
-        yield 'address and path set => valid' => ['https://vault.example.com', 'kv/data', true];
+        yield 'address and path set => valid' => [self::ADDRESS_EXAMPLE, 'kv/data', true];
         yield 'empty address => invalid' => ['', 'kv/data', false];
-        yield 'empty path => invalid' => ['https://vault.example.com', '', false];
+        yield 'empty path => invalid' => [self::ADDRESS_EXAMPLE, '', false];
         yield 'both empty => invalid' => ['', '', false];
     }
 
@@ -110,13 +120,13 @@ final class VaultServerConfigTest extends TestCase
     public function isValidIgnoresAuthMethodAndToken(): void
     {
         $withToken = new VaultServerConfig(
-            address: 'https://vault.com',
+            address: self::ADDRESS_VAULT,
             path: 'kv',
             authMethod: 'token',
             token: 's.abc',
         );
         $withoutToken = new VaultServerConfig(
-            address: 'https://vault.com',
+            address: self::ADDRESS_VAULT,
             path: 'kv',
         );
 
@@ -132,7 +142,7 @@ final class VaultServerConfigTest extends TestCase
         bool $expected,
     ): void {
         $subject = new VaultServerConfig(
-            address: 'https://vault.com',
+            address: self::ADDRESS_VAULT,
             path: 'kv',
             authMethod: $authMethod,
             token: $token,
@@ -154,15 +164,15 @@ final class VaultServerConfigTest extends TestCase
     public function toArrayReturnsCorrectStructure(): void
     {
         $subject = new VaultServerConfig(
-            address: 'https://vault.example.com',
-            path: 'kv/myapp',
+            address: self::ADDRESS_EXAMPLE,
+            path: self::PATH_KV_MYAPP,
             authMethod: 'token',
             token: 's.secret',
         );
 
         self::assertSame([
-            'address' => 'https://vault.example.com',
-            'path' => 'kv/myapp',
+            'address' => self::ADDRESS_EXAMPLE,
+            'path' => self::PATH_KV_MYAPP,
             'authMethod' => 'token',
             'token' => 's.secret',
         ], $subject->toArray());
@@ -193,8 +203,8 @@ final class VaultServerConfigTest extends TestCase
     public function fromArrayRoundTripToArray(): void
     {
         $original = [
-            'address' => 'https://vault.internal',
-            'path' => 'secret/data',
+            'address' => self::ADDRESS_INTERNAL,
+            'path' => self::PATH_SECRET_DATA,
             'authMethod' => 'token',
             'token' => 's.roundtrip',
         ];

--- a/Tests/Unit/Configuration/SiteConfigurationVaultProcessorTest.php
+++ b/Tests/Unit/Configuration/SiteConfigurationVaultProcessorTest.php
@@ -25,6 +25,8 @@ use TYPO3\CMS\Core\Site\Entity\Site;
 #[AllowMockObjectsWithoutExpectations]
 final class SiteConfigurationVaultProcessorTest extends TestCase
 {
+    private const VAULT_PLACEHOLDER = '%vault(my_key)%';
+
     private VaultServiceInterface&MockObject $vaultService;
 
     private LoggerInterface&MockObject $logger;
@@ -106,7 +108,7 @@ final class SiteConfigurationVaultProcessorTest extends TestCase
     public function processConfigurationPreservesNonVaultValues(): void
     {
         $config = [
-            'apiKey' => '%vault(my_key)%',
+            'apiKey' => self::VAULT_PLACEHOLDER,
             'regularValue' => 'not_a_vault_reference',
             'numericValue' => 42,
             'booleanValue' => true,
@@ -157,7 +159,7 @@ final class SiteConfigurationVaultProcessorTest extends TestCase
     #[Test]
     public function isVaultReferenceReturnsTrueForValidReferences(): void
     {
-        self::assertTrue($this->processor->isVaultReference('%vault(my_key)%'));
+        self::assertTrue($this->processor->isVaultReference(self::VAULT_PLACEHOLDER));
         self::assertTrue($this->processor->isVaultReference('%vault(some_long_identifier_123)%'));
     }
 
@@ -182,7 +184,7 @@ final class SiteConfigurationVaultProcessorTest extends TestCase
     #[Test]
     public function extractIdentifierReturnsIdentifier(): void
     {
-        $result = $this->processor->extractIdentifier('%vault(my_key)%');
+        $result = $this->processor->extractIdentifier(self::VAULT_PLACEHOLDER);
 
         self::assertSame('my_key', $result);
     }

--- a/Tests/Unit/Controller/AjaxControllerTest.php
+++ b/Tests/Unit/Controller/AjaxControllerTest.php
@@ -30,6 +30,10 @@ use RuntimeException;
 #[AllowMockObjectsWithoutExpectations]
 final class AjaxControllerTest extends TestCase
 {
+    private const MSG_NO_IDENTIFIER = 'No identifier provided';
+
+    private const MSG_ACCESS_DENIED = 'Access denied';
+
     private AjaxController $subject;
 
     private VaultServiceInterface&MockObject $vaultService;
@@ -58,7 +62,7 @@ final class AjaxControllerTest extends TestCase
         self::assertSame(400, $response->getStatusCode());
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
-        self::assertSame('No identifier provided', $body['error']);
+        self::assertSame(self::MSG_NO_IDENTIFIER, $body['error']);
     }
 
     #[Test]
@@ -109,14 +113,14 @@ final class AjaxControllerTest extends TestCase
 
         $this->vaultService
             ->method('retrieve')
-            ->willThrowException(new AccessDeniedException('Access denied', 1234567890));
+            ->willThrowException(new AccessDeniedException(self::MSG_ACCESS_DENIED, 1234567890));
 
         $response = $this->subject->revealAction($request);
 
         self::assertSame(403, $response->getStatusCode());
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
-        self::assertSame('Access denied', $body['error']);
+        self::assertSame(self::MSG_ACCESS_DENIED, $body['error']);
     }
 
     #[Test]
@@ -223,7 +227,7 @@ final class AjaxControllerTest extends TestCase
         self::assertSame(403, $response->getStatusCode());
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
-        self::assertSame('Access denied', $body['error']);
+        self::assertSame(self::MSG_ACCESS_DENIED, $body['error']);
     }
 
     #[Test]
@@ -255,7 +259,7 @@ final class AjaxControllerTest extends TestCase
         self::assertSame(403, $response->getStatusCode());
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
-        self::assertSame('Access denied', $body['error']);
+        self::assertSame(self::MSG_ACCESS_DENIED, $body['error']);
     }
 
     #[Test]
@@ -268,7 +272,7 @@ final class AjaxControllerTest extends TestCase
         self::assertSame(400, $response->getStatusCode());
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
-        self::assertSame('No identifier provided', $body['error']);
+        self::assertSame(self::MSG_NO_IDENTIFIER, $body['error']);
     }
 
     #[Test]
@@ -345,14 +349,14 @@ final class AjaxControllerTest extends TestCase
 
         $this->vaultService
             ->method('rotate')
-            ->willThrowException(new AccessDeniedException('Access denied', 1234567890));
+            ->willThrowException(new AccessDeniedException(self::MSG_ACCESS_DENIED, 1234567890));
 
         $response = $this->subject->rotateAction($request);
 
         self::assertSame(403, $response->getStatusCode());
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
-        self::assertSame('Access denied', $body['error']);
+        self::assertSame(self::MSG_ACCESS_DENIED, $body['error']);
     }
 
     #[Test]
@@ -463,7 +467,7 @@ final class AjaxControllerTest extends TestCase
 
         self::assertSame(400, $response->getStatusCode());
         $body = json_decode((string) $response->getBody(), true);
-        self::assertSame('No identifier provided', $body['error']);
+        self::assertSame(self::MSG_NO_IDENTIFIER, $body['error']);
     }
 
     #[Test]

--- a/Tests/Unit/Crypto/FileMasterKeyProviderTest.php
+++ b/Tests/Unit/Crypto/FileMasterKeyProviderTest.php
@@ -23,6 +23,14 @@ use PHPUnit\Framework\Attributes\Test;
 #[AllowMockObjectsWithoutExpectations]
 final class FileMasterKeyProviderTest extends TestCase
 {
+    private const MASTER_KEY_PATH = 'vault/master.key';
+
+    private const NONEXISTENT_KEY_PATH = 'vault/nonexistent.key';
+
+    private const AUTO_KEY_PATH = 'vault/auto.key';
+
+    private const INVALID_KEY_LENGTH_MESSAGE = 'Invalid master key length';
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -43,7 +51,7 @@ final class FileMasterKeyProviderTest extends TestCase
     #[Test]
     public function isAvailableReturnsTrueWhenFileExists(): void
     {
-        $keyPath = vfsStream::url('vault/master.key');
+        $keyPath = vfsStream::url(self::MASTER_KEY_PATH);
         // Use a fixed 32-byte key to avoid NUL byte issues
         file_put_contents($keyPath, base64_encode('AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH'));
 
@@ -59,7 +67,7 @@ final class FileMasterKeyProviderTest extends TestCase
     public function isAvailableReturnsFalseWhenFileDoesNotExist(): void
     {
         $config = $this->createMock(ExtensionConfigurationInterface::class);
-        $config->method('getMasterKeySource')->willReturn(vfsStream::url('vault/nonexistent.key'));
+        $config->method('getMasterKeySource')->willReturn(vfsStream::url(self::NONEXISTENT_KEY_PATH));
 
         $provider = new FileMasterKeyProvider($config);
 
@@ -82,7 +90,7 @@ final class FileMasterKeyProviderTest extends TestCase
     {
         // Use a fixed 32-byte key without NUL bytes or whitespace to avoid trim issues
         $key = 'XXXXYYYYZZZZAAAABBBBCCCCDDDDEEEE';
-        $keyPath = vfsStream::url('vault/master.key');
+        $keyPath = vfsStream::url(self::MASTER_KEY_PATH);
         file_put_contents($keyPath, base64_encode($key));
 
         $config = $this->createMock(ExtensionConfigurationInterface::class);
@@ -98,7 +106,7 @@ final class FileMasterKeyProviderTest extends TestCase
     {
         // Use a fixed 32-byte key without NUL bytes or whitespace to avoid trim issues
         $key = '12345678901234567890123456789012';
-        $keyPath = vfsStream::url('vault/master.key');
+        $keyPath = vfsStream::url(self::MASTER_KEY_PATH);
         file_put_contents($keyPath, $key);
 
         $config = $this->createMock(ExtensionConfigurationInterface::class);
@@ -114,7 +122,7 @@ final class FileMasterKeyProviderTest extends TestCase
     {
         $config = $this->createMock(ExtensionConfigurationInterface::class);
         $config->method('getMasterKeySource')->willReturn(ExtensionConfiguration::DEFAULT_MASTER_KEY_SOURCE);
-        $config->method('getAutoKeyPath')->willReturn(vfsStream::url('vault/auto.key'));
+        $config->method('getAutoKeyPath')->willReturn(vfsStream::url(self::AUTO_KEY_PATH));
 
         $provider = new FileMasterKeyProvider($config);
 
@@ -129,11 +137,11 @@ final class FileMasterKeyProviderTest extends TestCase
     {
         // Use a fixed 32-byte key without NUL bytes or whitespace to avoid trim issues
         $key = 'AAAABBBBCCCCDDDDEEEEFFFFGGGGHHHH';
-        $autoKeyPath = vfsStream::url('vault/auto.key');
+        $autoKeyPath = vfsStream::url(self::AUTO_KEY_PATH);
         file_put_contents($autoKeyPath, base64_encode($key));
 
         $config = $this->createMock(ExtensionConfigurationInterface::class);
-        $config->method('getMasterKeySource')->willReturn(vfsStream::url('vault/nonexistent.key'));
+        $config->method('getMasterKeySource')->willReturn(vfsStream::url(self::NONEXISTENT_KEY_PATH));
         $config->method('getAutoKeyPath')->willReturn($autoKeyPath);
 
         $provider = new FileMasterKeyProvider($config);
@@ -144,7 +152,7 @@ final class FileMasterKeyProviderTest extends TestCase
     #[Test]
     public function getMasterKeyThrowsWhenKeyLengthInvalid(): void
     {
-        $keyPath = vfsStream::url('vault/master.key');
+        $keyPath = vfsStream::url(self::MASTER_KEY_PATH);
         file_put_contents($keyPath, 'tooshort');
 
         $config = $this->createMock(ExtensionConfigurationInterface::class);
@@ -153,7 +161,7 @@ final class FileMasterKeyProviderTest extends TestCase
         $provider = new FileMasterKeyProvider($config);
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage('Invalid master key length');
+        $this->expectExceptionMessage(self::INVALID_KEY_LENGTH_MESSAGE);
 
         $provider->getMasterKey();
     }
@@ -178,7 +186,7 @@ final class FileMasterKeyProviderTest extends TestCase
     public function storeMasterKeyUsesAutoKeyPathWhenSourceEmpty(): void
     {
         $key = random_bytes(32);
-        $autoKeyPath = vfsStream::url('vault/auto.key');
+        $autoKeyPath = vfsStream::url(self::AUTO_KEY_PATH);
 
         $config = $this->createMock(ExtensionConfigurationInterface::class);
         $config->method('getMasterKeySource')->willReturn('');
@@ -197,7 +205,7 @@ final class FileMasterKeyProviderTest extends TestCase
         $provider = new FileMasterKeyProvider($config);
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage('Invalid master key length');
+        $this->expectExceptionMessage(self::INVALID_KEY_LENGTH_MESSAGE);
 
         $provider->storeMasterKey('tooshort');
     }
@@ -222,7 +230,7 @@ final class FileMasterKeyProviderTest extends TestCase
     {
         // Main path does not exist and auto path also does not exist
         $config = $this->createMock(ExtensionConfigurationInterface::class);
-        $config->method('getMasterKeySource')->willReturn(vfsStream::url('vault/nonexistent.key'));
+        $config->method('getMasterKeySource')->willReturn(vfsStream::url(self::NONEXISTENT_KEY_PATH));
         $config->method('getAutoKeyPath')->willReturn(vfsStream::url('vault/also-nonexistent.key'));
 
         $provider = new FileMasterKeyProvider($config);
@@ -247,7 +255,7 @@ final class FileMasterKeyProviderTest extends TestCase
         $provider = new FileMasterKeyProvider($config);
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage('Invalid master key length');
+        $this->expectExceptionMessage(self::INVALID_KEY_LENGTH_MESSAGE);
 
         $provider->getMasterKey();
     }

--- a/Tests/Unit/Domain/Dto/MigrationResultTest.php
+++ b/Tests/Unit/Domain/Dto/MigrationResultTest.php
@@ -18,6 +18,8 @@ use PHPUnit\Framework\Attributes\Test;
 #[CoversClass(MigrationResult::class)]
 final class MigrationResultTest extends TestCase
 {
+    private const SOME_ERROR = 'some error';
+
     #[Test]
     public function constructorSetsAllProperties(): void
     {
@@ -27,7 +29,7 @@ final class MigrationResultTest extends TestCase
             migrated: 10,
             failed: 2,
             skipped: 1,
-            error: 'some error',
+            error: self::SOME_ERROR,
         );
 
         self::assertSame('tt_content', $subject->table);
@@ -35,7 +37,7 @@ final class MigrationResultTest extends TestCase
         self::assertSame(10, $subject->migrated);
         self::assertSame(2, $subject->failed);
         self::assertSame(1, $subject->skipped);
-        self::assertSame('some error', $subject->error);
+        self::assertSame(self::SOME_ERROR, $subject->error);
     }
 
     #[Test]
@@ -145,7 +147,7 @@ final class MigrationResultTest extends TestCase
     #[Test]
     public function hasErrorReturnsTrueWhenErrorIsSet(): void
     {
-        $subject = MigrationResult::error('t', 'c', 'some error');
+        $subject = MigrationResult::error('t', 'c', self::SOME_ERROR);
 
         self::assertTrue($subject->hasError());
     }

--- a/Tests/Unit/Domain/Dto/SecretMetadataTest.php
+++ b/Tests/Unit/Domain/Dto/SecretMetadataTest.php
@@ -17,6 +17,8 @@ use PHPUnit\Framework\Attributes\Test;
 #[CoversClass(SecretMetadata::class)]
 final class SecretMetadataTest extends TestCase
 {
+    private const TEST_SECRET_DESCRIPTION = 'Test secret';
+
     #[Test]
     public function constructorSetsAllProperties(): void
     {
@@ -70,7 +72,7 @@ final class SecretMetadataTest extends TestCase
             'tstamp' => 1704153600,
             'read_count' => 10,
             'last_read_at' => 1704150000,
-            'description' => 'Test secret',
+            'description' => self::TEST_SECRET_DESCRIPTION,
             'version' => 2,
             'metadata' => ['key' => 'value'],
         ];
@@ -83,7 +85,7 @@ final class SecretMetadataTest extends TestCase
         self::assertEquals(1704153600, $metadata->updatedAt);
         self::assertEquals(10, $metadata->readCount);
         self::assertEquals(1704150000, $metadata->lastReadAt);
-        self::assertEquals('Test secret', $metadata->description);
+        self::assertEquals(self::TEST_SECRET_DESCRIPTION, $metadata->description);
         self::assertEquals(2, $metadata->version);
         self::assertEquals(['key' => 'value'], $metadata->metadata);
     }
@@ -116,7 +118,7 @@ final class SecretMetadataTest extends TestCase
             updatedAt: 1704153600,
             readCount: 10,
             lastReadAt: 1704150000,
-            description: 'Test secret',
+            description: self::TEST_SECRET_DESCRIPTION,
             version: 2,
             metadata: ['key' => 'value'],
         );
@@ -130,7 +132,7 @@ final class SecretMetadataTest extends TestCase
             'tstamp' => 1704153600,
             'read_count' => 10,
             'last_read_at' => 1704150000,
-            'description' => 'Test secret',
+            'description' => self::TEST_SECRET_DESCRIPTION,
             'version' => 2,
             'metadata' => ['key' => 'value'],
         ], $array);

--- a/Tests/Unit/Domain/Model/SecretTest.php
+++ b/Tests/Unit/Domain/Model/SecretTest.php
@@ -40,6 +40,8 @@ use PHPUnit\Framework\Attributes\Test;
 #[CoversClass(Secret::class)]
 final class SecretTest extends TestCase
 {
+    private const PAYMENT_GATEWAY_DESCRIPTION = 'Payment gateway API key';
+
     // ---------------------------------------------------------------
     // Constructor defaults.
     // ---------------------------------------------------------------
@@ -377,7 +379,7 @@ final class SecretTest extends TestCase
             'uid' => 42,
             'scope_pid' => 1,
             'identifier' => 'api-key',
-            'description' => 'Payment gateway API key',
+            'description' => self::PAYMENT_GATEWAY_DESCRIPTION,
             'encrypted_value' => 'base64_encrypted_data',
             'encrypted_dek' => 'base64_encrypted_dek',
             'dek_nonce' => 'base64_nonce',
@@ -407,7 +409,7 @@ final class SecretTest extends TestCase
         self::assertSame(42, $secret->getUid());
         self::assertSame(1, $secret->getScopePid());
         self::assertSame('api-key', $secret->getIdentifier());
-        self::assertSame('Payment gateway API key', $secret->getDescription());
+        self::assertSame(self::PAYMENT_GATEWAY_DESCRIPTION, $secret->getDescription());
         self::assertSame('base64_encrypted_data', $secret->getEncryptedValue());
         self::assertSame(5, $secret->getOwnerUid());
         self::assertSame([1, 2, 3], $secret->getAllowedGroups());
@@ -662,7 +664,7 @@ final class SecretTest extends TestCase
             'uid' => 42,
             'scope_pid' => 1,
             'identifier' => 'api-key',
-            'description' => 'Payment gateway API key',
+            'description' => self::PAYMENT_GATEWAY_DESCRIPTION,
             'encrypted_value' => 'enc_data',
             'encrypted_dek' => 'dek',
             'dek_nonce' => 'dn',
@@ -693,7 +695,7 @@ final class SecretTest extends TestCase
         self::assertSame(42, $secret->getUid());
         self::assertSame(1, $secret->getScopePid());
         self::assertSame('api-key', $secret->getIdentifier());
-        self::assertSame('Payment gateway API key', $secret->getDescription());
+        self::assertSame(self::PAYMENT_GATEWAY_DESCRIPTION, $secret->getDescription());
         self::assertSame('enc_data', $secret->getEncryptedValue());
         self::assertSame('dek', $secret->getEncryptedDek());
         self::assertSame('dn', $secret->getDekNonce());

--- a/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
@@ -33,6 +33,10 @@ use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 #[CoversClass(SecretRepository::class)]
 final class SecretRepositoryTest extends TestCase
 {
+    private const EXPR_EQ = 'field = ?';
+
+    private const EXPR_IN = 'field IN (?)';
+
     private SecretRepository $subject;
 
     private ConnectionPool $connectionPool;
@@ -417,7 +421,7 @@ final class SecretRepositoryTest extends TestCase
         $connectionPool = $this->createStub(ConnectionPool::class);
         $connection = $this->createStub(Connection::class);
         $expressionBuilder = $this->createStub(ExpressionBuilder::class);
-        $expressionBuilder->method('eq')->willReturn('field = ?');
+        $expressionBuilder->method('eq')->willReturn(self::EXPR_EQ);
 
         $connectionPool->method('getConnectionForTable')->willReturn($connection);
         $subject = new SecretRepository($connectionPool);
@@ -458,7 +462,7 @@ final class SecretRepositoryTest extends TestCase
         $connectionPool = $this->createStub(ConnectionPool::class);
         $connection = $this->createStub(Connection::class);
         $expressionBuilder = $this->createStub(ExpressionBuilder::class);
-        $expressionBuilder->method('eq')->willReturn('field = ?');
+        $expressionBuilder->method('eq')->willReturn(self::EXPR_EQ);
 
         $connectionPool->method('getConnectionForTable')->willReturn($connection);
         $subject = new SecretRepository($connectionPool);
@@ -585,8 +589,8 @@ final class SecretRepositoryTest extends TestCase
         $connectionPool = $this->createStub(ConnectionPool::class);
         $connection = $this->createStub(Connection::class);
         $expressionBuilder = $this->createStub(ExpressionBuilder::class);
-        $expressionBuilder->method('eq')->willReturn('field = ?');
-        $expressionBuilder->method('in')->willReturn('field IN (?)');
+        $expressionBuilder->method('eq')->willReturn(self::EXPR_EQ);
+        $expressionBuilder->method('in')->willReturn(self::EXPR_IN);
 
         $connectionPool->method('getConnectionForTable')->willReturn($connection);
         $subject = new SecretRepository($connectionPool);
@@ -663,8 +667,8 @@ final class SecretRepositoryTest extends TestCase
         $connectionPool = $this->createStub(ConnectionPool::class);
         $connection = $this->createStub(Connection::class);
         $expressionBuilder = $this->createStub(ExpressionBuilder::class);
-        $expressionBuilder->method('eq')->willReturn('field = ?');
-        $expressionBuilder->method('in')->willReturn('field IN (?)');
+        $expressionBuilder->method('eq')->willReturn(self::EXPR_EQ);
+        $expressionBuilder->method('in')->willReturn(self::EXPR_IN);
 
         $connectionPool->method('getConnectionForTable')->willReturn($connection);
 
@@ -1019,8 +1023,8 @@ final class SecretRepositoryTest extends TestCase
         $this->queryBuilder->method('executeQuery')->willReturn($result);
         $this->queryBuilder->method('createNamedParameter')->willReturn('?');
 
-        $this->expressionBuilder->method('eq')->willReturn('field = ?');
-        $this->expressionBuilder->method('in')->willReturn('field IN (?)');
+        $this->expressionBuilder->method('eq')->willReturn(self::EXPR_EQ);
+        $this->expressionBuilder->method('in')->willReturn(self::EXPR_IN);
         $this->expressionBuilder->method('gt')->willReturn('field > ?');
         $this->expressionBuilder->method('lt')->willReturn('field < ?');
         $this->expressionBuilder->method('lte')->willReturn('field <= ?');
@@ -1034,7 +1038,7 @@ final class SecretRepositoryTest extends TestCase
         $this->queryBuilder->method('executeQuery')->willReturn($result);
         $this->queryBuilder->method('createNamedParameter')->willReturn('?');
 
-        $this->expressionBuilder->method('eq')->willReturn('field = ?');
+        $this->expressionBuilder->method('eq')->willReturn(self::EXPR_EQ);
     }
 
     /**

--- a/Tests/Unit/Form/Element/VaultSecretElementTest.php
+++ b/Tests/Unit/Form/Element/VaultSecretElementTest.php
@@ -35,6 +35,14 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 #[AllowMockObjectsWithoutExpectations]
 final class VaultSecretElementTest extends TestCase
 {
+    private const FIELD_LABEL = 'API Key';
+
+    private const FIELD_DESCRIPTION = 'My field description';
+
+    private const VAULT_IDENTIFIER = '01937b6e-4b6c-7abc-8def-0123456789ab';
+
+    private const ITEM_FORM_EL_NAME = 'data[tx_test][1][api_key]';
+
     protected bool $resetSingletonInstances = true;
 
     private VaultSecretElement $subject;
@@ -146,14 +154,14 @@ final class VaultSecretElementTest extends TestCase
     {
         $langService = $this->createMock(LanguageService::class);
         $langService->method('sL')->willReturnCallback(
-            static fn (string $key): string => $key === 'My field description' ? 'My field description' : '',
+            static fn (string $key): string => $key === self::FIELD_DESCRIPTION ? self::FIELD_DESCRIPTION : '',
         );
         $GLOBALS['LANG'] = $langService;
 
         $this->setUpData([
             'fieldConf' => [
-                'label' => 'API Key',
-                'description' => 'My field description',
+                'label' => self::FIELD_LABEL,
+                'description' => self::FIELD_DESCRIPTION,
                 'config' => [
                     'type' => 'input',
                     'renderType' => 'vaultSecret',
@@ -166,7 +174,7 @@ final class VaultSecretElementTest extends TestCase
 
         self::assertIsString($result['html']);
         self::assertStringContainsString('form-description', $result['html']);
-        self::assertStringContainsString('My field description', $result['html']);
+        self::assertStringContainsString(self::FIELD_DESCRIPTION, $result['html']);
     }
 
     #[Test]
@@ -189,7 +197,7 @@ final class VaultSecretElementTest extends TestCase
 
         self::assertIsString($result['html']);
         self::assertStringContainsString('_vault_checksum', $result['html']);
-        $expectedChecksum = hash('sha256', '01937b6e-4b6c-7abc-8def-0123456789ab');
+        $expectedChecksum = hash('sha256', self::VAULT_IDENTIFIER);
         self::assertStringContainsString($expectedChecksum, $result['html']);
     }
 
@@ -265,7 +273,7 @@ final class VaultSecretElementTest extends TestCase
     {
         $this->setUpData([
             'fieldConf' => [
-                'label' => 'API Key',
+                'label' => self::FIELD_LABEL,
                 'config' => [
                     'type' => 'input',
                     'renderType' => 'vaultSecret',
@@ -286,7 +294,7 @@ final class VaultSecretElementTest extends TestCase
     {
         $this->setUpData([
             'fieldConf' => [
-                'label' => 'API Key',
+                'label' => self::FIELD_LABEL,
                 'config' => [
                     'type' => 'input',
                     'renderType' => 'vaultSecret',
@@ -342,7 +350,7 @@ final class VaultSecretElementTest extends TestCase
     #[Test]
     public function renderOutputHandlesVaultServiceExceptionGracefully(): void
     {
-        $vaultIdentifier = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $vaultIdentifier = self::VAULT_IDENTIFIER;
 
         $this->vaultService
             ->method('getMetadata')
@@ -354,10 +362,10 @@ final class VaultSecretElementTest extends TestCase
             'tableName' => 'tx_test',
             'fieldName' => 'api_key',
             'parameterArray' => [
-                'itemFormElName' => 'data[tx_test][1][api_key]',
+                'itemFormElName' => self::ITEM_FORM_EL_NAME,
                 'itemFormElValue' => $vaultIdentifier,
                 'fieldConf' => [
-                    'label' => 'API Key',
+                    'label' => self::FIELD_LABEL,
                     'config' => [
                         'type' => 'input',
                         'renderType' => 'vaultSecret',
@@ -381,7 +389,7 @@ final class VaultSecretElementTest extends TestCase
     {
         $this->setUpData([
             'fieldConf' => [
-                'label' => 'API Key',
+                'label' => self::FIELD_LABEL,
                 'config' => [
                     'type' => 'input',
                     'renderType' => 'vaultSecret',
@@ -403,10 +411,10 @@ final class VaultSecretElementTest extends TestCase
     private function setUpData(array $parameterArrayOverrides = []): void
     {
         $defaultParameterArray = [
-            'itemFormElName' => 'data[tx_test][1][api_key]',
+            'itemFormElName' => self::ITEM_FORM_EL_NAME,
             'itemFormElValue' => '',
             'fieldConf' => [
-                'label' => 'API Key',
+                'label' => self::FIELD_LABEL,
                 'config' => [
                     'type' => 'input',
                     'renderType' => 'vaultSecret',
@@ -426,7 +434,7 @@ final class VaultSecretElementTest extends TestCase
 
     private function setUpExistingSecretData(): void
     {
-        $vaultIdentifier = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $vaultIdentifier = self::VAULT_IDENTIFIER;
 
         $metadata = $this->createMock(SecretDetails::class);
         $this->vaultService
@@ -441,10 +449,10 @@ final class VaultSecretElementTest extends TestCase
             'tableName' => 'tx_test',
             'fieldName' => 'api_key',
             'parameterArray' => [
-                'itemFormElName' => 'data[tx_test][1][api_key]',
+                'itemFormElName' => self::ITEM_FORM_EL_NAME,
                 'itemFormElValue' => $vaultIdentifier,
                 'fieldConf' => [
-                    'label' => 'API Key',
+                    'label' => self::FIELD_LABEL,
                     'config' => [
                         'type' => 'input',
                         'renderType' => 'vaultSecret',

--- a/Tests/Unit/Hook/DataHandlerHookTest.php
+++ b/Tests/Unit/Hook/DataHandlerHookTest.php
@@ -38,6 +38,12 @@ final class DataHandlerHookTest extends TestCase
 {
     private const UUID_PATTERN = '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i';
 
+    private const EXISTING_UUID = '01937b6e-4b6c-7abc-8def-0123456789ab';
+
+    private const TEST_TITLE = 'Test Title';
+
+    private const STORAGE_FAILED = 'Storage failed';
+
     protected bool $resetSingletonInstances = true;
 
     protected TcaSchemaFactory&MockObject $tcaSchemaFactory;
@@ -92,7 +98,7 @@ final class DataHandlerHookTest extends TestCase
             'title' => ['type' => 'input'],
         ]);
 
-        $fieldArray = ['title' => 'Test Title'];
+        $fieldArray = ['title' => self::TEST_TITLE];
 
         $this->subject->processDatamap_preProcessFieldArray(
             $fieldArray,
@@ -100,7 +106,7 @@ final class DataHandlerHookTest extends TestCase
             1,
         );
 
-        self::assertSame(['title' => 'Test Title'], $fieldArray);
+        self::assertSame(['title' => self::TEST_TITLE], $fieldArray);
     }
 
     #[Test]
@@ -135,7 +141,7 @@ final class DataHandlerHookTest extends TestCase
             'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
         ]);
 
-        $existingUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $existingUuid = self::EXISTING_UUID;
         $fieldArray = [
             'api_key' => [
                 'value' => 'updated-secret',
@@ -251,7 +257,7 @@ final class DataHandlerHookTest extends TestCase
             'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
         ]);
 
-        $existingUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $existingUuid = self::EXISTING_UUID;
         $fieldArray = [
             'api_key' => [
                 'value' => 'updated-secret',
@@ -291,7 +297,7 @@ final class DataHandlerHookTest extends TestCase
             'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
         ]);
 
-        $existingUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $existingUuid = self::EXISTING_UUID;
         $fieldArray = [
             'api_key' => [
                 'value' => '',
@@ -348,7 +354,7 @@ final class DataHandlerHookTest extends TestCase
 
         $this->vaultService
             ->method('store')
-            ->willThrowException(new VaultException('Storage failed'));
+            ->willThrowException(new VaultException(self::STORAGE_FAILED));
 
         $this->dataHandler
             ->expects(self::once())
@@ -400,7 +406,7 @@ final class DataHandlerHookTest extends TestCase
 
         $this->vaultService
             ->method('store')
-            ->willThrowException(new VaultException('Storage failed'));
+            ->willThrowException(new VaultException(self::STORAGE_FAILED));
 
         $this->subject->processDatamap_afterDatabaseOperations(
             'update',
@@ -418,7 +424,7 @@ final class DataHandlerHookTest extends TestCase
             'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
         ]);
 
-        $existingUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $existingUuid = self::EXISTING_UUID;
 
         // Mock connection for rollback - update failure should keep existing identifier
         $connection = $this->createMock(Connection::class);
@@ -487,7 +493,7 @@ final class DataHandlerHookTest extends TestCase
 
         $this->vaultService
             ->method('store')
-            ->willThrowException(new VaultException('Storage failed'));
+            ->willThrowException(new VaultException(self::STORAGE_FAILED));
 
         $this->subject->processDatamap_afterDatabaseOperations(
             'update',
@@ -525,7 +531,7 @@ final class DataHandlerHookTest extends TestCase
 
         $this->vaultService
             ->method('store')
-            ->willThrowException(new VaultException('Storage failed'));
+            ->willThrowException(new VaultException(self::STORAGE_FAILED));
 
         $this->subject->processDatamap_afterDatabaseOperations(
             'new',
@@ -609,7 +615,7 @@ final class DataHandlerHookTest extends TestCase
         $fieldArray = [
             'api_key' => 'key-value',
             'api_secret' => 'secret-value',
-            'title' => 'Test Title',
+            'title' => self::TEST_TITLE,
         ];
 
         $this->subject->processDatamap_preProcessFieldArray(
@@ -624,7 +630,7 @@ final class DataHandlerHookTest extends TestCase
         // UUIDs should be different for each field
         self::assertNotSame($fieldArray['api_key'], $fieldArray['api_secret']);
         // Non-vault field unchanged
-        self::assertSame('Test Title', $fieldArray['title']);
+        self::assertSame(self::TEST_TITLE, $fieldArray['title']);
     }
 
     #[Test]
@@ -693,7 +699,7 @@ final class DataHandlerHookTest extends TestCase
             'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
         ]);
 
-        $existingUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $existingUuid = self::EXISTING_UUID;
         $fieldArray = [
             'api_key' => [
                 'value' => '',
@@ -815,7 +821,7 @@ final class DataHandlerHookTest extends TestCase
         ]);
 
         // Setup pending secrets via preProcess with existing UUID
-        $existingUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $existingUuid = self::EXISTING_UUID;
         $fieldArray = [
             'api_key' => [
                 'value' => 'updated-secret',
@@ -924,7 +930,7 @@ final class DataHandlerHookTest extends TestCase
             'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
         ]);
 
-        $existingUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $existingUuid = self::EXISTING_UUID;
 
         // Mock database connection
         $connection = $this->createMock(Connection::class);
@@ -959,7 +965,7 @@ final class DataHandlerHookTest extends TestCase
             'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
         ]);
 
-        $existingUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $existingUuid = self::EXISTING_UUID;
 
         // Mock database connection
         $connection = $this->createMock(Connection::class);
@@ -1069,7 +1075,7 @@ final class DataHandlerHookTest extends TestCase
             'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
         ]);
 
-        $sourceUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $sourceUuid = self::EXISTING_UUID;
 
         // Mock copy mapping
         $this->dataHandler->copyMappingArray = ['tx_test' => [42 => 100]];
@@ -1165,7 +1171,7 @@ final class DataHandlerHookTest extends TestCase
             'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
         ]);
 
-        $sourceUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $sourceUuid = self::EXISTING_UUID;
 
         $this->dataHandler->copyMappingArray = ['tx_test' => [42 => 100]];
 
@@ -1339,7 +1345,7 @@ final class DataHandlerHookTest extends TestCase
 
         $this->vaultService
             ->method('store')
-            ->willThrowException(new VaultException('Storage failed'));
+            ->willThrowException(new VaultException(self::STORAGE_FAILED));
 
         // Should not throw - rollback failure is silently caught
         $this->subject->processDatamap_afterDatabaseOperations(
@@ -1380,7 +1386,7 @@ final class DataHandlerHookTest extends TestCase
 
         $this->vaultService
             ->method('store')
-            ->willThrowException(new VaultException('Storage failed'));
+            ->willThrowException(new VaultException(self::STORAGE_FAILED));
 
         // Should not throw - flash message failure is silently caught
         $this->subject->processDatamap_afterDatabaseOperations(
@@ -1404,7 +1410,7 @@ final class DataHandlerHookTest extends TestCase
         ]);
 
         // Only 'title' is in fieldArray, 'api_key' vault field is not
-        $fieldArray = ['title' => 'Test Title'];
+        $fieldArray = ['title' => self::TEST_TITLE];
 
         $this->subject->processDatamap_preProcessFieldArray(
             $fieldArray,
@@ -1413,7 +1419,7 @@ final class DataHandlerHookTest extends TestCase
         );
 
         // Field array should remain unchanged - vault field was not present
-        self::assertSame(['title' => 'Test Title'], $fieldArray);
+        self::assertSame(['title' => self::TEST_TITLE], $fieldArray);
         self::assertArrayNotHasKey('api_key', $fieldArray);
     }
 
@@ -1424,7 +1430,7 @@ final class DataHandlerHookTest extends TestCase
             'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
         ]);
 
-        $sourceUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $sourceUuid = self::EXISTING_UUID;
 
         $this->dataHandler->copyMappingArray = ['tx_test' => [42 => 100]];
 

--- a/Tests/Unit/Hook/FlexFormVaultHookTest.php
+++ b/Tests/Unit/Hook/FlexFormVaultHookTest.php
@@ -36,6 +36,12 @@ final class FlexFormVaultHookTest extends TestCase
 {
     private const UUID_PATTERN = '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i';
 
+    private const VAULT_UUID = '01937b6e-4b6c-7abc-8def-0123456789ab';
+
+    private const EXISTING_UUID = '01234567-89ab-7cde-8f01-23456789abcd';
+
+    private const RECORD_DELETED = 'Record deleted';
+
     private ConnectionPool&MockObject $connectionPool;
 
     private TcaSchemaFactory&MockObject $tcaSchemaFactory;
@@ -370,7 +376,7 @@ final class FlexFormVaultHookTest extends TestCase
                 ],
             ]);
 
-        $existingUuid = '01234567-89ab-7cde-8f01-23456789abcd';
+        $existingUuid = self::EXISTING_UUID;
         $fieldArray = [
             'pi_flexform' => [
                 'data' => [
@@ -541,7 +547,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $GLOBALS['TCA']['tx_test']['ctrl'] = [];
 
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::VAULT_UUID;
         $xml = '<?xml version="1.0" encoding="utf-8" standalone="yes" ?><T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="settings.apiKey"><value index="vDEF">' . $uuid . '</value></field></language></sheet></data></T3FlexForms>';
 
         $this->vaultService
@@ -552,7 +558,7 @@ final class FlexFormVaultHookTest extends TestCase
         $this->vaultService
             ->expects(self::once())
             ->method('delete')
-            ->with($uuid, 'Record deleted');
+            ->with($uuid, self::RECORD_DELETED);
 
         $recordWasDeleted = false;
 
@@ -626,7 +632,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $GLOBALS['TCA']['tx_test']['ctrl'] = [];
 
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::VAULT_UUID;
         $xml = '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="key"><value index="vDEF">' . $uuid . '</value></field></language></sheet></data></T3FlexForms>';
 
         $this->vaultService->method('exists')->willReturn(true);
@@ -716,7 +722,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
 
-        $sourceUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $sourceUuid = self::VAULT_UUID;
         $xml = '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="key"><value index="vDEF">' . $sourceUuid . '</value></field></language></sheet></data></T3FlexForms>';
 
         $connection = $this->createMock(Connection::class);
@@ -762,7 +768,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
 
-        $sourceUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $sourceUuid = self::VAULT_UUID;
         $xml = '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="key"><value index="vDEF">' . $sourceUuid . '</value></field></language></sheet></data></T3FlexForms>';
 
         $connection = $this->createMock(Connection::class);
@@ -787,7 +793,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
 
-        $sourceUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $sourceUuid = self::VAULT_UUID;
         $xml = '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="key"><value index="vDEF">' . $sourceUuid . '</value></field></language></sheet></data></T3FlexForms>';
 
         $connection = $this->createMock(Connection::class);
@@ -867,7 +873,7 @@ final class FlexFormVaultHookTest extends TestCase
     {
         $this->dataHandler->substNEWwithIDs = [];
 
-        $existingUuid = '01234567-89ab-7cde-8f01-23456789abcd';
+        $existingUuid = self::EXISTING_UUID;
 
         $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
         $this->flexFormTools->method('getDataStructureIdentifier')->willReturn('test-ds');
@@ -896,7 +902,7 @@ final class FlexFormVaultHookTest extends TestCase
     {
         $this->dataHandler->substNEWwithIDs = [];
 
-        $existingUuid = '01234567-89ab-7cde-8f01-23456789abcd';
+        $existingUuid = self::EXISTING_UUID;
 
         $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
         $this->flexFormTools->method('getDataStructureIdentifier')->willReturn('test-ds');
@@ -1115,7 +1121,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $GLOBALS['TCA']['tx_test']['ctrl'] = [];
 
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::VAULT_UUID;
         $xml = '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="key"><value index="vDEF">' . $uuid . '</value></field></language></sheet></data></T3FlexForms>';
 
         $this->vaultService->method('exists')->willReturn(true);
@@ -1157,7 +1163,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
 
-        $sourceUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $sourceUuid = self::VAULT_UUID;
         $xml = '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="key"><value index="vDEF">' . $sourceUuid . '</value></field></language></sheet></data></T3FlexForms>';
 
         $connection = $this->createMock(Connection::class);
@@ -1338,7 +1344,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
 
-        $sourceUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $sourceUuid = self::VAULT_UUID;
         $xml = '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="k"><value index="vDEF">' . $sourceUuid . '</value></field></language></sheet></data></T3FlexForms>';
 
         $connection = $this->createMock(Connection::class);
@@ -1490,7 +1496,7 @@ final class FlexFormVaultHookTest extends TestCase
     {
         $this->dataHandler->substNEWwithIDs = [];
 
-        $uuid = '01234567-89ab-7cde-8f01-23456789abcd';
+        $uuid = self::EXISTING_UUID;
 
         $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
         $this->flexFormTools->method('getDataStructureIdentifier')->willReturn('ds');
@@ -1523,7 +1529,7 @@ final class FlexFormVaultHookTest extends TestCase
     {
         $this->dataHandler->substNEWwithIDs = [];
 
-        $uuid = '01234567-89ab-7cde-8f01-23456789abcd';
+        $uuid = self::EXISTING_UUID;
 
         $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
         $this->flexFormTools->method('getDataStructureIdentifier')->willReturn('ds');
@@ -1558,7 +1564,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
 
-        $sourceUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $sourceUuid = self::VAULT_UUID;
         $xml = '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="k"><value index="vDEF">' . $sourceUuid . '</value></field></language></sheet></data></T3FlexForms>';
 
         $connection = $this->createMock(Connection::class);
@@ -1594,14 +1600,14 @@ final class FlexFormVaultHookTest extends TestCase
 
         $GLOBALS['TCA']['tx_single']['ctrl'] = [];
 
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::VAULT_UUID;
         $xml = '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="k"><value index="vDEF">' . $uuid . '</value></field></language></sheet></data></T3FlexForms>';
 
         $this->vaultService->method('exists')->willReturn(true);
         $this->vaultService
             ->expects(self::once())
             ->method('delete')
-            ->with($uuid, 'Record deleted');
+            ->with($uuid, self::RECORD_DELETED);
 
         $recordWasDeleted = false;
 
@@ -1627,7 +1633,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $GLOBALS['TCA']['tx_test']['ctrl'] = [];
 
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::VAULT_UUID;
         // Same UUID appears twice — array_unique must collapse.
         $xml = '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="a"><value index="vDEF">' . $uuid . '</value></field><field index="b"><value index="vDEF">' . $uuid . '</value></field></language></sheet></data></T3FlexForms>';
 
@@ -1637,7 +1643,7 @@ final class FlexFormVaultHookTest extends TestCase
         $this->vaultService
             ->expects(self::once())
             ->method('delete')
-            ->with($uuid, 'Record deleted');
+            ->with($uuid, self::RECORD_DELETED);
 
         $recordWasDeleted = false;
 
@@ -1663,7 +1669,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $GLOBALS['TCA']['tx_test']['ctrl'] = [];
 
-        $uuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $uuid = self::VAULT_UUID;
         $xml = '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="k"><value index="vDEF">' . $uuid . '</value></field></language></sheet></data></T3FlexForms>';
 
         // Secret does NOT exist — delete must NOT be called.
@@ -1694,7 +1700,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
 
-        $sourceUuid = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $sourceUuid = self::VAULT_UUID;
         $xml = '<T3FlexForms><data><sheet index="sDEF"><language index="lDEF"><field index="key"><value index="vDEF">' . $sourceUuid . '</value></field></language></sheet></data></T3FlexForms>';
 
         $connection = $this->createMock(Connection::class);

--- a/Tests/Unit/Http/OAuth/OAuthConfigTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthConfigTest.php
@@ -21,25 +21,33 @@ use ReflectionClass;
 #[CoversClass(OAuthConfig::class)]
 final class OAuthConfigTest extends TestCase
 {
+    private const TOKEN_ENDPOINT = 'https://auth.example.com/token';
+
+    private const CLIENT_ID_SECRET = 'oauth/client-id';
+
+    private const CLIENT_SECRET_SECRET = 'oauth/client-secret';
+
+    private const REFRESH_TOKEN_SECRET = 'oauth/refresh-token';
+
     #[Test]
     public function constructorSetsAllProperties(): void
     {
         $config = new OAuthConfig(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
             grantType: 'client_credentials',
-            refreshTokenSecret: 'oauth/refresh-token',
+            refreshTokenSecret: self::REFRESH_TOKEN_SECRET,
             scopes: ['read', 'write'],
             tokenExpiryBuffer: 120,
             additionalParams: ['audience' => 'https://api.example.com'],
         );
 
-        self::assertSame('https://auth.example.com/token', $config->tokenEndpoint);
-        self::assertSame('oauth/client-id', $config->clientIdSecret);
-        self::assertSame('oauth/client-secret', $config->clientSecretSecret);
+        self::assertSame(self::TOKEN_ENDPOINT, $config->tokenEndpoint);
+        self::assertSame(self::CLIENT_ID_SECRET, $config->clientIdSecret);
+        self::assertSame(self::CLIENT_SECRET_SECRET, $config->clientSecretSecret);
         self::assertSame('client_credentials', $config->grantType);
-        self::assertSame('oauth/refresh-token', $config->refreshTokenSecret);
+        self::assertSame(self::REFRESH_TOKEN_SECRET, $config->refreshTokenSecret);
         self::assertSame(['read', 'write'], $config->scopes);
         self::assertSame(120, $config->tokenExpiryBuffer);
         self::assertSame(['audience' => 'https://api.example.com'], $config->additionalParams);
@@ -49,9 +57,9 @@ final class OAuthConfigTest extends TestCase
     public function constructorHasCorrectDefaults(): void
     {
         $config = new OAuthConfig(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         self::assertSame('client_credentials', $config->grantType);
@@ -65,15 +73,15 @@ final class OAuthConfigTest extends TestCase
     public function clientCredentialsCreatesCorrectConfig(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
             scopes: ['api.read'],
         );
 
-        self::assertSame('https://auth.example.com/token', $config->tokenEndpoint);
-        self::assertSame('oauth/client-id', $config->clientIdSecret);
-        self::assertSame('oauth/client-secret', $config->clientSecretSecret);
+        self::assertSame(self::TOKEN_ENDPOINT, $config->tokenEndpoint);
+        self::assertSame(self::CLIENT_ID_SECRET, $config->clientIdSecret);
+        self::assertSame(self::CLIENT_SECRET_SECRET, $config->clientSecretSecret);
         self::assertSame('client_credentials', $config->grantType);
         self::assertNull($config->refreshTokenSecret);
         self::assertSame(['api.read'], $config->scopes);
@@ -83,18 +91,18 @@ final class OAuthConfigTest extends TestCase
     public function refreshTokenCreatesCorrectConfig(): void
     {
         $config = OAuthConfig::refreshToken(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
-            refreshTokenSecret: 'oauth/refresh-token',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            refreshTokenSecret: self::REFRESH_TOKEN_SECRET,
             scopes: ['offline_access'],
         );
 
-        self::assertSame('https://auth.example.com/token', $config->tokenEndpoint);
-        self::assertSame('oauth/client-id', $config->clientIdSecret);
-        self::assertSame('oauth/client-secret', $config->clientSecretSecret);
+        self::assertSame(self::TOKEN_ENDPOINT, $config->tokenEndpoint);
+        self::assertSame(self::CLIENT_ID_SECRET, $config->clientIdSecret);
+        self::assertSame(self::CLIENT_SECRET_SECRET, $config->clientSecretSecret);
         self::assertSame('refresh_token', $config->grantType);
-        self::assertSame('oauth/refresh-token', $config->refreshTokenSecret);
+        self::assertSame(self::REFRESH_TOKEN_SECRET, $config->refreshTokenSecret);
         self::assertSame(['offline_access'], $config->scopes);
     }
 
@@ -102,9 +110,9 @@ final class OAuthConfigTest extends TestCase
     public function getScopesStringReturnsSpaceSeparatedScopes(): void
     {
         $config = new OAuthConfig(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
             scopes: ['read', 'write', 'admin'],
         );
 
@@ -115,9 +123,9 @@ final class OAuthConfigTest extends TestCase
     public function getScopesStringReturnsEmptyForNoScopes(): void
     {
         $config = new OAuthConfig(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
             scopes: [],
         );
 

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -41,6 +41,14 @@ use RuntimeException;
 #[AllowMockObjectsWithoutExpectations]
 final class OAuthTokenManagerTest extends TestCase
 {
+    private const TOKEN_ENDPOINT = 'https://auth.example.com/token';
+
+    private const CLIENT_ID_SECRET = 'oauth/client-id';
+
+    private const CLIENT_SECRET_SECRET = 'oauth/client-secret';
+
+    private const REFRESH_TOKEN_SECRET = 'oauth/refresh-token';
+
     private OAuthTokenManager $subject;
 
     private VaultServiceInterface&MockObject $vaultService;
@@ -80,16 +88,16 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenFetchesNewToken(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -113,16 +121,16 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenReturnsCachedToken(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -157,20 +165,20 @@ final class OAuthTokenManagerTest extends TestCase
     public function cacheKeyFragmentsOnClientSecretSecret(): void
     {
         $configA = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
             clientSecretSecret: 'oauth/client-secret-v1',
         );
         $configB = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
             clientSecretSecret: 'oauth/client-secret-v2',
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'same-client-id',
+                self::CLIENT_ID_SECRET => 'same-client-id',
                 'oauth/client-secret-v1' => 'old-secret',
                 'oauth/client-secret-v2' => 'rotated-secret',
                 default => null,
@@ -208,9 +216,9 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenRefreshesExpiredToken(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
         $config = new OAuthConfig(
             tokenEndpoint: $config->tokenEndpoint,
@@ -222,8 +230,8 @@ final class OAuthTokenManagerTest extends TestCase
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -259,14 +267,14 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenThrowsForMissingClientId(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
-            ->with('oauth/client-id')
+            ->with(self::CLIENT_ID_SECRET)
             ->willReturn(null);
 
         $this->expectException(SecretNotFoundException::class);
@@ -278,15 +286,15 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenThrowsForMissingClientSecret(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
+                self::CLIENT_ID_SECRET => 'my-client-id',
                 default => null,
             });
 
@@ -299,16 +307,16 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenThrowsForFailedRequest(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -329,16 +337,16 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenThrowsForMissingAccessToken(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -361,16 +369,16 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenHandlesHttpException(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -401,16 +409,16 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenDropsUnredactedPreviousOnClientException(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -454,17 +462,17 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenIncludesScopes(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
             scopes: ['read', 'write'],
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -537,16 +545,16 @@ final class OAuthTokenManagerTest extends TestCase
     public function clearCacheClearsAllConfigs(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -573,16 +581,16 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenThrowsForInvalidJsonResponse(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -608,19 +616,19 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenUsesRefreshTokenGrant(): void
     {
         $config = new OAuthConfig(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
             grantType: 'refresh_token',
-            refreshTokenSecret: 'oauth/refresh-token',
+            refreshTokenSecret: self::REFRESH_TOKEN_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
-                'oauth/refresh-token' => 'my-refresh-token',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
+                self::REFRESH_TOKEN_SECRET => 'my-refresh-token',
                 default => null,
             });
 
@@ -644,18 +652,18 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenThrowsForMissingRefreshToken(): void
     {
         $config = new OAuthConfig(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
             grantType: 'refresh_token',
-            refreshTokenSecret: 'oauth/refresh-token',
+            refreshTokenSecret: self::REFRESH_TOKEN_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 // refresh token returns null
                 default => null,
             });
@@ -669,17 +677,17 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenStoresNewRefreshToken(): void
     {
         $config = new OAuthConfig(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
-            refreshTokenSecret: 'oauth/refresh-token',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            refreshTokenSecret: self::REFRESH_TOKEN_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -688,7 +696,7 @@ final class OAuthTokenManagerTest extends TestCase
             ->expects(self::once())
             ->method('store')
             ->with(
-                'oauth/refresh-token',
+                self::REFRESH_TOKEN_SECRET,
                 'new-refresh-token',
                 self::callback(fn (array $meta): bool => $meta['source'] === 'oauth_refresh'),
             );
@@ -713,16 +721,16 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenUsesDefaultExpiresIn(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -746,16 +754,16 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenUsesDefaultTokenType(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -783,17 +791,17 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenIncludesAdditionalParams(): void
     {
         $config = new OAuthConfig(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
             additionalParams: ['audience' => 'https://api.example.com'],
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -818,17 +826,17 @@ final class OAuthTokenManagerTest extends TestCase
     {
         // Token expiry = now (or slightly in the past), buffer = 0 → should be refreshed
         $config = new OAuthConfig(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
             tokenExpiryBuffer: 0,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -861,16 +869,16 @@ final class OAuthTokenManagerTest extends TestCase
     public function clearTokenClearsAllCachedTokens(): void
     {
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -897,18 +905,18 @@ final class OAuthTokenManagerTest extends TestCase
     public function getAccessTokenWithRefreshTokenGrantStoresNewRefreshTokenWhenProvided(): void
     {
         $config = OAuthConfig::refreshToken(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
-            refreshTokenSecret: 'oauth/refresh-token',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            refreshTokenSecret: self::REFRESH_TOKEN_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
-                'oauth/refresh-token' => 'old-refresh-token',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
+                self::REFRESH_TOKEN_SECRET => 'old-refresh-token',
                 default => null,
             });
 
@@ -916,7 +924,7 @@ final class OAuthTokenManagerTest extends TestCase
             ->expects(self::once())
             ->method('store')
             ->with(
-                'oauth/refresh-token',
+                self::REFRESH_TOKEN_SECRET,
                 'new-refresh-token',
                 self::callback(fn (array $meta): bool => $meta['source'] === 'oauth_refresh'),
             );
@@ -949,18 +957,18 @@ final class OAuthTokenManagerTest extends TestCase
         // just obtained. The caller's current request succeeds; the next
         // refresh attempt will fall back to client_credentials.
         $config = OAuthConfig::refreshToken(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
-            refreshTokenSecret: 'oauth/refresh-token',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            refreshTokenSecret: self::REFRESH_TOKEN_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
-                'oauth/refresh-token' => 'old-refresh-token',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
+                self::REFRESH_TOKEN_SECRET => 'old-refresh-token',
                 default => null,
             });
 
@@ -1017,18 +1025,18 @@ final class OAuthTokenManagerTest extends TestCase
         );
 
         $config = OAuthConfig::refreshToken(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
-            refreshTokenSecret: 'oauth/refresh-token',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            refreshTokenSecret: self::REFRESH_TOKEN_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
-                'oauth/refresh-token' => 'old-refresh-token',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
+                self::REFRESH_TOKEN_SECRET => 'old-refresh-token',
                 default => null,
             });
         $this->vaultService
@@ -1059,17 +1067,17 @@ final class OAuthTokenManagerTest extends TestCase
         // it reveals which secrets the system uses. Log it as a short hash, not
         // the raw path.
         $config = OAuthConfig::refreshToken(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
             refreshTokenSecret: 'oauth/refresh-token-sensitive-path',
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 'oauth/refresh-token-sensitive-path' => 'old-refresh-token',
                 default => null,
             });
@@ -1112,16 +1120,16 @@ final class OAuthTokenManagerTest extends TestCase
     {
         // refreshTokenSecret = null → even if response contains refresh_token, do not store
         $config = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
-            clientIdSecret: 'oauth/client-id',
-            clientSecretSecret: 'oauth/client-secret',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
         );
 
         $this->vaultService
             ->method('retrieve')
             ->willReturnCallback(fn (string $id): ?string => match ($id) {
-                'oauth/client-id' => 'my-client-id',
-                'oauth/client-secret' => 'my-client-secret',
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
                 default => null,
             });
 
@@ -1191,15 +1199,15 @@ final class OAuthTokenManagerTest extends TestCase
         try {
             $config = OAuthConfig::clientCredentials(
                 tokenEndpoint: 'https://elsewhere.example/token',
-                clientIdSecret: 'oauth/client-id',
-                clientSecretSecret: 'oauth/client-secret',
+                clientIdSecret: self::CLIENT_ID_SECRET,
+                clientSecretSecret: self::CLIENT_SECRET_SECRET,
             );
 
             $this->vaultService
                 ->method('retrieve')
                 ->willReturnCallback(fn (string $id): string => match ($id) {
-                    'oauth/client-id' => 'cid',
-                    'oauth/client-secret' => 'csec',
+                    self::CLIENT_ID_SECRET => 'cid',
+                    self::CLIENT_SECRET_SECRET => 'csec',
                     default => '',
                 });
 

--- a/Tests/Unit/Http/OAuth/OAuthTokenTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenTest.php
@@ -22,10 +22,12 @@ use ReflectionClass;
 #[CoversClass(OAuthToken::class)]
 final class OAuthTokenTest extends TestCase
 {
+    private const EXPIRY_OFFSET = '+1 hour';
+
     #[Test]
     public function constructorSetsAllProperties(): void
     {
-        $expiresAt = new DateTimeImmutable('+1 hour');
+        $expiresAt = new DateTimeImmutable(self::EXPIRY_OFFSET);
 
         $token = new OAuthToken(
             accessToken: 'test-access-token',
@@ -46,7 +48,7 @@ final class OAuthTokenTest extends TestCase
         $token = new OAuthToken(
             accessToken: 'test-token',
             tokenType: 'Bearer',
-            expiresAt: new DateTimeImmutable('+1 hour'),
+            expiresAt: new DateTimeImmutable(self::EXPIRY_OFFSET),
         );
 
         self::assertNull($token->scope);
@@ -58,7 +60,7 @@ final class OAuthTokenTest extends TestCase
         $token = new OAuthToken(
             accessToken: 'test-token',
             tokenType: 'Bearer',
-            expiresAt: new DateTimeImmutable('+1 hour'),
+            expiresAt: new DateTimeImmutable(self::EXPIRY_OFFSET),
         );
 
         self::assertFalse($token->isExpired());
@@ -99,7 +101,7 @@ final class OAuthTokenTest extends TestCase
         $token = new OAuthToken(
             accessToken: 'my-access-token',
             tokenType: 'Bearer',
-            expiresAt: new DateTimeImmutable('+1 hour'),
+            expiresAt: new DateTimeImmutable(self::EXPIRY_OFFSET),
         );
 
         self::assertSame('Bearer my-access-token', $token->getAuthorizationHeader());
@@ -111,7 +113,7 @@ final class OAuthTokenTest extends TestCase
         $token = new OAuthToken(
             accessToken: 'my-token',
             tokenType: 'MAC',
-            expiresAt: new DateTimeImmutable('+1 hour'),
+            expiresAt: new DateTimeImmutable(self::EXPIRY_OFFSET),
         );
 
         self::assertSame('MAC my-token', $token->getAuthorizationHeader());

--- a/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
@@ -40,6 +40,12 @@ use TypeError;
 #[CoversClass(SecureHttpClientFactory::class)]
 final class SecureHttpClientFactoryRebindingTest extends TestCase
 {
+    private const METADATA_IP = '169.254.169.254';
+
+    private const DOCKER_IP = '172.18.0.5';
+
+    private const PUBLIC_IP = '93.184.216.34';
+
     private SecureHttpClientFactory $subject;
 
     private InMemoryDnsResolver $dnsResolver;
@@ -70,7 +76,7 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
     {
         // IPv4 and IPv6 literals are validated by isHostAllowed() — the
         // middleware doesn't need to add a pin entry.
-        self::assertSame([], $this->callBuildResolveEntries('93.184.216.34', 443));
+        self::assertSame([], $this->callBuildResolveEntries(self::PUBLIC_IP, 443));
         self::assertSame([], $this->callBuildResolveEntries('::1', 443));
     }
 
@@ -87,7 +93,7 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
     #[Test]
     public function buildResolveEntriesPinsSafeIpv4(): void
     {
-        $this->dnsResolver->program('api.example.com', [['ip' => '93.184.216.34']]);
+        $this->dnsResolver->program('api.example.com', [['ip' => self::PUBLIC_IP]]);
 
         $entries = $this->callBuildResolveEntries('api.example.com', 443);
 
@@ -113,8 +119,8 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
         // dangerous answer must kill the request — curl could otherwise pick
         // the internal one and we'd leak.
         $this->dnsResolver->program('rebind.example.com', [
-            ['ip' => '93.184.216.34'],
-            ['ip' => '169.254.169.254'], // AWS metadata
+            ['ip' => self::PUBLIC_IP],
+            ['ip' => self::METADATA_IP], // AWS metadata
         ]);
 
         $entries = $this->callBuildResolveEntries('rebind.example.com', 443);
@@ -130,7 +136,7 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
         // resolves to a private IP. With the allowlist flag set, the request
         // is NOT rejected — the resolved IP is pinned so a later rebind to a
         // different address is still blocked.
-        $this->dnsResolver->program('ollama', [['ip' => '172.18.0.5']]);
+        $this->dnsResolver->program('ollama', [['ip' => self::DOCKER_IP]]);
 
         $entries = $this->callBuildResolveEntries('ollama', 11434, true);
 
@@ -142,7 +148,7 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
     {
         // Same host, but without the allowlist opt-in: the private-IP guard
         // still rejects (this is the request-time middleware's default).
-        $this->dnsResolver->program('ollama', [['ip' => '172.18.0.5']]);
+        $this->dnsResolver->program('ollama', [['ip' => self::DOCKER_IP]]);
 
         $entries = $this->callBuildResolveEntries('ollama', 11434);
 
@@ -156,7 +162,7 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
         // middleware reach a private-resolving host instead of throwing — this
         // is the gap that 0.6.0 left open (the middleware ignored allowed_hosts).
         $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'] = ['ollama'];
-        $this->dnsResolver->program('ollama', [['ip' => '172.18.0.5']]);
+        $this->dnsResolver->program('ollama', [['ip' => self::DOCKER_IP]]);
         $client = $this->buildCapturingClient($capturedOptions);
 
         $client->get('http://ollama:11434/api/tags');
@@ -173,7 +179,7 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
         // Wildcards must NEVER bypass the private-IP guard: a wildcard owner
         // could register an internal DNS record under their zone and pivot.
         $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'] = ['*.example'];
-        $this->dnsResolver->program('evil.example', [['ip' => '169.254.169.254']]);
+        $this->dnsResolver->program('evil.example', [['ip' => self::METADATA_IP]]);
         $client = $this->buildCapturingClient($capturedOptions);
 
         $this->expectException(RequestException::class);
@@ -210,7 +216,7 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
     #[Test]
     public function middlewareRejectsRequestToHostResolvingToDangerousIp(): void
     {
-        $this->dnsResolver->program('attacker.example', [['ip' => '169.254.169.254']]);
+        $this->dnsResolver->program('attacker.example', [['ip' => self::METADATA_IP]]);
         $client = $this->buildCapturingClient($capturedOptions);
 
         $this->expectException(RequestException::class);
@@ -222,7 +228,7 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
     #[Test]
     public function middlewareAddsCurlResolvePinForResolvedHost(): void
     {
-        $this->dnsResolver->program('safe.example', [['ip' => '93.184.216.34']]);
+        $this->dnsResolver->program('safe.example', [['ip' => self::PUBLIC_IP]]);
         $client = $this->buildCapturingClient($capturedOptions);
 
         $client->get('https://safe.example/api');
@@ -245,7 +251,7 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
         // Verified indirectly: send to a bracketed FQDN-style host that
         // resolves via the in-memory resolver. If normalisation runs, the
         // resolver receives the bare host and the pin is generated.
-        $this->dnsResolver->program('safe.example', [['ip' => '93.184.216.34']]);
+        $this->dnsResolver->program('safe.example', [['ip' => self::PUBLIC_IP]]);
         $client = $this->buildCapturingClient($capturedOptions);
 
         $client->get('http://safe.example/api');

--- a/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
@@ -21,6 +21,8 @@ use PHPUnit\Framework\Attributes\Test;
 #[CoversClass(SecureHttpClientFactory::class)]
 final class SecureHttpClientFactorySsrfTest extends TestCase
 {
+    private const PRIVATE_IP = '10.0.0.42';
+
     private SecureHttpClientFactory $subject;
 
     private mixed $originalGlobals;
@@ -118,10 +120,10 @@ final class SecureHttpClientFactorySsrfTest extends TestCase
         // On-prem use case: vault server on RFC1918 must be reachable via
         // an explicit filesystem-only allowlist entry.
         $GLOBALS['TYPO3_CONF_VARS'] = [
-            'HTTP' => ['allowed_hosts' => ['10.0.0.42']],
+            'HTTP' => ['allowed_hosts' => [self::PRIVATE_IP]],
         ];
 
-        self::assertTrue($this->subject->isHostAllowed('10.0.0.42'));
+        self::assertTrue($this->subject->isHostAllowed(self::PRIVATE_IP));
     }
 
     #[Test]
@@ -133,7 +135,7 @@ final class SecureHttpClientFactorySsrfTest extends TestCase
             'HTTP' => ['allowed_hosts' => ['*.internal']],
         ];
 
-        self::assertFalse($this->subject->isHostAllowed('10.0.0.42'));
+        self::assertFalse($this->subject->isHostAllowed(self::PRIVATE_IP));
     }
 
     #[Test]
@@ -141,7 +143,7 @@ final class SecureHttpClientFactorySsrfTest extends TestCase
     {
         // Listing 10.0.0.42 must NOT implicitly allow 10.0.0.43.
         $GLOBALS['TYPO3_CONF_VARS'] = [
-            'HTTP' => ['allowed_hosts' => ['10.0.0.42']],
+            'HTTP' => ['allowed_hosts' => [self::PRIVATE_IP]],
         ];
 
         self::assertFalse($this->subject->isHostAllowed('10.0.0.43'));

--- a/Tests/Unit/Http/VaultHttpClientTest.php
+++ b/Tests/Unit/Http/VaultHttpClientTest.php
@@ -36,6 +36,12 @@ use ReflectionClass;
 #[AllowMockObjectsWithoutExpectations]
 final class VaultHttpClientTest extends TestCase
 {
+    private const API_URL = 'https://api.example.com/data';
+
+    private const TOKEN_ENDPOINT = 'https://auth.example.com/token';
+
+    private const CONTENT_TYPE_JSON = 'application/json';
+
     /** @phpstan-ignore property.uninitialized */
     private VaultServiceInterface&MockObject $vaultService;
 
@@ -88,7 +94,7 @@ final class VaultHttpClientTest extends TestCase
             $this->innerClient,
         );
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $response = $client->sendRequest($request);
 
         self::assertSame(200, $response->getStatusCode());
@@ -134,7 +140,7 @@ final class VaultHttpClientTest extends TestCase
 
         $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::Bearer);
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $response = $authenticatedClient->sendRequest($request);
 
         self::assertSame(200, $response->getStatusCode());
@@ -165,7 +171,7 @@ final class VaultHttpClientTest extends TestCase
 
         $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::ApiKey);
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $authenticatedClient->sendRequest($request);
     }
 
@@ -198,7 +204,7 @@ final class VaultHttpClientTest extends TestCase
             ['headerName' => 'X-Custom-Auth'],
         );
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $authenticatedClient->sendRequest($request);
     }
 
@@ -228,7 +234,7 @@ final class VaultHttpClientTest extends TestCase
 
         $authenticatedClient = $client->withAuthentication('my_credentials', SecretPlacement::BasicAuth);
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $authenticatedClient->sendRequest($request);
     }
 
@@ -264,7 +270,7 @@ final class VaultHttpClientTest extends TestCase
             ['usernameSecret' => 'my_username'],
         );
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $authenticatedClient->sendRequest($request);
     }
 
@@ -293,7 +299,7 @@ final class VaultHttpClientTest extends TestCase
 
         $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::QueryParam);
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $authenticatedClient->sendRequest($request);
     }
 
@@ -326,7 +332,7 @@ final class VaultHttpClientTest extends TestCase
             ['queryParam' => 'access_token'],
         );
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $authenticatedClient->sendRequest($request);
     }
 
@@ -377,7 +383,7 @@ final class VaultHttpClientTest extends TestCase
 
         $authenticatedClient = $client->withAuthentication('nonexistent_key', SecretPlacement::Bearer);
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
 
         $this->expectException(SecretNotFoundException::class);
         $authenticatedClient->sendRequest($request);
@@ -417,7 +423,7 @@ final class VaultHttpClientTest extends TestCase
             ->withAuthentication('my_key', SecretPlacement::Bearer)
             ->withReason('Custom audit reason');
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $authenticatedClient->sendRequest($request);
     }
 
@@ -433,7 +439,7 @@ final class VaultHttpClientTest extends TestCase
             ->method('sendRequest')
             ->willReturnCallback(function (RequestInterface $request): Response {
                 // Original headers should be preserved
-                self::assertSame('application/json', $request->getHeaderLine('Content-Type'));
+                self::assertSame(self::CONTENT_TYPE_JSON, $request->getHeaderLine('Content-Type'));
                 self::assertSame('CustomAgent', $request->getHeaderLine('User-Agent'));
                 // Auth header should be added
                 self::assertSame('Bearer token', $request->getHeaderLine('Authorization'));
@@ -449,8 +455,8 @@ final class VaultHttpClientTest extends TestCase
 
         $authenticatedClient = $client->withAuthentication('my_key', SecretPlacement::Bearer);
 
-        $request = new Request('POST', 'https://api.example.com/data', [
-            'Content-Type' => 'application/json',
+        $request = new Request('POST', self::API_URL, [
+            'Content-Type' => self::CONTENT_TYPE_JSON,
             'User-Agent' => 'CustomAgent',
         ]);
 
@@ -498,7 +504,7 @@ final class VaultHttpClientTest extends TestCase
 
         $authenticatedClient = $client->withAuthentication('my_key', SecretPlacement::Bearer);
 
-        $request = new Request('POST', 'https://api.example.com/data');
+        $request = new Request('POST', self::API_URL);
         $authenticatedClient->sendRequest($request);
     }
 
@@ -556,8 +562,8 @@ final class VaultHttpClientTest extends TestCase
 
         $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::BodyField);
 
-        $request = new Request('POST', 'https://api.example.com/data', [
-            'Content-Type' => 'application/json',
+        $request = new Request('POST', self::API_URL, [
+            'Content-Type' => self::CONTENT_TYPE_JSON,
         ], json_encode(['field' => 'existing']));
 
         $authenticatedClient->sendRequest($request);
@@ -591,7 +597,7 @@ final class VaultHttpClientTest extends TestCase
 
         $authenticatedClient = $client->withAuthentication('my_secret', SecretPlacement::BodyField);
 
-        $request = new Request('POST', 'https://api.example.com/data', [
+        $request = new Request('POST', self::API_URL, [
             'Content-Type' => 'application/x-www-form-urlencoded',
         ], 'other_field=existing_value');
 
@@ -629,8 +635,8 @@ final class VaultHttpClientTest extends TestCase
             ['bodyField' => 'access_token'],
         );
 
-        $request = new Request('POST', 'https://api.example.com/data', [
-            'Content-Type' => 'application/json',
+        $request = new Request('POST', self::API_URL, [
+            'Content-Type' => self::CONTENT_TYPE_JSON,
         ], '{}');
 
         $authenticatedClient->sendRequest($request);
@@ -672,7 +678,7 @@ final class VaultHttpClientTest extends TestCase
 
         $authenticatedClient = $client->withAuthentication('my_key', SecretPlacement::Bearer);
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
 
         $this->expectException(ClientExceptionInterface::class);
         $authenticatedClient->sendRequest($request);
@@ -688,7 +694,7 @@ final class VaultHttpClientTest extends TestCase
         );
 
         $oauthConfig = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
             clientIdSecret: 'oauth/client-id',
             clientSecretSecret: 'oauth/client-secret',
         );
@@ -709,7 +715,7 @@ final class VaultHttpClientTest extends TestCase
         );
 
         $oauthConfig = OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
             clientIdSecret: 'oauth/client-id',
             clientSecretSecret: 'oauth/client-secret',
         );
@@ -739,7 +745,7 @@ final class VaultHttpClientTest extends TestCase
             $this->innerClient,
         );
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $response = $client->sendRequest($request);
 
         self::assertSame(200, $response->getStatusCode());
@@ -769,7 +775,7 @@ final class VaultHttpClientTest extends TestCase
             $this->innerClient,
         );
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $client->sendRequest($request);
     }
 
@@ -800,7 +806,7 @@ final class VaultHttpClientTest extends TestCase
         // Header placement without custom headerName
         $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::Header);
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $authenticatedClient->sendRequest($request);
     }
 
@@ -832,8 +838,8 @@ final class VaultHttpClientTest extends TestCase
         $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::BodyField);
 
         // JSON request with empty body
-        $request = new Request('POST', 'https://api.example.com/data', [
-            'Content-Type' => 'application/json',
+        $request = new Request('POST', self::API_URL, [
+            'Content-Type' => self::CONTENT_TYPE_JSON,
         ], '');
 
         $authenticatedClient->sendRequest($request);
@@ -867,7 +873,7 @@ final class VaultHttpClientTest extends TestCase
         $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::BodyField);
 
         // Form request with empty body
-        $request = new Request('POST', 'https://api.example.com/data', [
+        $request = new Request('POST', self::API_URL, [
             'Content-Type' => 'application/x-www-form-urlencoded',
         ], '');
 
@@ -947,7 +953,7 @@ final class VaultHttpClientTest extends TestCase
                 $this->innerClient,
             );
 
-            $request = new Request('GET', 'https://api.example.com/data');
+            $request = new Request('GET', self::API_URL);
             $response = $client->sendRequest($request);
 
             self::assertSame(200, $response->getStatusCode());
@@ -992,7 +998,7 @@ final class VaultHttpClientTest extends TestCase
             ->withAuthentication('my_key', SecretPlacement::Bearer)
             ->withReason('Updated reason');
 
-        $request = new Request('GET', 'https://api.example.com/data');
+        $request = new Request('GET', self::API_URL);
         $authenticatedClient->sendRequest($request);
     }
 
@@ -1022,7 +1028,7 @@ final class VaultHttpClientTest extends TestCase
 
         $afterAuth = $client->withAuthentication('my_key', SecretPlacement::Bearer);
         $afterOAuth = $client->withOAuth(OAuthConfig::clientCredentials(
-            tokenEndpoint: 'https://auth.example.com/token',
+            tokenEndpoint: self::TOKEN_ENDPOINT,
             clientIdSecret: 'cid',
             clientSecretSecret: 'csec',
         ));

--- a/Tests/Unit/Http/VaultHttpResponseTest.php
+++ b/Tests/Unit/Http/VaultHttpResponseTest.php
@@ -24,6 +24,10 @@ use Psr\Http\Message\StreamInterface;
 #[AllowMockObjectsWithoutExpectations]
 final class VaultHttpResponseTest extends TestCase
 {
+    private const CONTENT_TYPE_JSON = 'application/json';
+
+    private const CONTENT_TYPE_HTML = 'text/html';
+
     #[Test]
     public function getStatusCodeReturnsResponseStatusCode(): void
     {
@@ -251,11 +255,11 @@ final class VaultHttpResponseTest extends TestCase
     public function getHeaderReturnsFirstHeaderValue(): void
     {
         $psrResponse = $this->createMock(ResponseInterface::class);
-        $psrResponse->method('getHeader')->with('Content-Type')->willReturn(['application/json', 'charset=utf-8']);
+        $psrResponse->method('getHeader')->with('Content-Type')->willReturn([self::CONTENT_TYPE_JSON, 'charset=utf-8']);
 
         $response = new VaultHttpResponse($psrResponse);
 
-        self::assertSame('application/json', $response->getHeader('Content-Type'));
+        self::assertSame(self::CONTENT_TYPE_JSON, $response->getHeader('Content-Type'));
     }
 
     #[Test]
@@ -273,11 +277,11 @@ final class VaultHttpResponseTest extends TestCase
     public function getHeaderValuesReturnsAllValues(): void
     {
         $psrResponse = $this->createMock(ResponseInterface::class);
-        $psrResponse->method('getHeader')->with('Accept')->willReturn(['application/json', 'text/html']);
+        $psrResponse->method('getHeader')->with('Accept')->willReturn([self::CONTENT_TYPE_JSON, self::CONTENT_TYPE_HTML]);
 
         $response = new VaultHttpResponse($psrResponse);
 
-        self::assertSame(['application/json', 'text/html'], $response->getHeaderValues('Accept'));
+        self::assertSame([self::CONTENT_TYPE_JSON, self::CONTENT_TYPE_HTML], $response->getHeaderValues('Accept'));
     }
 
     #[Test]
@@ -290,7 +294,7 @@ final class VaultHttpResponseTest extends TestCase
 
         $response = new VaultHttpResponse($psrResponse);
 
-        self::assertSame('application/json', $response->getContentType());
+        self::assertSame(self::CONTENT_TYPE_JSON, $response->getContentType());
     }
 
     #[Test]
@@ -299,7 +303,7 @@ final class VaultHttpResponseTest extends TestCase
         $jsonResponse = $this->createMock(ResponseInterface::class);
         $jsonResponse->method('getHeader')
             ->with('Content-Type')
-            ->willReturn(['application/json']);
+            ->willReturn([self::CONTENT_TYPE_JSON]);
 
         $apiResponse = $this->createMock(ResponseInterface::class);
         $apiResponse->method('getHeader')
@@ -309,7 +313,7 @@ final class VaultHttpResponseTest extends TestCase
         $htmlResponse = $this->createMock(ResponseInterface::class);
         $htmlResponse->method('getHeader')
             ->with('Content-Type')
-            ->willReturn(['text/html']);
+            ->willReturn([self::CONTENT_TYPE_HTML]);
 
         self::assertTrue((new VaultHttpResponse($jsonResponse))->isJson());
         self::assertTrue((new VaultHttpResponse($apiResponse))->isJson());
@@ -381,7 +385,7 @@ final class VaultHttpResponseTest extends TestCase
     public function getHeadersReturnsAllHeaders(): void
     {
         $headers = [
-            'Content-Type' => ['application/json'],
+            'Content-Type' => [self::CONTENT_TYPE_JSON],
             'X-Custom' => ['value1', 'value2'],
         ];
 

--- a/Tests/Unit/Service/Detection/ConfigSecretFindingTest.php
+++ b/Tests/Unit/Service/Detection/ConfigSecretFindingTest.php
@@ -19,11 +19,15 @@ use PHPUnit\Framework\Attributes\Test;
 #[CoversClass(ConfigSecretFinding::class)]
 final class ConfigSecretFindingTest extends TestCase
 {
+    private const SYS_KEY_PATH = 'SYS/key';
+
+    private const CUSTOM_MESSAGE = 'Custom message';
+
     #[Test]
     public function implementsSecretFinding(): void
     {
         $finding = new ConfigSecretFinding(
-            path: 'SYS/key',
+            path: self::SYS_KEY_PATH,
             severity: Severity::High,
             isLocalConfiguration: true,
         );
@@ -39,14 +43,14 @@ final class ConfigSecretFindingTest extends TestCase
             severity: Severity::Critical,
             isLocalConfiguration: false,
             patterns: ['API Key'],
-            message: 'Custom message',
+            message: self::CUSTOM_MESSAGE,
         );
 
         self::assertEquals('EXTENSIONS/my_ext/apiKey', $finding->path);
         self::assertEquals(Severity::Critical, $finding->severity);
         self::assertFalse($finding->isLocalConfiguration);
         self::assertEquals(['API Key'], $finding->patterns);
-        self::assertEquals('Custom message', $finding->message);
+        self::assertEquals(self::CUSTOM_MESSAGE, $finding->message);
     }
 
     #[Test]
@@ -164,7 +168,7 @@ final class ConfigSecretFindingTest extends TestCase
     public function jsonSerializeReturnsCorrectStructureForLocalConfig(): void
     {
         $finding = new ConfigSecretFinding(
-            path: 'SYS/key',
+            path: self::SYS_KEY_PATH,
             severity: Severity::High,
             isLocalConfiguration: true,
             patterns: ['Secret'],
@@ -173,7 +177,7 @@ final class ConfigSecretFindingTest extends TestCase
         $json = $finding->jsonSerialize();
 
         self::assertEquals('LocalConfiguration', $json['source']);
-        self::assertEquals('SYS/key', $json['path']);
+        self::assertEquals(self::SYS_KEY_PATH, $json['path']);
         self::assertEquals('high', $json['severity']);
         self::assertEquals(['Secret'], $json['patterns']);
         self::assertArrayNotHasKey('message', $json);
@@ -200,13 +204,13 @@ final class ConfigSecretFindingTest extends TestCase
             path: 'path',
             severity: Severity::High,
             isLocalConfiguration: true,
-            message: 'Custom message',
+            message: self::CUSTOM_MESSAGE,
         );
 
         $json = $finding->jsonSerialize();
 
         self::assertArrayHasKey('message', $json);
-        self::assertEquals('Custom message', $json['message']);
+        self::assertEquals(self::CUSTOM_MESSAGE, $json['message']);
     }
 
     #[Test]

--- a/Tests/Unit/Service/SecretDetectionServiceTest.php
+++ b/Tests/Unit/Service/SecretDetectionServiceTest.php
@@ -40,6 +40,8 @@ use TYPO3\CMS\Core\Package\PackageManager;
 #[AllowMockObjectsWithoutExpectations]
 final class SecretDetectionServiceTest extends TestCase
 {
+    private const UUID_V7 = '01937b6e-4b6c-7abc-8def-0123456789ab';
+
     private ConnectionPool&MockObject $connectionPool;
 
     private PackageManager&MockObject $packageManager;
@@ -205,7 +207,7 @@ final class SecretDetectionServiceTest extends TestCase
     public static function vaultIdentifierProvider(): array
     {
         return [
-            'UUID v7 format' => ['01937b6e-4b6c-7abc-8def-0123456789ab', true],
+            'UUID v7 format' => [self::UUID_V7, true],
             'vault reference' => ['%vault(my_secret_key)%', true],
             'old TCA format (no longer detected)' => ['tx_myext_config__api_key__123', false],
             'regular value' => ['some_regular_value', false],
@@ -473,7 +475,7 @@ final class SecretDetectionServiceTest extends TestCase
             ->with('test_ext')
             ->willReturn([
                 'apiKey' => '%vault(my_api_key)%',
-                'password' => '01937b6e-4b6c-7abc-8def-0123456789ab', // UUID v7
+                'password' => self::UUID_V7, // UUID v7
             ]);
 
         $this->service->scanExtensionConfiguration();
@@ -851,7 +853,7 @@ final class SecretDetectionServiceTest extends TestCase
         // All samples are vault identifiers — should NOT be flagged
         $sampleResult = $this->createMock(Result::class);
         $sampleResult->method('fetchAllAssociative')->willReturn([
-            ['api_token' => '01937b6e-4b6c-7abc-8def-0123456789ab'],
+            ['api_token' => self::UUID_V7],
         ]);
 
         $countQb = $this->createMock(QueryBuilder::class);

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -37,6 +37,10 @@ use PHPUnit\Framework\MockObject\MockObject;
 #[AllowMockObjectsWithoutExpectations]
 final class VaultServiceTest extends TestCase
 {
+    private const TEST_DESCRIPTION = 'Test description';
+
+    private const AUDIT_WRITE_ERROR = 'audit down';
+
     private VaultService $subject;
 
     private VaultAdapterInterface&MockObject $adapter;
@@ -586,7 +590,7 @@ final class VaultServiceTest extends TestCase
         $secret = $this->createSecretEntity(
             $identifier,
             version: 3,
-            description: 'Test description',
+            description: self::TEST_DESCRIPTION,
             context: 'testing',
             metadata: ['key' => 'value'],
         );
@@ -602,7 +606,7 @@ final class VaultServiceTest extends TestCase
         $result = $this->subject->getMetadata($identifier);
 
         self::assertEquals($identifier, $result->identifier);
-        self::assertEquals('Test description', $result->description);
+        self::assertEquals(self::TEST_DESCRIPTION, $result->description);
         self::assertEquals('testing', $result->context);
         self::assertEquals(3, $result->version);
         self::assertEquals(['key' => 'value'], $result->metadata);
@@ -661,7 +665,7 @@ final class VaultServiceTest extends TestCase
             ->expects(self::once())
             ->method('store')
             ->with(self::callback(static fn (Secret $s): bool => $s->getOwnerUid() === 5
-                && $s->getDescription() === 'Test description'
+                && $s->getDescription() === self::TEST_DESCRIPTION
                 && $s->getContext() === 'testing'
                 && $s->getScopePid() === 100
                 && $s->isFrontendAccessible()
@@ -672,7 +676,7 @@ final class VaultServiceTest extends TestCase
             'owner' => 5,
             'groups' => [1, 2, 3],
             'context' => 'testing',
-            'description' => 'Test description',
+            'description' => self::TEST_DESCRIPTION,
             'metadata' => ['key' => 'value'],
             'scopePid' => 100,
             'expiresAt' => $expiresAt,
@@ -989,7 +993,7 @@ final class VaultServiceTest extends TestCase
         // the just-inserted record so it never persists without an audit entry.
         $this->auditLogService
             ->method('log')
-            ->willThrowException(new AuditWriteException('audit down', 1747825331));
+            ->willThrowException(new AuditWriteException(self::AUDIT_WRITE_ERROR, 1747825331));
 
         $this->adapter
             ->expects(self::once())
@@ -1015,7 +1019,7 @@ final class VaultServiceTest extends TestCase
 
         $this->auditLogService
             ->method('log')
-            ->willThrowException(new AuditWriteException('audit down', 1747825331));
+            ->willThrowException(new AuditWriteException(self::AUDIT_WRITE_ERROR, 1747825331));
 
         // On update, the compensating action restores the prior instance:
         // store() is called twice — once for the mutation, once to restore.
@@ -1051,7 +1055,7 @@ final class VaultServiceTest extends TestCase
 
         $this->auditLogService
             ->method('log')
-            ->willThrowException(new AuditWriteException('audit down', 1747825331));
+            ->willThrowException(new AuditWriteException(self::AUDIT_WRITE_ERROR, 1747825331));
 
         // Compensating action: re-insert the just-deleted record.
         $this->adapter
@@ -1079,7 +1083,7 @@ final class VaultServiceTest extends TestCase
 
         $this->auditLogService
             ->method('log')
-            ->willThrowException(new AuditWriteException('audit down', 1747825331));
+            ->willThrowException(new AuditWriteException(self::AUDIT_WRITE_ERROR, 1747825331));
 
         // store() called twice: rotated value, then compensating restore of
         // the pre-rotation instance.

--- a/Tests/Unit/TCA/VaultFieldHelperTest.php
+++ b/Tests/Unit/TCA/VaultFieldHelperTest.php
@@ -15,6 +15,8 @@ use PHPUnit\Framework\Attributes\Test;
 
 final class VaultFieldHelperTest extends TestCase
 {
+    private const LABEL_API_KEY = 'API Key';
+
     protected bool $resetSingletonInstances = true;
 
     #[Test]
@@ -31,9 +33,9 @@ final class VaultFieldHelperTest extends TestCase
     #[Test]
     public function getFieldConfigAcceptsLabel(): void
     {
-        $config = VaultFieldHelper::getFieldConfig(['label' => 'API Key']);
+        $config = VaultFieldHelper::getFieldConfig(['label' => self::LABEL_API_KEY]);
 
-        self::assertSame('API Key', $config['label']);
+        self::assertSame(self::LABEL_API_KEY, $config['label']);
     }
 
     #[Test]
@@ -107,9 +109,9 @@ final class VaultFieldHelperTest extends TestCase
     #[Test]
     public function getSecureFieldConfigIncludesDefaults(): void
     {
-        $config = VaultFieldHelper::getSecureFieldConfig('API Key');
+        $config = VaultFieldHelper::getSecureFieldConfig(self::LABEL_API_KEY);
 
-        self::assertSame('API Key', $config['label']);
+        self::assertSame(self::LABEL_API_KEY, $config['label']);
         self::assertTrue($config['exclude']);
         self::assertSame('exclude', $config['l10n_mode']);
         self::assertSame('vaultSecret', $config['config']['renderType']);
@@ -118,7 +120,7 @@ final class VaultFieldHelperTest extends TestCase
     #[Test]
     public function getSecureFieldConfigAllowsOverrides(): void
     {
-        $config = VaultFieldHelper::getSecureFieldConfig('API Key', [
+        $config = VaultFieldHelper::getSecureFieldConfig(self::LABEL_API_KEY, [
             'exclude' => false,
             'required' => true,
         ]);
@@ -145,7 +147,7 @@ final class VaultFieldHelperTest extends TestCase
         ];
 
         $result = VaultFieldHelper::addVaultFields($tca, [
-            'api_key' => ['label' => 'API Key'],
+            'api_key' => ['label' => self::LABEL_API_KEY],
             'api_secret' => ['label' => 'API Secret', 'required' => true],
         ]);
 

--- a/Tests/Unit/Task/OrphanCleanupTaskTest.php
+++ b/Tests/Unit/Task/OrphanCleanupTaskTest.php
@@ -36,6 +36,8 @@ use TYPO3\CMS\Scheduler\Scheduler;
 #[AllowMockObjectsWithoutExpectations]
 final class OrphanCleanupTaskTest extends TestCase
 {
+    private const CLEANUP_REASON = 'Scheduler orphan cleanup';
+
     protected bool $resetSingletonInstances = true;
 
     private VaultServiceInterface&MockObject $vaultService;
@@ -155,7 +157,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $this->vaultService
             ->expects($this->once())
             ->method('delete')
-            ->with('tx_myext__api_key__1', 'Scheduler orphan cleanup');
+            ->with('tx_myext__api_key__1', self::CLEANUP_REASON);
 
         $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 7]);
@@ -208,7 +210,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $this->vaultService
             ->expects($this->once())
             ->method('delete')
-            ->with('tx_myext__api_key__1', 'Scheduler orphan cleanup');
+            ->with('tx_myext__api_key__1', self::CLEANUP_REASON);
 
         $task = $this->createTask();
         $task->setTaskParameters([
@@ -260,7 +262,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $this->vaultService
             ->expects($this->once())
             ->method('delete')
-            ->with('tx_myext__api_key__1', 'Scheduler orphan cleanup');
+            ->with('tx_myext__api_key__1', self::CLEANUP_REASON);
 
         $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
@@ -361,7 +363,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $this->vaultService
             ->expects($this->once())
             ->method('delete')
-            ->with('uuid_flex_secret', 'Scheduler orphan cleanup');
+            ->with('uuid_flex_secret', self::CLEANUP_REASON);
 
         $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
@@ -519,7 +521,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $this->vaultService
             ->expects($this->once())
             ->method('delete')
-            ->with('tx_myext__api_key__1', 'Scheduler orphan cleanup');
+            ->with('tx_myext__api_key__1', self::CLEANUP_REASON);
 
         $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
@@ -554,7 +556,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $this->vaultService
             ->expects($this->once())
             ->method('delete')
-            ->with('tx_myext__api_key__1', 'Scheduler orphan cleanup');
+            ->with('tx_myext__api_key__1', self::CLEANUP_REASON);
 
         $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
@@ -589,7 +591,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $this->vaultService
             ->expects($this->once())
             ->method('delete')
-            ->with('tx_myext__api_key__1', 'Scheduler orphan cleanup');
+            ->with('tx_myext__api_key__1', self::CLEANUP_REASON);
 
         $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0, 'nr_vault_table_filter' => 'tx_myext']);
@@ -701,7 +703,7 @@ final class OrphanCleanupTaskTest extends TestCase
         $this->vaultService
             ->expects($this->once())
             ->method('delete')
-            ->with('uuid_flex', 'Scheduler orphan cleanup');
+            ->with('uuid_flex', self::CLEANUP_REASON);
 
         $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);

--- a/Tests/Unit/Utility/FlexFormVaultResolverTest.php
+++ b/Tests/Unit/Utility/FlexFormVaultResolverTest.php
@@ -24,6 +24,10 @@ use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 #[AllowMockObjectsWithoutExpectations]
 final class FlexFormVaultResolverTest extends TestCase
 {
+    private const TEST_UUID = '01937b6e-4b6c-7abc-8def-0123456789ab';
+
+    private const DECRYPTION_FAILED_MESSAGE = 'Decryption failed';
+
     private VaultServiceInterface&MockObject $vaultService;
 
     private LoggerInterface&MockObject $logger;
@@ -52,7 +56,7 @@ final class FlexFormVaultResolverTest extends TestCase
     {
         // FlexForm and TCA vault fields now use UUID v7 format
         self::assertTrue($this->subject->isVaultIdentifier(
-            '01937b6e-4b6c-7abc-8def-0123456789ab',
+            self::TEST_UUID,
         ));
         self::assertTrue($this->subject->isVaultIdentifier(
             '01937b6f-0000-7000-8000-000000000000',
@@ -112,7 +116,7 @@ final class FlexFormVaultResolverTest extends TestCase
     #[Test]
     public function resolveSettingsResolvesVaultIdentifiers(): void
     {
-        $identifier = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $identifier = self::TEST_UUID;
         $secretValue = 'my-secret-api-key';
 
         $this->vaultService
@@ -142,7 +146,7 @@ final class FlexFormVaultResolverTest extends TestCase
     public static function uuidIdentifierProvider(): array
     {
         return [
-            'valid uuid v7 lowercase' => ['01937b6e-4b6c-7abc-8def-0123456789ab', true],
+            'valid uuid v7 lowercase' => [self::TEST_UUID, true],
             'valid uuid v7 uppercase' => ['01937B6E-4B6C-7ABC-8DEF-0123456789AB', true],
             'valid uuid v7 mixed case' => ['01937b6e-4B6C-7abc-8DEF-0123456789ab', true],
             'empty string' => ['', false],
@@ -161,7 +165,7 @@ final class FlexFormVaultResolverTest extends TestCase
     #[Test]
     public function resolveAllResolvesNestedVaultIdentifiers(): void
     {
-        $identifier1 = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $identifier1 = self::TEST_UUID;
         $identifier2 = '01937b6f-0000-7000-8000-000000000000';
 
         $this->vaultService
@@ -192,7 +196,7 @@ final class FlexFormVaultResolverTest extends TestCase
     #[Test]
     public function resolveSettingsReturnsNullForSecretNotFound(): void
     {
-        $identifier = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $identifier = self::TEST_UUID;
 
         $this->vaultService
             ->method('retrieve')
@@ -210,18 +214,18 @@ final class FlexFormVaultResolverTest extends TestCase
     #[Test]
     public function resolveSettingsLogsErrorForVaultException(): void
     {
-        $identifier = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $identifier = self::TEST_UUID;
 
         $this->vaultService
             ->method('retrieve')
-            ->willThrowException(new VaultException('Decryption failed', 1234567890));
+            ->willThrowException(new VaultException(self::DECRYPTION_FAILED_MESSAGE, 1234567890));
 
         $this->logger
             ->expects(self::once())
             ->method('error')
             ->with('Failed to resolve FlexForm vault field', self::callback(fn (array $context): bool => $context['field'] === 'apiKey'
                 && $context['identifier'] === $identifier
-                && str_contains((string) $context['error'], 'Decryption failed')));
+                && str_contains((string) $context['error'], self::DECRYPTION_FAILED_MESSAGE)));
 
         $settings = [
             'apiKey' => $identifier,
@@ -235,11 +239,11 @@ final class FlexFormVaultResolverTest extends TestCase
     #[Test]
     public function resolveSettingsThrowsWhenThrowOnErrorIsTrue(): void
     {
-        $identifier = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $identifier = self::TEST_UUID;
 
         $this->vaultService
             ->method('retrieve')
-            ->willThrowException(new VaultException('Decryption failed', 1234567890));
+            ->willThrowException(new VaultException(self::DECRYPTION_FAILED_MESSAGE, 1234567890));
 
         $settings = [
             'apiKey' => $identifier,
@@ -252,18 +256,18 @@ final class FlexFormVaultResolverTest extends TestCase
     #[Test]
     public function resolveAllLogsErrorForVaultException(): void
     {
-        $identifier = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $identifier = self::TEST_UUID;
 
         $this->vaultService
             ->method('retrieve')
-            ->willThrowException(new VaultException('Decryption failed', 1234567890));
+            ->willThrowException(new VaultException(self::DECRYPTION_FAILED_MESSAGE, 1234567890));
 
         $this->logger
             ->expects(self::once())
             ->method('error')
             ->with('Failed to resolve vault identifier', self::callback(fn (array $context): bool => $context['key'] === 'apiKey'
                 && $context['identifier'] === $identifier
-                && str_contains((string) $context['error'], 'Decryption failed')));
+                && str_contains((string) $context['error'], self::DECRYPTION_FAILED_MESSAGE)));
 
         $settings = [
             'apiKey' => $identifier,
@@ -277,7 +281,7 @@ final class FlexFormVaultResolverTest extends TestCase
     #[Test]
     public function resolveAllHandlesSecretNotFoundException(): void
     {
-        $identifier = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $identifier = self::TEST_UUID;
 
         $this->vaultService
             ->method('retrieve')

--- a/Tests/Unit/Utility/IdentifierValidatorTest.php
+++ b/Tests/Unit/Utility/IdentifierValidatorTest.php
@@ -19,6 +19,10 @@ use PHPUnit\Framework\Attributes\Test;
 #[CoversClass(IdentifierValidator::class)]
 final class IdentifierValidatorTest extends TestCase
 {
+    private const TEST_UUID = '01937b6e-4b6c-7abc-8def-0123456789ab';
+
+    private const EXPECTED_VALIDATION_EXCEPTION = 'Expected ValidationException';
+
     #[Test]
     public function validateAcceptsValidIdentifier(): void
     {
@@ -457,7 +461,7 @@ final class IdentifierValidatorTest extends TestCase
     {
         try {
             IdentifierValidator::validate('');
-            self::fail('Expected ValidationException');
+            self::fail(self::EXPECTED_VALIDATION_EXCEPTION);
         } catch (ValidationException $e) {
             // Kills ConcatOperandRemoval — exact message text matters.
             self::assertStringContainsString('empty', $e->getMessage());
@@ -469,7 +473,7 @@ final class IdentifierValidatorTest extends TestCase
     {
         try {
             IdentifierValidator::validate('a');
-            self::fail('Expected ValidationException');
+            self::fail(self::EXPECTED_VALIDATION_EXCEPTION);
         } catch (ValidationException $e) {
             // Kills IncrementInteger/DecrementInteger on MIN_LENGTH (3).
             self::assertStringContainsString('at least 3', $e->getMessage());
@@ -481,7 +485,7 @@ final class IdentifierValidatorTest extends TestCase
     {
         try {
             IdentifierValidator::validate(str_repeat('a', 300));
-            self::fail('Expected ValidationException');
+            self::fail(self::EXPECTED_VALIDATION_EXCEPTION);
         } catch (ValidationException $e) {
             // Kills IncrementInteger/DecrementInteger on MAX_LENGTH (255).
             self::assertStringContainsString('255', $e->getMessage());
@@ -541,7 +545,7 @@ final class IdentifierValidatorTest extends TestCase
     #[Test]
     public function looksLikeVaultIdentifierUuidV7CaseInsensitive(): void
     {
-        $lower = '01937b6e-4b6c-7abc-8def-0123456789ab';
+        $lower = self::TEST_UUID;
         $upper = '01937B6E-4B6C-7ABC-8DEF-0123456789AB';
 
         self::assertTrue(IdentifierValidator::looksLikeVaultIdentifier($lower));
@@ -554,7 +558,7 @@ final class IdentifierValidatorTest extends TestCase
     public static function uuidVariantProvider(): iterable
     {
         // Only [89ab] is a valid UUID variant (RFC 4122 10xx).
-        yield 'variant 8' => ['01937b6e-4b6c-7abc-8def-0123456789ab', true];
+        yield 'variant 8' => [self::TEST_UUID, true];
         yield 'variant 9' => ['01937b6e-4b6c-7abc-9def-0123456789ab', true];
         yield 'variant a' => ['01937b6e-4b6c-7abc-adef-0123456789ab', true];
         yield 'variant b' => ['01937b6e-4b6c-7abc-bdef-0123456789ab', true];
@@ -577,7 +581,7 @@ final class IdentifierValidatorTest extends TestCase
      */
     public static function uuidVersionProvider(): iterable
     {
-        yield 'version 7 accepted' => ['01937b6e-4b6c-7abc-8def-0123456789ab', true];
+        yield 'version 7 accepted' => [self::TEST_UUID, true];
         yield 'version 4 rejected' => ['01937b6e-4b6c-4abc-8def-0123456789ab', false];
         yield 'version 1 rejected' => ['01937b6e-4b6c-1abc-8def-0123456789ab', false];
         yield 'version 6 rejected' => ['01937b6e-4b6c-6abc-8def-0123456789ab', false];


### PR DESCRIPTION
Wave 2 of the SonarCloud cleanup. Resolves all **90 `php:S1192`** (duplicated string literal) findings across **41 test files** by extracting each repeated literal into a named `private const`.

- Value-preserving: literal values are unchanged; distinct variants (e.g. `auth1/auth2.example.com`) left untouched.
- `php -l` clean on all 40 changed files.
- Test behavior unchanged — relying on the CI unit+functional matrix as the authoritative check.

No production code touched (Tests/ only).