### PR TITLE
Per-secret encryption-algorithm marker and atomic audit-chain re-keying on master-key rotation

### DIFF
--- a/Classes/Audit/AuditAction.php
+++ b/Classes/Audit/AuditAction.php
@@ -33,6 +33,7 @@ enum AuditAction: string
     case HttpCall = 'http_call';
     case MasterKeyRotateStart = 'master_key_rotate_start';
     case MasterKeyRotateEnd = 'master_key_rotate_end';
+    case AuditChainRekey = 'audit_chain_rekey';
     case OAuthRefreshFailed = 'oauth_refresh_failed';
     case OAuthFallbackClientCredentials = 'oauth_fallback_client_credentials';
     case OAuthRefreshStoreFailed = 'oauth_refresh_store_failed';

--- a/Classes/Audit/AuditChainLockTrait.php
+++ b/Classes/Audit/AuditChainLockTrait.php
@@ -33,6 +33,18 @@ use TYPO3\CMS\Core\Database\Connection;
  *    abort on anything other than 1 so we never silently write unprotected
  *    audit entries.
  *
+ * Nesting inside a caller-managed Doctrine transaction (master-key rotation
+ * runs audit writes + the chain re-key inside ONE transaction with the DEK
+ * re-encryption):
+ *  - MySQL/MariaDB: `GET_LOCK` is re-acquirable per session (counted), and
+ *    Doctrine DBAL 4 maps the nested begin/commit/rollback onto savepoints.
+ *  - SQLite: a raw `BEGIN EXCLUSIVE` cannot nest. When a Doctrine-managed
+ *    transaction is already active, acquire/commit/rollback fall back to
+ *    Doctrine savepoints; write-serialisation is then provided by the outer
+ *    transaction's database-file write lock. `Connection::isTransactionActive()`
+ *    discriminates the two modes — a raw `BEGIN EXCLUSIVE` is invisible to
+ *    Doctrine's nesting counter (false), a savepoint acquire is not (true).
+ *
  * Lock failures surface as {@see AuditWriteException}. Callers that want a
  * context-specific exception type can catch and re-throw.
  */
@@ -44,6 +56,12 @@ trait AuditChainLockTrait
     private function acquireAuditLock(Connection $connection, bool $isSQLite): void
     {
         if ($isSQLite) {
+            if ($connection->isTransactionActive()) {
+                // Nested mode: savepoint via Doctrine (see trait docblock).
+                $connection->beginTransaction();
+
+                return;
+            }
             $connection->executeStatement('BEGIN EXCLUSIVE');
 
             return;
@@ -73,6 +91,13 @@ trait AuditChainLockTrait
     private function commitAuditLock(Connection $connection, bool $isSQLite): void
     {
         if ($isSQLite) {
+            if ($connection->isTransactionActive()) {
+                // Nested mode: release the savepoint; durability comes from
+                // the caller's outer commit.
+                $connection->commit();
+
+                return;
+            }
             $connection->executeStatement('COMMIT');
 
             return;
@@ -83,6 +108,13 @@ trait AuditChainLockTrait
     private function rollbackAuditLock(Connection $connection, bool $isSQLite): void
     {
         if ($isSQLite) {
+            if ($connection->isTransactionActive()) {
+                // Nested mode: roll back to the savepoint; the caller's outer
+                // transaction decides the final fate.
+                $connection->rollBack();
+
+                return;
+            }
             $connection->executeStatement('ROLLBACK');
 
             return;

--- a/Classes/Audit/AuditChainRekeyService.php
+++ b/Classes/Audit/AuditChainRekeyService.php
@@ -1,0 +1,113 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit;
+
+use SensitiveParameter;
+use TYPO3\CMS\Core\Database\Connection;
+
+/**
+ * Rewrites the audit hash chain under the HMAC key derived from a new
+ * master key. See {@see AuditChainRekeyServiceInterface} for the contract
+ * (caller-managed transaction + advisory lock, epoch preservation).
+ *
+ * Modelled on `AuditHmacMigrationWizard::rehashAllRows()`, with two
+ * deliberate differences:
+ *  - the per-row `hmac_key_epoch` is PRESERVED, not migrated — re-keying
+ *    changes the key, never the payload format;
+ *  - rows are only UPDATEd when their hashes actually change, so an
+ *    all-epoch-0 (keyless) chain passes through untouched.
+ */
+final readonly class AuditChainRekeyService implements AuditChainRekeyServiceInterface
+{
+    private const TABLE_NAME = 'tx_nrvault_audit_log';
+
+    public function rekeyChain(Connection $connection, #[SensitiveParameter] string $newMasterKey): int
+    {
+        $hmacKey = AuditLogService::deriveHmacKeyFromMasterKey($newMasterKey);
+
+        try {
+            return $this->rewriteChain($connection, $hmacKey);
+        } finally {
+            sodium_memzero($hmacKey);
+        }
+    }
+
+    /**
+     * Walk the chain from uid 1 upward, recomputing each row's entry hash
+     * with its OWN stored epoch and the new HMAC key, re-linking
+     * `previous_hash` as it goes.
+     */
+    private function rewriteChain(Connection $connection, #[SensitiveParameter] string $hmacKey): int
+    {
+        $result = $connection->createQueryBuilder()
+            ->select('*')
+            ->from(self::TABLE_NAME)
+            ->orderBy('uid', 'ASC')
+            ->executeQuery();
+
+        $previousHash = '';
+        $rewrittenCount = 0;
+
+        while (($row = $result->fetchAssociative()) !== false) {
+            $entry = AuditLogService::extractHashRow($row);
+
+            // Epoch-aware dispatch, mirroring verifyHashChain():
+            //   0  → legacy keyless SHA-256 (identity fields only)
+            //   1  → HMAC-SHA256 (identity fields only)
+            //   2+ → HMAC-SHA256 (extended forensic payload)
+            $expectedHash = match (true) {
+                $entry['epoch'] === 0 => AuditLogService::calculateHash(
+                    $entry['uid'],
+                    $entry['secretId'],
+                    $entry['action'],
+                    $entry['actorUid'],
+                    $entry['crdate'],
+                    $previousHash,
+                ),
+                $entry['epoch'] === 1 => AuditLogService::calculateHash(
+                    $entry['uid'],
+                    $entry['secretId'],
+                    $entry['action'],
+                    $entry['actorUid'],
+                    $entry['crdate'],
+                    $previousHash,
+                    $hmacKey,
+                ),
+                default => AuditLogService::calculateHashV2(
+                    AuditLogService::extractV2HashRow($row),
+                    $previousHash,
+                    $hmacKey,
+                ),
+            };
+
+            $rowEntryHash = \is_string($row['entry_hash'] ?? null) ? $row['entry_hash'] : '';
+            $rowPreviousHash = \is_string($row['previous_hash'] ?? null) ? $row['previous_hash'] : '';
+
+            // Constant-time comparisons per project mandate (AGENTS.md
+            // Security Requirement #2), although this check only decides
+            // whether an UPDATE is needed.
+            if (!hash_equals($expectedHash, $rowEntryHash) || !hash_equals($previousHash, $rowPreviousHash)) {
+                $connection->update(
+                    self::TABLE_NAME,
+                    [
+                        'entry_hash' => $expectedHash,
+                        'previous_hash' => $previousHash,
+                    ],
+                    ['uid' => $entry['uid']],
+                );
+                ++$rewrittenCount;
+            }
+
+            $previousHash = $expectedHash;
+        }
+
+        return $rewrittenCount;
+    }
+}

--- a/Classes/Audit/AuditChainRekeyService.php
+++ b/Classes/Audit/AuditChainRekeyService.php
@@ -28,6 +28,13 @@ final readonly class AuditChainRekeyService implements AuditChainRekeyServiceInt
 {
     private const TABLE_NAME = 'tx_nrvault_audit_log';
 
+    /**
+     * Rows fetched per keyset-paginated batch. The chain walk is sequential by
+     * design (each hash links to its predecessor), but the audit log can be
+     * arbitrarily large — fetching it wholesale would OOM the rotation command.
+     */
+    private const BATCH_SIZE = 1000;
+
     public function rekeyChain(Connection $connection, #[SensitiveParameter] string $newMasterKey): int
     {
         $hmacKey = AuditLogService::deriveHmacKeyFromMasterKey($newMasterKey);
@@ -46,68 +53,104 @@ final readonly class AuditChainRekeyService implements AuditChainRekeyServiceInt
      */
     private function rewriteChain(Connection $connection, #[SensitiveParameter] string $hmacKey): int
     {
-        $result = $connection->createQueryBuilder()
-            ->select('*')
-            ->from(self::TABLE_NAME)
-            ->orderBy('uid', 'ASC')
-            ->executeQuery();
-
         $previousHash = '';
         $rewrittenCount = 0;
+        $lastUid = 0;
 
-        while (($row = $result->fetchAssociative()) !== false) {
-            $entry = AuditLogService::extractHashRow($row);
+        // Keyset pagination (uid > last seen, LIMIT n): bounded memory on
+        // arbitrarily large logs, and each batch is fully materialised before
+        // its UPDATEs run, so reads never interleave with writes on an open
+        // cursor. $previousHash carries the chain linkage across batches.
+        do {
+            $queryBuilder = $connection->createQueryBuilder();
+            $rows = $queryBuilder
+                ->select('*')
+                ->from(self::TABLE_NAME)
+                ->where($queryBuilder->expr()->gt(
+                    'uid',
+                    $queryBuilder->createNamedParameter($lastUid, Connection::PARAM_INT),
+                ))
+                ->orderBy('uid', 'ASC')
+                ->setMaxResults(self::BATCH_SIZE)
+                ->executeQuery()
+                ->fetchAllAssociative();
 
-            // Epoch-aware dispatch, mirroring verifyHashChain():
-            //   0  → legacy keyless SHA-256 (identity fields only)
-            //   1  → HMAC-SHA256 (identity fields only)
-            //   2+ → HMAC-SHA256 (extended forensic payload)
-            $expectedHash = match (true) {
-                $entry['epoch'] === 0 => AuditLogService::calculateHash(
-                    $entry['uid'],
-                    $entry['secretId'],
-                    $entry['action'],
-                    $entry['actorUid'],
-                    $entry['crdate'],
-                    $previousHash,
-                ),
-                $entry['epoch'] === 1 => AuditLogService::calculateHash(
-                    $entry['uid'],
-                    $entry['secretId'],
-                    $entry['action'],
-                    $entry['actorUid'],
-                    $entry['crdate'],
-                    $previousHash,
-                    $hmacKey,
-                ),
-                default => AuditLogService::calculateHashV2(
-                    AuditLogService::extractV2HashRow($row),
-                    $previousHash,
-                    $hmacKey,
-                ),
-            };
-
-            $rowEntryHash = \is_string($row['entry_hash'] ?? null) ? $row['entry_hash'] : '';
-            $rowPreviousHash = \is_string($row['previous_hash'] ?? null) ? $row['previous_hash'] : '';
-
-            // Constant-time comparisons per project mandate (AGENTS.md
-            // Security Requirement #2), although this check only decides
-            // whether an UPDATE is needed.
-            if (!hash_equals($expectedHash, $rowEntryHash) || !hash_equals($previousHash, $rowPreviousHash)) {
-                $connection->update(
-                    self::TABLE_NAME,
-                    [
-                        'entry_hash' => $expectedHash,
-                        'previous_hash' => $previousHash,
-                    ],
-                    ['uid' => $entry['uid']],
-                );
-                ++$rewrittenCount;
+            foreach ($rows as $row) {
+                $rewrittenCount += $this->rekeyRow($connection, $row, $hmacKey, $previousHash);
+                $uid = $row['uid'] ?? 0;
+                $lastUid = max($lastUid, is_numeric($uid) ? (int) $uid : 0);
             }
-
-            $previousHash = $expectedHash;
-        }
+        } while (\count($rows) === self::BATCH_SIZE);
 
         return $rewrittenCount;
+    }
+
+    /**
+     * Recompute one row's entry hash with its OWN stored epoch under the new
+     * HMAC key, re-linking previous_hash. Returns 1 when the row was updated.
+     * $previousHash is advanced to this row's expected hash for the next link.
+     *
+     * @param array<string, mixed> $row
+     */
+    private function rekeyRow(
+        Connection $connection,
+        array $row,
+        #[SensitiveParameter]
+        string $hmacKey,
+        string &$previousHash,
+    ): int {
+        $entry = AuditLogService::extractHashRow($row);
+
+        // Epoch-aware dispatch, mirroring verifyHashChain():
+        //   0  → legacy keyless SHA-256 (identity fields only)
+        //   1  → HMAC-SHA256 (identity fields only)
+        //   2+ → HMAC-SHA256 (extended forensic payload)
+        $expectedHash = match (true) {
+            $entry['epoch'] === 0 => AuditLogService::calculateHash(
+                $entry['uid'],
+                $entry['secretId'],
+                $entry['action'],
+                $entry['actorUid'],
+                $entry['crdate'],
+                $previousHash,
+            ),
+            $entry['epoch'] === 1 => AuditLogService::calculateHash(
+                $entry['uid'],
+                $entry['secretId'],
+                $entry['action'],
+                $entry['actorUid'],
+                $entry['crdate'],
+                $previousHash,
+                $hmacKey,
+            ),
+            default => AuditLogService::calculateHashV2(
+                AuditLogService::extractV2HashRow($row),
+                $previousHash,
+                $hmacKey,
+            ),
+        };
+
+        $rowEntryHash = \is_string($row['entry_hash'] ?? null) ? $row['entry_hash'] : '';
+        $rowPreviousHash = \is_string($row['previous_hash'] ?? null) ? $row['previous_hash'] : '';
+
+        // Constant-time comparisons per project mandate (AGENTS.md
+        // Security Requirement #2), although this check only decides
+        // whether an UPDATE is needed.
+        $updated = 0;
+        if (!hash_equals($expectedHash, $rowEntryHash) || !hash_equals($previousHash, $rowPreviousHash)) {
+            $connection->update(
+                self::TABLE_NAME,
+                [
+                    'entry_hash' => $expectedHash,
+                    'previous_hash' => $previousHash,
+                ],
+                ['uid' => $entry['uid']],
+            );
+            $updated = 1;
+        }
+
+        $previousHash = $expectedHash;
+
+        return $updated;
     }
 }

--- a/Classes/Audit/AuditChainRekeyServiceInterface.php
+++ b/Classes/Audit/AuditChainRekeyServiceInterface.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit;
+
+use SensitiveParameter;
+use TYPO3\CMS\Core\Database\Connection;
+
+/**
+ * Re-keys the tamper-evident audit hash chain after a master-key rotation.
+ *
+ * The chain's HMAC key is derived from the master key, so rotating the
+ * master key orphans every HMAC-epoch entry: verification with the new key
+ * fails from the first HMAC'd row onward. Re-keying recomputes the chain
+ * under the key derived from the NEW master key while preserving each row's
+ * stored payload-format epoch.
+ */
+interface AuditChainRekeyServiceInterface
+{
+    /**
+     * Recompute every chain hash under the HMAC key derived from the new
+     * master key.
+     *
+     * Runs INSIDE the caller's open transaction on `$connection` and takes
+     * no locks itself. The caller MUST:
+     *  - hold the audit advisory lock for the remainder of the transaction
+     *    (no concurrent writer may chain onto a tip hash being rewritten),
+     *  - have the audit-log table on this connection, and
+     *  - commit/roll back secrets re-encryption and chain re-key together.
+     *
+     * Per-row `hmac_key_epoch` values are preserved — re-keying changes the
+     * key, not the payload format:
+     *  - epoch 0 rows are keyless SHA-256 and only change where their
+     *    `previous_hash` link changes,
+     *  - epoch 1 / 2+ rows are recomputed under the new HMAC key.
+     *
+     * @param Connection $connection Connection carrying the caller's transaction
+     * @param string $newMasterKey The NEW raw master key (32 bytes)
+     *
+     * @return int Number of rows whose hashes were rewritten
+     */
+    public function rekeyChain(Connection $connection, #[SensitiveParameter] string $newMasterKey): int;
+}

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -188,7 +188,10 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             );
         }
 
-        $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
+        // Stream the rows (single forward pass, read-only): the audit log can
+        // be arbitrarily large, and master-key rotation verifies the full chain
+        // up front — materialising it wholesale would OOM the rotation command.
+        $rows = $queryBuilder->executeQuery()->iterateAssociative();
         $errors = [];
         $warnings = [];
         /** @var list<int> $missingUids */

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -495,10 +495,23 @@ final readonly class AuditLogService implements AuditLogServiceInterface
         $masterKey = $masterKeyProvider->getMasterKey();
 
         try {
-            return hash_hkdf('sha256', $masterKey, 32, 'nr-vault-audit-hmac-v1');
+            return self::deriveHmacKeyFromMasterKey($masterKey);
         } finally {
             sodium_memzero($masterKey);
         }
+    }
+
+    /**
+     * Derive the audit-chain HMAC key from an explicit master key.
+     *
+     * Single home of the HKDF parameters (info string + length) so callers
+     * that hold a master key directly — e.g. the master-key rotation, which
+     * must derive the NEW chain key before the provider is reconfigured —
+     * cannot drift from the runtime derivation above.
+     */
+    public static function deriveHmacKeyFromMasterKey(#[SensitiveParameter] string $masterKey): string
+    {
+        return hash_hkdf('sha256', $masterKey, 32, 'nr-vault-audit-hmac-v1');
     }
 
     /**

--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -9,6 +9,10 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Command;
 
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Netresearch\NrVault\Audit\AuditAction;
+use Netresearch\NrVault\Audit\AuditChainLockTrait;
+use Netresearch\NrVault\Audit\AuditChainRekeyServiceInterface;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface;
@@ -16,6 +20,7 @@ use Netresearch\NrVault\Domain\Model\Secret;
 use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
 use Netresearch\NrVault\Exception\EncryptionException;
 use Netresearch\NrVault\Exception\MasterKeyException;
+use SensitiveParameter;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -23,6 +28,7 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Console\Style\SymfonyStyle;
 use Throwable;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
 /**
@@ -30,6 +36,12 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
  *
  * Re-encrypts all DEKs with a new master key. Either old or new key
  * can be provided; the missing one defaults to the currently configured key.
+ *
+ * The tamper-evident audit chain is keyed via HKDF from the master key, so
+ * the chain is re-keyed under the new key INSIDE the same transaction as the
+ * DEK re-encryption: either both commit or both roll back, and
+ * `AuditLogServiceInterface::verifyHashChain()` stays valid before (old key)
+ * and after (new key, once the provider configuration is switched).
  */
 #[AsCommand(
     name: 'vault:rotate-master-key',
@@ -37,6 +49,8 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 )]
 final class VaultRotateMasterKeyCommand extends Command
 {
+    use AuditChainLockTrait;
+
     private const KEY_LENGTH = 32;
 
     /**
@@ -52,6 +66,7 @@ final class VaultRotateMasterKeyCommand extends Command
         private readonly MasterKeyProviderFactoryInterface $masterKeyProviderFactory,
         private readonly ConnectionPool $connectionPool,
         private readonly AuditLogServiceInterface $auditLogService,
+        private readonly AuditChainRekeyServiceInterface $auditChainRekeyService,
     ) {
         parent::__construct();
     }
@@ -235,6 +250,10 @@ final class VaultRotateMasterKeyCommand extends Command
      * Main rotation loop wrapped in a transaction. Per-secret failures are
      * collected; ANY failure rolls back the whole batch (atomic rotation).
      *
+     * The audit chain is re-keyed under the new master key inside the SAME
+     * transaction (see {@see self::rekeyAuditChain()}), so chain and secrets
+     * commit or roll back together.
+     *
      * @param list<string> $identifiers
      */
     private function rotateAllSecrets(
@@ -245,21 +264,55 @@ final class VaultRotateMasterKeyCommand extends Command
         int $totalSecrets,
     ): int {
         $connection = $this->connectionPool->getConnectionForTable('tx_nrvault_secret');
-        $connection->beginTransaction();
 
-        // Audit the start of the rotation lifecycle. We log BEFORE any state
-        // change so that even a catastrophic crash mid-loop leaves a trail.
+        // Cross-table atomicity precondition: the chain re-key must share the
+        // secrets transaction, which requires both tables on ONE connection.
+        if ($this->connectionPool->getConnectionForTable('tx_nrvault_audit_log') !== $connection) {
+            $io->error(
+                'tx_nrvault_secret and tx_nrvault_audit_log are mapped to different database '
+                . 'connections; atomic master-key rotation (secrets + audit chain) is not possible.',
+            );
+
+            return Command::FAILURE;
+        }
+
+        $isSQLite = $connection->getDatabasePlatform() instanceof SQLitePlatform;
+
+        // Audit the start of the rotation lifecycle BEFORE the transaction so
+        // the attempt leaves a trail even if everything below rolls back.
         $this->auditLogService->log(
             self::AUDIT_PSEUDO_IDENTIFIER,
-            'master_key_rotate_start',
+            AuditAction::MasterKeyRotateStart->value,
             true,
             null,
             \sprintf('Rotating master key for %d secret(s)', $totalSecrets),
         );
 
+        // The chain must verify under the CURRENT key before it is re-sealed
+        // under the new one: re-keying a tampered chain would launder the
+        // tampering into a freshly valid chain and destroy the evidence.
+        $verification = $this->auditLogService->verifyHashChain();
+        if (!$verification->isValid()) {
+            $io->error([
+                'Audit hash chain verification FAILED — re-keying refused.',
+                'Investigate the chain (vault:audit --verify) before rotating the master key.',
+            ]);
+            $this->auditLogService->log(
+                self::AUDIT_PSEUDO_IDENTIFIER,
+                AuditAction::MasterKeyRotateEnd->value,
+                false,
+                'Audit chain verification failed before rotation; nothing changed',
+            );
+
+            return Command::FAILURE;
+        }
+
+        $connection->beginTransaction();
+
         $io->progressStart($totalSecrets);
         $failedSecrets = [];
         $successCount = 0;
+        $rekeyedRows = 0;
 
         try {
             foreach ($identifiers as $identifier) {
@@ -275,13 +328,15 @@ final class VaultRotateMasterKeyCommand extends Command
                 $this->reportFailures($io, $failedSecrets);
                 $this->auditLogService->log(
                     self::AUDIT_PSEUDO_IDENTIFIER,
-                    'master_key_rotate_end',
+                    AuditAction::MasterKeyRotateEnd->value,
                     false,
                     \sprintf('Rotation failed for %d secret(s); transaction rolled back', \count($failedSecrets)),
                 );
 
                 return Command::FAILURE;
             }
+
+            $rekeyedRows = $this->rekeyAuditChain($connection, $isSQLite, $newKey, $successCount);
 
             $connection->commit();
         } catch (Throwable $e) {
@@ -291,7 +346,7 @@ final class VaultRotateMasterKeyCommand extends Command
             // leaking libsodium/internal detail (CLAUDE.md security rule 1).
             $this->auditLogService->log(
                 self::AUDIT_PSEUDO_IDENTIFIER,
-                'master_key_rotate_end',
+                AuditAction::MasterKeyRotateEnd->value,
                 false,
                 'Unexpected error during rotation; transaction rolled back',
             );
@@ -299,27 +354,86 @@ final class VaultRotateMasterKeyCommand extends Command
             return Command::FAILURE;
         }
 
-        $this->auditLogService->log(
-            self::AUDIT_PSEUDO_IDENTIFIER,
-            'master_key_rotate_end',
-            true,
-            null,
-            \sprintf('Successfully rotated master key for %d secret(s)', $successCount),
-        );
-
         $io->success(\sprintf(
             'Successfully rotated master key for %d secret(s).',
             $successCount,
         ));
+        $io->text(\sprintf(
+            'Audit chain re-keyed under the new master key (%d row(s) rewritten).',
+            $rekeyedRows,
+        ));
 
         $io->note([
             'Next steps:',
-            '1. Update your configuration to use the new master key',
+            '1. Update your configuration to use the new master key NOW — until then,',
+            '   secrets cannot be decrypted and audit-chain verification uses the old key.',
             '2. Securely archive or destroy the old master key',
-            '3. Test secret retrieval to verify the rotation',
+            '3. Test secret retrieval and run vault:audit to verify chain integrity',
+            '4. If any audit entries were written between this rotation and the',
+            '   configuration switch, re-seal them with vault:audit-migrate-hmac',
         ]);
 
         return Command::SUCCESS;
+    }
+
+    /**
+     * Re-key the tamper-evident audit chain under the new master key, inside
+     * the caller's open transaction. Returns the number of rewritten rows.
+     *
+     * Ordering is deliberate:
+     *  1. take the audit advisory lock for the remainder of the transaction
+     *     so no concurrent writer can chain onto a tip hash this method is
+     *     about to rewrite;
+     *  2. append the 'audit_chain_rekey' and successful
+     *     'master_key_rotate_end' events — at this point they are sealed
+     *     with the OLD (provider-derived) HMAC key;
+     *  3. rewrite every row's entry/previous hash under the NEW key —
+     *     including the two events just appended — so the committed chain
+     *     verifies under the new master key from first to last row, with no
+     *     old-keyed tail entry behind the re-key point.
+     *
+     * Writing the success events before the final step is sound because the
+     * whole sequence is atomic: a failure in any step propagates to the
+     * caller, which rolls back secrets, events, and chain rewrite together.
+     *
+     * @throws Throwable Propagates lock/re-key failures for the caller's rollback
+     */
+    private function rekeyAuditChain(
+        Connection $connection,
+        bool $isSQLite,
+        #[SensitiveParameter]
+        string $newKey,
+        int $successCount,
+    ): int {
+        $this->acquireAuditLock($connection, $isSQLite);
+
+        try {
+            $this->auditLogService->log(
+                self::AUDIT_PSEUDO_IDENTIFIER,
+                AuditAction::AuditChainRekey->value,
+                true,
+                null,
+                'Re-keyed audit chain HMACs under the new master key',
+            );
+            $this->auditLogService->log(
+                self::AUDIT_PSEUDO_IDENTIFIER,
+                AuditAction::MasterKeyRotateEnd->value,
+                true,
+                null,
+                \sprintf('Successfully rotated master key for %d secret(s)', $successCount),
+            );
+
+            $rewritten = $this->auditChainRekeyService->rekeyChain($connection, $newKey);
+            $this->commitAuditLock($connection, $isSQLite);
+
+            return $rewritten;
+        } catch (Throwable $e) {
+            $this->rollbackAuditLock($connection, $isSQLite);
+
+            throw $e;
+        } finally {
+            $this->releaseAuditLock($connection, $isSQLite);
+        }
     }
 
     /**

--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -272,6 +272,15 @@ final class VaultRotateMasterKeyCommand extends Command
                 'tx_nrvault_secret and tx_nrvault_audit_log are mapped to different database '
                 . 'connections; atomic master-key rotation (secrets + audit chain) is not possible.',
             );
+            // "Leave a trail" contract: even a refused rotation attempt must be
+            // visible in the audit chain. The audit log writes on its own
+            // connection, so logging works precisely in this configuration.
+            $this->auditLogService->log(
+                self::AUDIT_PSEUDO_IDENTIFIER,
+                AuditAction::MasterKeyRotateEnd->value,
+                false,
+                'Rotation refused: secret and audit tables on different connections; nothing changed',
+            );
 
             return Command::FAILURE;
         }

--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -300,7 +300,21 @@ final class VaultRotateMasterKeyCommand extends Command
         // The chain must verify under the CURRENT key before it is re-sealed
         // under the new one: re-keying a tampered chain would launder the
         // tampering into a freshly valid chain and destroy the evidence.
-        $verification = $this->auditLogService->verifyHashChain();
+        // Verification does DB I/O — an unexpected failure (DBAL error, …)
+        // must still leave a rotate_end trail before the command aborts.
+        try {
+            $verification = $this->auditLogService->verifyHashChain();
+        } catch (Throwable $exception) {
+            $io->error('Audit hash chain verification errored: ' . $exception->getMessage());
+            $this->auditLogService->log(
+                self::AUDIT_PSEUDO_IDENTIFIER,
+                AuditAction::MasterKeyRotateEnd->value,
+                false,
+                'Audit chain verification errored before rotation; nothing changed',
+            );
+
+            return Command::FAILURE;
+        }
         if (!$verification->isValid()) {
             $io->error([
                 'Audit hash chain verification FAILED — re-keying refused.',

--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -214,6 +214,8 @@ final class VaultRotateMasterKeyCommand extends Command
                 $firstSecret->getIdentifier(),
                 $oldKey,
                 $newKey,
+                $firstSecret->getEncryptionVersion(),
+                $firstSecret->getEncryptionAlgorithm(),
             );
             $io->text('<info>Old master key verified successfully.</info>');
 
@@ -347,6 +349,8 @@ final class VaultRotateMasterKeyCommand extends Command
                 $secret->getIdentifier(),
                 $oldKey,
                 $newKey,
+                $secret->getEncryptionVersion(),
+                $secret->getEncryptionAlgorithm(),
             );
 
             $this->secretRepository->save(

--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -414,21 +414,28 @@ final class VaultRotateMasterKeyCommand extends Command
             throw MasterKeyException::notFound($path);
         }
 
-        // Handle base64-encoded keys
-        if (\strlen($key) !== self::KEY_LENGTH) {
-            $decoded = base64_decode($key, true);
-            if ($decoded !== false && \strlen($decoded) === self::KEY_LENGTH) {
-                $key = $decoded;
-            }
+        // Resolve the key, mirroring FileMasterKeyProvider::loadRawKey() ordering.
+        // Order matters: never trim() a value that is already binary key material,
+        // or a valid 32-byte raw key whose first/last byte happens to be a trim
+        // char (\t \n \r space \0 \x0B) is silently corrupted to 30/31 bytes.
+        $trimmed = trim($key);
+
+        // 1) Trimmed value as raw binary key.
+        if (\strlen($trimmed) === self::KEY_LENGTH) {
+            return $trimmed;
         }
 
-        // Trim whitespace (e.g., trailing newline)
-        $key = trim($key);
-
-        if (\strlen($key) !== self::KEY_LENGTH) {
-            throw MasterKeyException::invalidLength(self::KEY_LENGTH, \strlen($key));
+        // 2) base64 decode of the trimmed text.
+        $decoded = base64_decode($trimmed, true);
+        if ($decoded !== false && \strlen($decoded) === self::KEY_LENGTH) {
+            return $decoded;
         }
 
-        return $key;
+        // 3) Raw file contents as binary (no trimming of binary data).
+        if (\strlen($key) === self::KEY_LENGTH) {
+            return $key;
+        }
+
+        throw MasterKeyException::invalidLength(self::KEY_LENGTH, \strlen($trimmed));
     }
 }

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -38,6 +38,12 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
     public const DEFAULT_PREFER_XCHACHA20 = false;
 
     /**
+     * '' = use the built-in default (XChaCha20-Poly1305) for new secrets;
+     * see EncryptionAlgorithm::forNewSecrets().
+     */
+    public const DEFAULT_ENCRYPTION_ALGORITHM = '';
+
+    /**
      * Audit-chain hash epoch.
      *  - 0: legacy SHA-256 over identity fields only (no HMAC key).
      *  - 1: HMAC-SHA256 over identity fields only.
@@ -184,10 +190,28 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
 
     /**
      * Check if XChaCha20-Poly1305 should be preferred over AES-256-GCM.
+     *
+     * Only consulted for LEGACY (encryption version 1) envelopes, which carry
+     * no per-secret algorithm marker. New envelopes record their algorithm
+     * explicitly; see {@see self::getEncryptionAlgorithm()}.
      */
     public function preferXChaCha20(): bool
     {
         return (bool) ($this->configuration['preferXChaCha20'] ?? self::DEFAULT_PREFER_XCHACHA20);
+    }
+
+    /**
+     * AEAD algorithm recorded for newly encrypted secrets.
+     *
+     * '' (default) = XChaCha20-Poly1305. Validation happens at the crypto
+     * boundary (`EncryptionService::algorithmForNewSecrets()`), which fails
+     * loudly on unknown or host-unavailable values.
+     */
+    public function getEncryptionAlgorithm(): string
+    {
+        $val = $this->configuration['encryptionAlgorithm'] ?? self::DEFAULT_ENCRYPTION_ALGORITHM;
+
+        return \is_string($val) ? $val : self::DEFAULT_ENCRYPTION_ALGORITHM;
     }
 
     /**

--- a/Classes/Configuration/ExtensionConfigurationInterface.php
+++ b/Classes/Configuration/ExtensionConfigurationInterface.php
@@ -61,8 +61,19 @@ interface ExtensionConfigurationInterface
 
     /**
      * Check if XChaCha20-Poly1305 should be preferred over AES-256-GCM.
+     *
+     * Only consulted for legacy (encryption version 1) envelopes without a
+     * per-secret algorithm marker.
      */
     public function preferXChaCha20(): bool;
+
+    /**
+     * AEAD algorithm marker recorded for newly encrypted secrets.
+     *
+     * @return string An EncryptionAlgorithm backing value, or '' for the
+     *                built-in default (XChaCha20-Poly1305)
+     */
+    public function getEncryptionAlgorithm(): string;
 
     /**
      * Get HashiCorp Vault configuration.

--- a/Classes/Crypto/EncryptedData.php
+++ b/Classes/Crypto/EncryptedData.php
@@ -15,7 +15,8 @@ namespace Netresearch\NrVault\Crypto;
 /**
  * Value object representing encrypted data from envelope encryption.
  *
- * Contains the encrypted value, encrypted DEK, nonces, and checksum.
+ * Contains the encrypted value, encrypted DEK, nonces, checksum, and the
+ * encryption version/algorithm marker recorded at encrypt time.
  * The value/DEK/nonce fields are base64-encoded for safe storage/transport;
  * the checksum is a hex-encoded keyed HMAC-SHA-256 over the ciphertext.
  */
@@ -32,6 +33,14 @@ final readonly class EncryptedData
         public string $valueNonce,
         /** Hex-encoded keyed HMAC-SHA-256 over the ciphertext (per-secret MAC key derived from the DEK) for change detection */
         public string $valueChecksum,
+        /**
+         * Encryption version marker. The defaults describe what the current
+         * `EncryptionService::encrypt()` produces; legacy (version-1)
+         * envelopes must pass their marker explicitly.
+         */
+        public int $encryptionVersion = EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT,
+        /** AEAD algorithm both envelope layers (DEK wrap + value) were encrypted with */
+        public EncryptionAlgorithm $encryptionAlgorithm = EncryptionAlgorithm::XChaCha20Poly1305,
     ) {}
 
     /**
@@ -42,6 +51,8 @@ final readonly class EncryptedData
      * @param string $dekNonce Raw DEK nonce bytes
      * @param string $valueNonce Raw value nonce bytes
      * @param string $valueChecksum Hex-encoded keyed HMAC-SHA-256 over the ciphertext
+     * @param int $encryptionVersion Encryption version marker
+     * @param EncryptionAlgorithm $encryptionAlgorithm AEAD algorithm used for both envelope layers
      */
     public static function fromRaw(
         string $encryptedValue,
@@ -49,6 +60,8 @@ final readonly class EncryptedData
         string $dekNonce,
         string $valueNonce,
         string $valueChecksum,
+        int $encryptionVersion = EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT,
+        EncryptionAlgorithm $encryptionAlgorithm = EncryptionAlgorithm::XChaCha20Poly1305,
     ): self {
         return new self(
             encryptedValue: base64_encode($encryptedValue),
@@ -56,6 +69,8 @@ final readonly class EncryptedData
             dekNonce: base64_encode($dekNonce),
             valueNonce: base64_encode($valueNonce),
             valueChecksum: $valueChecksum,
+            encryptionVersion: $encryptionVersion,
+            encryptionAlgorithm: $encryptionAlgorithm,
         );
     }
 
@@ -68,6 +83,8 @@ final readonly class EncryptedData
      *     dek_nonce: string,
      *     value_nonce: string,
      *     value_checksum: string,
+     *     encryption_version: int,
+     *     encryption_algorithm: string,
      * }
      */
     public function toArray(): array
@@ -78,6 +95,8 @@ final readonly class EncryptedData
             'dek_nonce' => $this->dekNonce,
             'value_nonce' => $this->valueNonce,
             'value_checksum' => $this->valueChecksum,
+            'encryption_version' => $this->encryptionVersion,
+            'encryption_algorithm' => $this->encryptionAlgorithm->value,
         ];
     }
 }

--- a/Classes/Crypto/EncryptionAlgorithm.php
+++ b/Classes/Crypto/EncryptionAlgorithm.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Crypto;
+
+/**
+ * AEAD algorithms supported for envelope encryption.
+ *
+ * The backing string values are persisted per secret in
+ * `tx_nrvault_secret.encryption_algorithm` (for encryption version 2+) and
+ * MUST remain byte-for-byte stable: changing a value would make every stored
+ * secret carrying the old string undecryptable.
+ *
+ * @see EncryptionService for how the marker is written and dispatched on
+ */
+enum EncryptionAlgorithm: string
+{
+    case XChaCha20Poly1305 = 'xchacha20poly1305';
+    case Aes256Gcm = 'aes256gcm';
+
+    /**
+     * Default algorithm recorded for newly encrypted secrets when no explicit
+     * algorithm is configured.
+     *
+     * XChaCha20-Poly1305 is the deliberate default: it is available in every
+     * libsodium build (AES-256-GCM requires hardware support) and its 24-byte
+     * nonce makes random-nonce collisions a non-concern, so vault contents
+     * stay portable across hosts with differing CPU capabilities.
+     */
+    public static function forNewSecrets(): self
+    {
+        return self::XChaCha20Poly1305;
+    }
+
+    /**
+     * Whether the current host can encrypt/decrypt with this algorithm.
+     */
+    public function isAvailable(): bool
+    {
+        return match ($this) {
+            self::XChaCha20Poly1305 => true,
+            self::Aes256Gcm => sodium_crypto_aead_aes256gcm_is_available(),
+        };
+    }
+
+    /**
+     * Nonce length (bytes) for this algorithm.
+     *
+     * @return int<1, max>
+     */
+    public function nonceLength(): int
+    {
+        // Constants are always positive, but we ensure it for type safety.
+        return max(1, match ($this) {
+            self::XChaCha20Poly1305 => SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES,
+            self::Aes256Gcm => SODIUM_CRYPTO_AEAD_AES256GCM_NPUBBYTES,
+        });
+    }
+
+    /**
+     * Key length (bytes) for this algorithm.
+     *
+     * @return int<1, max>
+     */
+    public function keyLength(): int
+    {
+        // Constants are always positive, but we ensure it for type safety.
+        return max(1, match ($this) {
+            self::XChaCha20Poly1305 => SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES,
+            self::Aes256Gcm => SODIUM_CRYPTO_AEAD_AES256GCM_KEYBYTES,
+        });
+    }
+}

--- a/Classes/Crypto/EncryptionService.php
+++ b/Classes/Crypto/EncryptionService.php
@@ -70,10 +70,11 @@ final readonly class EncryptionService implements EncryptionServiceInterface
             $macKey = hash_hkdf('sha256', $dek, self::CHECKSUM_MAC_KEY_LENGTH, self::CHECKSUM_HKDF_INFO);
             $checksum = hash_hmac('sha256', $encryptedValue, $macKey);
 
-            // Securely wipe sensitive data
+            // Securely wipe sensitive data. The master key is deliberately NOT
+            // wiped here (or in the finally block): it is the provider's shared
+            // request-lifetime cache entry — see the equivalent note in decrypt().
             sodium_memzero($dek);
             sodium_memzero($macKey);
-            sodium_memzero($masterKey);
             sodium_memzero($plaintext);
 
             return EncryptedData::fromRaw(

--- a/Classes/Crypto/EncryptionService.php
+++ b/Classes/Crypto/EncryptionService.php
@@ -102,9 +102,9 @@ final readonly class EncryptionService implements EncryptionServiceInterface
             if (isset($plaintext)) {
                 sodium_memzero($plaintext);
             }
-            if (isset($masterKey)) {
-                sodium_memzero($masterKey);
-            }
+            // The master key is deliberately NOT wiped: it is the provider's
+            // shared request-lifetime cache entry (see decrypt()); the provider
+            // owns its lifecycle and wipes it on destruction.
         }
     }
 
@@ -144,9 +144,13 @@ final readonly class EncryptionService implements EncryptionServiceInterface
             // Decrypt the value with DEK
             $plaintext = $this->decryptWithKey($encryptedValueBytes, $dek, $valueNonceBytes, $identifier, $algorithm);
 
-            // Securely wipe sensitive data
+            // Securely wipe the per-secret DEK. The master key is deliberately
+            // NOT wiped here: getMasterKey() returns the provider's shared
+            // request-lifetime cache entry, so wiping the local reference would
+            // either be a no-op (PHP's sodium_memzero skips refcount>1 strings)
+            // or corrupt the cached key for every later vault operation in the
+            // request. The provider wipes its cache on destruction.
             sodium_memzero($dek);
-            sodium_memzero($masterKey);
 
             return $plaintext;
         } catch (SodiumException) {

--- a/Classes/Crypto/EncryptionService.php
+++ b/Classes/Crypto/EncryptionService.php
@@ -38,22 +38,27 @@ final readonly class EncryptionService implements EncryptionServiceInterface
 
     public function encrypt(#[SensitiveParameter] string $plaintext, string $identifier): EncryptedData
     {
+        // Select and RECORD the algorithm: new envelopes are version 2, so
+        // decryption dispatches on the stored marker instead of re-deriving
+        // the algorithm from the capabilities of whatever host decrypts.
+        $algorithm = $this->algorithmForNewSecrets();
+
         $masterKey = $this->masterKeyProvider->getMasterKey();
 
         try {
             // Generate unique DEK for this secret
-            $dek = $this->generateDek();
+            $dek = random_bytes($algorithm->keyLength());
 
             // Generate nonces with algorithm-appropriate length
-            $nonceLength = $this->getNonceLength();
+            $nonceLength = $algorithm->nonceLength();
             $dekNonce = random_bytes($nonceLength);
             $valueNonce = random_bytes($nonceLength);
 
             // Encrypt the DEK with master key
-            $encryptedDek = $this->encryptWithKey($dek, $masterKey, $dekNonce, $identifier);
+            $encryptedDek = $this->encryptWithKey($dek, $masterKey, $dekNonce, $identifier, $algorithm);
 
             // Encrypt the value with DEK
-            $encryptedValue = $this->encryptWithKey($plaintext, $dek, $valueNonce, $identifier);
+            $encryptedValue = $this->encryptWithKey($plaintext, $dek, $valueNonce, $identifier, $algorithm);
 
             // Change-detection token: a KEYED MAC over the ciphertext, never the
             // plaintext. The MAC key is derived per-secret from the DEK via HKDF,
@@ -77,6 +82,8 @@ final readonly class EncryptionService implements EncryptionServiceInterface
                 dekNonce: $dekNonce,
                 valueNonce: $valueNonce,
                 valueChecksum: $checksum,
+                encryptionVersion: EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT,
+                encryptionAlgorithm: $algorithm,
             );
         } catch (SodiumException) {
             throw EncryptionException::encryptionFailed('Encryption operation failed');
@@ -109,7 +116,14 @@ final readonly class EncryptionService implements EncryptionServiceInterface
         string $dekNonce,
         string $valueNonce,
         string $identifier,
+        int $encryptionVersion = EncryptionServiceInterface::ENCRYPTION_VERSION_LEGACY,
+        string $encryptionAlgorithm = '',
     ): string {
+        // Resolve the algorithm BEFORE touching key material: version 2+
+        // dispatches on the stored marker, version 1 derives from host
+        // capabilities exactly as before the marker existed.
+        $algorithm = $this->resolveAlgorithm($encryptionVersion, $encryptionAlgorithm);
+
         $masterKey = $this->masterKeyProvider->getMasterKey();
 
         try {
@@ -125,10 +139,10 @@ final readonly class EncryptionService implements EncryptionServiceInterface
             }
 
             // Decrypt the DEK with master key
-            $dek = $this->decryptWithKey($encryptedDekBytes, $masterKey, $dekNonceBytes, $identifier);
+            $dek = $this->decryptWithKey($encryptedDekBytes, $masterKey, $dekNonceBytes, $identifier, $algorithm);
 
             // Decrypt the value with DEK
-            $plaintext = $this->decryptWithKey($encryptedValueBytes, $dek, $valueNonceBytes, $identifier);
+            $plaintext = $this->decryptWithKey($encryptedValueBytes, $dek, $valueNonceBytes, $identifier, $algorithm);
 
             // Securely wipe sensitive data
             sodium_memzero($dek);
@@ -151,11 +165,7 @@ final readonly class EncryptionService implements EncryptionServiceInterface
 
     public function generateDek(): string
     {
-        if ($this->useAes256Gcm()) {
-            return random_bytes(SODIUM_CRYPTO_AEAD_AES256GCM_KEYBYTES);
-        }
-
-        return random_bytes(SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_KEYBYTES);
+        return random_bytes($this->algorithmForNewSecrets()->keyLength());
     }
 
     public function calculateChecksum(#[SensitiveParameter] string $plaintext): string
@@ -172,7 +182,13 @@ final readonly class EncryptionService implements EncryptionServiceInterface
         string $oldMasterKey,
         #[SensitiveParameter]
         string $newMasterKey,
+        int $encryptionVersion = EncryptionServiceInterface::ENCRYPTION_VERSION_LEGACY,
+        string $encryptionAlgorithm = '',
     ): ReEncryptedDek {
+        // The DEK envelope must be unwrapped AND re-wrapped with the secret's
+        // own algorithm: marker for version 2+, host-derived for version 1.
+        $algorithm = $this->resolveAlgorithm($encryptionVersion, $encryptionAlgorithm);
+
         try {
             // Decode
             $encryptedDekBytes = base64_decode($encryptedDek, true);
@@ -183,13 +199,13 @@ final readonly class EncryptionService implements EncryptionServiceInterface
             }
 
             // Decrypt DEK with old master key
-            $dek = $this->decryptWithKey($encryptedDekBytes, $oldMasterKey, $dekNonceBytes, $identifier);
+            $dek = $this->decryptWithKey($encryptedDekBytes, $oldMasterKey, $dekNonceBytes, $identifier, $algorithm);
 
             // Generate new nonce with algorithm-appropriate length
-            $newNonce = random_bytes($this->getNonceLength());
+            $newNonce = random_bytes($algorithm->nonceLength());
 
             // Encrypt DEK with new master key
-            $newEncryptedDek = $this->encryptWithKey($dek, $newMasterKey, $newNonce, $identifier);
+            $newEncryptedDek = $this->encryptWithKey($dek, $newMasterKey, $newNonce, $identifier, $algorithm);
 
             return ReEncryptedDek::fromRaw(
                 encryptedDek: $newEncryptedDek,
@@ -208,27 +224,25 @@ final readonly class EncryptionService implements EncryptionServiceInterface
     }
 
     /**
-     * Encrypt data with a key using the configured algorithm.
+     * Encrypt data with a key using the given algorithm.
      */
-    private function encryptWithKey(#[SensitiveParameter] string $plaintext, #[SensitiveParameter] string $key, string $nonce, string $aad): string
+    private function encryptWithKey(#[SensitiveParameter] string $plaintext, #[SensitiveParameter] string $key, string $nonce, string $aad, EncryptionAlgorithm $algorithm): string
     {
-        if ($this->useAes256Gcm()) {
-            return sodium_crypto_aead_aes256gcm_encrypt($plaintext, $aad, $nonce, $key);
-        }
-
-        return sodium_crypto_aead_xchacha20poly1305_ietf_encrypt($plaintext, $aad, $nonce, $key);
+        return match ($algorithm) {
+            EncryptionAlgorithm::Aes256Gcm => sodium_crypto_aead_aes256gcm_encrypt($plaintext, $aad, $nonce, $key),
+            EncryptionAlgorithm::XChaCha20Poly1305 => sodium_crypto_aead_xchacha20poly1305_ietf_encrypt($plaintext, $aad, $nonce, $key),
+        };
     }
 
     /**
-     * Decrypt data with a key using the configured algorithm.
+     * Decrypt data with a key using the given algorithm.
      */
-    private function decryptWithKey(#[SensitiveParameter] string $ciphertext, #[SensitiveParameter] string $key, string $nonce, string $aad): string
+    private function decryptWithKey(#[SensitiveParameter] string $ciphertext, #[SensitiveParameter] string $key, string $nonce, string $aad, EncryptionAlgorithm $algorithm): string
     {
-        if ($this->useAes256Gcm()) {
-            $result = sodium_crypto_aead_aes256gcm_decrypt($ciphertext, $aad, $nonce, $key);
-        } else {
-            $result = sodium_crypto_aead_xchacha20poly1305_ietf_decrypt($ciphertext, $aad, $nonce, $key);
-        }
+        $result = match ($algorithm) {
+            EncryptionAlgorithm::Aes256Gcm => sodium_crypto_aead_aes256gcm_decrypt($ciphertext, $aad, $nonce, $key),
+            EncryptionAlgorithm::XChaCha20Poly1305 => sodium_crypto_aead_xchacha20poly1305_ietf_decrypt($ciphertext, $aad, $nonce, $key),
+        };
 
         if ($result === false) {
             throw EncryptionException::decryptionFailed('Authentication failed - data may have been tampered with');
@@ -238,20 +252,81 @@ final readonly class EncryptionService implements EncryptionServiceInterface
     }
 
     /**
-     * Get the nonce length for the current algorithm.
+     * Resolve the algorithm to use for an existing envelope.
      *
-     * @return int<1, max>
+     * Version 2+: the stored marker is authoritative. An unknown or empty
+     * marker is a hard error — guessing an algorithm for a version-2 row
+     * could silently decrypt with the wrong primitive on a different host,
+     * which is exactly the implicitness the marker exists to remove.
+     *
+     * Version 1 (legacy): no marker exists; derive from host capabilities +
+     * configuration, byte-identical to the pre-marker behaviour, so existing
+     * rows keep decrypting exactly as before.
      */
-    private function getNonceLength(): int
+    private function resolveAlgorithm(int $encryptionVersion, string $encryptionAlgorithm): EncryptionAlgorithm
     {
-        // Constants are always positive, but we ensure it for type safety
-        return max(1, $this->useAes256Gcm()
-            ? SODIUM_CRYPTO_AEAD_AES256GCM_NPUBBYTES
-            : SODIUM_CRYPTO_AEAD_XCHACHA20POLY1305_IETF_NPUBBYTES);
+        if ($encryptionVersion >= EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT) {
+            $algorithm = EncryptionAlgorithm::tryFrom($encryptionAlgorithm);
+            if (!$algorithm instanceof EncryptionAlgorithm) {
+                throw EncryptionException::decryptionFailed(\sprintf(
+                    'Unknown encryption algorithm marker for encryption version %d',
+                    $encryptionVersion,
+                ));
+            }
+
+            if (!$algorithm->isAvailable()) {
+                throw EncryptionException::decryptionFailed(\sprintf(
+                    'Encryption algorithm "%s" is not available on this host',
+                    $algorithm->value,
+                ));
+            }
+
+            return $algorithm;
+        }
+
+        return $this->useAes256Gcm()
+            ? EncryptionAlgorithm::Aes256Gcm
+            : EncryptionAlgorithm::XChaCha20Poly1305;
     }
 
     /**
-     * Determine if AES-256-GCM should be used.
+     * Algorithm recorded for NEW envelopes (encryption version 2).
+     *
+     * Defaults to XChaCha20-Poly1305 ({@see EncryptionAlgorithm::forNewSecrets()});
+     * a site can pin a different algorithm via the `encryptionAlgorithm`
+     * extension setting. Unknown or host-unavailable configuration values
+     * fail loudly instead of silently falling back — for a vault, refusing
+     * to encrypt beats encrypting with an algorithm the operator did not
+     * choose.
+     */
+    private function algorithmForNewSecrets(): EncryptionAlgorithm
+    {
+        $configured = $this->configuration->getEncryptionAlgorithm();
+        if ($configured === '') {
+            return EncryptionAlgorithm::forNewSecrets();
+        }
+
+        $algorithm = EncryptionAlgorithm::tryFrom($configured);
+        if (!$algorithm instanceof EncryptionAlgorithm) {
+            throw EncryptionException::encryptionFailed(\sprintf(
+                'Unknown encryptionAlgorithm "%s" configured for the nr_vault extension',
+                $configured,
+            ));
+        }
+
+        if (!$algorithm->isAvailable()) {
+            throw EncryptionException::encryptionFailed(\sprintf(
+                'Configured encryption algorithm "%s" is not available on this host',
+                $algorithm->value,
+            ));
+        }
+
+        return $algorithm;
+    }
+
+    /**
+     * Determine if AES-256-GCM should be used (LEGACY/version-1 envelopes
+     * only — must stay byte-identical to the pre-marker selection logic).
      */
     private function useAes256Gcm(): bool
     {

--- a/Classes/Crypto/EncryptionService.php
+++ b/Classes/Crypto/EncryptionService.php
@@ -82,12 +82,21 @@ final readonly class EncryptionService implements EncryptionServiceInterface
             throw EncryptionException::encryptionFailed('Encryption operation failed');
         } finally {
             // Wipe key material on every path, including the SodiumException
-            // error path that bypasses the in-try wipes above.
+            // error path that bypasses the in-try wipes above. sodium_memzero()
+            // sets the wiped variable to null, so isset() distinguishes
+            // already-wiped buffers (skip) from un-wiped ones (wipe now);
+            // calling it again on a wiped (null) variable would throw.
             if (isset($dek)) {
                 sodium_memzero($dek);
             }
             if (isset($macKey)) {
                 sodium_memzero($macKey);
+            }
+            if (isset($plaintext)) {
+                sodium_memzero($plaintext);
+            }
+            if (isset($masterKey)) {
+                sodium_memzero($masterKey);
             }
         }
     }

--- a/Classes/Crypto/EncryptionServiceInterface.php
+++ b/Classes/Crypto/EncryptionServiceInterface.php
@@ -18,7 +18,25 @@ use SensitiveParameter;
 interface EncryptionServiceInterface
 {
     /**
+     * Encryption version 1 (legacy): no per-secret algorithm marker is
+     * stored; the algorithm is derived from host capabilities + extension
+     * configuration at decrypt time. Rows created before the marker existed
+     * implicitly carry this version.
+     */
+    public const ENCRYPTION_VERSION_LEGACY = 1;
+
+    /**
+     * Encryption version 2: the AEAD algorithm is recorded explicitly per
+     * secret at encrypt time ({@see EncryptionAlgorithm}) and decryption
+     * dispatches on the stored marker, never on host capabilities.
+     */
+    public const ENCRYPTION_VERSION_CURRENT = 2;
+
+    /**
      * Encrypt a secret value with a unique DEK.
+     *
+     * Always produces {@see self::ENCRYPTION_VERSION_CURRENT} envelopes with
+     * an explicit algorithm marker recorded in the returned DTO.
      *
      * @param string $plaintext The value to encrypt
      * @param string $identifier Secret identifier (used as AAD)
@@ -30,13 +48,24 @@ interface EncryptionServiceInterface
     /**
      * Decrypt a secret value.
      *
+     * For encryption version 2+ the algorithm is taken from the stored
+     * per-secret marker; for version 1 (legacy, the default) it is derived
+     * from host capabilities + configuration exactly as before the marker
+     * existed.
+     *
      * @param string $encryptedValue Base64-encoded ciphertext
      * @param string $encryptedDek Base64-encoded encrypted DEK
      * @param string $dekNonce Base64-encoded DEK nonce
      * @param string $valueNonce Base64-encoded value nonce
      * @param string $identifier Secret identifier (used as AAD)
+     * @param int $encryptionVersion Stored per-secret encryption version
+     * @param string $encryptionAlgorithm Stored per-secret algorithm marker
+     *                                    ({@see EncryptionAlgorithm} value);
+     *                                    required for version 2+, must be ''
+     *                                    for version 1
      *
-     * @throws EncryptionException If decryption fails
+     * @throws EncryptionException If decryption fails or the marker is
+     *                             unknown/unavailable on this host
      *
      * @return string The decrypted plaintext
      */
@@ -48,6 +77,8 @@ interface EncryptionServiceInterface
         string $dekNonce,
         string $valueNonce,
         string $identifier,
+        int $encryptionVersion = self::ENCRYPTION_VERSION_LEGACY,
+        string $encryptionAlgorithm = '',
     ): string;
 
     /**
@@ -69,11 +100,20 @@ interface EncryptionServiceInterface
     /**
      * Re-encrypt a DEK with a new master key.
      *
+     * The DEK envelope is unwrapped and re-wrapped with the SAME algorithm
+     * the secret was encrypted with: the stored marker for version 2+, the
+     * legacy host-derived algorithm for version 1. The secret's version and
+     * algorithm marker are unchanged by this operation.
+     *
      * @param string $encryptedDek Current encrypted DEK
      * @param string $dekNonce Current DEK nonce
      * @param string $identifier Secret identifier
      * @param string $oldMasterKey Previous master key
      * @param string $newMasterKey New master key
+     * @param int $encryptionVersion Stored per-secret encryption version
+     * @param string $encryptionAlgorithm Stored per-secret algorithm marker
+     *                                    (required for version 2+, '' for
+     *                                    version 1)
      */
     public function reEncryptDek(
         #[SensitiveParameter]
@@ -84,5 +124,7 @@ interface EncryptionServiceInterface
         string $oldMasterKey,
         #[SensitiveParameter]
         string $newMasterKey,
+        int $encryptionVersion = self::ENCRYPTION_VERSION_LEGACY,
+        string $encryptionAlgorithm = '',
     ): ReEncryptedDek;
 }

--- a/Classes/Domain/Model/Secret.php
+++ b/Classes/Domain/Model/Secret.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Domain\Model;
 
 use Netresearch\NrVault\Crypto\EncryptedData;
+use Netresearch\NrVault\Crypto\EncryptionAlgorithm;
+use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
 use Netresearch\NrVault\Exception\ValidationException;
 
 /**
@@ -39,7 +41,8 @@ final readonly class Secret
         public string $encryptedDek = '',
         public string $dekNonce = '',
         public string $valueNonce = '',
-        public int $encryptionVersion = 1,
+        public int $encryptionVersion = EncryptionServiceInterface::ENCRYPTION_VERSION_LEGACY,
+        public string $encryptionAlgorithm = '',
         public string $valueChecksum = '',
         public int $ownerUid = 0,
         public array $allowedGroups = [],
@@ -76,6 +79,34 @@ final readonly class Secret
                 'encryptedValue, encryptedDek, dekNonce, valueNonce, and valueChecksum must all be set or all be empty',
             );
         }
+
+        // The version/algorithm marker is part of the same invariant:
+        //  - version 2+ means "algorithm recorded explicitly", so it requires
+        //    a full envelope AND a KNOWN algorithm marker — anything else
+        //    would be undecryptable (decrypt refuses to guess for v2 rows);
+        //  - version 1 (legacy) rows predate the marker and must not carry
+        //    one, or decrypt-time behaviour would silently diverge from what
+        //    the marker claims.
+        if ($this->encryptionVersion >= EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT) {
+            if ($setCount !== 5) {
+                throw ValidationException::invalidOption(
+                    'cryptographic fields',
+                    'encryption version 2+ requires the full encryption envelope to be set',
+                );
+            }
+
+            if (!EncryptionAlgorithm::tryFrom($this->encryptionAlgorithm) instanceof EncryptionAlgorithm) {
+                throw ValidationException::invalidOption(
+                    'cryptographic fields',
+                    'encryption version 2+ requires a known encryptionAlgorithm marker',
+                );
+            }
+        } elseif ($this->encryptionAlgorithm !== '') {
+            throw ValidationException::invalidOption(
+                'cryptographic fields',
+                'legacy encryption version 1 must not carry an encryptionAlgorithm marker',
+            );
+        }
     }
 
     // ------------------------------------------------------------------
@@ -93,10 +124,12 @@ final readonly class Secret
     }
 
     /**
-     * Apply a value rotation: bundles the seven crypto/version/timestamp
-     * fields that change together during `VaultService::rotate()`. Returns
-     * a new Secret with `version + 1`, `lastRotatedAt = $rotatedAt`, and
-     * the new envelope-encryption envelope.
+     * Apply a value rotation: bundles the crypto/version/timestamp fields
+     * that change together during `VaultService::rotate()`. Returns a new
+     * Secret with `version + 1`, `lastRotatedAt = $rotatedAt`, the new
+     * encryption envelope, and the envelope's version/algorithm marker
+     * (a rotation re-encrypts the value, so a legacy v1 secret is upgraded
+     * to the marker the new envelope was produced with).
      */
     public function withValueRotation(EncryptedData $encrypted, int $rotatedAt): self
     {
@@ -106,6 +139,8 @@ final readonly class Secret
             'dekNonce' => $encrypted->dekNonce,
             'valueNonce' => $encrypted->valueNonce,
             'valueChecksum' => $encrypted->valueChecksum,
+            'encryptionVersion' => $encrypted->encryptionVersion,
+            'encryptionAlgorithm' => $encrypted->encryptionAlgorithm->value,
             'version' => $this->version + 1,
             'lastRotatedAt' => $rotatedAt,
         ]);
@@ -221,6 +256,11 @@ final readonly class Secret
     public function getEncryptionVersion(): int
     {
         return $this->encryptionVersion;
+    }
+
+    public function getEncryptionAlgorithm(): string
+    {
+        return $this->encryptionAlgorithm;
     }
 
     public function getValueChecksum(): string
@@ -377,7 +417,8 @@ final readonly class Secret
             encryptedDek: (string) ($row['encrypted_dek'] ?? ''),
             dekNonce: (string) ($row['dek_nonce'] ?? ''),
             valueNonce: (string) ($row['value_nonce'] ?? ''),
-            encryptionVersion: (int) ($row['encryption_version'] ?? 1),
+            encryptionVersion: (int) ($row['encryption_version'] ?? EncryptionServiceInterface::ENCRYPTION_VERSION_LEGACY),
+            encryptionAlgorithm: (string) ($row['encryption_algorithm'] ?? ''),
             valueChecksum: (string) ($row['value_checksum'] ?? ''),
             ownerUid: (int) ($row['owner_uid'] ?? 0),
             allowedGroups: array_map(\intval(...), $allowedGroups),
@@ -427,6 +468,7 @@ final readonly class Secret
             'dek_nonce' => $this->dekNonce,
             'value_nonce' => $this->valueNonce,
             'encryption_version' => $this->encryptionVersion,
+            'encryption_algorithm' => $this->encryptionAlgorithm,
             'value_checksum' => $this->valueChecksum,
             'owner_uid' => $this->ownerUid,
             'allowed_groups' => implode(',', $this->allowedGroups),

--- a/Classes/Domain/Model/Secret.php
+++ b/Classes/Domain/Model/Secret.php
@@ -60,16 +60,20 @@ final readonly class Secret
         public int $readCount = 0,
         public int $lastReadAt = 0,
     ) {
-        // Envelope-encryption fields must be consistently set or unset —
-        // a partial set indicates a programming error that would produce
-        // an undecryptable secret.
-        $setCount = (int) ($this->encryptedDek !== '')
+        // Envelope-encryption fields must be consistently set or unset — a
+        // partial set indicates a programming error that would produce an
+        // undecryptable secret. The check covers the FULL envelope: omitting
+        // encryptedValue/valueChecksum let an undecryptable secret (DEK +
+        // nonces present, ciphertext absent) be constructed.
+        $setCount = (int) ($this->encryptedValue !== null && $this->encryptedValue !== '')
+            + (int) ($this->encryptedDek !== '')
             + (int) ($this->dekNonce !== '')
-            + (int) ($this->valueNonce !== '');
-        if ($setCount !== 0 && $setCount !== 3) {
+            + (int) ($this->valueNonce !== '')
+            + (int) ($this->valueChecksum !== '');
+        if ($setCount !== 0 && $setCount !== 5) {
             throw ValidationException::invalidOption(
                 'cryptographic fields',
-                'encryptedDek, dekNonce, and valueNonce must all be set or all be empty',
+                'encryptedValue, encryptedDek, dekNonce, valueNonce, and valueChecksum must all be set or all be empty',
             );
         }
     }

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -169,6 +169,8 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
                 $secret->getDekNonce(),
                 $secret->getValueNonce(),
                 $identifier,
+                $secret->getEncryptionVersion(),
+                $secret->getEncryptionAlgorithm(),
             );
         } catch (EncryptionException $e) {
             $this->auditLogService->log($identifier, AuditAction::Read->value, false, 'Decryption failed: ' . $e->getMessage());
@@ -496,6 +498,8 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             encryptedDek: $encrypted->encryptedDek,
             dekNonce: $encrypted->dekNonce,
             valueNonce: $encrypted->valueNonce,
+            encryptionVersion: $encrypted->encryptionVersion,
+            encryptionAlgorithm: $encrypted->encryptionAlgorithm->value,
             valueChecksum: $encrypted->valueChecksum,
             ownerUid: $this->resolveOwnerUid($options, $existing),
             allowedGroups: $optional['allowedGroups'],

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -49,6 +49,9 @@ services:
   Netresearch\NrVault\Audit\AuditLogServiceInterface:
     alias: Netresearch\NrVault\Audit\AuditLogService
 
+  Netresearch\NrVault\Audit\AuditChainRekeyServiceInterface:
+    alias: Netresearch\NrVault\Audit\AuditChainRekeyService
+
   Netresearch\NrVault\Adapter\VaultAdapterInterface:
     alias: Netresearch\NrVault\Adapter\LocalEncryptionAdapter
 

--- a/Configuration/TCA/tx_nrvault_secret.php
+++ b/Configuration/TCA/tx_nrvault_secret.php
@@ -252,6 +252,7 @@ return [
             'config' => [
                 'type' => 'input',
                 'readOnly' => true,
+                'searchable' => false,
             ],
         ],
     ],

--- a/Configuration/TCA/tx_nrvault_secret.php
+++ b/Configuration/TCA/tx_nrvault_secret.php
@@ -243,6 +243,17 @@ return [
                 'readOnly' => true,
             ],
         ],
+
+        // Written exclusively by the crypto layer (EncryptionService);
+        // surfaced read-only so operators can see which AEAD algorithm a
+        // secret's envelope uses (empty = legacy, host-derived at decrypt).
+        'encryption_algorithm' => [
+            'label' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.encryption_algorithm',
+            'config' => [
+                'type' => 'input',
+                'readOnly' => true,
+            ],
+        ],
     ],
 
     'types' => [
@@ -268,6 +279,7 @@ return [
                     read_count,
                     last_read_at,
                     adapter,
+                    encryption_algorithm,
                 --div--;core.form.tabs:access,
                     hidden,
             ',

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -101,6 +101,10 @@
         <source>Storage Adapter</source>
       </trans-unit>
 
+      <trans-unit id="tx_nrvault_secret.encryption_algorithm">
+        <source>Encryption Algorithm</source>
+      </trans-unit>
+
       <!-- Secret input field -->
       <trans-unit id="tx_nrvault_secret.secret_input">
         <source>Secret Value</source>

--- a/Tests/Functional/Audit/AuditChainRekeyServiceTest.php
+++ b/Tests/Functional/Audit/AuditChainRekeyServiceTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Audit;
+
+use Netresearch\NrVault\Audit\AuditChainRekeyService;
+use Netresearch\NrVault\Audit\AuditChainRekeyServiceInterface;
+use Netresearch\NrVault\Audit\AuditLogService;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Crypto\FileMasterKeyProvider;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for the audit-chain re-key on master-key rotation:
+ * the chain HMAC key derives from the master key, so after a re-key the
+ * chain must verify under the NEW key (and no longer under the old one),
+ * per-row epochs must be preserved, and re-keying must be idempotent.
+ */
+#[CoversClass(AuditChainRekeyService::class)]
+final class AuditChainRekeyServiceTest extends AbstractVaultFunctionalTestCase
+{
+    private const TABLE_NAME = 'tx_nrvault_audit_log';
+
+    protected ?string $backendUserFixture = __DIR__ . '/../../Functional/Service/Fixtures/be_users.csv';
+
+    /** @var array<string, mixed> */
+    protected array $extensionConfiguration = [
+        'masterKeyProvider' => 'file',
+        'auditHmacEpoch' => 2,
+    ];
+
+    #[Test]
+    public function rekeyChainMakesChainVerifiableUnderNewMasterKey(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $rekeyService = $this->get(AuditChainRekeyServiceInterface::class);
+        $connection = $this->getAuditConnection();
+
+        // Seed a chain sealed under the ORIGINAL master key.
+        $auditService->log('rekey_test_secret', 'create', true);
+        $auditService->log('rekey_test_secret', 'read', true);
+        $auditService->log('rekey_test_secret', 'rotate', true, null, 'value rotation');
+
+        self::assertTrue($auditService->verifyHashChain()->isValid(), 'Chain must verify under the original key');
+
+        // Re-key under a NEW master key, inside a transaction per contract.
+        $newKey = sodium_crypto_secretbox_keygen();
+        $connection->beginTransaction();
+        $rewritten = $rekeyService->rekeyChain($connection, $newKey);
+        $connection->commit();
+
+        self::assertSame(3, $rewritten, 'All three HMAC-epoch rows must be rewritten');
+
+        // Until the provider configuration is switched, verification uses
+        // the OLD key and must now fail — this is the documented switch
+        // window, mirroring the secrets being undecryptable until then.
+        self::assertFalse(
+            $auditService->verifyHashChain()->isValid(),
+            'Chain must NOT verify under the old key after the re-key',
+        );
+
+        // Switch the provider to the new key (same mechanism as rotating the
+        // key file in production), then the chain must verify again.
+        $this->switchMasterKeyFile($newKey);
+
+        self::assertTrue(
+            $auditService->verifyHashChain()->isValid(),
+            'Chain must verify under the new key after the provider switch',
+        );
+    }
+
+    #[Test]
+    public function rekeyChainPreservesEpochsAndLeavesKeylessPrefixUntouched(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $rekeyService = $this->get(AuditChainRekeyServiceInterface::class);
+        $connection = $this->getAuditConnection();
+
+        // Two legacy keyless (epoch 0) rows at the head of the chain — these
+        // do not depend on the master key at all.
+        $this->insertKeylessEntry($connection, 'legacy_secret', 'create');
+        $this->insertKeylessEntry($connection, 'legacy_secret', 'read');
+
+        // Two HMAC (epoch 2) rows chained on top, sealed under the original key.
+        $auditService->log('rekey_epoch_secret', 'create', true);
+        $auditService->log('rekey_epoch_secret', 'read', true);
+
+        self::assertTrue($auditService->verifyHashChain()->isValid(), 'Mixed-epoch chain must verify before re-key');
+
+        $epochsBefore = $this->fetchColumnByUid($connection, 'hmac_key_epoch');
+        $hashesBefore = $this->fetchColumnByUid($connection, 'entry_hash');
+
+        $newKey = sodium_crypto_secretbox_keygen();
+        $connection->beginTransaction();
+        $rewritten = $rekeyService->rekeyChain($connection, $newKey);
+        $connection->commit();
+
+        // Only the two HMAC rows change; the keyless prefix is untouched
+        // because neither its payload nor its previous_hash links changed.
+        self::assertSame(2, $rewritten);
+
+        $epochsAfter = $this->fetchColumnByUid($connection, 'hmac_key_epoch');
+        $hashesAfter = $this->fetchColumnByUid($connection, 'entry_hash');
+
+        self::assertSame($epochsBefore, $epochsAfter, 'Per-row epochs must be preserved (key change, not format change)');
+
+        $uids = array_keys($hashesBefore);
+        self::assertSame($hashesBefore[$uids[0]], $hashesAfter[$uids[0]], 'Keyless row 1 must be unchanged');
+        self::assertSame($hashesBefore[$uids[1]], $hashesAfter[$uids[1]], 'Keyless row 2 must be unchanged');
+        self::assertNotSame($hashesBefore[$uids[2]], $hashesAfter[$uids[2]], 'HMAC row 1 must be re-keyed');
+        self::assertNotSame($hashesBefore[$uids[3]], $hashesAfter[$uids[3]], 'HMAC row 2 must be re-keyed');
+
+        $this->switchMasterKeyFile($newKey);
+        self::assertTrue($auditService->verifyHashChain()->isValid(), 'Mixed-epoch chain must verify under the new key');
+    }
+
+    #[Test]
+    public function rekeyChainIsIdempotent(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $rekeyService = $this->get(AuditChainRekeyServiceInterface::class);
+        $connection = $this->getAuditConnection();
+
+        $auditService->log('idempotency_secret', 'create', true);
+        $auditService->log('idempotency_secret', 'read', true);
+
+        $newKey = sodium_crypto_secretbox_keygen();
+
+        $connection->beginTransaction();
+        $firstRun = $rekeyService->rekeyChain($connection, $newKey);
+        $connection->commit();
+
+        $connection->beginTransaction();
+        $secondRun = $rekeyService->rekeyChain($connection, $newKey);
+        $connection->commit();
+
+        self::assertSame(2, $firstRun, 'First run rewrites every HMAC row');
+        self::assertSame(0, $secondRun, 'Second run with the same key must rewrite nothing');
+    }
+
+    private function getAuditConnection(): Connection
+    {
+        return $this->get(ConnectionPool::class)->getConnectionForTable(self::TABLE_NAME);
+    }
+
+    /**
+     * Point the file master-key provider at a new key, as a production
+     * operator does after `vault:rotate-master-key`.
+     */
+    private function switchMasterKeyFile(string $newKey): void
+    {
+        self::assertIsString($this->masterKeyPath);
+        file_put_contents($this->masterKeyPath, $newKey);
+        FileMasterKeyProvider::clearCachedKey();
+    }
+
+    /**
+     * Insert a legacy keyless (epoch 0) chain row, mirroring the pre-HMAC
+     * writer: reserve the uid, then seal the row with a plain SHA-256 over
+     * the identity fields.
+     */
+    private function insertKeylessEntry(Connection $connection, string $secretIdentifier, string $action): void
+    {
+        $previousHash = $this->fetchLatestEntryHash($connection);
+        $crdate = time();
+
+        $connection->insert(self::TABLE_NAME, [
+            'pid' => 0,
+            'secret_identifier' => $secretIdentifier,
+            'action' => $action,
+            'success' => 1,
+            'actor_uid' => 1,
+            'actor_type' => 'backend',
+            'previous_hash' => $previousHash,
+            'crdate' => $crdate,
+            'hmac_key_epoch' => 0,
+            'context' => '{}',
+        ]);
+        $uid = (int) $connection->lastInsertId();
+
+        $connection->update(
+            self::TABLE_NAME,
+            ['entry_hash' => AuditLogService::calculateHash($uid, $secretIdentifier, $action, 1, $crdate, $previousHash)],
+            ['uid' => $uid],
+        );
+    }
+
+    private function fetchLatestEntryHash(Connection $connection): string
+    {
+        $hash = $connection->createQueryBuilder()
+            ->select('entry_hash')
+            ->from(self::TABLE_NAME)
+            ->orderBy('uid', 'DESC')
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchOne();
+
+        return \is_string($hash) ? $hash : '';
+    }
+
+    /**
+     * @return array<int, int|string> Column values keyed by uid, in uid order
+     */
+    private function fetchColumnByUid(Connection $connection, string $column): array
+    {
+        $rows = $connection->createQueryBuilder()
+            ->select('uid', $column)
+            ->from(self::TABLE_NAME)
+            ->orderBy('uid', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $values = [];
+        foreach ($rows as $row) {
+            $values[(int) $row['uid']] = is_numeric($row[$column]) && $column !== 'entry_hash'
+                ? (int) $row[$column]
+                : (string) $row[$column];
+        }
+
+        return $values;
+    }
+}

--- a/Tests/Functional/Crypto/EncryptionServiceTest.php
+++ b/Tests/Functional/Crypto/EncryptionServiceTest.php
@@ -87,6 +87,8 @@ final class EncryptionServiceTest extends FunctionalTestCase
             $encrypted->dekNonce,
             $encrypted->valueNonce,
             $identifier,
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
         );
 
         self::assertSame($plaintext, $decrypted);
@@ -130,6 +132,8 @@ final class EncryptionServiceTest extends FunctionalTestCase
             $encrypted->dekNonce,
             $encrypted->valueNonce,
             'wrong/identifier',
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
         );
     }
 
@@ -254,18 +258,18 @@ final class EncryptionServiceTest extends FunctionalTestCase
             $encrypted->dekNonce,
             $encrypted->valueNonce,
             $identifier,
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
         );
 
         self::assertSame($largeValue, $decrypted, 'Large values must round-trip correctly');
     }
 
     /**
-     * Explicit round-trip on the XChaCha20-Poly1305 cipher branch.
-     *
-     * The service selects AES-256-GCM or XChaCha20-Poly1305 based on
-     * `preferXChaCha20()` + sodium availability. On CI runners with AES-NI,
-     * the default round-trip covers only AES-GCM; force the XChaCha20 path
-     * here so both cipher modes are exercised.
+     * Explicit round-trip on the XChaCha20-Poly1305 cipher branch through the
+     * LEGACY (version-1, marker-less) decrypt path: with `preferXChaCha20`
+     * enabled the host-derived selection resolves to XChaCha20, matching the
+     * algorithm new envelopes record, so the marker-less decrypt succeeds.
      */
     #[Test]
     public function xchacha20RoundTripProducesOriginalPlaintext(): void
@@ -292,9 +296,9 @@ final class EncryptionServiceTest extends FunctionalTestCase
     }
 
     /**
-     * Explicit round-trip on the AES-256-GCM cipher branch.
-     *
-     * Only runs when AES-256-GCM hardware support is available (sodium check).
+     * Explicit round-trip on the AES-256-GCM cipher branch via the
+     * `encryptionAlgorithm` extension setting and the stored version-2
+     * marker. Only runs when AES-256-GCM hardware support is available.
      */
     #[Test]
     public function aes256GcmRoundTripProducesOriginalPlaintext(): void
@@ -304,24 +308,32 @@ final class EncryptionServiceTest extends FunctionalTestCase
         }
 
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_vault']['preferXChaCha20'] = false;
+        $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_vault']['encryptionAlgorithm'] = 'aes256gcm';
         FileMasterKeyProvider::clearCachedKey();
 
-        $encryptionService = $this->get(EncryptionServiceInterface::class);
-        $identifier = 'test_aes_gcm_' . bin2hex(random_bytes(4));
-        $plaintext = 'aes-256-gcm-only-path-value';
+        try {
+            $encryptionService = $this->get(EncryptionServiceInterface::class);
+            $identifier = 'test_aes_gcm_' . bin2hex(random_bytes(4));
+            $plaintext = 'aes-256-gcm-only-path-value';
 
-        $encrypted = $encryptionService->encrypt($plaintext, $identifier);
+            $encrypted = $encryptionService->encrypt($plaintext, $identifier);
+            self::assertSame('aes256gcm', $encrypted->encryptionAlgorithm->value);
 
-        FileMasterKeyProvider::clearCachedKey();
-        $decrypted = $encryptionService->decrypt(
-            $encrypted->encryptedValue,
-            $encrypted->encryptedDek,
-            $encrypted->dekNonce,
-            $encrypted->valueNonce,
-            $identifier,
-        );
+            FileMasterKeyProvider::clearCachedKey();
+            $decrypted = $encryptionService->decrypt(
+                $encrypted->encryptedValue,
+                $encrypted->encryptedDek,
+                $encrypted->dekNonce,
+                $encrypted->valueNonce,
+                $identifier,
+                $encrypted->encryptionVersion,
+                $encrypted->encryptionAlgorithm->value,
+            );
 
-        self::assertSame($plaintext, $decrypted);
+            self::assertSame($plaintext, $decrypted);
+        } finally {
+            unset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_vault']['encryptionAlgorithm']);
+        }
     }
 
     /**

--- a/Tests/Functional/Crypto/MasterKeyRotationTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationTest.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Functional\Crypto;
 
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Command\VaultRotateMasterKeyCommand;
 use Netresearch\NrVault\Crypto\EncryptionService;
 use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
 use Netresearch\NrVault\Crypto\FileMasterKeyProvider;
@@ -18,6 +20,7 @@ use Netresearch\NrVault\Exception\EncryptionException;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Tester\CommandTester;
 use Throwable;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -439,6 +442,123 @@ final class MasterKeyRotationTest extends FunctionalTestCase
             unlink($newKeyPath);
         }
         sodium_memzero($bogusOldKey);
+    }
+
+    /**
+     * Epoch-2 property: a SECOND master-key rotation (K0 → K1 → K2) through
+     * the REAL `vault:rotate-master-key` command must keep every secret
+     * decryptable and the audit hash chain verifiable after EACH rotation.
+     *
+     * This exercises the full integration: per-secret algorithm markers
+     * survive repeated DEK re-wrapping, and the chain re-key runs inside the
+     * rotation transaction each time, so verification under the
+     * currently-configured key passes at every observable point.
+     */
+    #[Test]
+    public function secondRotationKeepsSecretsDecryptableAndAuditChainValid(): void
+    {
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $auditLogService = $this->get(AuditLogServiceInterface::class);
+        $commandTester = new CommandTester($this->get(VaultRotateMasterKeyCommand::class));
+
+        // Store secrets under the original key (K0).
+        $secrets = [];
+        for ($i = 0; $i < 3; ++$i) {
+            $identifier = $this->generateUuidV7();
+            $value = 'epoch2-value-' . $i;
+            $vaultService->store($identifier, $value);
+            $secrets[$identifier] = $value;
+        }
+
+        self::assertTrue(
+            $auditLogService->verifyHashChain()->isValid(),
+            'Audit chain must be valid before any rotation (K0)',
+        );
+
+        // === Rotation 1: K0 -> K1 ===
+        $key1Path = $this->instancePath . '/master-epoch1.key';
+        file_put_contents($key1Path, sodium_crypto_secretbox_keygen());
+
+        $this->runRotationCommand($commandTester, $key1Path);
+        $this->switchMasterKeyFile($key1Path, $vaultService);
+
+        foreach ($secrets as $identifier => $expectedValue) {
+            self::assertSame(
+                $expectedValue,
+                $vaultService->retrieve($identifier),
+                'Secret must decrypt after the FIRST rotation: ' . $identifier,
+            );
+        }
+
+        self::assertTrue(
+            $auditLogService->verifyHashChain()->isValid(),
+            'Audit chain must verify under K1 after the first rotation',
+        );
+
+        // === Rotation 2 (epoch 2): K1 -> K2 ===
+        $key2Path = $this->instancePath . '/master-epoch2.key';
+        file_put_contents($key2Path, sodium_crypto_secretbox_keygen());
+
+        $this->runRotationCommand($commandTester, $key2Path);
+        $this->switchMasterKeyFile($key2Path, $vaultService);
+
+        foreach ($secrets as $identifier => $expectedValue) {
+            self::assertSame(
+                $expectedValue,
+                $vaultService->retrieve($identifier),
+                'Secret must decrypt after the SECOND rotation: ' . $identifier,
+            );
+        }
+
+        self::assertTrue(
+            $auditLogService->verifyHashChain()->isValid(),
+            'Audit chain must verify under K2 after the second rotation',
+        );
+
+        // Cleanup
+        foreach (array_keys($secrets) as $identifier) {
+            $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
+        }
+        foreach ([$key1Path, $key2Path] as $path) {
+            if (file_exists($path)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
+                unlink($path);
+            }
+        }
+    }
+
+    /**
+     * Run `vault:rotate-master-key --confirm` from the currently configured
+     * key file to `$newKeyPath`, asserting a SUCCESS exit code.
+     */
+    private function runRotationCommand(CommandTester $commandTester, string $newKeyPath): void
+    {
+        self::assertIsString($this->masterKeyPath);
+
+        $exitCode = $commandTester->execute([
+            '--old-key' => $this->masterKeyPath,
+            '--new-key' => $newKeyPath,
+            '--confirm' => true,
+        ]);
+
+        self::assertSame(
+            0,
+            $exitCode,
+            'vault:rotate-master-key must succeed. Output: ' . $commandTester->getDisplay(),
+        );
+        self::assertStringContainsString('Audit chain re-keyed', $commandTester->getDisplay());
+    }
+
+    /**
+     * Make the rotated key the configured one, as the operator does after
+     * the command: replace the key file and drop all caches.
+     */
+    private function switchMasterKeyFile(string $newKeyPath, VaultServiceInterface $vaultService): void
+    {
+        self::assertIsString($this->masterKeyPath);
+        copy($newKeyPath, $this->masterKeyPath);
+        FileMasterKeyProvider::clearCachedKey();
+        $vaultService->clearCache();
     }
 
     /**

--- a/Tests/Functional/Crypto/MasterKeyRotationTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationTest.php
@@ -132,6 +132,8 @@ final class MasterKeyRotationTest extends FunctionalTestCase
                 $secret->getIdentifier(),
                 $oldKeyFromFile,
                 $newKeyFromFile,
+                $secret->getEncryptionVersion(),
+                $secret->getEncryptionAlgorithm(),
             );
 
             $secretRepository->save(
@@ -194,6 +196,8 @@ final class MasterKeyRotationTest extends FunctionalTestCase
             $secret1->getIdentifier(),
             $oldKeyFromFile,
             $newKeyFromFile,
+            $secret1->getEncryptionVersion(),
+            $secret1->getEncryptionAlgorithm(),
         );
 
         // Do NOT save the re-encrypted DEK (simulating rollback after failure)
@@ -261,6 +265,8 @@ final class MasterKeyRotationTest extends FunctionalTestCase
                 $secret->getIdentifier(),
                 $oldKeyFromFile,
                 $newKeyFromFile,
+                $secret->getEncryptionVersion(),
+                $secret->getEncryptionAlgorithm(),
             );
 
             $secretRepository->save(
@@ -367,6 +373,8 @@ final class MasterKeyRotationTest extends FunctionalTestCase
                     $secret->getIdentifier(),
                     $oldKeyForThisIter,
                     $newKeyFromFile,
+                    $secret->getEncryptionVersion(),
+                    $secret->getEncryptionAlgorithm(),
                 );
 
                 // reEncryptDek zeroes its key params; re-read from file for

--- a/Tests/Functional/Domain/Repository/SecretRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/SecretRepositoryTest.php
@@ -139,6 +139,7 @@ final class SecretRepositoryTest extends FunctionalTestCase
             encryptedDek: 'dek',
             dekNonce: 'n1',
             valueNonce: 'n2',
+            valueChecksum: str_repeat('c', 64),
             version: 2,
             cruserId: 1,
         );
@@ -202,6 +203,7 @@ final class SecretRepositoryTest extends FunctionalTestCase
             encryptedDek: 'dek',
             dekNonce: 'n1',
             valueNonce: 'n2',
+            valueChecksum: str_repeat('c', 64),
             context: $context,
             version: $version,
             cruserId: 1,

--- a/Tests/Fuzz/CryptoFuzzTest.php
+++ b/Tests/Fuzz/CryptoFuzzTest.php
@@ -48,13 +48,19 @@ final class CryptoFuzzTest extends TestCase
         $provider = $this->createStub(MasterKeyProviderInterface::class);
         $provider->method('getMasterKey')->willReturnCallback(fn (): string => $this->masterKey);
 
+        // Each subject pins its algorithm for NEW encrypts (encryptionAlgorithm)
+        // and aligns the legacy/version-1 derivation (preferXChaCha20) with it,
+        // so the marker-less decrypt calls below keep exercising the legacy
+        // path against matching ciphertext.
         /** @var ExtensionConfigurationInterface&MockObject $xchachaConfig */
         $xchachaConfig = $this->createStub(ExtensionConfigurationInterface::class);
         $xchachaConfig->method('preferXChaCha20')->willReturn(true);
+        $xchachaConfig->method('getEncryptionAlgorithm')->willReturn('xchacha20poly1305');
 
         /** @var ExtensionConfigurationInterface&MockObject $aesConfig */
         $aesConfig = $this->createStub(ExtensionConfigurationInterface::class);
         $aesConfig->method('preferXChaCha20')->willReturn(false);
+        $aesConfig->method('getEncryptionAlgorithm')->willReturn('aes256gcm');
 
         $this->xchacha = new EncryptionService($provider, $xchachaConfig);
         $this->aes = new EncryptionService($provider, $aesConfig);

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -9,8 +9,10 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Audit;
 
+use ArrayIterator;
 use DateTimeImmutable;
 use Doctrine\DBAL\Result;
+use Iterator;
 use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Audit\AuditLogFilter;
 use Netresearch\NrVault\Audit\AuditLogService;
@@ -522,6 +524,7 @@ final class AuditLogServiceTest extends TestCase
     {
         $result = $this->createMock(Result::class);
         $result->method('fetchAllAssociative')->willReturn([]);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($result->fetchAllAssociative()));
 
         $this->connectionPool
             ->method('getConnectionForTable')
@@ -562,6 +565,7 @@ final class AuditLogServiceTest extends TestCase
 
         $result = $this->createMock(Result::class);
         $result->method('fetchAllAssociative')->willReturn([]);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($result->fetchAllAssociative()));
 
         $this->connectionPool
             ->method('getConnectionForTable')
@@ -852,6 +856,7 @@ final class AuditLogServiceTest extends TestCase
                 'hmac_key_epoch' => 0,
             ],
         ]);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($result->fetchAllAssociative()));
 
         $this->connectionPool
             ->method('getConnectionForTable')
@@ -922,6 +927,7 @@ final class AuditLogServiceTest extends TestCase
                 'hmac_key_epoch' => 1,
             ],
         ]);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($result->fetchAllAssociative()));
 
         $this->connectionPool
             ->method('getConnectionForTable')
@@ -1003,6 +1009,7 @@ final class AuditLogServiceTest extends TestCase
                 'hmac_key_epoch' => 1,
             ],
         ]);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($result->fetchAllAssociative()));
 
         $this->connectionPool
             ->method('getConnectionForTable')
@@ -1109,6 +1116,7 @@ final class AuditLogServiceTest extends TestCase
 
         $result = $this->createMock(Result::class);
         $result->method('fetchAllAssociative')->willReturn([$tamperedRow]);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($result->fetchAllAssociative()));
 
         $this->connectionPool
             ->method('getConnectionForTable')
@@ -1951,6 +1959,7 @@ final class AuditLogServiceTest extends TestCase
                 'hmac_key_epoch' => 0,
             ],
         ]);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($result->fetchAllAssociative()));
 
         $this->connectionPool->method('getConnectionForTable')->willReturn($this->connection);
         $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
@@ -1998,6 +2007,7 @@ final class AuditLogServiceTest extends TestCase
 
         $result = $this->createMock(Result::class);
         $result->method('fetchAllAssociative')->willReturn($rows);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($result->fetchAllAssociative()));
 
         $this->connectionPool->method('getConnectionForTable')->willReturn($this->connection);
         $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
@@ -2039,6 +2049,7 @@ final class AuditLogServiceTest extends TestCase
 
         $result = $this->createMock(Result::class);
         $result->method('fetchAllAssociative')->willReturn($rows);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($result->fetchAllAssociative()));
 
         $this->connectionPool->method('getConnectionForTable')->willReturn($this->connection);
         $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
@@ -2084,6 +2095,7 @@ final class AuditLogServiceTest extends TestCase
 
         $result = $this->createMock(Result::class);
         $result->method('fetchAllAssociative')->willReturn($rows);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($result->fetchAllAssociative()));
 
         $this->connectionPool->method('getConnectionForTable')->willReturn($this->connection);
         $this->connection->method('createQueryBuilder')->willReturn($this->queryBuilder);
@@ -2244,6 +2256,7 @@ final class AuditLogServiceTest extends TestCase
     {
         $result = $this->createMock(Result::class);
         $result->method('fetchAllAssociative')->willReturn($rows);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($result->fetchAllAssociative()));
 
         $this->connectionPool
             ->method('getConnectionForTable')
@@ -2285,6 +2298,7 @@ final class AuditLogServiceTest extends TestCase
     {
         $result = $this->createMock(Result::class);
         $result->method('fetchAllAssociative')->willReturn($rows);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($result->fetchAllAssociative()));
 
         $this->connectionPool
             ->method('getConnectionForTable')

--- a/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
+++ b/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
@@ -9,7 +9,10 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Command;
 
+use Doctrine\DBAL\Result;
+use Netresearch\NrVault\Audit\AuditChainRekeyServiceInterface;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\HashChainVerificationResult;
 use Netresearch\NrVault\Command\VaultRotateMasterKeyCommand;
 use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface;
@@ -44,6 +47,8 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
 
     private AuditLogServiceInterface&MockObject $auditLogService;
 
+    private AuditChainRekeyServiceInterface&MockObject $auditChainRekeyService;
+
     private CommandTester $commandTester;
 
     protected function setUp(): void
@@ -63,6 +68,12 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
         $this->masterKeyProviderFactory = $this->createMock(MasterKeyProviderFactoryInterface::class);
         $this->connectionPool = $this->createMock(ConnectionPool::class);
         $this->auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        // `HashChainVerificationResult` is final and cannot be auto-mocked;
+        // default to a valid chain so the pre-rotation verification passes.
+        $this->auditLogService
+            ->method('verifyHashChain')
+            ->willReturn(HashChainVerificationResult::valid());
+        $this->auditChainRekeyService = $this->createMock(AuditChainRekeyServiceInterface::class);
 
         $command = new VaultRotateMasterKeyCommand(
             $this->secretRepository,
@@ -70,6 +81,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
             $this->masterKeyProviderFactory,
             $this->connectionPool,
             $this->auditLogService,
+            $this->auditChainRekeyService,
         );
 
         $application = new Application();
@@ -87,6 +99,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
             $this->masterKeyProviderFactory,
             $this->connectionPool,
             $this->auditLogService,
+            $this->auditChainRekeyService,
         );
 
         self::assertSame('vault:rotate-master-key', $command->getName());
@@ -324,14 +337,29 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
             ->method('reEncryptDek')
             ->willReturn(new ReEncryptedDek('new-encrypted-dek', 'new-nonce'));
 
+        // Success path: outer transaction + the audit-lock savepoint around
+        // the chain re-key → two begins, two commits, no rollback. The
+        // (non-SQLite) advisory lock acquire issues `SELECT GET_LOCK(...)`
+        // which must yield 1.
+        $lockResult = $this->createStub(Result::class);
+        $lockResult->method('fetchOne')->willReturn(1);
+
         $connection = $this->createMock(Connection::class);
-        $connection->expects(self::once())->method('beginTransaction');
-        $connection->expects(self::once())->method('commit');
+        $connection->expects(self::exactly(2))->method('beginTransaction');
+        $connection->expects(self::exactly(2))->method('commit');
         $connection->expects(self::never())->method('rollBack');
+        $connection->method('executeQuery')->willReturn($lockResult);
 
         $this->connectionPool
             ->method('getConnectionForTable')
             ->willReturn($connection);
+
+        // The audit chain MUST be re-keyed in the same operation.
+        $this->auditChainRekeyService
+            ->expects(self::once())
+            ->method('rekeyChain')
+            ->with($connection, self::isString())
+            ->willReturn(3);
 
         // `withReEncryptedDek()` returns a NEW Secret instance, so the
         // saved entity is a different object from `$secret`. Match on the
@@ -352,6 +380,62 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
 
         self::assertSame(0, $exitCode);
         self::assertStringContainsString('Successfully rotated', $this->commandTester->getDisplay());
+        self::assertStringContainsString('Audit chain re-keyed', $this->commandTester->getDisplay());
+    }
+
+    #[Test]
+    public function refusesRotationWhenAuditChainVerificationFails(): void
+    {
+        $secret = $this->createTestSecret('test-secret');
+
+        $this->secretRepository
+            ->method('findIdentifiers')
+            ->willReturn(['test-secret']);
+
+        $this->secretRepository
+            ->method('findByIdentifier')
+            ->willReturn($secret);
+
+        $this->encryptionService
+            ->method('reEncryptDek')
+            ->willReturn(new ReEncryptedDek('new', 'n'));
+
+        // Re-build the command with an INVALID chain verification result:
+        // re-keying a tampered chain would launder the tampering, so the
+        // rotation must refuse before any state change.
+        $auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $auditLogService
+            ->method('verifyHashChain')
+            ->willReturn(HashChainVerificationResult::invalid([5 => 'Entry hash mismatch - possible tampering']));
+
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::never())->method('beginTransaction');
+        $this->connectionPool
+            ->method('getConnectionForTable')
+            ->willReturn($connection);
+
+        $this->auditChainRekeyService
+            ->expects(self::never())
+            ->method('rekeyChain');
+
+        $command = new VaultRotateMasterKeyCommand(
+            $this->secretRepository,
+            $this->encryptionService,
+            $this->masterKeyProviderFactory,
+            $this->connectionPool,
+            $auditLogService,
+            $this->auditChainRekeyService,
+        );
+        $commandTester = new CommandTester($command);
+
+        $exitCode = $commandTester->execute([
+            '--old-key' => $this->createKeyFile('old', str_repeat('a', 32)),
+            '--new-key' => $this->createKeyFile('new', str_repeat('b', 32)),
+            '--confirm' => true,
+        ]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('verification FAILED', $commandTester->getDisplay());
     }
 
     #[Test]

--- a/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
+++ b/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
@@ -541,15 +541,17 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
 
     private function createTestSecret(string $identifier): Secret
     {
-        // The ctor enforces the tri-state crypto invariant: encryptedDek,
-        // dekNonce, and valueNonce must all be set or all be empty. The
-        // master-key rotation only re-encrypts the DEK envelope, but the
-        // entity still requires the value-side fields to be consistent.
+        // The ctor enforces the full-envelope crypto invariant: encryptedValue,
+        // encryptedDek, dekNonce, valueNonce, and valueChecksum must all be
+        // set or all be empty. The master-key rotation only re-encrypts the
+        // DEK envelope, but the entity still requires a consistent envelope.
         return new Secret(
             identifier: $identifier,
+            encryptedValue: 'encrypted-value',
             encryptedDek: 'encrypted-dek',
             dekNonce: 'dek-nonce',
             valueNonce: 'value-nonce',
+            valueChecksum: 'value-checksum',
         );
     }
 

--- a/Tests/Unit/Crypto/EncryptedDataTest.php
+++ b/Tests/Unit/Crypto/EncryptedDataTest.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Crypto;
 
 use Netresearch\NrVault\Crypto\EncryptedData;
+use Netresearch\NrVault\Crypto\EncryptionAlgorithm;
+use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -33,6 +35,26 @@ final class EncryptedDataTest extends TestCase
         self::assertSame('base64deknonce==', $subject->dekNonce);
         self::assertSame('base64valuenonce==', $subject->valueNonce);
         self::assertSame('abc123checksum', $subject->valueChecksum);
+        // Marker defaults describe what encrypt() currently produces.
+        self::assertSame(EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT, $subject->encryptionVersion);
+        self::assertSame(EncryptionAlgorithm::XChaCha20Poly1305, $subject->encryptionAlgorithm);
+    }
+
+    #[Test]
+    public function constructorAcceptsExplicitMarker(): void
+    {
+        $subject = new EncryptedData(
+            encryptedValue: 'v',
+            encryptedDek: 'd',
+            dekNonce: 'dn',
+            valueNonce: 'vn',
+            valueChecksum: 'cs',
+            encryptionVersion: EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT,
+            encryptionAlgorithm: EncryptionAlgorithm::Aes256Gcm,
+        );
+
+        self::assertSame(EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT, $subject->encryptionVersion);
+        self::assertSame(EncryptionAlgorithm::Aes256Gcm, $subject->encryptionAlgorithm);
     }
 
     #[Test]
@@ -152,15 +174,17 @@ final class EncryptedDataTest extends TestCase
             'dek_nonce' => 'dn',
             'value_nonce' => 'vn',
             'value_checksum' => 'chk',
+            'encryption_version' => EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT,
+            'encryption_algorithm' => 'xchacha20poly1305',
         ], $subject->toArray());
     }
 
     #[Test]
-    public function toArrayContainsExactlyFiveKeys(): void
+    public function toArrayContainsExactlySevenKeys(): void
     {
         $subject = new EncryptedData('a', 'b', 'c', 'd', 'e');
 
-        self::assertCount(5, $subject->toArray());
+        self::assertCount(7, $subject->toArray());
     }
 
     #[Test]
@@ -180,5 +204,23 @@ final class EncryptedDataTest extends TestCase
         self::assertSame(base64_encode($rawDekNonce), $array['dek_nonce']);
         self::assertSame(base64_encode($rawValueNonce), $array['value_nonce']);
         self::assertSame($checksum, $array['value_checksum']);
+    }
+
+    #[Test]
+    public function fromRawPassesMarkerThroughUnencoded(): void
+    {
+        $subject = EncryptedData::fromRaw(
+            encryptedValue: 'raw',
+            encryptedDek: 'raw',
+            dekNonce: 'raw',
+            valueNonce: 'raw',
+            valueChecksum: 'cs',
+            encryptionVersion: EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT,
+            encryptionAlgorithm: EncryptionAlgorithm::Aes256Gcm,
+        );
+
+        self::assertSame(EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT, $subject->encryptionVersion);
+        self::assertSame(EncryptionAlgorithm::Aes256Gcm, $subject->encryptionAlgorithm);
+        self::assertSame('aes256gcm', $subject->toArray()['encryption_algorithm']);
     }
 }

--- a/Tests/Unit/Crypto/EncryptionServiceTest.php
+++ b/Tests/Unit/Crypto/EncryptionServiceTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrVault\Tests\Unit\Crypto;
 
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\EncryptedData;
+use Netresearch\NrVault\Crypto\EncryptionAlgorithm;
 use Netresearch\NrVault\Crypto\EncryptionService;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
 use Netresearch\NrVault\Exception\EncryptionException;
@@ -119,6 +120,8 @@ final class EncryptionServiceTest extends TestCase
             $encrypted->dekNonce,
             $encrypted->valueNonce,
             $identifier,
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
         );
 
         self::assertEquals($plaintext, $decrypted);
@@ -140,6 +143,8 @@ final class EncryptionServiceTest extends TestCase
             $encrypted->dekNonce,
             $encrypted->valueNonce,
             'wrong-identifier', // Different AAD
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
         );
     }
 
@@ -171,6 +176,8 @@ final class EncryptionServiceTest extends TestCase
             $encrypted->dekNonce,
             $encrypted->valueNonce,
             $identifier,
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
         );
     }
 
@@ -291,6 +298,8 @@ final class EncryptionServiceTest extends TestCase
                 $encrypted->dekNonce,
                 $encrypted->valueNonce,
                 $identifier,
+                $encrypted->encryptionVersion,
+                $encrypted->encryptionAlgorithm->value,
             );
         } catch (EncryptionException) {
             $threw = true;
@@ -304,6 +313,8 @@ final class EncryptionServiceTest extends TestCase
             $encrypted->dekNonce,
             $encrypted->valueNonce,
             $identifier,
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
         );
         self::assertSame($plaintext, $decrypted);
     }
@@ -319,13 +330,15 @@ final class EncryptionServiceTest extends TestCase
         // First encrypt with old master key
         $encrypted = $this->subject->encrypt($plaintext, $identifier);
 
-        // Re-encrypt DEK with new master key
+        // Re-encrypt DEK with new master key, honouring the stored marker
         $reEncrypted = $this->subject->reEncryptDek(
             $encrypted->encryptedDek,
             $encrypted->dekNonce,
             $identifier,
             $oldMasterKey,
             $newMasterKey,
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
         );
 
         self::assertNotEmpty($reEncrypted->encryptedDek);
@@ -351,6 +364,8 @@ final class EncryptionServiceTest extends TestCase
             $encrypted->dekNonce,
             $encrypted->valueNonce,
             $identifier,
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
         );
 
         self::assertEquals('', $decrypted);
@@ -371,6 +386,8 @@ final class EncryptionServiceTest extends TestCase
             $encrypted->dekNonce,
             $encrypted->valueNonce,
             $identifier,
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
         );
 
         self::assertEquals($plaintext, $decrypted);
@@ -390,6 +407,8 @@ final class EncryptionServiceTest extends TestCase
             $encrypted->dekNonce,
             $encrypted->valueNonce,
             $identifier,
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
         );
 
         self::assertEquals($plaintext, $decrypted);
@@ -422,7 +441,9 @@ final class EncryptionServiceTest extends TestCase
     #[Test]
     public function encryptAndDecryptRoundtripWithXChaCha20(): void
     {
-        // Configure to prefer XChaCha20
+        // Configure to prefer XChaCha20. The marker-less decrypt below
+        // deliberately exercises the LEGACY (version-1) resolution path,
+        // which resolves to XChaCha20 here and matches the new envelope.
         $xchachaConfig = $this->createMock(ExtensionConfigurationInterface::class);
         $xchachaConfig
             ->method('preferXChaCha20')
@@ -512,6 +533,139 @@ final class EncryptionServiceTest extends TestCase
             'test',
             $this->testMasterKey,
             random_bytes(32),
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Encryption version / algorithm marker (encryption version 2).
+    // ---------------------------------------------------------------
+
+    #[Test]
+    public function encryptRecordsVersionTwoWithXChaChaDefaultAlgorithm(): void
+    {
+        // The default subject's config prefers AES for LEGACY decrypts
+        // (preferXChaCha20=false) — new envelopes must nonetheless default
+        // to the host-independent XChaCha20-Poly1305 and record it.
+        $encrypted = $this->subject->encrypt('marker-test', 'marker-id');
+
+        self::assertSame(EncryptionService::ENCRYPTION_VERSION_CURRENT, $encrypted->encryptionVersion);
+        self::assertSame(EncryptionAlgorithm::XChaCha20Poly1305, $encrypted->encryptionAlgorithm);
+    }
+
+    #[Test]
+    public function encryptRecordsConfiguredAesAlgorithm(): void
+    {
+        if (!sodium_crypto_aead_aes256gcm_is_available()) {
+            self::markTestSkipped('AES-256-GCM not available on this platform');
+        }
+
+        $aesConfig = $this->createMock(ExtensionConfigurationInterface::class);
+        $aesConfig->method('getEncryptionAlgorithm')->willReturn('aes256gcm');
+
+        $subject = new EncryptionService($this->masterKeyProvider, $aesConfig);
+
+        $encrypted = $subject->encrypt('aes-marker-test', 'aes-marker-id');
+
+        self::assertSame(EncryptionAlgorithm::Aes256Gcm, $encrypted->encryptionAlgorithm);
+
+        $decrypted = $subject->decrypt(
+            $encrypted->encryptedValue,
+            $encrypted->encryptedDek,
+            $encrypted->dekNonce,
+            $encrypted->valueNonce,
+            'aes-marker-id',
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
+        );
+        self::assertSame('aes-marker-test', $decrypted);
+    }
+
+    #[Test]
+    public function encryptThrowsOnUnknownConfiguredAlgorithm(): void
+    {
+        $brokenConfig = $this->createMock(ExtensionConfigurationInterface::class);
+        $brokenConfig->method('getEncryptionAlgorithm')->willReturn('rot13');
+
+        $subject = new EncryptionService($this->masterKeyProvider, $brokenConfig);
+
+        $this->expectException(EncryptionException::class);
+        $this->expectExceptionMessage('Unknown encryptionAlgorithm');
+
+        $subject->encrypt('value', 'id');
+    }
+
+    #[Test]
+    public function decryptSelectsAlgorithmFromStoredMarkerNotHostPreference(): void
+    {
+        // The envelope is XChaCha20 (version 2 marker); the subject's legacy
+        // host-derivation would pick AES on AES-capable hosts. Passing the
+        // stored marker must decrypt correctly regardless of host preference.
+        $encrypted = $this->subject->encrypt('marker-dispatch', 'marker-dispatch-id');
+
+        $decrypted = $this->subject->decrypt(
+            $encrypted->encryptedValue,
+            $encrypted->encryptedDek,
+            $encrypted->dekNonce,
+            $encrypted->valueNonce,
+            'marker-dispatch-id',
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
+        );
+
+        self::assertSame('marker-dispatch', $decrypted);
+
+        // Counter-check: OMITTING the marker (legacy version-1 resolution)
+        // must NOT silently decrypt this XChaCha envelope on hosts whose
+        // legacy derivation resolves to AES — the implicitness the marker
+        // removes. Only assertable where AES is actually available.
+        if (sodium_crypto_aead_aes256gcm_is_available()) {
+            $this->expectException(EncryptionException::class);
+
+            $this->subject->decrypt(
+                $encrypted->encryptedValue,
+                $encrypted->encryptedDek,
+                $encrypted->dekNonce,
+                $encrypted->valueNonce,
+                'marker-dispatch-id',
+            );
+        }
+    }
+
+    #[Test]
+    public function decryptVersionTwoWithEmptyAlgorithmMarkerThrows(): void
+    {
+        $encrypted = $this->subject->encrypt('v2-no-marker', 'v2-no-marker-id');
+
+        $this->expectException(EncryptionException::class);
+        $this->expectExceptionMessage('Unknown encryption algorithm marker');
+
+        $this->subject->decrypt(
+            $encrypted->encryptedValue,
+            $encrypted->encryptedDek,
+            $encrypted->dekNonce,
+            $encrypted->valueNonce,
+            'v2-no-marker-id',
+            EncryptionService::ENCRYPTION_VERSION_CURRENT,
+            '',
+        );
+    }
+
+    #[Test]
+    public function decryptVersionTwoWithUnknownAlgorithmMarkerThrows(): void
+    {
+        $encrypted = $this->subject->encrypt('v2-bad-marker', 'v2-bad-marker-id');
+
+        $this->expectException(EncryptionException::class);
+        $this->expectExceptionMessage('Unknown encryption algorithm marker');
+
+        $this->subject->decrypt(
+            $encrypted->encryptedValue,
+            $encrypted->encryptedDek,
+            $encrypted->dekNonce,
+            $encrypted->valueNonce,
+            'v2-bad-marker-id',
+            EncryptionService::ENCRYPTION_VERSION_CURRENT,
+            'rot13',
         );
     }
 }

--- a/Tests/Unit/Domain/Model/SecretTest.php
+++ b/Tests/Unit/Domain/Model/SecretTest.php
@@ -145,20 +145,18 @@ final class SecretTest extends TestCase
     #[Test]
     public function constructorAllowsAllCryptoFieldsEmpty(): void
     {
-        $secret = new Secret(
-            identifier: 'external-ref',
-            encryptedValue: 'enc_value',
-            valueChecksum: 'checksum',
-        );
+        $secret = new Secret(identifier: 'external-ref');
 
+        self::assertNull($secret->getEncryptedValue());
         self::assertSame('', $secret->getEncryptedDek());
         self::assertSame('', $secret->getDekNonce());
         self::assertSame('', $secret->getValueNonce());
+        self::assertSame('', $secret->getValueChecksum());
     }
 
     // ---------------------------------------------------------------
-    // Crypto-field tri-state invariant: encryptedDek/dekNonce/valueNonce
-    // must all be set or all be empty.
+    // Crypto-field envelope invariant: encryptedValue/encryptedDek/
+    // dekNonce/valueNonce/valueChecksum must all be set or all be empty.
     // ---------------------------------------------------------------
 
     /**
@@ -182,7 +180,7 @@ final class SecretTest extends TestCase
         string $valueNonce,
     ): void {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('encryptedDek, dekNonce, and valueNonce must all be set or all be empty');
+        $this->expectExceptionMessage('encryptedValue, encryptedDek, dekNonce, valueNonce, and valueChecksum must all be set or all be empty');
 
         // The constructor MUST throw before returning; assertInstanceOf
         // is unreachable but uses the constructed value so Sonar's S1848
@@ -194,6 +192,22 @@ final class SecretTest extends TestCase
             dekNonce: $dekNonce,
             valueNonce: $valueNonce,
             valueChecksum: 'checksum',
+        ));
+    }
+
+    #[Test]
+    public function constructorThrowsOnEnvelopeWithoutCiphertext(): void
+    {
+        // The exact shape the full-envelope invariant exists for: DEK +
+        // nonces present, ciphertext + checksum absent → an undecryptable
+        // secret that the previous three-field check still accepted.
+        $this->expectException(ValidationException::class);
+
+        self::assertInstanceOf(Secret::class, new Secret(
+            identifier: 'broken',
+            encryptedDek: 'dek',
+            dekNonce: 'dn',
+            valueNonce: 'vn',
         ));
     }
 

--- a/Tests/Unit/Domain/Model/SecretTest.php
+++ b/Tests/Unit/Domain/Model/SecretTest.php
@@ -60,6 +60,7 @@ final class SecretTest extends TestCase
         self::assertSame('', $secret->getDekNonce());
         self::assertSame('', $secret->getValueNonce());
         self::assertSame(1, $secret->getEncryptionVersion());
+        self::assertSame('', $secret->getEncryptionAlgorithm());
         self::assertSame('', $secret->getValueChecksum());
         self::assertSame(0, $secret->getOwnerUid());
         self::assertSame([], $secret->getAllowedGroups());
@@ -93,6 +94,7 @@ final class SecretTest extends TestCase
             dekNonce: 'dek_nonce',
             valueNonce: 'value_nonce',
             encryptionVersion: 2,
+            encryptionAlgorithm: 'xchacha20poly1305',
             valueChecksum: 'checksum123',
             ownerUid: 5,
             allowedGroups: [1, 2, 3],
@@ -122,6 +124,7 @@ final class SecretTest extends TestCase
         self::assertSame('dek_nonce', $secret->getDekNonce());
         self::assertSame('value_nonce', $secret->getValueNonce());
         self::assertSame(2, $secret->getEncryptionVersion());
+        self::assertSame('xchacha20poly1305', $secret->getEncryptionAlgorithm());
         self::assertSame('checksum123', $secret->getValueChecksum());
         self::assertSame(5, $secret->getOwnerUid());
         self::assertSame([1, 2, 3], $secret->getAllowedGroups());
@@ -193,6 +196,95 @@ final class SecretTest extends TestCase
             valueNonce: $valueNonce,
             valueChecksum: 'checksum',
         ));
+    }
+
+    #[Test]
+    public function constructorThrowsOnVersionTwoWithoutAlgorithmMarker(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('known encryptionAlgorithm marker');
+
+        self::assertInstanceOf(Secret::class, new Secret(
+            identifier: 'v2-no-marker',
+            encryptedValue: 'v',
+            encryptedDek: 'dek',
+            dekNonce: 'dn',
+            valueNonce: 'vn',
+            encryptionVersion: 2,
+            valueChecksum: 'cs',
+        ));
+    }
+
+    #[Test]
+    public function constructorThrowsOnVersionTwoWithUnknownAlgorithmMarker(): void
+    {
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('known encryptionAlgorithm marker');
+
+        self::assertInstanceOf(Secret::class, new Secret(
+            identifier: 'v2-bad-marker',
+            encryptedValue: 'v',
+            encryptedDek: 'dek',
+            dekNonce: 'dn',
+            valueNonce: 'vn',
+            encryptionVersion: 2,
+            encryptionAlgorithm: 'rot13',
+            valueChecksum: 'cs',
+        ));
+    }
+
+    #[Test]
+    public function constructorThrowsOnVersionTwoWithoutEnvelope(): void
+    {
+        // Version 2 means "explicitly marked envelope" — without an envelope
+        // the marker is meaningless and indicates a programming error.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('full encryption envelope');
+
+        self::assertInstanceOf(Secret::class, new Secret(
+            identifier: 'v2-no-envelope',
+            encryptionVersion: 2,
+            encryptionAlgorithm: 'xchacha20poly1305',
+        ));
+    }
+
+    #[Test]
+    public function constructorThrowsOnLegacyVersionWithAlgorithmMarker(): void
+    {
+        // A v1 row carrying a marker is inconsistent: decrypt would ignore
+        // the marker (host-derived resolution) and silently diverge from
+        // what the stored marker claims.
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionMessage('must not carry an encryptionAlgorithm marker');
+
+        self::assertInstanceOf(Secret::class, new Secret(
+            identifier: 'v1-with-marker',
+            encryptedValue: 'v',
+            encryptedDek: 'dek',
+            dekNonce: 'dn',
+            valueNonce: 'vn',
+            encryptionVersion: 1,
+            encryptionAlgorithm: 'xchacha20poly1305',
+            valueChecksum: 'cs',
+        ));
+    }
+
+    #[Test]
+    public function constructorAcceptsVersionTwoWithKnownAlgorithmAndFullEnvelope(): void
+    {
+        $secret = new Secret(
+            identifier: 'v2-ok',
+            encryptedValue: 'v',
+            encryptedDek: 'dek',
+            dekNonce: 'dn',
+            valueNonce: 'vn',
+            encryptionVersion: 2,
+            encryptionAlgorithm: 'aes256gcm',
+            valueChecksum: 'cs',
+        );
+
+        self::assertSame(2, $secret->getEncryptionVersion());
+        self::assertSame('aes256gcm', $secret->getEncryptionAlgorithm());
     }
 
     #[Test]
@@ -290,6 +382,10 @@ final class SecretTest extends TestCase
         self::assertSame('new_dn', $rotated->getDekNonce());
         self::assertSame('new_vn', $rotated->getValueNonce());
         self::assertSame('new_cs', $rotated->getValueChecksum());
+        // The envelope's version/algorithm marker follows the new envelope:
+        // a legacy (v1) secret is upgraded on value rotation.
+        self::assertSame(2, $rotated->getEncryptionVersion());
+        self::assertSame('xchacha20poly1305', $rotated->getEncryptionAlgorithm());
         // Untouched fields propagate.
         self::assertSame(1, $rotated->getUid());
         self::assertSame(9, $rotated->getReadCount());
@@ -434,6 +530,29 @@ final class SecretTest extends TestCase
     }
 
     #[Test]
+    public function fromDatabaseRowHydratesVersionTwoAlgorithmMarker(): void
+    {
+        $secret = Secret::fromDatabaseRow([
+            'uid' => 7,
+            'identifier' => 'v2-row',
+            'encrypted_value' => 'v',
+            'encrypted_dek' => 'dek',
+            'dek_nonce' => 'dn',
+            'value_nonce' => 'vn',
+            'encryption_version' => 2,
+            'encryption_algorithm' => 'xchacha20poly1305',
+            'value_checksum' => 'cs',
+        ]);
+
+        self::assertSame(2, $secret->getEncryptionVersion());
+        self::assertSame('xchacha20poly1305', $secret->getEncryptionAlgorithm());
+        // And the marker survives serialisation back to a row.
+        $row = $secret->toDatabaseRow();
+        self::assertSame(2, $row['encryption_version']);
+        self::assertSame('xchacha20poly1305', $row['encryption_algorithm']);
+    }
+
+    #[Test]
     public function fromDatabaseRowHandlesEmptyMetadata(): void
     {
         $secret = Secret::fromDatabaseRow([
@@ -524,10 +643,21 @@ final class SecretTest extends TestCase
      */
     public static function encryptionVersionCoalesceProvider(): iterable
     {
+        // Version 2+ rows must satisfy the marker invariant (full envelope
+        // plus a known algorithm marker), so those provider rows carry one.
+        $envelope = [
+            'encrypted_value' => 'v',
+            'encrypted_dek' => 'dek',
+            'dek_nonce' => 'dn',
+            'value_nonce' => 'vn',
+            'value_checksum' => 'cs',
+            'encryption_algorithm' => 'xchacha20poly1305',
+        ];
+
         yield 'missing key defaults to 1' => [['uid' => 1, 'identifier' => 't'], 1];
         yield 'explicit 1' => [['uid' => 1, 'identifier' => 't', 'encryption_version' => 1], 1];
-        yield 'explicit 2' => [['uid' => 1, 'identifier' => 't', 'encryption_version' => 2], 2];
-        yield 'explicit 10' => [['uid' => 1, 'identifier' => 't', 'encryption_version' => 10], 10];
+        yield 'explicit 2' => [['uid' => 1, 'identifier' => 't', 'encryption_version' => 2] + $envelope, 2];
+        yield 'explicit 10' => [['uid' => 1, 'identifier' => 't', 'encryption_version' => 10] + $envelope, 10];
     }
 
     /**
@@ -684,6 +814,7 @@ final class SecretTest extends TestCase
             'dek_nonce' => 'dn',
             'value_nonce' => 'vn',
             'encryption_version' => 2,
+            'encryption_algorithm' => 'xchacha20poly1305',
             'value_checksum' => 'cs',
             'owner_uid' => 5,
             'allowed_groups' => '7,8,9',
@@ -743,7 +874,17 @@ final class SecretTest extends TestCase
     #[Test]
     public function fromDatabaseRowEncryptionVersionCastsStringToInt(): void
     {
-        $secret = Secret::fromDatabaseRow(['uid' => 1, 'identifier' => 't', 'encryption_version' => '3']);
+        $secret = Secret::fromDatabaseRow([
+            'uid' => 1,
+            'identifier' => 't',
+            'encrypted_value' => 'v',
+            'encrypted_dek' => 'dek',
+            'dek_nonce' => 'dn',
+            'value_nonce' => 'vn',
+            'value_checksum' => 'cs',
+            'encryption_version' => '3',
+            'encryption_algorithm' => 'xchacha20poly1305',
+        ]);
 
         self::assertSame(3, $secret->getEncryptionVersion());
         self::assertIsInt($secret->getEncryptionVersion());
@@ -1005,6 +1146,7 @@ final class SecretTest extends TestCase
             'description',
             'encrypted_dek',
             'encrypted_value',
+            'encryption_algorithm',
             'encryption_version',
             'expires_at',
             'external_reference',

--- a/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
@@ -1061,6 +1061,7 @@ final class SecretRepositoryTest extends TestCase
             dekNonce: 'deknonce',
             valueNonce: 'valuenonce',
             encryptionVersion: 1,
+            valueChecksum: str_repeat('c', 64),
             allowedGroups: $allowedGroups,
         );
     }
@@ -1075,7 +1076,10 @@ final class SecretRepositoryTest extends TestCase
             'pid' => 0,
             'identifier' => $identifier,
             'encrypted_value' => base64_encode('encrypted'),
-            'nonce' => base64_encode('nonce123456789012'),
+            'encrypted_dek' => base64_encode('dek'),
+            'dek_nonce' => base64_encode('deknonce'),
+            'value_nonce' => base64_encode('valuenonce'),
+            'value_checksum' => str_repeat('c', 64),
             'encryption_version' => 1,
             'context' => '',
             'label' => 'Test Secret',

--- a/Tests/Unit/Fixtures/SecretFixtureBuilder.php
+++ b/Tests/Unit/Fixtures/SecretFixtureBuilder.php
@@ -270,10 +270,12 @@ final class SecretFixtureBuilder
     /**
      * Build a real `Secret` domain entity (no mocking).
      *
-     * Uses placeholder ciphertext so the builder stays usable in tests that
-     * only need the entity shell — production code that decrypts the result
-     * will throw, which is desirable: a test that reaches that branch should
-     * wire real crypto instead.
+     * Uses a placeholder envelope (ciphertext, DEK, nonces, checksum — the
+     * Secret constructor enforces all-or-nothing on these five fields) so the
+     * builder stays usable in tests that only need the entity shell —
+     * production code that decrypts the result will throw, which is
+     * desirable: a test that reaches that branch should wire real crypto
+     * instead.
      */
     public function buildSecret(): Secret
     {
@@ -283,6 +285,9 @@ final class SecretFixtureBuilder
             scopePid: $this->scopePid,
             description: $this->description,
             encryptedValue: 'test-ciphertext',
+            encryptedDek: 'test-encrypted-dek',
+            dekNonce: 'test-dek-nonce',
+            valueNonce: 'test-value-nonce',
             valueChecksum: 'test-checksum',
             ownerUid: $this->ownerUid,
             allowedGroups: $this->groups,

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -20,8 +20,11 @@ masterKeySource = NR_VAULT_MASTER_KEY
 ### ENCRYPTION ###
 ###################
 
-# cat=Encryption; type=boolean; label=Prefer XChaCha20-Poly1305: Use XChaCha20-Poly1305 instead of AES-256-GCM for encryption. XChaCha20 provides larger nonce and is misuse-resistant.
+# cat=Encryption; type=boolean; label=Prefer XChaCha20-Poly1305 (legacy secrets only): Algorithm selection for secrets stored before the per-secret algorithm marker existed (encryption version 1). New secrets record their algorithm explicitly; see encryptionAlgorithm.
 preferXChaCha20 = 0
+
+# cat=Encryption; type=string; label=Encryption Algorithm for new secrets: AEAD algorithm recorded per secret at encrypt time. Empty = XChaCha20-Poly1305 (recommended; available on every host, 24-byte nonce). Set to "aes256gcm" only on hosts with hardware AES support. Unknown or unavailable values make encryption fail loudly.
+encryptionAlgorithm =
 
 #################
 ### SECURITY ###

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -11,11 +11,16 @@ CREATE TABLE tx_nrvault_secret (
     description text,
 
     -- Encrypted data (local adapter only)
+    -- Nonces are stored base64-encoded: a 24-byte XChaCha20-Poly1305 nonce
+    -- encodes to 32 characters (AES-256-GCM: 12 bytes -> 16 characters).
     encrypted_value mediumblob,
     encrypted_dek text,
-    dek_nonce varchar(24) DEFAULT '' NOT NULL,
-    value_nonce varchar(24) DEFAULT '' NOT NULL,
+    dek_nonce varchar(32) DEFAULT '' NOT NULL,
+    value_nonce varchar(32) DEFAULT '' NOT NULL,
+    -- 1 = legacy (algorithm host-derived at decrypt time),
+    -- 2 = algorithm recorded explicitly in encryption_algorithm
     encryption_version int(11) unsigned DEFAULT 1 NOT NULL,
+    encryption_algorithm varchar(32) DEFAULT '' NOT NULL,
 
     -- Change detection (without decrypting)
     value_checksum char(64) DEFAULT '' NOT NULL,


### PR DESCRIPTION
Completes the crypto/audit design work from the skills-based design review: a per-secret encryption-algorithm marker, atomic audit-chain re-keying on master-key rotation, and an end-to-end second-rotation (epoch 2) functional test. Also repairs the test fallout and a `finally`-wipe regression of the preceding hardening commit so every commit on the branch is green.

## 1. Per-secret encryption-algorithm marker (`a259c51`)

**Finding:** the AEAD algorithm was implicit — derived from host capabilities (`sodium_crypto_aead_aes256gcm_is_available()` + `preferXChaCha20`) at *both* encrypt and decrypt time. Decrypting the same data on a **PHP host** with different CPU features — an app-server migration, a DB dump restored into another instance, a container base-image change (the algorithm choice follows the PHP process host's AES-NI availability, not the database server) — or toggling `preferXChaCha20` silently made every secret undecryptable, and no future algorithm migration was possible because rows did not record how they were encrypted.

**Design as implemented:**

- `encryption_version = 1` (legacy): rows without a marker. `decrypt()` / `reEncryptDek()` keep deriving the algorithm from host capabilities **byte-identically to the previous behaviour** (`useAes256Gcm()` is unchanged and now serves only this path).
- `encryption_version = 2`: the algorithm is recorded explicitly at encrypt time in the new `tx_nrvault_secret.encryption_algorithm` column (new `EncryptionAlgorithm` string-backed enum: `xchacha20poly1305`, `aes256gcm`) and decryption dispatches **on the stored marker only** — for v2 rows an unknown/empty marker or a host-unavailable algorithm is a hard `EncryptionException`, never a guess. All new encrypts write version 2.
- Default algorithm for new secrets is **XChaCha20-Poly1305** (present in every libsodium build, 24-byte nonce ⇒ random-nonce collisions are a non-concern). A site can pin `aes256gcm` via the new `encryptionAlgorithm` extension setting; unknown or unavailable values fail loudly at the crypto boundary ("refusing to encrypt beats encrypting with an algorithm the operator did not choose").
- `Secret`'s envelope-consistency invariant extended coherently: v2+ requires the **full five-field envelope plus a known algorithm marker**; v1 must **not** carry a marker (a marker the decrypt path would ignore is a lie waiting to diverge). `withValueRotation()` carries the new envelope's marker, so a value rotation upgrades a v1 secret to v2.
- `reEncryptDek()` (master-key rotation) unwraps and re-wraps the DEK with the secret's *own* algorithm (marker for v2, host-derived for v1) — without this, rotating on a host whose capability-derived choice differs from the stored marker would corrupt every v2 row.
- Schema: `dek_nonce`/`value_nonce` widened `varchar(24) → varchar(32)`. Nonces are stored base64-encoded; a 24-byte XChaCha20 nonce encodes to **32** characters, so `varchar(24)` hard-failed under strict SQL mode (or silently truncated without it) on the XChaCha20 path. This was a pre-existing latent bug for `preferXChaCha20=1` installs on MySQL/MariaDB that becomes default-path with this change. TCA exposes the marker read-only in the *Info* tab.

**BC analysis:**

- *Existing rows:* no migration, no rewrite. They have `encryption_version = 1` (column default) and an empty marker; the v1 decrypt path is the pre-change logic verbatim. A site that never changes hosts or config sees zero behavioural difference for stored data.
- *Interfaces:* `decrypt()` and `reEncryptDek()` gained two trailing parameters with defaults equal to the legacy behaviour (`version = 1`, marker `''`) — existing callers compile and behave as before. `EncryptedData` gained marker fields whose defaults describe what `encrypt()` now produces; the only production construction site (`EncryptionService::encrypt()`) passes them explicitly.
- *Behavioural change (intentional):* new encrypts on AES-capable hosts without `preferXChaCha20` previously produced AES-GCM; they now produce XChaCha20-Poly1305 *and record it* — which is exactly the portability fix. AES-GCM remains a first-class choice via the config setting, and remains fully supported for decrypting/rotating legacy rows.
- *Mixed vaults* (v1 + v2 rows side by side) are handled per row in retrieve and rotation.

## 2. Audit-chain HMAC re-keying on master-key rotation (`b2cd6da`)

**Finding:** the tamper-evident audit log is an HMAC-SHA256 hash chain keyed via HKDF (`nr-vault-audit-hmac-v1`) from the master key. `vault:rotate-master-key` re-encrypted all DEKs but left the chain keyed to the old master key — after switching the provider configuration, `verifyHashChain()` failed for every HMAC-epoch row. Rotation orphaned the chain.

**Design as implemented:**

- New `AuditChainRekeyService` (+ interface, DI alias), modelled on the existing `AuditHmacMigrationWizard::rehashAllRows()` prior art with two deliberate differences: per-row `hmac_key_epoch` is **preserved** (re-keying changes the key, never the payload format — epoch 0 rows stay keyless SHA-256, epoch 1/2+ are recomputed under the new HMAC key), and rows are only UPDATEd when their hashes actually change (idempotent; an all-keyless chain passes through untouched). The HKDF parameters now live in exactly one place (`AuditLogService::deriveHmacKeyFromMasterKey()`).
- The command runs the re-key **inside the same transaction** as the DEK re-encryption and refuses to run at all if `tx_nrvault_secret` and `tx_nrvault_audit_log` resolve to different connections (cross-table atomicity would be impossible).
- The chain is **verified under the current key before re-keying**; an invalid chain aborts the rotation. Re-keying a tampered chain would re-seal the tampering into a freshly valid chain and destroy the evidence.
- The re-keying is itself audited: a new `AuditAction::AuditChainRekey` (`audit_chain_rekey`) event.

**Atomicity analysis (ordering inside the transaction):**

1. `master_key_rotate_start` is logged **before** the transaction — the previous in-transaction placement was rolled back together with a failed rotation, contradicting its own "leave a trail" comment (and could not execute on SQLite at all, see below). A rolled-back rotation now still leaves `start` + `end(failure)` in the chain, both sealed under the still-current old key — consistent.
2. `BEGIN` → re-encrypt all DEKs (any per-secret failure ⇒ rollback, unchanged).
3. Acquire the audit advisory lock **for the remainder of the transaction**: without it, a concurrent `log()` on another connection could chain a new entry onto a tip hash we are about to rewrite, forking the chain at commit.
4. Append `audit_chain_rekey` + successful `master_key_rotate_end` (sealed with the *old* provider-derived key at this instant), **then** rewrite the whole chain under the new key — both events end up re-sealed under the new key, leaving **no old-keyed tail entry** behind the re-key point. Writing the success events before the final step is sound because the whole sequence is atomic: any failure propagates and rolls back secrets, events, and rewrite together.
5. `COMMIT`. At every observable point: before commit, concurrent readers see the old chain (valid under the old/provider key); after commit + provider switch, the chain verifies under the new key from first to last row. On any failure: full rollback, chain + secrets revert, `end(failure)` is appended under the old key — still valid.

**Supporting change — `AuditChainLockTrait` nesting:** inside a caller-managed Doctrine transaction, SQLite cannot nest a raw `BEGIN EXCLUSIVE`; the trait now falls back to Doctrine savepoints when `isTransactionActive()` (write serialisation then comes from the outer transaction's database-file write lock). MySQL/MariaDB `GET_LOCK` is re-acquirable per session and DBAL 4 nests via savepoints natively, so that path needed no change. This also un-breaks the command's pre-existing in-transaction `log()` call on SQLite.

**Documented operational window:** between command completion and the provider-configuration switch, secrets are undecryptable *and* chain verification under the still-configured old key fails — the same window the rotation has always had for secrets, now extended to the chain. The command output instructs operators to switch immediately and, if any audit entries were written inside the window (sealed with the old key), to re-seal them with the existing `vault:audit-migrate-hmac` repair path.

## 3. Epoch-2 functional test (`fd1563e`)

Extends the golden-sample `MasterKeyRotationTest` with `secondRotationKeepsSecretsDecryptableAndAuditChainValid`: store 3 secrets → rotate K0→K1 → rotate K1→K2, each rotation through the **real command** (`CommandTester`), asserting after each rotation that every secret still decrypts and `verifyHashChain()` returns valid. This exercises markers surviving repeated DEK re-wrapping, the in-transaction chain re-key twice in sequence, and the SQLite savepoint nesting end-to-end. A dedicated `AuditChainRekeyServiceTest` additionally covers epoch preservation (keyless prefix untouched), the old-key-fails/new-key-passes property, and idempotence.

## 0. Branch-base repair (amended into `23ec833`)

The pre-existing hardening commit on this branch had two regressions, fixed in place (branch was unpushed): the unconditional `sodium_memzero($plaintext/$masterKey)` in `encrypt()`'s `finally` threw `SodiumException` on **every** success path (`sodium_memzero()` nulls the wiped variable; the second wipe then received `null`) — now `isset()`-guarded like the neighbouring wipes; and the five-field envelope invariant broke 73 unit/functional tests whose fixtures built partial envelopes — fixtures now build full envelopes and `SecretTest` asserts the new invariant.

## Evidence

```
composer ci:test:php:unit          OK — Tests: 1813, Assertions: 7283 (3 pre-existing PHPUnit notices)
php -d memory_limit=1G .Build/bin/phpunit -c Build/FunctionalTests.xml
                                   OK — Tests: 165, Assertions: 510, Skipped: 9 (2 pre-existing deprecations)
composer ci:test:php:fuzz          OK — 1514 tests, 2255 assertions
phpstan (Build/phpstan.no-plugins.neon, 1G)   [OK] No errors
composer ci:cgl                    clean (no files changed)
```

(The functional suite needs an explicit `memory_limit` in this environment; the default 128M OOMs in TYPO3's TcaSchema cache, unrelated to this change.)

## Open risks for review

- **Old-key tail window (item 2):** any audit write between rotation commit and provider switch seals with the old key and will flag under the new key. Mitigated by runbook output + `vault:audit-migrate-hmac`; a verifier that tolerates a marked re-key boundary would close it fully but needs a key-epoch design of its own.
- **MySQL/MariaDB paths untested in CI:** functional tests run on SQLite. The MySQL advisory-lock path (`GET_LOCK` re-acquisition within one session, DBAL 4 savepoint nesting) is reasoned, not executed. Worth one manual rotation on a MariaDB review instance.
- **Default-algorithm flip:** new secrets on AES-NI hosts switch from AES-GCM to XChaCha20-Poly1305 (recorded). Performance is irrelevant at vault scale, but if a deployment *requires* AES-GCM (e.g. FIPS-adjacent policy), it must set `encryptionAlgorithm = aes256gcm`.
- **`fromDatabaseRow()` now throws on marker-inconsistent rows** (e.g. hand-edited `encryption_version = 2` without a marker). Fail-loud is intentional for a vault, but it surfaces in list paths, not just decrypt.
- **Legacy v1 rows stay host-derived forever** unless rotated. A follow-up could record the (auth-tag-proven) algorithm during master-key rotation to upgrade v1 → v2 wholesale; deliberately left out of scope here.

