### PR TITLE
Add Authorization scheme prefix option to vault HTTP client

### DIFF
--- a/Classes/Http/VaultHttpClient.php
+++ b/Classes/Http/VaultHttpClient.php
@@ -83,8 +83,6 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
      * @param SecretPlacement|null $placement Configured placement type
      * @param OAuthConfig|null $oauthConfig Configured OAuth config
      * @param string|null $headerName Custom header name for Header placement
-     * @param string|null $authPrefix Optional scheme/prefix prepended to the secret for
-     *                                Header placement (e.g. "Key " → "Authorization: Key <secret>")
      * @param string|null $queryParam Custom query param for QueryParam placement
      * @param string|null $bodyField Custom body field for BodyField placement
      * @param string|null $usernameSecretIdentifier Username secret for BasicAuth
@@ -102,6 +100,10 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
      *                                                              (b) the `isHostAllowed()` gate the OAuth manager applies to its
      *                                                              token endpoint. When null, `GeneralUtility::makeInstance()` resolves
      *                                                              it from the DI container. Trailing position preserves positional BC.
+     * @param string|null $authPrefix Optional scheme/prefix prepended to the secret for Header
+     *                                placement (e.g. "Key " → "Authorization: Key <secret>").
+     *                                Logically a Header-placement option, but placed last in the
+     *                                signature to preserve positional BC for pre-PR callers.
      */
     public function __construct(
         private VaultServiceInterface $vaultService,
@@ -321,15 +323,21 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
         \assert($this->secretIdentifier !== null);
         $secret = $this->retrieveSecret($this->secretIdentifier);
         $headerName = $this->headerName ?? 'X-API-Key';
-        // Optional auth scheme/prefix (e.g. "Key " for FAL, "DeepL-Auth-Key " for DeepL)
-        // so non-Bearer "Authorization: <scheme> <secret>" schemes use audited injection.
-        $value = ($this->authPrefix ?? '') . $secret;
+        // Optional auth scheme/prefix ("Key " for FAL, "DeepL-Auth-Key " for DeepL) so
+        // non-Bearer "Authorization: <scheme> <secret>" schemes use audited injection.
+        // Only concatenate when a prefix is set: for the common no-prefix case this avoids
+        // copying the secret into a second buffer (extra allocation + wider exposure window).
+        $value = $this->authPrefix !== null ? $this->authPrefix . $secret : $secret;
 
         try {
             return $request->withHeader($headerName, $value);
         } finally {
             sodium_memzero($secret);
-            sodium_memzero($value);
+            // $value is a distinct buffer only when a prefix was prepended; otherwise it
+            // aliases $secret (already zeroed above), so a second memzero would be redundant.
+            if ($this->authPrefix !== null) {
+                sodium_memzero($value);
+            }
         }
     }
 

--- a/Classes/Http/VaultHttpClient.php
+++ b/Classes/Http/VaultHttpClient.php
@@ -83,6 +83,8 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
      * @param SecretPlacement|null $placement Configured placement type
      * @param OAuthConfig|null $oauthConfig Configured OAuth config
      * @param string|null $headerName Custom header name for Header placement
+     * @param string|null $authPrefix Optional scheme/prefix prepended to the secret for
+     *                                Header placement (e.g. "Key " → "Authorization: Key <secret>")
      * @param string|null $queryParam Custom query param for QueryParam placement
      * @param string|null $bodyField Custom body field for BodyField placement
      * @param string|null $usernameSecretIdentifier Username secret for BasicAuth
@@ -115,6 +117,7 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
         private string $reason = 'HTTP API call',
         ?OAuthTokenManager $oauthManager = null,
         ?SecureHttpClientFactory $secureHttpClientFactory = null,
+        private ?string $authPrefix = null,
     ) {
         // Resolve the factory once: it builds the inner client (when missing)
         // AND backs the OAuth manager's `isHostAllowed()` gate. VaultHttpClient
@@ -157,6 +160,7 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             reason: $options['reason'] ?? $this->reason,
             oauthManager: $this->oauthManager,
             secureHttpClientFactory: $this->secureHttpClientFactory,
+            authPrefix: $options['prefix'] ?? null,
         );
     }
 
@@ -195,6 +199,7 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             reason: $reason,
             oauthManager: $this->oauthManager,
             secureHttpClientFactory: $this->secureHttpClientFactory,
+            authPrefix: $this->authPrefix,
         );
     }
 
@@ -316,11 +321,15 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
         \assert($this->secretIdentifier !== null);
         $secret = $this->retrieveSecret($this->secretIdentifier);
         $headerName = $this->headerName ?? 'X-API-Key';
+        // Optional auth scheme/prefix (e.g. "Key " for FAL, "DeepL-Auth-Key " for DeepL)
+        // so non-Bearer "Authorization: <scheme> <secret>" schemes use audited injection.
+        $value = ($this->authPrefix ?? '') . $secret;
 
         try {
-            return $request->withHeader($headerName, $secret);
+            return $request->withHeader($headerName, $value);
         } finally {
             sodium_memzero($secret);
+            sodium_memzero($value);
         }
     }
 

--- a/Classes/Http/VaultHttpClientInterface.php
+++ b/Classes/Http/VaultHttpClientInterface.php
@@ -38,12 +38,15 @@ interface VaultHttpClientInterface extends ClientInterface
      * @param SecretPlacement $placement How to inject the secret
      * @param array{
      *     headerName?: string,
+     *     prefix?: string,
      *     queryParam?: string,
      *     bodyField?: string,
      *     usernameSecret?: string,
      *     reason?: string
      * } $options Additional options:
      *     - headerName: Custom header name (for SecretPlacement::Header)
+     *     - prefix: Auth scheme/prefix prepended to the secret (for SecretPlacement::Header),
+     *       e.g. 'Key ' → "Authorization: Key <secret>" or 'DeepL-Auth-Key ' for DeepL
      *     - queryParam: Custom query param name (for SecretPlacement::QueryParam)
      *     - bodyField: Custom body field name (for SecretPlacement::BodyField)
      *     - usernameSecret: Username secret identifier (for SecretPlacement::BasicAuth)

--- a/Documentation/Developer/Api.rst
+++ b/Documentation/Developer/Api.rst
@@ -298,7 +298,7 @@ Via VaultService
 
       :param string $secretIdentifier: Vault identifier for the secret.
       :param SecretPlacement $placement: How to inject the secret.
-      :param array $options: Additional options (headerName, queryParam, usernameSecret, reason).
+      :param array $options: Additional options (headerName, prefix, queryParam, usernameSecret, reason).
       :returns: New client instance with authentication configured.
 
    .. php:method:: withOAuth(OAuthConfig $config, string $reason = 'OAuth2 API call'): static
@@ -333,6 +333,11 @@ The :php:`withAuthentication()` method accepts these options:
 
 headerName
    Custom header name (for :php:`SecretPlacement::Header`, default: ``X-API-Key``).
+
+prefix
+   Auth scheme/prefix prepended to the secret (for :php:`SecretPlacement::Header`).
+   Use for non-Bearer ``Authorization: <scheme> <secret>`` schemes — e.g. ``'Key '``
+   for the TYPO3 FAL providers or ``'DeepL-Auth-Key '`` for DeepL.
 
 queryParam
    Query parameter name (for :php:`SecretPlacement::QueryParam`, default: ``api_key``).
@@ -384,6 +389,16 @@ placement
        ]);
    $response = $client->sendRequest(
        new Request('GET', 'https://api.example.com/data')
+   );
+
+   // Custom Authorization scheme (e.g. DeepL "Authorization: DeepL-Auth-Key <key>")
+   $client = $this->vault->http()
+       ->withAuthentication('deepl_api_key', SecretPlacement::Header, [
+           'headerName' => 'Authorization',
+           'prefix' => 'DeepL-Auth-Key ',
+       ]);
+   $response = $client->sendRequest(
+       new Request('POST', 'https://api-free.deepl.com/v2/translate', [], $body)
    );
 
    // Basic authentication with separate credentials

--- a/Documentation/Developer/Api.rst
+++ b/Documentation/Developer/Api.rst
@@ -298,7 +298,7 @@ Via VaultService
 
       :param string $secretIdentifier: Vault identifier for the secret.
       :param SecretPlacement $placement: How to inject the secret.
-      :param array $options: Additional options (headerName, prefix, queryParam, usernameSecret, reason).
+      :param array $options: Additional options (headerName, prefix, queryParam, bodyField, usernameSecret, reason).
       :returns: New client instance with authentication configured.
 
    .. php:method:: withOAuth(OAuthConfig $config, string $reason = 'OAuth2 API call'): static

--- a/Documentation/Usage/_DeepLServiceVault.php
+++ b/Documentation/Usage/_DeepLServiceVault.php
@@ -49,9 +49,15 @@ final class DeepLService
                 'target_lang' => $targetLang,
             ])));
 
-        // Secret resolved at use time, not config load time
+        // Secret resolved at use time, not config load time.
+        // DeepL uses the "Authorization: DeepL-Auth-Key <key>" scheme (not Bearer),
+        // expressed via the Header placement + prefix option.
         $response = $this->vault->http()
-            ->withAuthentication($this->apiKeyRef->identifier, SecretPlacement::Bearer)
+            ->withAuthentication(
+                $this->apiKeyRef->identifier,
+                SecretPlacement::Header,
+                ['headerName' => 'Authorization', 'prefix' => 'DeepL-Auth-Key '],
+            )
             ->withReason('DeepL translation request')
             ->sendRequest($request);
 

--- a/Tests/Unit/Http/VaultHttpClientTest.php
+++ b/Tests/Unit/Http/VaultHttpClientTest.php
@@ -209,6 +209,40 @@ final class VaultHttpClientTest extends TestCase
     }
 
     #[Test]
+    public function withAuthenticationAppliesSchemePrefixToHeader(): void
+    {
+        // FAL/DeepL-style "Authorization: <scheme> <secret>" schemes that Bearer can't express.
+        $this->vaultService
+            ->method('retrieve')
+            ->with('my_api_key')
+            ->willReturn('fal-secret');
+
+        $this->innerClient
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturnCallback(function (RequestInterface $request): Response {
+                self::assertSame('Key fal-secret', $request->getHeaderLine('Authorization'));
+
+                return new Response(200);
+            });
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $authenticatedClient = $client->withAuthentication(
+            'my_api_key',
+            SecretPlacement::Header,
+            ['headerName' => 'Authorization', 'prefix' => 'Key '],
+        );
+
+        $request = new Request('GET', self::API_URL);
+        $authenticatedClient->sendRequest($request);
+    }
+
+    #[Test]
     public function withAuthenticationInjectsBasicAuthFromCombinedSecret(): void
     {
         $this->vaultService


### PR DESCRIPTION
## Summary

The secure HTTP client's `Header` placement could only inject the bare secret as the header value. Non-Bearer `Authorization: <scheme> <secret>` schemes — TYPO3 FAL providers use `Key `, DeepL uses `DeepL-Auth-Key ` — therefore could **not** use the audited secure client and had to build the header manually with a plaintext key.

This adds an optional `prefix` option to `withAuthentication()` for `Header` placement. The prefix is prepended to the secret before injection, so these schemes get the same audited, memory-scrubbed secret handling as Bearer.

```php
$vault->http()->withAuthentication('deepl_api_key', SecretPlacement::Header, [
    'headerName' => 'Authorization',
    'prefix'     => 'DeepL-Auth-Key ',
]);
// → Authorization: DeepL-Auth-Key <secret>
```

## Why

This unblocks the downstream `nr-llm` work: its specialized services (FAL image, DeepL) can migrate off plaintext API keys onto the vault secure HTTP client without losing their custom `Authorization` scheme.

## Changes

- `VaultHttpClient`: new trailing `?string $authPrefix` constructor param (positional BC), threaded through `withAuthentication()` (`prefix` option) and `withReason()`. `injectHeader()` prepends it and zeroes the combined value alongside the raw secret. `withOAuth()` leaves it unset (OAuth uses its own injection path).
- `VaultHttpClientInterface`: added `prefix?: string` to the documented `$options` shape.
- Docs: `Api.rst` options list + a custom-`Authorization`-scheme example; the `DeepL` usage example (which previously documented `Bearer` incorrectly — DeepL never used Bearer).

## Verification (PHP 8.5, `runTests.sh`)

- CGL: SUCCESS
- PHPStan (level 10): No errors
- Unit: 1797 tests / 7235 assertions, SUCCESS — including the new `withAuthenticationAppliesSchemePrefixToHeader` test asserting `Authorization: Key fal-secret`.
