### PR TITLE
Resolve mechanical SonarCloud findings in production code

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -36,6 +36,8 @@ use TYPO3\CMS\Core\Http\JsonResponse;
 #[AsController]
 final readonly class AjaxController
 {
+    private const ERROR_ACCESS_DENIED = 'Access denied';
+
     public function __construct(
         private VaultServiceInterface $vaultService,
         private AccessControlServiceInterface $accessControlService,
@@ -60,7 +62,7 @@ final readonly class AjaxController
         }
 
         if (!$this->accessControlService->isCurrentActorAdmin()) {
-            return $this->jsonError('Access denied', 403);
+            return $this->jsonError(self::ERROR_ACCESS_DENIED, 403);
         }
 
         $identifier = $this->getIdentifierFromRequest($request);
@@ -83,7 +85,7 @@ final readonly class AjaxController
                 'secret' => $secret,
             ]);
         } catch (AccessDeniedException) {
-            return $this->jsonError('Access denied', 403);
+            return $this->jsonError(self::ERROR_ACCESS_DENIED, 403);
         } catch (SecretExpiredException) {
             return $this->jsonError('Secret has expired', 410);
         } catch (EncryptionException) {
@@ -111,7 +113,7 @@ final readonly class AjaxController
 
         // SEC-ACCESS-6: defense-in-depth admin re-check (see revealAction).
         if (!$this->accessControlService->isCurrentActorAdmin()) {
-            return $this->jsonError('Access denied', 403);
+            return $this->jsonError(self::ERROR_ACCESS_DENIED, 403);
         }
 
         $body = $this->getJsonBody($request);
@@ -144,7 +146,7 @@ final readonly class AjaxController
         } catch (ValidationException $e) { // @phpstan-ignore catch.neverThrown
             return $this->jsonError('Validation error: ' . $e->getMessage(), 400);
         } catch (AccessDeniedException) {
-            return $this->jsonError('Access denied', 403);
+            return $this->jsonError(self::ERROR_ACCESS_DENIED, 403);
         } catch (EncryptionException) {
             return $this->jsonError('Encryption failed', 500);
         } catch (Exception) {

--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -41,6 +41,8 @@ use Throwable;
  */
 final class OAuthTokenManager
 {
+    private const REDACT_REPLACEMENT = '$1[REDACTED]';
+
     /**
      * Cached tokens indexed by config hash.
      *
@@ -572,12 +574,7 @@ final class OAuthTokenManager
                 '/(Authorization:\s*Bearer\s+)\S+/i',
                 '/(Authorization:\s*Basic\s+)\S+/i',
             ],
-            [
-                '$1[REDACTED]',
-                '$1[REDACTED]',
-                '$1[REDACTED]',
-                '$1[REDACTED]',
-            ],
+            self::REDACT_REPLACEMENT,
             $message,
         );
     }

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -590,9 +590,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
         }
 
         return [
-            'scopePid' => isset($options['scopePid'])
-                ? (is_numeric($options['scopePid']) ? (int) $options['scopePid'] : 0)
-                : 0,
+            'scopePid' => (isset($options['scopePid']) && is_numeric($options['scopePid'])) ? (int) $options['scopePid'] : 0,
             'description' => isset($options['description']) ? $this->coerceToString($options['description']) : '',
             'allowedGroups' => isset($options['groups']) ? $this->coerceGroupList($options['groups']) : [],
             'context' => isset($options['context']) ? $this->coerceToString($options['context']) : '',


### PR DESCRIPTION
Production `Classes/` cleanup — the 3 **mechanical** findings (safe, value-preserving):
- `S1192` — `AjaxController`: extract `'Access denied'` (×4) to `ERROR_ACCESS_DENIED`.
- `S1192` — `OAuthTokenManager`: extract the `'$1[REDACTED]'` preg_replace replacement (×4) to `REDACT_REPLACEMENT`.
- `S3358` — `VaultService`: flatten the nested `scopePid` ternary to a single `isset() && is_numeric()` ternary (PHPStan-clean, behavior-identical).

Verified locally before push: php-cs-fixer clean, PHPStan (no-plugins) no errors, 103 affected unit tests green.

The `S3776` cognitive-complexity extractions (×20) follow in separate, individually-verified PRs; `S1142`/`S100`/`S1172`/`S107`/`S1448` are KEEP (early-return idiom, TYPO3 hook contracts, Ask-First public-API/architecture).