### PR TITLE
Default runTests.sh to the upper supported PHP bound

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -223,10 +223,10 @@ Options:
 
     -p <8.2|8.3|8.4|8.5>
         Specifies the PHP minor version to be used
-            - 8.2: (default) use PHP 8.2
+            - 8.2: use PHP 8.2
             - 8.3: use PHP 8.3
             - 8.4: use PHP 8.4
-            - 8.5: use PHP 8.5
+            - 8.5: (default) use PHP 8.5
 
     -x
         Only with -s functional|unit
@@ -250,13 +250,13 @@ Options:
         Show this help.
 
 Examples:
-    # Run unit tests using PHP 8.2
+    # Run unit tests using the default PHP (upper supported bound)
     ./Build/Scripts/runTests.sh -s unit
 
     # Run unit tests with code coverage
     ./Build/Scripts/runTests.sh -s unitCoverage
 
-    # Run functional tests using PHP 8.2 and SQLite (default)
+    # Run functional tests using the default PHP and SQLite
     ./Build/Scripts/runTests.sh -s functional
 
     # Run functional tests with code coverage
@@ -298,7 +298,7 @@ TEST_SUITE="unit"
 DATABASE_DRIVER=""
 DBMS="sqlite"
 DBMS_VERSION=""
-PHP_VERSION="8.2"
+PHP_VERSION="8.5"
 PHP_XDEBUG_ON=0
 PHP_XDEBUG_PORT=9003
 CGLCHECK_DRY_RUN=0


### PR DESCRIPTION
## Summary

`runTests.sh` defaulted to PHP 8.2 (the lower constraint bound); local runs without `-p` now use PHP 8.5, matching the convention that dev defaults track the upper supported bound. Helptext and examples updated. CI pins `-p` explicitly in its matrix, so workflows are unaffected.

## Test plan

- `Build/Scripts/runTests.sh -s unit` (no -p) — reports `PHP: 8.5`, SUCCESS