### PR TITLE
Fix actor-type misclassification of CLI and worker reads

### DIFF
--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -16,6 +16,7 @@ use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Domain\Model\Secret;
 use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
@@ -115,18 +116,30 @@ final class AccessControlService implements AccessControlServiceInterface
 
     public function getCurrentActorType(): string
     {
-        $backendUser = $this->getBackendUser();
-        if ($backendUser instanceof BackendUserAuthentication) {
-            return 'backend';
-        }
-
+        // CLI detection must run BEFORE the backend-user check: the TYPO3 CLI
+        // bootstrap (console commands, messenger workers) sets
+        // $GLOBALS['BE_USER'] to a CommandLineUserAuthentication instance —
+        // which extends BackendUserAuthentication — so a backend-user-first
+        // order misclassified every CLI/worker access as 'backend'.
         if ($this->isRealCliContext()) {
             return 'cli';
         }
 
-        /** @phpstan-ignore constant.notFound */
-        if (\defined('TYPO3_cliMode') && \TYPO3_CLIMODE) {
+        if (\defined('TYPO3_cliMode') && \constant('TYPO3_cliMode') === true) {
             return 'cli';
+        }
+
+        $backendUser = $this->getBackendUser();
+
+        // A CommandLineUserAuthentication BE user only ever exists in CLI
+        // context — classify it as 'cli' even when SAPI detection is
+        // suppressed (e.g. under PHPUnit, where isRealCliContext() is guarded).
+        if ($backendUser instanceof CommandLineUserAuthentication) {
+            return 'cli';
+        }
+
+        if ($backendUser instanceof BackendUserAuthentication) {
+            return 'backend';
         }
 
         return 'api';

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -141,8 +141,10 @@ Automation-stale
 
    The automated-versus-manual split is derived from the audit log
    (``actor_type``), so it reflects only reads recorded while audit logging was
-   active. The day thresholds are configurable - see
-   :ref:`usage-extension-settings`.
+   active. Reads in TYPO3 CLI context (console commands, scheduled jobs, queue
+   workers) are recorded with actor type ``cli`` and count as automated, even
+   though the CLI bootstrap authenticates the ``_cli_`` backend user. The day
+   thresholds are configurable - see :ref:`usage-extension-settings`.
 
 .. tip::
 

--- a/Tests/Unit/Security/AccessControlServiceTest.php
+++ b/Tests/Unit/Security/AccessControlServiceTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -513,6 +514,40 @@ final class AccessControlServiceTest extends TestCase
     }
 
     #[Test]
+    public function getCurrentActorTypeReturnsCliForCommandLineUser(): void
+    {
+        // Regression test for the CLI misclassification bug: the TYPO3 CLI
+        // bootstrap (vendor/bin/typo3, messenger workers) sets BE_USER to a
+        // CommandLineUserAuthentication instance, which EXTENDS
+        // BackendUserAuthentication. The backend-user check must not win —
+        // CLI/worker reads are 'cli', not 'backend' (otherwise the analytics
+        // module counts every automated read as a manual reveal).
+        $this->setCommandLineUser();
+
+        self::assertSame('cli', $this->subject->getCurrentActorType());
+    }
+
+    #[Test]
+    public function getCurrentActorTypeReturnsBackendForRegularUserDespiteCliFirstOrdering(): void
+    {
+        // Counter-check for the CLI-first ordering: a regular (web) backend
+        // user is still classified as 'backend'.
+        $this->setBackendUser(uid: 1, isAdmin: false);
+
+        self::assertSame('backend', $this->subject->getCurrentActorType());
+    }
+
+    #[Test]
+    public function getCurrentActorUsernameReturnsCliUsernameForCommandLineUser(): void
+    {
+        // Audit rows for CLI/worker reads keep the informative `_cli_`
+        // username from the authenticated CLI backend user record.
+        $this->setCommandLineUser();
+
+        self::assertSame('_cli_', $this->subject->getCurrentActorUsername());
+    }
+
+    #[Test]
     public function canReadReturnsFalseForDisabledUser(): void
     {
         // BUG FIX verification: AccessControlService::hasBackendUserAccess() now
@@ -661,6 +696,23 @@ final class AccessControlServiceTest extends TestCase
             ->willReturn($isSystemMaintainer);
 
         $GLOBALS['BE_USER'] = $backendUser;
+    }
+
+    /**
+     * Set up a mock CLI backend user in GLOBALS, as created by the TYPO3 CLI
+     * bootstrap (`vendor/bin/typo3`, messenger workers).
+     */
+    private function setCommandLineUser(): void
+    {
+        $commandLineUser = $this->createMock(CommandLineUserAuthentication::class);
+        $commandLineUser->user = [
+            'uid' => 1,
+            'username' => '_cli_',
+            'disable' => 0,
+        ];
+        $commandLineUser->userGroupsUID = [];
+
+        $GLOBALS['BE_USER'] = $commandLineUser;
     }
 
     /**


### PR DESCRIPTION
## Summary

Fixes a confirmed live misclassification bug: `AccessControlService::getCurrentActorType()` checked for a `BackendUserAuthentication` before the CLI check. The TYPO3 CLI bootstrap (`vendor/bin/typo3`, `messenger:consume` workers) sets `$GLOBALS['BE_USER']` to a `CommandLineUserAuthentication` instance - which **extends** `BackendUserAuthentication` - so every CLI/worker read was logged with `actor_type='backend'`.

Verified consequence on a live instance: `VaultAnalyticsService` (`AUTOMATED_ACTORS = ['cli', 'api', 'scheduler']`) counted 0 automated / 39 manual reads for a secret read exclusively by the messenger worker, and `StalenessEvaluator` then flagged it "Automation-stale".

### Changes

- `getCurrentActorType()`: CLI detection (`isRealCliContext()`, legacy `TYPO3_cliMode` constant) now runs **before** the backend-user check - matching the ordering already documented in ADR-005. A `CommandLineUserAuthentication` BE user is additionally classified as `cli` directly: that instance only ever exists in CLI context, and it is the deterministic test seam (`isRealCliContext()` is intentionally guarded against PHPUnit, and the `final` class offers no override seam).
- The relocated legacy constant check now reads the constant it actually tests: the old `\TYPO3_CLIMODE` reference was a case mismatch (`defined('TYPO3_cliMode')` vs constant `TYPO3_CLIMODE`) that would have thrown an undefined-constant `Error` had it ever fired.
- `canRead()`/`canCreate()`/`isCurrentActorAdmin()` keep their backend-user-first ordering on purpose - the CLI BE user legitimately drives permission checks.
- `getCurrentActorUsername()` unchanged after verification: it already returns the informative `_cli_` username for the authenticated CLI user and `CLI` when no BE user is set.
- `VaultAnalyticsService::AUTOMATED_ACTORS` already contains `cli` - new audit rows land in the automated bucket with no analytics change. Historic audit rows are **not** rewritten (tamper-evident HMAC chain).
- `Documentation/Usage/Index.rst`: the analytics note now states that CLI-context reads are recorded as `cli` and count as automated.

## Test plan

- [x] New regression test: `CommandLineUserAuthentication` in `$GLOBALS['BE_USER']` yields `cli` (failed with `backend` before the fix)
- [x] Counter-checks: regular BE user still yields `backend`; no BE user and no CLI yields `api`; CLI username stays `_cli_`
- [x] Full unit suite via `runTests.sh -p 8.5 -s unit`: 1840 tests, 7326 assertions, OK (baseline on unmodified tree: 1837/7323 with the same 3 pre-existing PHPUnit notices)
- [x] `runTests.sh -p 8.5 -s fuzz`: SUCCESS
- [x] `runTests.sh -p 8.5 -s cgl`: SUCCESS
- [x] `phpstan analyse --configuration=Build/phpstan.no-plugins.neon --memory-limit=1G`: no errors (full `phpstan.neon` plugin config errors in this worktree as documented in AGENTS.md; CI runs the full config)
- [x] `php -l` on both changed PHP files: no syntax errors
- [x] `Tests/scripts/check-test-base-class.php`: no new violations
