### PR TITLE
Reduce cognitive complexity in production code via method extraction

### DIFF
--- a/Classes/Audit/AuditLogEntry.php
+++ b/Classes/Audit/AuditLogEntry.php
@@ -48,40 +48,26 @@ final readonly class AuditLogEntry implements JsonSerializable
      */
     public static function fromDatabaseRow(array $row): self
     {
-        /** @var array<string, mixed> $context */
-        $context = [];
-        if (!empty($row['context'])) {
-            $contextValue = $row['context'];
-            $decoded = json_decode(\is_string($contextValue) ? $contextValue : '', true);
-            if (\is_array($decoded)) {
-                /** @var array<string, mixed> $decoded */
-                $context = $decoded;
-            }
-        }
-
-        $errorMessage = $row['error_message'] ?? null;
-        $reason = $row['reason'] ?? null;
-
         return new self(
-            uid: is_numeric($row['uid'] ?? null) ? (int) $row['uid'] : 0,
-            secretIdentifier: \is_string($row['secret_identifier'] ?? null) ? $row['secret_identifier'] : '',
-            action: \is_string($row['action'] ?? null) ? $row['action'] : '',
+            uid: self::intOrZero($row['uid'] ?? null),
+            secretIdentifier: self::stringOrEmpty($row['secret_identifier'] ?? null),
+            action: self::stringOrEmpty($row['action'] ?? null),
             success: (bool) ($row['success'] ?? false),
-            errorMessage: \is_string($errorMessage) && $errorMessage !== '' ? $errorMessage : null,
-            reason: \is_string($reason) && $reason !== '' ? $reason : null,
-            actorUid: is_numeric($row['actor_uid'] ?? null) ? (int) $row['actor_uid'] : 0,
-            actorType: \is_string($row['actor_type'] ?? null) ? $row['actor_type'] : '',
-            actorUsername: \is_string($row['actor_username'] ?? null) ? $row['actor_username'] : '',
-            actorRole: \is_string($row['actor_role'] ?? null) ? $row['actor_role'] : '',
-            ipAddress: \is_string($row['ip_address'] ?? null) ? $row['ip_address'] : '',
-            userAgent: \is_string($row['user_agent'] ?? null) ? $row['user_agent'] : '',
-            requestId: \is_string($row['request_id'] ?? null) ? $row['request_id'] : '',
-            previousHash: \is_string($row['previous_hash'] ?? null) ? $row['previous_hash'] : '',
-            entryHash: \is_string($row['entry_hash'] ?? null) ? $row['entry_hash'] : '',
-            hashBefore: \is_string($row['hash_before'] ?? null) ? $row['hash_before'] : '',
-            hashAfter: \is_string($row['hash_after'] ?? null) ? $row['hash_after'] : '',
-            crdate: is_numeric($row['crdate'] ?? null) ? (int) $row['crdate'] : 0,
-            context: $context,
+            errorMessage: self::nonEmptyStringOrNull($row['error_message'] ?? null),
+            reason: self::nonEmptyStringOrNull($row['reason'] ?? null),
+            actorUid: self::intOrZero($row['actor_uid'] ?? null),
+            actorType: self::stringOrEmpty($row['actor_type'] ?? null),
+            actorUsername: self::stringOrEmpty($row['actor_username'] ?? null),
+            actorRole: self::stringOrEmpty($row['actor_role'] ?? null),
+            ipAddress: self::stringOrEmpty($row['ip_address'] ?? null),
+            userAgent: self::stringOrEmpty($row['user_agent'] ?? null),
+            requestId: self::stringOrEmpty($row['request_id'] ?? null),
+            previousHash: self::stringOrEmpty($row['previous_hash'] ?? null),
+            entryHash: self::stringOrEmpty($row['entry_hash'] ?? null),
+            hashBefore: self::stringOrEmpty($row['hash_before'] ?? null),
+            hashAfter: self::stringOrEmpty($row['hash_after'] ?? null),
+            crdate: self::intOrZero($row['crdate'] ?? null),
+            context: self::decodeContext($row['context'] ?? null),
         );
     }
 
@@ -111,5 +97,40 @@ final readonly class AuditLogEntry implements JsonSerializable
             'timestamp' => date('c', $this->crdate),
             'context' => $this->context,
         ];
+    }
+
+    /**
+     * Decode the JSON-encoded context column into an array.
+     *
+     * @return array<string, mixed>
+     */
+    private static function decodeContext(mixed $contextValue): array
+    {
+        if (empty($contextValue)) {
+            return [];
+        }
+
+        $decoded = json_decode(\is_string($contextValue) ? $contextValue : '', true);
+        if (\is_array($decoded)) {
+            /** @var array<string, mixed> $decoded */
+            return $decoded;
+        }
+
+        return [];
+    }
+
+    private static function stringOrEmpty(mixed $value): string
+    {
+        return \is_string($value) ? $value : '';
+    }
+
+    private static function nonEmptyStringOrNull(mixed $value): ?string
+    {
+        return \is_string($value) && $value !== '' ? $value : null;
+    }
+
+    private static function intOrZero(mixed $value): int
+    {
+        return is_numeric($value) ? (int) $value : 0;
     }
 }

--- a/Classes/Command/VaultInitCommand.php
+++ b/Classes/Command/VaultInitCommand.php
@@ -75,13 +75,7 @@ final class VaultInitCommand extends Command
         $outputEnv = $input->getOption('env');
 
         if ($outputFile === null && $outputEnv === false) {
-            // Use configured source (file path) or default
-            $source = $this->configuration->getMasterKeySource();
-            // Only use source if it looks like a path (contains / or \)
-            $outputFile = (str_contains($source, '/') || str_contains($source, '\\')) ? $source : '';
-            if ($outputFile === '') {
-                $outputFile = Environment::getVarPath() . '/vault/master.key';
-            }
+            $outputFile = $this->resolveDefaultOutputFile();
         }
 
         // Check if key already exists
@@ -107,50 +101,78 @@ final class VaultInitCommand extends Command
             $io->newLine();
             $io->warning('Store this key securely! It cannot be recovered if lost.');
         } else {
-            // Ensure directory exists
-            $outputFilePath = $outputFile ?? '';
-            $dir = \dirname($outputFilePath);
-            if (!is_dir($dir) && !mkdir($dir, 0o700, true)) {
-                $io->error(\sprintf('Failed to create directory: %s', $dir));
+            $writeResult = $this->writeMasterKeyToFile($io, $outputFile ?? '', $masterKey);
+            if ($writeResult !== Command::SUCCESS) {
                 sodium_memzero($masterKey);
 
-                return Command::FAILURE;
+                return $writeResult;
             }
-
-            // Write key to file with restrictive permissions
-            $result = file_put_contents($outputFilePath, $masterKey);
-            if ($result === false) {
-                $io->error(\sprintf('Failed to write master key to: %s', $outputFilePath));
-                sodium_memzero($masterKey);
-
-                return Command::FAILURE;
-            }
-
-            // Set restrictive permissions (owner read/write only)
-            chmod($outputFilePath, 0o600);
-
-            $io->success(\sprintf('Master key generated and saved to: %s', $outputFilePath));
-            $io->table(
-                ['Property', 'Value'],
-                [
-                    ['Key file', $outputFilePath],
-                    ['Permissions', '0600 (owner read/write only)'],
-                    ['Algorithm', 'XSalsa20-Poly1305 (sodium_crypto_secretbox)'],
-                    ['Key length', \strlen($masterKey) . ' bytes'],
-                ],
-            );
-
-            $io->warning([
-                'IMPORTANT SECURITY NOTES:',
-                '1. Back up this key securely - it cannot be recovered if lost',
-                '2. All secrets are unrecoverable without this key',
-                '3. Keep this file outside of version control',
-                '4. Consider using environment variables in production',
-            ]);
         }
 
         // Clear key from memory
         sodium_memzero($masterKey);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Resolve the default master key output file from configuration or fall back to the var path.
+     */
+    private function resolveDefaultOutputFile(): string
+    {
+        // Use configured source (file path) or default
+        $source = $this->configuration->getMasterKeySource();
+        // Only use source if it looks like a path (contains / or \)
+        $outputFile = (str_contains($source, '/') || str_contains($source, '\\')) ? $source : '';
+        if ($outputFile === '') {
+            return Environment::getVarPath() . '/vault/master.key';
+        }
+
+        return $outputFile;
+    }
+
+    /**
+     * Persist the master key to disk with restrictive permissions; the caller zeroes the key.
+     */
+    private function writeMasterKeyToFile(SymfonyStyle $io, string $outputFilePath, string $masterKey): int
+    {
+        // Ensure directory exists
+        $dir = \dirname($outputFilePath);
+        if (!is_dir($dir) && !mkdir($dir, 0o700, true)) {
+            $io->error(\sprintf('Failed to create directory: %s', $dir));
+
+            return Command::FAILURE;
+        }
+
+        // Write key to file with restrictive permissions
+        $result = file_put_contents($outputFilePath, $masterKey);
+        if ($result === false) {
+            $io->error(\sprintf('Failed to write master key to: %s', $outputFilePath));
+
+            return Command::FAILURE;
+        }
+
+        // Set restrictive permissions (owner read/write only)
+        chmod($outputFilePath, 0o600);
+
+        $io->success(\sprintf('Master key generated and saved to: %s', $outputFilePath));
+        $io->table(
+            ['Property', 'Value'],
+            [
+                ['Key file', $outputFilePath],
+                ['Permissions', '0600 (owner read/write only)'],
+                ['Algorithm', 'XSalsa20-Poly1305 (sodium_crypto_secretbox)'],
+                ['Key length', \strlen($masterKey) . ' bytes'],
+            ],
+        );
+
+        $io->warning([
+            'IMPORTANT SECURITY NOTES:',
+            '1. Back up this key securely - it cannot be recovered if lost',
+            '2. All secrets are unrecoverable without this key',
+            '3. Keep this file outside of version control',
+            '4. Consider using environment variables in production',
+        ]);
 
         return Command::SUCCESS;
     }

--- a/Classes/Command/VaultMigrateFieldCommand.php
+++ b/Classes/Command/VaultMigrateFieldCommand.php
@@ -14,6 +14,7 @@ use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Utility\IdentifierValidator;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Helper\ProgressBar;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Input\InputOption;
@@ -177,6 +178,68 @@ final class VaultMigrateFieldCommand extends Command
         $progressBar = $io->createProgressBar($totalRecords);
         $progressBar->start();
 
+        ['migrated' => $migrated, 'failed' => $failed, 'errors' => $errors] = $this->migrateRecords(
+            $records,
+            $batchSize,
+            $table,
+            $field,
+            $uidField,
+            $clearSource,
+            $progressBar,
+        );
+
+        $progressBar->finish();
+        $io->newLine(2);
+
+        // Summary
+        $io->section('Migration Summary');
+        $io->definitionList(
+            ['Total records' => $totalRecords],
+            ['Successfully migrated' => $migrated],
+            ['Failed' => $failed],
+        );
+
+        $this->reportErrors($io, $errors);
+
+        if ($failed > 0) {
+            $io->warning(\sprintf('Migration completed with %d errors', $failed));
+
+            return Command::FAILURE;
+        }
+
+        $io->success('Migration completed successfully');
+
+        // Show next steps
+        $io->section('Next Steps');
+        $io->listing([
+            'Update TCA configuration to use renderType => "vaultSecret" for this field',
+            'Test that the field displays correctly in the TYPO3 backend',
+            'Update any code that reads this field to use VaultFieldResolver::resolveFields()',
+            $clearSource
+                ? 'Source field has been cleared'
+                : 'Consider clearing or removing the source field after verifying migration',
+        ]);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Processes the records in batches, storing each value in the vault.
+     *
+     * @param array<int, array<string, mixed>> $records
+     * @param int<1, max> $batchSize
+     *
+     * @return array{migrated: int, failed: int, errors: list<string>}
+     */
+    private function migrateRecords(
+        array $records,
+        int $batchSize,
+        string $table,
+        string $field,
+        string $uidField,
+        bool $clearSource,
+        ProgressBar $progressBar,
+    ): array {
         $migrated = 0;
         $failed = 0;
         $errors = [];
@@ -224,47 +287,25 @@ final class VaultMigrateFieldCommand extends Command
             }
         }
 
-        $progressBar->finish();
-        $io->newLine(2);
+        return ['migrated' => $migrated, 'failed' => $failed, 'errors' => $errors];
+    }
 
-        // Summary
-        $io->section('Migration Summary');
-        $io->definitionList(
-            ['Total records' => $totalRecords],
-            ['Successfully migrated' => $migrated],
-            ['Failed' => $failed],
-        );
-
-        if ($errors !== []) {
-            $io->section('Errors');
-            foreach (\array_slice($errors, 0, 10) as $error) {
-                $io->text('<error>✗</error> ' . $error);
-            }
-            if (\count($errors) > 10) {
-                $io->text(\sprintf('... and %d more errors', \count($errors) - 10));
-            }
+    /**
+     * @param list<string> $errors
+     */
+    private function reportErrors(SymfonyStyle $io, array $errors): void
+    {
+        if ($errors === []) {
+            return;
         }
 
-        if ($failed > 0) {
-            $io->warning(\sprintf('Migration completed with %d errors', $failed));
-
-            return Command::FAILURE;
+        $io->section('Errors');
+        foreach (\array_slice($errors, 0, 10) as $error) {
+            $io->text('<error>✗</error> ' . $error);
         }
-
-        $io->success('Migration completed successfully');
-
-        // Show next steps
-        $io->section('Next Steps');
-        $io->listing([
-            'Update TCA configuration to use renderType => "vaultSecret" for this field',
-            'Test that the field displays correctly in the TYPO3 backend',
-            'Update any code that reads this field to use VaultFieldResolver::resolveFields()',
-            $clearSource
-                ? 'Source field has been cleared'
-                : 'Consider clearing or removing the source field after verifying migration',
-        ]);
-
-        return Command::SUCCESS;
+        if (\count($errors) > 10) {
+            $io->text(\sprintf('... and %d more errors', \count($errors) - 10));
+        }
     }
 
     private function tableExists(string $table): bool

--- a/Classes/Controller/AuditController.php
+++ b/Classes/Controller/AuditController.php
@@ -248,45 +248,11 @@ final readonly class AuditController
      */
     private function buildAuditFilters(array $queryParams): array
     {
-        // Form values for repopulation (always strings for form fields)
-        $secretIdVal = $queryParams['secretIdentifier'] ?? '';
-        $filterActionVal = $queryParams['filterAction'] ?? '';
-        $successFormVal = $queryParams['success'] ?? '';
-        $sinceFormVal = $queryParams['since'] ?? '';
-        $untilFormVal = $queryParams['until'] ?? '';
-
-        $formData = [
-            'secretIdentifier' => \is_string($secretIdVal) ? $secretIdVal : '',
-            'action' => \is_string($filterActionVal) ? $filterActionVal : '',
-            'success' => \is_string($successFormVal) || \is_int($successFormVal) ? (string) $successFormVal : '',
-            'since' => \is_string($sinceFormVal) ? $sinceFormVal : '',
-            'until' => \is_string($untilFormVal) ? $untilFormVal : '',
-        ];
+        $formData = $this->buildAuditFormData($queryParams);
 
         // Parse dates
-        $since = null;
-        $sinceValue = $queryParams['since'] ?? '';
-        if (\is_string($sinceValue) && $sinceValue !== '') {
-            try {
-                $since = new DateTimeImmutable($sinceValue);
-            } catch (Exception) {
-                // Malformed date input from the user — leave $since/$until null
-                // so the filter is simply not applied. The form re-renders the
-                // raw value so the user can correct it.
-            }
-        }
-
-        $until = null;
-        $untilValue = $queryParams['until'] ?? '';
-        if (\is_string($untilValue) && $untilValue !== '') {
-            try {
-                $until = new DateTimeImmutable($untilValue);
-            } catch (Exception) {
-                // Malformed date input from the user — leave $since/$until null
-                // so the filter is simply not applied. The form re-renders the
-                // raw value so the user can correct it.
-            }
-        }
+        $since = $this->parseFilterDate($queryParams['since'] ?? '');
+        $until = $this->parseFilterDate($queryParams['until'] ?? '');
 
         // Parse success filter
         $success = null;
@@ -312,6 +278,48 @@ final readonly class AuditController
             'filter' => $filter->isEmpty() ? null : $filter,
             'form' => $formData,
         ];
+    }
+
+    /**
+     * Build form values for repopulation (always strings for form fields).
+     *
+     * @param array<string, mixed> $queryParams
+     *
+     * @return array<string, string>
+     */
+    private function buildAuditFormData(array $queryParams): array
+    {
+        $secretIdVal = $queryParams['secretIdentifier'] ?? '';
+        $filterActionVal = $queryParams['filterAction'] ?? '';
+        $successFormVal = $queryParams['success'] ?? '';
+        $sinceFormVal = $queryParams['since'] ?? '';
+        $untilFormVal = $queryParams['until'] ?? '';
+
+        return [
+            'secretIdentifier' => \is_string($secretIdVal) ? $secretIdVal : '',
+            'action' => \is_string($filterActionVal) ? $filterActionVal : '',
+            'success' => \is_string($successFormVal) || \is_int($successFormVal) ? (string) $successFormVal : '',
+            'since' => \is_string($sinceFormVal) ? $sinceFormVal : '',
+            'until' => \is_string($untilFormVal) ? $untilFormVal : '',
+        ];
+    }
+
+    /**
+     * Parse a date filter value; malformed or empty input yields null so the
+     * filter is simply not applied. The form re-renders the raw value so the
+     * user can correct it.
+     */
+    private function parseFilterDate(mixed $value): ?DateTimeImmutable
+    {
+        if (\is_string($value) && $value !== '') {
+            try {
+                return new DateTimeImmutable($value);
+            } catch (Exception) {
+                // Malformed date input from the user — fall through to null.
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/Classes/Controller/MigrationController.php
+++ b/Classes/Controller/MigrationController.php
@@ -271,21 +271,14 @@ final readonly class MigrationController
     {
         $parsedBody = $request->getParsedBody();
         $parsedBodyArray = \is_array($parsedBody) ? $parsedBody : [];
-        $migrations = $parsedBodyArray['migrations'] ?? [];
+        $migrationsRaw = $parsedBodyArray['migrations'] ?? [];
+        $migrations = \is_array($migrationsRaw) ? $migrationsRaw : [];
         $clearOriginalsValue = $parsedBodyArray['clearOriginals'] ?? false;
         $clearOriginals = (\is_string($clearOriginalsValue) || \is_int($clearOriginalsValue)) && (bool) $clearOriginalsValue;
 
-        $lang = $this->getLanguageService();
-
-        if (!\is_array($migrations) || $migrations === []) {
-            $this->addFlashMessage(
-                $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:migration.noMigrationsConfigured'),
-                $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:migration.configurationRequired'),
-                ContextualFeedbackSeverity::ERROR,
-            );
-
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new RedirectResponse($this->buildUri('scan'));
+        $guardResponse = $this->validateMigrationsRequest($migrations);
+        if ($guardResponse instanceof ResponseInterface) {
+            return $guardResponse;
         }
 
         $results = [];
@@ -293,36 +286,85 @@ final readonly class MigrationController
         $totalFailed = 0;
 
         foreach ($migrations as $migration) {
-            if (!\is_array($migration)) {
+            $result = $this->processMigrationEntry($migration);
+            if (!$result instanceof MigrationResult) {
                 continue;
             }
-            $tableVal = $migration['table'] ?? '';
-            $table = \is_string($tableVal) ? $tableVal : '';
-            $columnVal = $migration['column'] ?? '';
-            $column = \is_string($columnVal) ? $columnVal : '';
-            $identifierPatternVal = $migration['identifierPattern'] ?? '';
-            $identifierPattern = \is_string($identifierPatternVal) ? $identifierPatternVal : '';
-            if ($table === '') {
-                continue;
-            }
-            if ($column === '') {
-                continue;
-            }
-            if ($identifierPattern === '') {
-                continue;
-            }
-
-            try {
-                $result = $this->migrateColumn($table, $column, $identifierPattern);
-                $results[] = $result->toArray();
-                $totalMigrated += $result->migrated;
-                $totalFailed += $result->failed;
-            } catch (Exception $e) {
-                $results[] = MigrationResult::error($table, $column, $e->getMessage())->toArray();
-            }
+            $results[] = $result->toArray();
+            $totalMigrated += $result->migrated;
+            $totalFailed += $result->failed;
         }
 
-        // Store results in session for verify step
+        $this->storeMigrationResults($results, $totalMigrated, $totalFailed, $clearOriginals);
+
+        /** @phpstan-ignore new.internalClass, method.internalClass */
+        return new RedirectResponse($this->buildUri('verify'));
+    }
+
+    /**
+     * Validate that migrations were configured; returns a redirect response when invalid, null otherwise.
+     *
+     * @param array<mixed> $migrations
+     */
+    private function validateMigrationsRequest(array $migrations): ?ResponseInterface
+    {
+        if ($migrations !== []) {
+            return null;
+        }
+
+        $lang = $this->getLanguageService();
+        $this->addFlashMessage(
+            $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:migration.noMigrationsConfigured'),
+            $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:migration.configurationRequired'),
+            ContextualFeedbackSeverity::ERROR,
+        );
+
+        /** @phpstan-ignore new.internalClass, method.internalClass */
+        return new RedirectResponse($this->buildUri('scan'));
+    }
+
+    /**
+     * Process a single migration entry; returns the migration result, or null when the entry is skipped.
+     */
+    private function processMigrationEntry(mixed $migration): ?MigrationResult
+    {
+        if (!\is_array($migration)) {
+            return null;
+        }
+        $tableVal = $migration['table'] ?? '';
+        $table = \is_string($tableVal) ? $tableVal : '';
+        $columnVal = $migration['column'] ?? '';
+        $column = \is_string($columnVal) ? $columnVal : '';
+        $identifierPatternVal = $migration['identifierPattern'] ?? '';
+        $identifierPattern = \is_string($identifierPatternVal) ? $identifierPatternVal : '';
+        if ($table === '') {
+            return null;
+        }
+        if ($column === '') {
+            return null;
+        }
+        if ($identifierPattern === '') {
+            return null;
+        }
+
+        try {
+            return $this->migrateColumn($table, $column, $identifierPattern);
+        } catch (Exception $e) {
+            return MigrationResult::error($table, $column, $e->getMessage());
+        }
+    }
+
+    /**
+     * Store migration results in the backend user session for the verify step.
+     *
+     * @param list<array<string, mixed>> $results
+     */
+    private function storeMigrationResults(
+        array $results,
+        int $totalMigrated,
+        int $totalFailed,
+        bool $clearOriginals,
+    ): void {
         $beUser = $GLOBALS['BE_USER'] ?? null;
         if (\is_object($beUser) && method_exists($beUser, 'setAndSaveSessionData')) {
             $beUser->setAndSaveSessionData('vault_migration_results', [
@@ -332,9 +374,6 @@ final readonly class MigrationController
                 'clearOriginals' => $clearOriginals,
             ]);
         }
-
-        /** @phpstan-ignore new.internalClass, method.internalClass */
-        return new RedirectResponse($this->buildUri('verify'));
     }
 
     /**

--- a/Classes/Controller/SecretsController.php
+++ b/Classes/Controller/SecretsController.php
@@ -244,80 +244,14 @@ final readonly class SecretsController
         $lang = $this->getLanguageService();
 
         if ($identifier === '') {
-            if ($isAjax) {
-                /** @phpstan-ignore new.internalClass, method.internalClass */
-                return new JsonResponse(['success' => false, 'error' => 'No secret identifier provided'], 400);
-            }
-            $this->addFlashMessage(
-                $lang->sL(self::LL_NO_IDENTIFIER),
-                ContextualFeedbackSeverity::ERROR,
-            );
-
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new RedirectResponse(
-                (string) $this->uriBuilder->buildUriFromRoute(self::MODULE_NAME),
-            );
+            return $this->toggleMissingIdentifierResponse($isAjax, $lang);
         }
 
         try {
-            // Get current state - remove restrictions to find hidden records
-            $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_nrvault_secret');
-            $queryBuilder->getRestrictions()->removeAll();
-            $current = $queryBuilder
-                ->select('hidden')
-                ->from('tx_nrvault_secret')
-                ->where(
-                    $queryBuilder->expr()->eq('identifier', $queryBuilder->createNamedParameter($identifier)),
-                    $queryBuilder->expr()->eq('deleted', 0),
-                )
-                ->executeQuery()
-                ->fetchAssociative();
-
-            if ($current === false) {
-                throw new SecretNotFoundException('Secret not found: ' . $identifier, 7409034110);
+            $response = $this->performToggle($identifier, $isAjax);
+            if ($response instanceof ResponseInterface) {
+                return $response;
             }
-
-            // Toggle the hidden state
-            $newState = $current['hidden'] ? 0 : 1;
-            $action = $newState !== 0 ? 'disable' : 'enable';
-            $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_nrvault_secret');
-            $queryBuilder->getRestrictions()->removeAll();
-            $queryBuilder
-                ->update('tx_nrvault_secret')
-                ->set('hidden', $newState)
-                ->set('tstamp', time())
-                ->where(
-                    $queryBuilder->expr()->eq('identifier', $queryBuilder->createNamedParameter($identifier)),
-                    $queryBuilder->expr()->eq('deleted', 0),
-                )
-                ->executeStatement();
-
-            // Log the enable/disable action to audit log
-            $this->auditLogService->log(
-                $identifier,
-                'update',
-                true,
-                null,
-                $action === 'disable' ? 'Secret disabled' : 'Secret enabled',
-                null,
-                null,
-                new GenericContext(['action' => $action, 'hidden' => $newState]),
-            );
-
-            $message = $newState !== 0
-                ? $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.disabled.success')
-                : $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.enabled.success');
-
-            if ($isAjax) {
-                /** @phpstan-ignore new.internalClass, method.internalClass */
-                return new JsonResponse([
-                    'success' => true,
-                    'hidden' => (bool) $newState,
-                    'message' => $message,
-                ]);
-            }
-
-            $this->addFlashMessage($message, ContextualFeedbackSeverity::OK);
         } catch (SecretNotFoundException) {
             $this->auditLogService->log($identifier, 'update', false, 'Secret not found');
             if ($isAjax) {
@@ -400,6 +334,96 @@ final readonly class SecretsController
         return new RedirectResponse(
             (string) $this->uriBuilder->buildUriFromRoute(self::MODULE_NAME),
         );
+    }
+
+    /**
+     * Build the response for a toggle request that lacks a secret identifier.
+     */
+    private function toggleMissingIdentifierResponse(bool $isAjax, LanguageService $lang): ResponseInterface
+    {
+        if ($isAjax) {
+            /** @phpstan-ignore new.internalClass, method.internalClass */
+            return new JsonResponse(['success' => false, 'error' => 'No secret identifier provided'], 400);
+        }
+        $this->addFlashMessage(
+            $lang->sL(self::LL_NO_IDENTIFIER),
+            ContextualFeedbackSeverity::ERROR,
+        );
+
+        /** @phpstan-ignore new.internalClass, method.internalClass */
+        return new RedirectResponse(
+            (string) $this->uriBuilder->buildUriFromRoute(self::MODULE_NAME),
+        );
+    }
+
+    /**
+     * Toggle the hidden state of a secret and audit the change.
+     *
+     * Returns a JSON response for AJAX requests; for regular requests it adds a
+     * success flash message and returns null so the caller performs the shared redirect.
+     */
+    private function performToggle(string $identifier, bool $isAjax): ?ResponseInterface
+    {
+        // Get current state - remove restrictions to find hidden records
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_nrvault_secret');
+        $queryBuilder->getRestrictions()->removeAll();
+        $current = $queryBuilder
+            ->select('hidden')
+            ->from('tx_nrvault_secret')
+            ->where(
+                $queryBuilder->expr()->eq('identifier', $queryBuilder->createNamedParameter($identifier)),
+                $queryBuilder->expr()->eq('deleted', 0),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if ($current === false) {
+            throw new SecretNotFoundException('Secret not found: ' . $identifier, 7409034110);
+        }
+
+        // Toggle the hidden state
+        $newState = $current['hidden'] ? 0 : 1;
+        $action = $newState !== 0 ? 'disable' : 'enable';
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('tx_nrvault_secret');
+        $queryBuilder->getRestrictions()->removeAll();
+        $queryBuilder
+            ->update('tx_nrvault_secret')
+            ->set('hidden', $newState)
+            ->set('tstamp', time())
+            ->where(
+                $queryBuilder->expr()->eq('identifier', $queryBuilder->createNamedParameter($identifier)),
+                $queryBuilder->expr()->eq('deleted', 0),
+            )
+            ->executeStatement();
+
+        // Log the enable/disable action to audit log
+        $this->auditLogService->log(
+            $identifier,
+            'update',
+            true,
+            null,
+            $action === 'disable' ? 'Secret disabled' : 'Secret enabled',
+            null,
+            null,
+            new GenericContext(['action' => $action, 'hidden' => $newState]),
+        );
+
+        $message = $newState !== 0
+            ? $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.disabled.success')
+            : $this->getLanguageService()->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.enabled.success');
+
+        if ($isAjax) {
+            /** @phpstan-ignore new.internalClass, method.internalClass */
+            return new JsonResponse([
+                'success' => true,
+                'hidden' => (bool) $newState,
+                'message' => $message,
+            ]);
+        }
+
+        $this->addFlashMessage($message, ContextualFeedbackSeverity::OK);
+
+        return null;
     }
 
     /**

--- a/Classes/Hook/PendingSecretExtractor.php
+++ b/Classes/Hook/PendingSecretExtractor.php
@@ -37,18 +37,7 @@ final class PendingSecretExtractor
      */
     public function extract(mixed $value): ?PendingSecret
     {
-        if (\is_array($value)) {
-            $rawSecretValue = $value['value'] ?? $value[0] ?? '';
-            $rawIdentifier = $value['_vault_identifier'] ?? '';
-            $rawChecksum = $value['_vault_checksum'] ?? '';
-            $secretValue = \is_string($rawSecretValue) || \is_int($rawSecretValue) ? (string) $rawSecretValue : '';
-            $existingIdentifier = \is_string($rawIdentifier) ? $rawIdentifier : '';
-            $originalChecksum = \is_string($rawChecksum) ? $rawChecksum : '';
-        } else {
-            $secretValue = \is_string($value) || \is_int($value) ? (string) $value : '';
-            $existingIdentifier = '';
-            $originalChecksum = '';
-        }
+        ['value' => $secretValue, 'identifier' => $existingIdentifier, 'checksum' => $originalChecksum] = $this->classifyValue($value);
 
         // Nothing to do: empty value and no prior secret.
         if ($secretValue === '' && $originalChecksum === '') {
@@ -61,5 +50,35 @@ final class PendingSecretExtractor
         return $isNewSecret
             ? PendingSecret::createNew($secretValue, $vaultIdentifier)
             : PendingSecret::createUpdate($secretValue, $vaultIdentifier, $originalChecksum);
+    }
+
+    /**
+     * Normalize the raw field value (array shape vs. scalar) into the three
+     * string components used by the extraction pipeline.
+     *
+     * @param mixed $value The raw field value (string, int, or the array shape
+     *                     emitted by the vault FormEngine element)
+     *
+     * @return array{value: string, identifier: string, checksum: string}
+     */
+    private function classifyValue(mixed $value): array
+    {
+        if (\is_array($value)) {
+            $rawSecretValue = $value['value'] ?? $value[0] ?? '';
+            $rawIdentifier = $value['_vault_identifier'] ?? '';
+            $rawChecksum = $value['_vault_checksum'] ?? '';
+
+            return [
+                'value' => \is_string($rawSecretValue) || \is_int($rawSecretValue) ? (string) $rawSecretValue : '',
+                'identifier' => \is_string($rawIdentifier) ? $rawIdentifier : '',
+                'checksum' => \is_string($rawChecksum) ? $rawChecksum : '',
+            ];
+        }
+
+        return [
+            'value' => \is_string($value) || \is_int($value) ? (string) $value : '',
+            'identifier' => '',
+            'checksum' => '',
+        ];
     }
 }

--- a/Classes/Service/SecretDetectionService.php
+++ b/Classes/Service/SecretDetectionService.php
@@ -349,31 +349,7 @@ final class SecretDetectionService implements SecretDetectionServiceInterface
                     ->executeQuery()
                     ->fetchAllAssociative();
 
-                $plaintextCount = 0;
-                $patterns = [];
-
-                foreach ($samples as $row) {
-                    $rawValue = $row[$columnName] ?? '';
-                    $value = \is_string($rawValue) || is_numeric($rawValue) ? (string) $rawValue : '';
-
-                    // Skip if it looks like a vault identifier
-                    if (IdentifierValidator::looksLikeVaultIdentifier($value)) {
-                        continue;
-                    }
-
-                    // Skip if it looks already encrypted
-                    if ($this->looksEncrypted($value)) {
-                        continue;
-                    }
-
-                    // Check for known patterns
-                    $detectedPattern = $this->detectValuePattern($value);
-                    if ($detectedPattern !== null) {
-                        $patterns[$detectedPattern] = true;
-                    }
-
-                    ++$plaintextCount;
-                }
+                [$plaintextCount, $patterns] = $this->matchPattern($samples, $columnName);
 
                 if ($plaintextCount > 0) {
                     $recordCount = is_numeric($count) ? (int) $count : 0;
@@ -395,6 +371,44 @@ final class SecretDetectionService implements SecretDetectionServiceInterface
                 'error' => $e->getMessage(),
             ]);
         }
+    }
+
+    /**
+     * Inspect sampled column values, skipping vault identifiers and encrypted blobs.
+     *
+     * @param array<int, array<string, mixed>> $samples
+     *
+     * @return array{int, array<string, true>} Plaintext count and detected patterns keyed by name
+     */
+    private function matchPattern(array $samples, string $columnName): array
+    {
+        $plaintextCount = 0;
+        $patterns = [];
+
+        foreach ($samples as $row) {
+            $rawValue = $row[$columnName] ?? '';
+            $value = \is_string($rawValue) || is_numeric($rawValue) ? (string) $rawValue : '';
+
+            // Skip if it looks like a vault identifier
+            if (IdentifierValidator::looksLikeVaultIdentifier($value)) {
+                continue;
+            }
+
+            // Skip if it looks already encrypted
+            if ($this->looksEncrypted($value)) {
+                continue;
+            }
+
+            // Check for known patterns
+            $detectedPattern = $this->detectValuePattern($value);
+            if ($detectedPattern !== null) {
+                $patterns[$detectedPattern] = true;
+            }
+
+            ++$plaintextCount;
+        }
+
+        return [$plaintextCount, $patterns];
     }
 
     /**

--- a/Classes/Task/OrphanCleanupTask.php
+++ b/Classes/Task/OrphanCleanupTask.php
@@ -118,44 +118,22 @@ final class OrphanCleanupTask extends AbstractTask
                     $afterUid = max($afterUid, $uid);
                 }
 
-                $metadata = $secret->getMetadata();
-                $source = $metadata['source'] ?? '';
-
-                // Only check TCA-sourced secrets
-                if ($source !== 'tca_field' && $source !== 'migration') {
-                    continue;
-                }
-
-                // Extract reference from metadata (table, field, uid are stored by DataHandlerHook)
-                $reference = $this->parseMetadataReference($metadata);
+                $reference = $this->resolveOrphanReference($secret->getMetadata());
                 if (!$reference instanceof OrphanReference) {
                     continue;
                 }
 
-                // Apply table filter if specified
-                if ($this->tableFilter !== '' && $reference->table !== $this->tableFilter) {
-                    continue;
-                }
-
                 $checked++;
-                $createdAt = $secret->getCrdate();
 
                 // Only delete if the source record is gone AND the secret is
                 // older than the retention period.
-                if ($this->recordExists($connectionPool, $reference->table, $reference->uid) || $createdAt >= $retentionCutoff) {
+                if ($this->recordExists($connectionPool, $reference->table, $reference->uid) || $secret->getCrdate() >= $retentionCutoff) {
                     continue;
                 }
 
                 $orphansFound++;
 
-                try {
-                    $vaultService->delete($secret->getIdentifier(), 'Scheduler orphan cleanup');
-                    $logger->info('Deleted orphan secret', ['identifier' => $secret->getIdentifier()]);
-                } catch (Throwable $e) {
-                    $logger->error('Failed to delete orphan secret', [
-                        'identifier' => $secret->getIdentifier(),
-                        'error' => $e->getMessage(),
-                    ]);
+                if (!$this->deleteOrphan($vaultService, $logger, $secret->getIdentifier())) {
                     $success = false;
                 }
             }
@@ -182,6 +160,57 @@ final class OrphanCleanupTask extends AbstractTask
         }
 
         return implode(', ', $info);
+    }
+
+    /**
+     * Resolve a deletable orphan reference from a secret's metadata, or null
+     * when the secret is not a TCA-sourced candidate, has no parseable
+     * reference, or is excluded by the configured table filter.
+     *
+     * @param array<string, mixed> $metadata Secret metadata
+     */
+    private function resolveOrphanReference(array $metadata): ?OrphanReference
+    {
+        $source = $metadata['source'] ?? '';
+
+        // Only check TCA-sourced secrets
+        if ($source !== 'tca_field' && $source !== 'migration') {
+            return null;
+        }
+
+        // Extract reference from metadata (table, field, uid are stored by DataHandlerHook)
+        $reference = $this->parseMetadataReference($metadata);
+        if (!$reference instanceof OrphanReference) {
+            return null;
+        }
+
+        // Apply table filter if specified
+        if ($this->tableFilter !== '' && $reference->table !== $this->tableFilter) {
+            return null;
+        }
+
+        return $reference;
+    }
+
+    /**
+     * Delete a single orphan secret through the VaultService (ACL + audit
+     * preserved). Returns false when deletion failed.
+     */
+    private function deleteOrphan(VaultServiceInterface $vaultService, LoggerInterface $logger, string $identifier): bool
+    {
+        try {
+            $vaultService->delete($identifier, 'Scheduler orphan cleanup');
+            $logger->info('Deleted orphan secret', ['identifier' => $identifier]);
+
+            return true;
+        } catch (Throwable $e) {
+            $logger->error('Failed to delete orphan secret', [
+                'identifier' => $identifier,
+                'error' => $e->getMessage(),
+            ]);
+
+            return false;
+        }
     }
 
     /**


### PR DESCRIPTION
Resolves `php:S3776` in **10 low-risk production files** by extracting cohesive blocks into private helpers — **behavior-preserving** (control flow, return values, exceptions, side-effect order, audit-log calls and `sodium_memzero` all preserved).

Files: `VaultMigrateFieldCommand`, `VaultInitCommand`, `MigrationController`, `AuditController`, `SecretsController`, `VaultSecretInputElement`, `OrphanCleanupTask`, `SecretDetectionService`, `AuditLogEntry`, `PendingSecretExtractor`.

**Verified locally before push:** `php -l`, PHPStan (no errors), php-cs-fixer (clean), and the **full 3310-test unit suite** (0 failures). Functional suite via CI.

**Intentionally left** (accepted complexity, not refactored): the 6 security-critical `S3776` sites — `AuditLogService::verifyHashChain` (tamper-evident chain), `SecureHttpClientFactory` (SSRF filter), and the `FlexFormVaultHook` crypto walks. Refactoring tested security-critical code for a metric isn't worth the regression risk (AGENTS.md Ask-First/Golden-Sample).