### PR TITLE
Fix peripheral code-review findings in migration, OAuth, and HTTP layers

### DIFF
--- a/Classes/Controller/MigrationController.php
+++ b/Classes/Controller/MigrationController.php
@@ -252,7 +252,7 @@ final readonly class MigrationController
                     'key' => $key,
                     'table' => $table,
                     'column' => $column,
-                    'identifierPattern' => "{$table}__{$column}__{{uid}}",
+                    'identifierPattern' => "{$table}__{$column}__{uid}",
                 ];
             }
         }

--- a/Classes/Http/OAuth/OAuthConfig.php
+++ b/Classes/Http/OAuth/OAuthConfig.php
@@ -12,6 +12,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Http\OAuth;
 
+use Netresearch\NrVault\Exception\ValidationException;
+
 /**
  * Configuration for OAuth 2.0 authentication.
  *
@@ -19,6 +21,9 @@ namespace Netresearch\NrVault\Http\OAuth;
  */
 final readonly class OAuthConfig
 {
+    /** Supported OAuth 2.0 grant types — anything else fails fast. */
+    private const SUPPORTED_GRANT_TYPES = ['client_credentials', 'refresh_token'];
+
     /**
      * @param string $tokenEndpoint OAuth token endpoint URL
      * @param string $clientIdSecret Vault identifier for client ID
@@ -28,6 +33,10 @@ final readonly class OAuthConfig
      * @param array<string> $scopes OAuth scopes to request
      * @param int $tokenExpiryBuffer Seconds before expiry to trigger refresh (default: 60)
      * @param array<string, string> $additionalParams Additional parameters for token request
+     *
+     * @throws ValidationException If the grant type is unsupported, or the
+     *                             refresh_token grant is requested without a
+     *                             refresh-token secret identifier
      */
     public function __construct(
         public string $tokenEndpoint,
@@ -38,7 +47,29 @@ final readonly class OAuthConfig
         public array $scopes = [],
         public int $tokenExpiryBuffer = 60,
         public array $additionalParams = [],
-    ) {}
+    ) {
+        if (!\in_array($this->grantType, self::SUPPORTED_GRANT_TYPES, true)) {
+            throw ValidationException::invalidOption(
+                'grantType',
+                \sprintf(
+                    'must be one of: %s',
+                    implode(', ', self::SUPPORTED_GRANT_TYPES),
+                ),
+            );
+        }
+
+        // A refresh_token grant with no refresh-token secret is an illegal
+        // state: the manager would silently fall back to client_credentials,
+        // hiding a misconfiguration. Reject it at construction time.
+        if ($this->grantType === 'refresh_token'
+            && ($this->refreshTokenSecret === null || $this->refreshTokenSecret === '')
+        ) {
+            throw ValidationException::invalidOption(
+                'refreshTokenSecret',
+                'is required for the refresh_token grant type',
+            );
+        }
+    }
 
     /**
      * Create config for client credentials flow.

--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -570,8 +570,9 @@ final class OAuthTokenManager
      * body, not the request — so a well-behaved server doesn't leak the
      * `client_secret` we sent. But:
      *
-     *  - OAuth servers sometimes echo the offending input back ("Invalid
-     *    client_secret 'xyz'"). RFC 6749 doesn't forbid it.
+     *  - OAuth servers sometimes echo the offending input back, either in a
+     *    JSON error body (`{"error":"...","client_secret":"xyz"}`) or quoted
+     *    in prose (`Invalid client_secret 'xyz'`). RFC 6749 doesn't forbid it.
      *  - A future refactor could land HTTP Basic auth (`Authorization: Basic
      *    base64(client_id:client_secret)`) which DOES appear in
      *    `RequestException::getMessage()` when verbose error formatting kicks
@@ -581,11 +582,16 @@ final class OAuthTokenManager
      *
      * Defence in depth: never trust upstream error messages to be free of
      * credentials. Cheap to apply, eliminates an entire class of accidental
-     * leaks through logs/audit/exception chains.
+     * leaks through logs/audit/exception chains. All patterns are BOUNDED
+     * (delimiter-anchored character classes, no `.*?`/nested quantifiers) so
+     * they cannot trigger catastrophic regex backtracking.
      */
     private function redactCredentials(string $message): string
     {
-        return (string) preg_replace(
+        // Pass 1: prefix-anchored forms whose value runs to a delimiter. The
+        // shared replacement keeps capture group 1 (the key/prefix) and drops
+        // the value.
+        $message = (string) preg_replace(
             [
                 // form-encoded `client_secret=...` (request bodies, query strings)
                 '/(client_secret=)[^&\s"\'<>]+/i',
@@ -596,6 +602,21 @@ final class OAuthTokenManager
                 '/(Authorization:\s*Basic\s+)\S+/i',
             ],
             self::REDACT_REPLACEMENT,
+            $message,
+        );
+
+        // Pass 2: quoted-value forms where the credential is wrapped in matching
+        // quotes — a JSON error body (`"client_secret":"xyz"`) or a prose echo
+        // (`client_secret 'xyz'`). Group 1 keeps the key + opening quote,
+        // group 2 keeps the closing quote; the value between is dropped.
+        return (string) preg_replace(
+            [
+                // JSON: "client_secret":"...", "refresh_token":"...", "access_token":"..."
+                '/("(?:client_secret|refresh_token|access_token)"\s*:\s*")[^"]*(")/i',
+                // Quoted echo: client_secret '...' or client_secret "..."
+                '/((?:client_secret|refresh_token|access_token)\s+["\'])[^"\']*(["\'])/i',
+            ],
+            '$1[REDACTED]$2',
             $message,
         );
     }

--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -612,7 +612,13 @@ final class OAuthTokenManager
         return (string) preg_replace(
             [
                 // JSON: "client_secret":"...", "refresh_token":"...", "access_token":"..."
-                '/("(?:client_secret|refresh_token|access_token)"\s*:\s*")[^"]*(")/i',
+                // The value part handles JSON escape sequences (`\"`, `\\`, …)
+                // via the unrolled-loop idiom `[^"\x5c]*(?:\x5c.[^"\x5c]*)*`
+                // (\x5c = backslash): a credential containing an escaped quote
+                // would otherwise end the match early and leak its remainder.
+                // The idiom is linear — each position is matched by exactly one
+                // branch, so no catastrophic backtracking.
+                '/("(?:client_secret|refresh_token|access_token)"\s*:\s*")[^"\x5c]*(?:\x5c.[^"\x5c]*)*(")/i',
                 // Quoted echo: client_secret '...' or client_secret "..."
                 '/((?:client_secret|refresh_token|access_token)\s+["\'])[^"\']*(["\'])/i',
             ],

--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -523,21 +523,42 @@ final class OAuthTokenManager
      * Sonar flags them across the board, and avoid sha256 because the extra
      * cost is wasted for a non-security use.
      *
-     * `clientSecretSecret` is included so two configs that share the same
-     * client_id-secret identifier but reference different client_secret-secret
-     * identifiers don't collide on the cache (e.g. a key rotation that swaps
-     * the secret identifier without changing the client_id). The cache holds
-     * the access token, NOT the client_secret value — the identifier is
-     * non-sensitive enough to feed into a cache key.
+     * The key folds in every input that changes WHICH token the endpoint
+     * returns:
+     *  - `clientSecretSecret` so a credential rotation that swaps the
+     *    client_secret vault handle (without changing the client_id) gets a
+     *    fresh slot rather than serving the pre-rotation token;
+     *  - `refreshTokenSecret` so a config pointing at a different refresh-token
+     *    source is a distinct identity;
+     *  - `additionalParams` (audience / resource / tenant / …) so two configs
+     *    that differ only in audience don't collide — otherwise a token minted
+     *    for audience A leaks to a request asking for audience B.
+     *
+     * The cache holds the access token, NOT the secret VALUES — only the vault
+     * identifiers and request params, which are non-sensitive enough to key on.
      */
     private function getCacheKey(OAuthConfig $config): string
     {
+        // `additionalParams` (audience, resource, tenant, …) materially change
+        // which token the endpoint returns. Two configs identical except for
+        // these params MUST get distinct cache slots, otherwise a token minted
+        // for audience A would be served to a request that asked for audience B
+        // (cross-audience token confusion). Serialize deterministically (ksort)
+        // so key order never affects the hash.
+        $params = $config->additionalParams;
+        ksort($params);
+
         return hash('xxh128', implode(':', [
             $config->tokenEndpoint,
             $config->clientIdSecret,
             $config->clientSecretSecret,
             $config->grantType,
+            // For the refresh_token grant the refresh-token vault handle is part
+            // of the identity — a config pointing at a different refresh-token
+            // secret is a different token source.
+            $config->refreshTokenSecret ?? '',
             $config->getScopesString(),
+            hash('xxh128', json_encode($params, JSON_THROW_ON_ERROR)),
         ]));
     }
 

--- a/Classes/Http/VaultHttpClient.php
+++ b/Classes/Http/VaultHttpClient.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Http;
 
 use GuzzleHttp\Psr7\Utils;
+use JsonException;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Audit\HttpCallContext;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
@@ -405,11 +406,18 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
      * the secret field.
      *
      * An empty (or whitespace-only) body is treated as "no fields yet" and
-     * yields `[]`. Anything else MUST decode to a JSON object — a scalar
-     * (`"x"`, `42`, `true`) would make the subsequent `$data[$field] = ...`
-     * fatal, and a JSON array/list would silently reshape into a mixed-key
-     * structure. Both indicate the caller paired a non-object body with
-     * body-field secret injection, so we fail loudly instead of corrupting it.
+     * yields `[]`. Anything else MUST be a JSON object — a scalar (`"x"`,
+     * `42`, `true`) would make the subsequent `$data[$field] = ...` fatal,
+     * and a JSON array/list (including the empty list `[]`) would silently
+     * reshape into a mixed-key structure. Both indicate the caller paired a
+     * non-object body with body-field secret injection, so we fail loudly
+     * instead of corrupting it. Malformed JSON is rejected explicitly for the
+     * same reason — the old `?: []` coercion silently dropped the payload.
+     *
+     * Because `json_decode(..., true)` maps both `{}` and `[]` to the same
+     * PHP value (`[]`), the decoded value alone cannot distinguish an empty
+     * object from an empty list; the first non-whitespace character is the
+     * deterministic discriminator (a JSON object always starts with `{`).
      *
      * @throws VaultException If the body is non-empty but not a JSON object
      *
@@ -417,11 +425,31 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
      */
     private function decodeJsonObjectBody(string $body): array
     {
-        if (trim($body) === '') {
+        $trimmed = trim($body);
+        if ($trimmed === '') {
             return [];
         }
 
-        $decoded = json_decode($body, true);
+        if (!str_starts_with($trimmed, '{')) {
+            throw new VaultException(
+                'Cannot inject body-field secret: request body must be a JSON object',
+                1735858524,
+            );
+        }
+
+        try {
+            $decoded = json_decode($trimmed, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            throw new VaultException(
+                'Cannot inject body-field secret: request body is not valid JSON',
+                1781076764,
+                $exception,
+            );
+        }
+
+        // Type guard for static analysis plus rejection of JSON objects whose
+        // numeric string keys decode to a PHP list ({"0":"a"} → [0 => 'a']) —
+        // injecting a named field there would re-encode a reshaped structure.
         if (!\is_array($decoded) || ($decoded !== [] && array_is_list($decoded))) {
             throw new VaultException(
                 'Cannot inject body-field secret: request body must be a JSON object',

--- a/Classes/Http/VaultHttpClient.php
+++ b/Classes/Http/VaultHttpClient.php
@@ -382,8 +382,7 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             $body = (string) $request->getBody();
 
             if (str_contains($contentType, 'application/json')) {
-                /** @var array<string, mixed> $data */
-                $data = json_decode($body, true) ?: [];
+                $data = $this->decodeJsonObjectBody($body);
                 $data[$fieldName] = $secret;
                 $newBody = json_encode($data, JSON_THROW_ON_ERROR);
             } else {
@@ -399,6 +398,39 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
         } finally {
             sodium_memzero($secret);
         }
+    }
+
+    /**
+     * Decode a JSON request body into a string-keyed array suitable for adding
+     * the secret field.
+     *
+     * An empty (or whitespace-only) body is treated as "no fields yet" and
+     * yields `[]`. Anything else MUST decode to a JSON object — a scalar
+     * (`"x"`, `42`, `true`) would make the subsequent `$data[$field] = ...`
+     * fatal, and a JSON array/list would silently reshape into a mixed-key
+     * structure. Both indicate the caller paired a non-object body with
+     * body-field secret injection, so we fail loudly instead of corrupting it.
+     *
+     * @throws VaultException If the body is non-empty but not a JSON object
+     *
+     * @return array<string, mixed>
+     */
+    private function decodeJsonObjectBody(string $body): array
+    {
+        if (trim($body) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($body, true);
+        if (!\is_array($decoded) || ($decoded !== [] && array_is_list($decoded))) {
+            throw new VaultException(
+                'Cannot inject body-field secret: request body must be a JSON object',
+                1735858524,
+            );
+        }
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
     }
 
     private function injectOAuth(RequestInterface $request): RequestInterface

--- a/Classes/Utility/IdentifierValidator.php
+++ b/Classes/Utility/IdentifierValidator.php
@@ -109,7 +109,7 @@ final class IdentifierValidator
             ($time >> 16) & 0xFFFFFFFF,           // timestamp high 32 bits
             $time & 0xFFFF,                        // timestamp low 16 bits
             \ord($random[0]) << 4 | \ord($random[1]) >> 4 & 0x0FFF, // version 7 + 12 random bits
-            (\ord($random[1]) & 0x0F) << 8 | \ord($random[2]) & 0x3FFF | 0x8000, // variant 10 + 14 random bits
+            ((\ord($random[1]) << 8 | \ord($random[2])) & 0x3FFF) | 0x8000, // variant 10 + 14 random bits
             (\ord($random[3]) << 40) | (\ord($random[4]) << 32) | (\ord($random[5]) << 24)
                 | (\ord($random[6]) << 16) | (\ord($random[7]) << 8) | \ord($random[8]), // 48 random bits
         );

--- a/Tests/Functional/Controller/MigrationControllerTest.php
+++ b/Tests/Functional/Controller/MigrationControllerTest.php
@@ -9,11 +9,18 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Functional\Controller;
 
+use Doctrine\DBAL\Schema\Table;
+use Doctrine\DBAL\Types\Types;
 use Netresearch\NrVault\Controller\MigrationController;
+use Netresearch\NrVault\Domain\Dto\MigrationResult;
 use Netresearch\NrVault\Service\SecretDetectionServiceInterface;
+use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use Netresearch\NrVault\Utility\IdentifierValidator;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 
 /**
  * Functional tests for MigrationController.
@@ -24,7 +31,25 @@ use PHPUnit\Framework\Attributes\Test;
 #[CoversClass(MigrationController::class)]
 final class MigrationControllerTest extends AbstractVaultFunctionalTestCase
 {
+    private const FIXTURE_TABLE = 'tx_nrvault_test_migration';
+
+    private const FIXTURE_COLUMN = 'secret_value';
+
     protected ?string $backendUserFixture = __DIR__ . '/../Hook/Fixtures/be_users.csv';
+
+    protected function tearDown(): void
+    {
+        if (isset($GLOBALS['TYPO3_CONF_VARS'])) {
+            $schemaManager = $this->get(ConnectionPool::class)
+                ->getConnectionForTable(self::FIXTURE_TABLE)
+                ->createSchemaManager();
+            if ($schemaManager->tablesExist([self::FIXTURE_TABLE])) {
+                $schemaManager->dropTable(self::FIXTURE_TABLE);
+            }
+        }
+
+        parent::tearDown();
+    }
 
     #[Test]
     public function secretDetectionServiceIsInjectable(): void
@@ -71,5 +96,127 @@ final class MigrationControllerTest extends AbstractVaultFunctionalTestCase
         $grouped = $detectionService->getDetectedSecretsBySeverity();
 
         self::assertIsArray($grouped);
+    }
+
+    /**
+     * End-to-end migration: a plaintext column value is stored in the vault and
+     * the column is rewritten to a VALID vault identifier.
+     *
+     * This is the regression guard for the `{{uid}}` double-brace bug in the
+     * configure step (`MigrationController::configureAction`): the migration
+     * substitutes `{uid}` in the identifier pattern via `str_replace`. A
+     * double-brace pattern (`table__column__{{uid}}`) leaves literal braces
+     * after substitution, which `IdentifierValidator` rejects — so
+     * `VaultService::store()` throws and EVERY column migration fails. Here we
+     * drive the (private) `migrateColumn` with the single-brace pattern the
+     * fixed controller produces and assert the secret is actually stored and
+     * the column now holds a syntactically valid identifier.
+     */
+    #[Test]
+    public function migrateColumnStoresSecretAndRewritesColumnWithValidIdentifier(): void
+    {
+        $this->createMigrationFixtureTable();
+        $connectionPool = $this->get(ConnectionPool::class);
+        $connection = $connectionPool->getConnectionForTable(self::FIXTURE_TABLE);
+        $connection->insert(self::FIXTURE_TABLE, [self::FIXTURE_COLUMN => 'plaintext-api-key']);
+        $uid = (int) $connection->lastInsertId();
+
+        // Pattern exactly as the fixed configureAction builds it: single braces.
+        $pattern = self::FIXTURE_TABLE . '__' . self::FIXTURE_COLUMN . '__{uid}';
+        $result = $this->invokeMigrateColumn(self::FIXTURE_TABLE, self::FIXTURE_COLUMN, $pattern);
+
+        self::assertSame(1, $result->migrated, 'Expected exactly one row to be migrated');
+        self::assertSame(0, $result->failed, 'Migration must not report failures: ' . ($result->error ?? ''));
+
+        // The column now holds the substituted identifier, which must be valid.
+        $expectedIdentifier = self::FIXTURE_TABLE . '__' . self::FIXTURE_COLUMN . '__' . $uid;
+        self::assertTrue(
+            IdentifierValidator::isValid($expectedIdentifier),
+            'The substituted identifier must pass IdentifierValidator',
+        );
+
+        $storedColumn = $connection
+            ->select([self::FIXTURE_COLUMN], self::FIXTURE_TABLE, ['uid' => $uid])
+            ->fetchOne();
+        self::assertSame($expectedIdentifier, $storedColumn, 'Column must be rewritten with the vault identifier');
+
+        // The secret is actually retrievable from the vault under that identifier.
+        $vaultService = $this->get(VaultServiceInterface::class);
+        self::assertTrue($vaultService->exists($expectedIdentifier));
+        self::assertSame('plaintext-api-key', $vaultService->retrieve($expectedIdentifier));
+
+        $vaultService->delete($expectedIdentifier, 'test cleanup');
+    }
+
+    /**
+     * Bug characterisation: the OLD double-brace pattern leaves literal braces
+     * after `{uid}` substitution, producing an INVALID identifier so the row
+     * fails to migrate and nothing is stored. This documents precisely why the
+     * `{{uid}}` regression broke every backend column migration.
+     */
+    #[Test]
+    public function migrateColumnWithDoubleBracePatternFailsAndStoresNothing(): void
+    {
+        $this->createMigrationFixtureTable();
+        $connectionPool = $this->get(ConnectionPool::class);
+        $connection = $connectionPool->getConnectionForTable(self::FIXTURE_TABLE);
+        $connection->insert(self::FIXTURE_TABLE, [self::FIXTURE_COLUMN => 'plaintext-api-key']);
+        $uid = (int) $connection->lastInsertId();
+
+        // The buggy pattern: double braces around uid.
+        $buggyPattern = self::FIXTURE_TABLE . '__' . self::FIXTURE_COLUMN . '__{{uid}}';
+        $result = $this->invokeMigrateColumn(self::FIXTURE_TABLE, self::FIXTURE_COLUMN, $buggyPattern);
+
+        self::assertSame(0, $result->migrated, 'A literal-brace identifier must not migrate');
+        self::assertSame(1, $result->failed, 'The row must be reported as failed');
+
+        // Column is untouched and nothing landed in the vault.
+        $storedColumn = $connection
+            ->select([self::FIXTURE_COLUMN], self::FIXTURE_TABLE, ['uid' => $uid])
+            ->fetchOne();
+        self::assertSame('plaintext-api-key', $storedColumn, 'Failed migration must leave the column unchanged');
+
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $brokenIdentifier = self::FIXTURE_TABLE . '__' . self::FIXTURE_COLUMN . '__{' . $uid . '}';
+        self::assertFalse($vaultService->exists($brokenIdentifier));
+    }
+
+    /**
+     * Invoke the private `MigrationController::migrateColumn()` via reflection.
+     * The full backend-module render path (`handleRequest`/`configureAction`)
+     * needs a module routing attribute on the request that functional tests do
+     * not provide (see {@see OverviewControllerTest}); the column-rewrite logic
+     * we care about lives in `migrateColumn`, which renders nothing.
+     */
+    private function invokeMigrateColumn(string $table, string $column, string $pattern): MigrationResult
+    {
+        $controller = $this->get(MigrationController::class);
+        $method = (new ReflectionClass(MigrationController::class))->getMethod('migrateColumn');
+        $result = $method->invoke($controller, $table, $column, $pattern);
+        self::assertInstanceOf(MigrationResult::class, $result);
+
+        return $result;
+    }
+
+    /**
+     * Create the throwaway fixture table the migration runs against. Built via
+     * the same schema manager `migrateColumn` uses for validation, so the table
+     * and column pass its `listTables()` / `listTableColumns()` checks.
+     */
+    private function createMigrationFixtureTable(): void
+    {
+        $schemaManager = $this->get(ConnectionPool::class)
+            ->getConnectionForTable(self::FIXTURE_TABLE)
+            ->createSchemaManager();
+
+        if ($schemaManager->tablesExist([self::FIXTURE_TABLE])) {
+            return;
+        }
+
+        $table = new Table(self::FIXTURE_TABLE);
+        $table->addColumn('uid', Types::INTEGER, ['autoincrement' => true, 'unsigned' => true]);
+        $table->addColumn(self::FIXTURE_COLUMN, Types::TEXT, ['notnull' => false]);
+        $table->setPrimaryKey(['uid']);
+        $schemaManager->createTable($table);
     }
 }

--- a/Tests/Fuzz/MasterKeyFuzzTest.php
+++ b/Tests/Fuzz/MasterKeyFuzzTest.php
@@ -111,7 +111,13 @@ final class MasterKeyFuzzTest extends TestCase
             if ($len === 32) {
                 $len = 31;
             }
-            $bytes = random_bytes($len);
+            do {
+                $bytes = random_bytes($len);
+                // FileMasterKeyProvider trim()s file content before the length
+                // check, so a blob with whitespace-class lead/trail bytes can
+                // shrink to a VALID 32-byte key (e.g. 33 bytes ending in \n).
+                // Regenerate until the trimmed form stays invalid.
+            } while (\strlen(trim($bytes)) === 32);
             $cases["random_bytes_{$i}_len{$len}"] = [$bytes];
         }
 

--- a/Tests/Unit/Http/OAuth/OAuthConfigTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthConfigTest.php
@@ -118,13 +118,16 @@ final class OAuthConfigTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessageMatches('/refreshTokenSecret.*required for the refresh_token grant/i');
 
-        new OAuthConfig(
+        // The assertion is unreachable when the guard works — it exists so the
+        // construction result is consumed (Sonar S1848) and to fail loudly if not.
+        $config = new OAuthConfig(
             tokenEndpoint: self::TOKEN_ENDPOINT,
             clientIdSecret: self::CLIENT_ID_SECRET,
             clientSecretSecret: self::CLIENT_SECRET_SECRET,
             grantType: 'refresh_token',
             // refreshTokenSecret omitted → null
         );
+        self::assertInstanceOf(OAuthConfig::class, $config);
     }
 
     #[Test]
@@ -133,13 +136,14 @@ final class OAuthConfigTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessageMatches('/refreshTokenSecret.*required for the refresh_token grant/i');
 
-        new OAuthConfig(
+        $config = new OAuthConfig(
             tokenEndpoint: self::TOKEN_ENDPOINT,
             clientIdSecret: self::CLIENT_ID_SECRET,
             clientSecretSecret: self::CLIENT_SECRET_SECRET,
             grantType: 'refresh_token',
             refreshTokenSecret: '',
         );
+        self::assertInstanceOf(OAuthConfig::class, $config);
     }
 
     /**
@@ -152,12 +156,13 @@ final class OAuthConfigTest extends TestCase
         $this->expectException(ValidationException::class);
         $this->expectExceptionMessageMatches('/grantType.*must be one of/i');
 
-        new OAuthConfig(
+        $config = new OAuthConfig(
             tokenEndpoint: self::TOKEN_ENDPOINT,
             clientIdSecret: self::CLIENT_ID_SECRET,
             clientSecretSecret: self::CLIENT_SECRET_SECRET,
             grantType: 'password',
         );
+        self::assertInstanceOf(OAuthConfig::class, $config);
     }
 
     #[Test]

--- a/Tests/Unit/Http/OAuth/OAuthConfigTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthConfigTest.php
@@ -12,6 +12,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Http\OAuth;
 
+use Netresearch\NrVault\Exception\ValidationException;
 use Netresearch\NrVault\Http\OAuth\OAuthConfig;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -104,6 +105,59 @@ final class OAuthConfigTest extends TestCase
         self::assertSame('refresh_token', $config->grantType);
         self::assertSame(self::REFRESH_TOKEN_SECRET, $config->refreshTokenSecret);
         self::assertSame(['offline_access'], $config->scopes);
+    }
+
+    /**
+     * Illegal-state guard: a `refresh_token` grant with no refresh-token secret
+     * identifier must be rejected at construction time. Otherwise the token
+     * manager silently downgrades to client_credentials, hiding a config error.
+     */
+    #[Test]
+    public function constructorRejectsRefreshTokenGrantWithNullSecret(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessageMatches('/refreshTokenSecret.*required for the refresh_token grant/i');
+
+        new OAuthConfig(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            grantType: 'refresh_token',
+            // refreshTokenSecret omitted → null
+        );
+    }
+
+    #[Test]
+    public function constructorRejectsRefreshTokenGrantWithEmptySecret(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessageMatches('/refreshTokenSecret.*required for the refresh_token grant/i');
+
+        new OAuthConfig(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            grantType: 'refresh_token',
+            refreshTokenSecret: '',
+        );
+    }
+
+    /**
+     * Unknown grant types must fail fast rather than reaching the token manager
+     * (which only branches on `client_credentials` / `refresh_token`).
+     */
+    #[Test]
+    public function constructorRejectsUnsupportedGrantType(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessageMatches('/grantType.*must be one of/i');
+
+        new OAuthConfig(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            grantType: 'password',
+        );
     }
 
     #[Test]

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -1340,6 +1340,26 @@ final class OAuthTokenManagerTest extends TestCase
             'Connection refused (timeout after 10s)',
             'Connection refused (timeout after 10s)',
         ];
+        yield 'client_secret in JSON error body' => [
+            '{"error":"invalid_client","client_secret":"topSecr3t"}',
+            '{"error":"invalid_client","client_secret":"[REDACTED]"}',
+        ];
+        yield 'refresh_token in JSON error body' => [
+            '{"error":"invalid_grant","refresh_token":"eyJabc.def.ghi"}',
+            '{"error":"invalid_grant","refresh_token":"[REDACTED]"}',
+        ];
+        yield 'access_token in JSON error body with spaces' => [
+            '{ "access_token" : "leaked-bearer" }',
+            '{ "access_token" : "[REDACTED]" }',
+        ];
+        yield 'client_secret echoed in single-quoted prose' => [
+            "Invalid client_secret 'topSecr3t' supplied",
+            "Invalid client_secret '[REDACTED]' supplied",
+        ];
+        yield 'client_secret echoed in double-quoted prose' => [
+            'rejected client_secret "topSecr3t"',
+            'rejected client_secret "[REDACTED]"',
+        ];
     }
 
     /**

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -212,6 +212,63 @@ final class OAuthTokenManagerTest extends TestCase
         );
     }
 
+    /**
+     * Cross-audience token confusion guard: two configs identical except for
+     * `additionalParams` (e.g. a different `audience`/`resource`) MUST produce
+     * distinct cache keys. Otherwise a token minted for audience A would be
+     * served from cache to a request that asked for audience B.
+     */
+    #[Test]
+    public function cacheKeyFragmentsOnAdditionalParams(): void
+    {
+        $configA = new OAuthConfig(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            additionalParams: ['audience' => 'https://api-a.example.com'],
+        );
+        $configB = new OAuthConfig(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            additionalParams: ['audience' => 'https://api-b.example.com'],
+        );
+
+        self::assertNotSame(
+            $this->cacheKeyFor($configA),
+            $this->cacheKeyFor($configB),
+            'Configs differing only in additionalParams (audience) must not share a cache slot',
+        );
+    }
+
+    /**
+     * Deterministic-key guard: the cache key must NOT depend on the array order
+     * of `additionalParams` — `ksort` normalises it. Two configs with the same
+     * params in different order are the same identity and must share a slot.
+     */
+    #[Test]
+    public function cacheKeyIsStableAcrossAdditionalParamsOrder(): void
+    {
+        $configA = new OAuthConfig(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            additionalParams: ['audience' => 'https://api.example.com', 'resource' => 'r1'],
+        );
+        $configB = new OAuthConfig(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            additionalParams: ['resource' => 'r1', 'audience' => 'https://api.example.com'],
+        );
+
+        self::assertSame(
+            $this->cacheKeyFor($configA),
+            $this->cacheKeyFor($configB),
+            'additionalParams order must not change the cache key (ksort normalises it)',
+        );
+    }
+
     #[Test]
     public function getAccessTokenRefreshesExpiredToken(): void
     {
@@ -1283,6 +1340,18 @@ final class OAuthTokenManagerTest extends TestCase
             'Connection refused (timeout after 10s)',
             'Connection refused (timeout after 10s)',
         ];
+    }
+
+    /**
+     * Invoke the private `getCacheKey()` via reflection. Handles static and
+     * instance forms so cgl / rector can flip the method freely.
+     */
+    private function cacheKeyFor(OAuthConfig $config): string
+    {
+        $method = (new ReflectionClass(OAuthTokenManager::class))->getMethod('getCacheKey');
+        $target = $method->isStatic() ? null : $this->subject;
+
+        return (string) $method->invoke($target, $config);
     }
 
     private function setupRequestFactory(): void

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -1354,6 +1354,16 @@ final class OAuthTokenManagerTest extends TestCase
             '{ "access_token" : "leaked-bearer" }',
             '{ "access_token" : "[REDACTED]" }',
         ];
+        yield 'client_secret with escaped quote in JSON error body' => [
+            // JSON-escaped quote inside the secret (`top\"Secr3t`): a naive
+            // `[^"]*` value match stops at the escape and leaks `Secr3t"`.
+            '{"error":"invalid_client","client_secret":"top\"Secr3t"}',
+            '{"error":"invalid_client","client_secret":"[REDACTED]"}',
+        ];
+        yield 'client_secret with escaped backslashes in JSON error body' => [
+            '{"error":"invalid_client","client_secret":"a\\\\b\"c\\\\"}',
+            '{"error":"invalid_client","client_secret":"[REDACTED]"}',
+        ];
         yield 'client_secret echoed in single-quoted prose' => [
             "Invalid client_secret 'topSecr3t' supplied",
             "Invalid client_secret '[REDACTED]' supplied",

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -49,6 +49,8 @@ final class OAuthTokenManagerTest extends TestCase
 
     private const REFRESH_TOKEN_SECRET = 'oauth/refresh-token';
 
+    private const AUDIENCE = 'https://api.example.com';
+
     private OAuthTokenManager $subject;
 
     private VaultServiceInterface&MockObject $vaultService;
@@ -253,13 +255,13 @@ final class OAuthTokenManagerTest extends TestCase
             tokenEndpoint: self::TOKEN_ENDPOINT,
             clientIdSecret: self::CLIENT_ID_SECRET,
             clientSecretSecret: self::CLIENT_SECRET_SECRET,
-            additionalParams: ['audience' => 'https://api.example.com', 'resource' => 'r1'],
+            additionalParams: ['audience' => self::AUDIENCE, 'resource' => 'r1'],
         );
         $configB = new OAuthConfig(
             tokenEndpoint: self::TOKEN_ENDPOINT,
             clientIdSecret: self::CLIENT_ID_SECRET,
             clientSecretSecret: self::CLIENT_SECRET_SECRET,
-            additionalParams: ['resource' => 'r1', 'audience' => 'https://api.example.com'],
+            additionalParams: ['resource' => 'r1', 'audience' => self::AUDIENCE],
         );
 
         self::assertSame(
@@ -851,7 +853,7 @@ final class OAuthTokenManagerTest extends TestCase
             tokenEndpoint: self::TOKEN_ENDPOINT,
             clientIdSecret: self::CLIENT_ID_SECRET,
             clientSecretSecret: self::CLIENT_SECRET_SECRET,
-            additionalParams: ['audience' => 'https://api.example.com'],
+            additionalParams: ['audience' => self::AUDIENCE],
         );
 
         $this->vaultService

--- a/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
@@ -70,6 +70,19 @@ final class SecureHttpClientFactorySsrfTest extends TestCase
         yield 'ipv6 link-local fe80::/10' => ['fe80::1'];
         yield 'ipv6 multicast ff00::/8' => ['ff02::1'];
 
+        // IPv6 transition forms — each embeds a dangerous IPv4 that a naive
+        // range check would let through (CVE-2026-48736 class). The deny logic
+        // decodes the embedded IPv4 and recurses into the v4 check.
+        yield 'ipv4-mapped metadata ::ffff:169.254.169.254' => ['::ffff:169.254.169.254'];
+        yield 'ipv4-mapped loopback ::ffff:127.0.0.1' => ['::ffff:127.0.0.1'];
+        yield '6to4 metadata 2002:a9fe:a9fe::' => ['2002:a9fe:a9fe::'];
+        yield 'nat64 metadata 64:ff9b::169.254.169.254' => ['64:ff9b::169.254.169.254'];
+        yield 'ipv4-compatible loopback ::127.0.0.1' => ['::127.0.0.1'];
+        // Teredo (2001:0::/32): server 8.8.8.8 (public), client 127.0.0.1
+        // stored obfuscated (XOR 0xffffffff). The client IPv4 alone is enough
+        // to deny: 127.0.0.1 ^ 0xffffffff packed back → 2001:0:808:808::80ff:fffe.
+        yield 'teredo internal client 127.0.0.1' => ['2001:0:808:808::80ff:fffe'];
+
         // host:port / [ipv6]:port — port-stripping must not bypass the guard
         yield 'ipv4 with port' => ['127.0.0.1:8080'];
         yield 'aws metadata with port' => ['169.254.169.254:80'];
@@ -112,6 +125,17 @@ final class SecureHttpClientFactorySsrfTest extends TestCase
         // 8.8.8.8 is a public IPv4 — once IP guards pass and no allowlist is set,
         // the method must return true (default-allow gated by IP/DNS checks).
         self::assertTrue($this->subject->isHostAllowed('8.8.8.8'));
+    }
+
+    #[Test]
+    public function isHostAllowedAllowsPublicIpv6WithNoAllowlist(): void
+    {
+        // 2606:4700:4700::1111 (Cloudflare) is a public IPv6 literal — it is
+        // NOT a transition form and embeds no dangerous IPv4, so once the IPv6
+        // guards pass and no allowlist is set it must be allowed. This is the
+        // control that proves the transition-form deny rows aren't over-blocking
+        // all IPv6.
+        self::assertTrue($this->subject->isHostAllowed('2606:4700:4700::1111'));
     }
 
     #[Test]

--- a/Tests/Unit/Http/VaultHttpClientTest.php
+++ b/Tests/Unit/Http/VaultHttpClientTest.php
@@ -750,10 +750,47 @@ final class VaultHttpClientTest extends TestCase
     }
 
     /**
+     * An empty JSON array body (`[]`) decodes to the same PHP value as `{}`,
+     * so it used to slip through the list guard and get silently reshaped
+     * into an object once the secret field was assigned. The leading-token
+     * check (`{`) must reject it deterministically before any HTTP call.
+     */
+    #[Test]
+    public function injectBodyFieldRejectsEmptyJsonArrayBody(): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->with('my_api_key')
+            ->willReturn('secret-value');
+
+        $this->innerClient
+            ->expects(self::never())
+            ->method('sendRequest');
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::BodyField);
+
+        $request = new Request('POST', self::API_URL, [
+            'Content-Type' => self::CONTENT_TYPE_JSON,
+        ], '[]');
+
+        $this->expectException(VaultException::class);
+        $this->expectExceptionMessage(self::NON_OBJECT_BODY_MESSAGE);
+
+        $authenticatedClient->sendRequest($request);
+    }
+
+    /**
      * Behavioural change guard: a syntactically INVALID JSON body used to be
      * silently coerced to `[]` (`json_decode(...) ?: []`), so the request went
      * out as `{"field":"secret"}` and the caller's original payload was
-     * dropped. Now it must be rejected before any HTTP call.
+     * dropped. Now it must be rejected before any HTTP call — with the
+     * explicit malformed-JSON message, not the generic non-object one.
      */
     #[Test]
     public function injectBodyFieldRejectsMalformedJsonBody(): void
@@ -780,7 +817,7 @@ final class VaultHttpClientTest extends TestCase
         ], '{"broken": ');
 
         $this->expectException(VaultException::class);
-        $this->expectExceptionMessage(self::NON_OBJECT_BODY_MESSAGE);
+        $this->expectExceptionMessage('request body is not valid JSON');
 
         $authenticatedClient->sendRequest($request);
     }

--- a/Tests/Unit/Http/VaultHttpClientTest.php
+++ b/Tests/Unit/Http/VaultHttpClientTest.php
@@ -676,6 +676,113 @@ final class VaultHttpClientTest extends TestCase
         $authenticatedClient->sendRequest($request);
     }
 
+    /**
+     * A JSON request body that decodes to a list (not an object) cannot carry a
+     * named secret field. The old code did `$data[$field] = ...` on the list,
+     * silently reshaping it into a mixed-key structure. Reject it deterministically.
+     */
+    #[Test]
+    public function injectBodyFieldRejectsJsonArrayBody(): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->with('my_api_key')
+            ->willReturn('secret-value');
+
+        // The malformed body must be rejected BEFORE any HTTP call is made.
+        $this->innerClient
+            ->expects(self::never())
+            ->method('sendRequest');
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::BodyField);
+
+        $request = new Request('POST', self::API_URL, [
+            'Content-Type' => self::CONTENT_TYPE_JSON,
+        ], json_encode([1, 2, 3]));
+
+        $this->expectException(VaultException::class);
+        $this->expectExceptionMessage('request body must be a JSON object');
+
+        $authenticatedClient->sendRequest($request);
+    }
+
+    /**
+     * A scalar JSON body (`"value"`, `42`, `true`) is even worse — the old
+     * `$data[$field] = ...` on a string/int would fatally error after the
+     * secret was already retrieved. Reject it with a clear exception instead.
+     */
+    #[Test]
+    public function injectBodyFieldRejectsJsonScalarBody(): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->with('my_api_key')
+            ->willReturn('secret-value');
+
+        $this->innerClient
+            ->expects(self::never())
+            ->method('sendRequest');
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::BodyField);
+
+        $request = new Request('POST', self::API_URL, [
+            'Content-Type' => self::CONTENT_TYPE_JSON,
+        ], json_encode('just-a-string'));
+
+        $this->expectException(VaultException::class);
+        $this->expectExceptionMessage('request body must be a JSON object');
+
+        $authenticatedClient->sendRequest($request);
+    }
+
+    /**
+     * Behavioural change guard: a syntactically INVALID JSON body used to be
+     * silently coerced to `[]` (`json_decode(...) ?: []`), so the request went
+     * out as `{"field":"secret"}` and the caller's original payload was
+     * dropped. Now it must be rejected before any HTTP call.
+     */
+    #[Test]
+    public function injectBodyFieldRejectsMalformedJsonBody(): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->with('my_api_key')
+            ->willReturn('secret-value');
+
+        $this->innerClient
+            ->expects(self::never())
+            ->method('sendRequest');
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::BodyField);
+
+        $request = new Request('POST', self::API_URL, [
+            'Content-Type' => self::CONTENT_TYPE_JSON,
+        ], '{"broken": ');
+
+        $this->expectException(VaultException::class);
+        $this->expectExceptionMessage('request body must be a JSON object');
+
+        $authenticatedClient->sendRequest($request);
+    }
+
     #[Test]
     public function auditLogsFailedRequest(): void
     {

--- a/Tests/Unit/Http/VaultHttpClientTest.php
+++ b/Tests/Unit/Http/VaultHttpClientTest.php
@@ -42,6 +42,8 @@ final class VaultHttpClientTest extends TestCase
 
     private const CONTENT_TYPE_JSON = 'application/json';
 
+    private const NON_OBJECT_BODY_MESSAGE = 'request body must be a JSON object';
+
     /** @phpstan-ignore property.uninitialized */
     private VaultServiceInterface&MockObject $vaultService;
 
@@ -707,7 +709,7 @@ final class VaultHttpClientTest extends TestCase
         ], json_encode([1, 2, 3]));
 
         $this->expectException(VaultException::class);
-        $this->expectExceptionMessage('request body must be a JSON object');
+        $this->expectExceptionMessage(self::NON_OBJECT_BODY_MESSAGE);
 
         $authenticatedClient->sendRequest($request);
     }
@@ -742,7 +744,7 @@ final class VaultHttpClientTest extends TestCase
         ], json_encode('just-a-string'));
 
         $this->expectException(VaultException::class);
-        $this->expectExceptionMessage('request body must be a JSON object');
+        $this->expectExceptionMessage(self::NON_OBJECT_BODY_MESSAGE);
 
         $authenticatedClient->sendRequest($request);
     }
@@ -778,7 +780,7 @@ final class VaultHttpClientTest extends TestCase
         ], '{"broken": ');
 
         $this->expectException(VaultException::class);
-        $this->expectExceptionMessage('request body must be a JSON object');
+        $this->expectExceptionMessage(self::NON_OBJECT_BODY_MESSAGE);
 
         $authenticatedClient->sendRequest($request);
     }

--- a/Tests/Unit/Utility/IdentifierValidatorTest.php
+++ b/Tests/Unit/Utility/IdentifierValidatorTest.php
@@ -211,6 +211,34 @@ final class IdentifierValidatorTest extends TestCase
         self::assertContains($uuid[19], ['8', '9', 'a', 'b']);
     }
 
+    /**
+     * The variant nibble (position 19) must draw bits 12-13 from randomness
+     * (RFC 9562: 10xx). A regression that hard-codes those bits to zero leaves
+     * the nibble pinned to '8' and loses ~2 bits of entropy. A single sample
+     * can't catch that — collect the nibble over many generations and assert
+     * the full {8, 9, a, b} set appears.
+     */
+    #[Test]
+    public function generateUuidVariantNibbleCoversAllRfc9562Values(): void
+    {
+        // Collect nibble characters into a list (not array keys — numeric-string
+        // keys like '8'/'9' would silently cast to int and break the compare).
+        $variants = [];
+        for ($i = 0; $i < 500; $i++) {
+            $variants[] = IdentifierValidator::generateUuid()[19];
+        }
+        $variants = array_values(array_unique($variants));
+        sort($variants);
+
+        self::assertSame(
+            ['8', '9', 'a', 'b'],
+            $variants,
+            'Variant nibble must vary across {8, 9, a, b}; a pinned value means '
+            . 'the random variant bits (12-13) were lost.',
+        );
+        self::assertCount(4, $variants);
+    }
+
     #[Test]
     public function looksLikeVaultIdentifierRecognisesUuidV7(): void
     {


### PR DESCRIPTION
Completes the code-review bugfix branch: seven peripheral (non-crypto-core) findings from the skills-based code review, each fixed in its own commit with regression tests.

## Findings → Fixes

| # | Finding | Fix | Commit |
|---|---------|-----|--------|
| 1 | `MigrationController::configureAction` built identifier patterns as `table__column__{{uid}}`; `migrateColumn()` substitutes `{uid}` via `str_replace`, so literal braces survived, `IdentifierValidator` rejected every identifier, and **every backend column migration failed** | Single-brace placeholder; functional tests drive `migrateColumn()` end-to-end for both the fixed and the buggy pattern | e55aaef |
| 2 | `IdentifierValidator::generateUuid()` pinned UUID v7 variant bits 12–13 to zero (`& 0x3FFF` applied to a single byte), so the variant nibble was always `8` and ~2 bits of entropy were lost | Combine both random bytes before masking to 14 bits + RFC 9562 variant; distribution test asserts the nibble covers `{8, 9, a, b}` | 4d7f535 |
| 3 | `OAuthConfig` accepted any grant-type string and a `refresh_token` grant without a refresh-token secret — both surfaced only as silent downgrades inside the token manager | Constructor validation: grant type must be `client_credentials`/`refresh_token`; `refreshTokenSecret` required for the refresh grant. Unit tests for null/empty secret and unknown grant | 8df8a09 |
| 4 | OAuth token cache key omitted `refreshTokenSecret` and `additionalParams` — two configs differing only in `audience`/`resource` shared a cache slot (cross-audience token confusion); a rotated refresh-token handle kept serving the pre-rotation token | Fold `refreshTokenSecret` and a `ksort`-normalised hash of `additionalParams` into the key; tests assert fragmentation on params and stability across param order | f6d41e9 |
| 5 | `redactCredentials()` missed credentials echoed in JSON error bodies (`"client_secret":"xyz"`) and quote-wrapped prose (`Invalid client_secret 'xyz'`) — they reached logs, audit entries, and exception chains unredacted | Second redaction pass for JSON pairs and quoted echoes of `client_secret`/`refresh_token`/`access_token`; all patterns delimiter-anchored (no backtracking risk); new provider cases | ca7b75d |
| 6 | `VaultHttpClient` body-field injection used `json_decode($body, true) ?: []` — invalid JSON silently dropped the caller's payload, scalar bodies fataled after the secret was already retrieved, JSON lists were reshaped into mixed-key structures | `decodeJsonObjectBody()` guard: empty body → `[]`, anything else must be a JSON object or a `VaultException` (1735858524) is thrown before any HTTP call. Tests for list, scalar, and malformed bodies | fc590d8 |
| 7 | SSRF guard's IPv6-transition handling (decode embedded IPv4, recurse into v4 deny check) had no test coverage | Deny cases for IPv4-mapped, 6to4, NAT64, IPv4-compatible, and Teredo (obfuscated loopback client) plus a public-IPv6 control proving no over-blocking. Test-only — production code already handles these | 9a70d9d |

Security bar: finding 5 strengthens the `[REDACTED]` guarantee for logs/audit/exceptions; findings 4 and 7 are covered by unit tests against the existing hardened code paths. No crypto-core code touched.

## Tests

Unit (`composer ci:test:php:unit`):
```
Tests: 1818, Assertions: 7269, PHPUnit Notices: 3.
```
(The 3 notices are pre-existing in `VaultAuditMigrateCommandTest` / `SecretRepositoryTest`, untouched by this branch.)

Functional (`phpunit -c Build/FunctionalTests.xml`, `memory_limit=1G`):
```
Tests: 163, Assertions: 488, Deprecations: 2, Skipped: 9.
```
(Deprecations/skips pre-existing.)

PHPStan (`.Build/bin/phpstan analyse --configuration=Build/phpstan.no-plugins.neon --memory-limit=1G`, level 10):
```
[OK] No errors
```

CGL (`composer ci:test:php:cgl`):
```
"files":[]  — nothing to fix
```

Fuzz (`composer ci:test:php:fuzz`):
```
OK (1514 tests, 2255 assertions)
```

Architecture check (`composer ci:test:php:arch`):
```
OK: 0 legacy tests allow-listed, no new violations.
```
