### PR TITLE
Add per-instance request timeout override to VaultHttpClient

### DIFF
--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -49,8 +49,18 @@ final class SecureHttpClientFactory
 
     /**
      * Create a PSR-18 HTTP client with TYPO3 settings and security hardening.
+     *
+     * @param int|null $timeoutSeconds Optional override for Guzzle's `timeout`
+     *                                 option (total request duration in seconds)
+     *                                 used by `VaultHttpClient::withTimeout()`.
+     *                                 Null or non-positive values keep the
+     *                                 platform default from
+     *                                 $GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout'].
+     *                                 `connect_timeout` deliberately stays
+     *                                 platform-managed: the override bounds the
+     *                                 whole transfer, not the TCP/TLS handshake.
      */
-    public function create(): ClientInterface
+    public function create(?int $timeoutSeconds = null): ClientInterface
     {
         /** @var array<string, array<string, mixed>> $confVars */
         $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? [];
@@ -72,6 +82,15 @@ final class SecureHttpClientFactory
             // Respect TYPO3's HTTP version preference
             'version' => \is_string($typo3Config['version'] ?? null) ? $typo3Config['version'] : '1.1',
         ];
+
+        // Per-client timeout override: long-running API calls (LLM generation,
+        // large exports) may legitimately exceed the instance-wide TYPO3
+        // timeout. Only `timeout` is overridden — `connect_timeout` keeps the
+        // platform value because a slow RESPONSE never justifies waiting
+        // longer for the connection to be established.
+        if ($timeoutSeconds !== null && $timeoutSeconds > 0) {
+            $options['timeout'] = $timeoutSeconds;
+        }
 
         // Proxy settings (critical for corporate networks)
         if (!empty($typo3Config['proxy'])) {

--- a/Classes/Http/VaultHttpClient.php
+++ b/Classes/Http/VaultHttpClient.php
@@ -38,6 +38,7 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * - proxy: Corporate proxy settings from TYPO3 or environment (HTTP_PROXY, HTTPS_PROXY)
  * - verify, cert, ssl_key: SSL/TLS certificate configuration
  * - timeout, connect_timeout: Connection timeouts
+ *   (the total-duration `timeout` can be overridden per instance via withTimeout())
  * - allow_redirects: Redirect behavior
  *
  * Security Hardening:
@@ -200,6 +201,37 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             bodyField: $this->bodyField,
             usernameSecretIdentifier: $this->usernameSecretIdentifier,
             reason: $reason,
+            oauthManager: $this->oauthManager,
+            secureHttpClientFactory: $this->secureHttpClientFactory,
+            authPrefix: $this->authPrefix,
+        );
+    }
+
+    public function withTimeout(int $seconds): static
+    {
+        // PSR-18 sendRequest() carries no per-request options, so the override
+        // must be baked into the inner Guzzle client's configuration. The
+        // shared SecureHttpClientFactory rebuilds the inner client with the
+        // full security hardening (SSRF DNS pinning, debug off, redirects off)
+        // plus the `timeout` override, so EVERY send path through the returned
+        // instance — plain and authenticated alike — honours it. Non-positive
+        // values rebuild with the platform default (no override). A custom
+        // inner client injected at construction time is replaced by the
+        // factory-built one. The forwarded OAuth token manager keeps its own
+        // platform-default client: the override governs the API call, not the
+        // token-endpoint round trip, and forwarding preserves the token cache.
+        return new self(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            innerClient: $this->secureHttpClientFactory->create($seconds > 0 ? $seconds : null),
+            secretIdentifier: $this->secretIdentifier,
+            placement: $this->placement,
+            oauthConfig: $this->oauthConfig,
+            headerName: $this->headerName,
+            queryParam: $this->queryParam,
+            bodyField: $this->bodyField,
+            usernameSecretIdentifier: $this->usernameSecretIdentifier,
+            reason: $this->reason,
             oauthManager: $this->oauthManager,
             secureHttpClientFactory: $this->secureHttpClientFactory,
             authPrefix: $this->authPrefix,

--- a/Classes/Http/VaultHttpClientInterface.php
+++ b/Classes/Http/VaultHttpClientInterface.php
@@ -80,4 +80,21 @@ interface VaultHttpClientInterface extends ClientInterface
      * @return static New client instance with reason configured
      */
     public function withReason(string $reason): static;
+
+    /**
+     * Create a new client instance with a request timeout override.
+     *
+     * Returns a new immutable instance - the original is unchanged. The
+     * override applies Guzzle's `timeout` option (total request duration in
+     * seconds) to every request sent through the returned instance,
+     * authenticated or not. Connection establishment (`connect_timeout`)
+     * stays platform-managed.
+     *
+     * @param int $seconds Timeout in seconds; non-positive values mean
+     *                     "no override" and fall back to the platform default
+     *                     ($GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout'])
+     *
+     * @return static New client instance with the timeout configured
+     */
+    public function withTimeout(int $seconds): static;
 }

--- a/Documentation/Developer/Api.rst
+++ b/Documentation/Developer/Api.rst
@@ -316,6 +316,18 @@ Via VaultService
       :param string $reason: Audit log reason for requests.
       :returns: New client instance with reason configured.
 
+   .. php:method:: withTimeout(int $seconds): static
+
+      Create a new client instance with a request timeout override.
+      Applies Guzzle's ``timeout`` option (total request duration) to every
+      request sent through the returned instance, authenticated or not — use
+      it for long-running API calls that exceed the instance-wide
+      :php:`$GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout']`. Connection
+      establishment (``connect_timeout``) stays platform-managed.
+
+      :param int $seconds: Timeout in seconds; non-positive values mean "no override" and fall back to the platform default.
+      :returns: New client instance with the timeout configured.
+
    .. php:method:: sendRequest(RequestInterface $request): ResponseInterface
 
       Send an HTTP request (PSR-18 method).

--- a/Tests/Unit/Http/GuzzleClientConfigTrait.php
+++ b/Tests/Unit/Http/GuzzleClientConfigTrait.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Http;
+
+use GuzzleHttp\Client;
+use Psr\Http\Client\ClientInterface;
+use ReflectionProperty;
+
+/**
+ * Reads the request-option configuration out of a built Guzzle client.
+ *
+ * The options array is private on GuzzleHttp\Client and the supported
+ * accessor (getConfig()) is deprecated, so tests reflect into it instead.
+ */
+trait GuzzleClientConfigTrait
+{
+    /**
+     * @return array<string, mixed>
+     */
+    private function getGuzzleConfig(ClientInterface $client): array
+    {
+        self::assertInstanceOf(Client::class, $client);
+
+        $config = (new ReflectionProperty(Client::class, 'config'))->getValue($client);
+        self::assertIsArray($config);
+
+        /** @var array<string, mixed> $config */
+        return $config;
+    }
+}

--- a/Tests/Unit/Http/SecureHttpClientFactoryTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryTest.php
@@ -12,12 +12,15 @@ namespace Netresearch\NrVault\Tests\Unit\Http;
 use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Client\ClientInterface;
 
 #[CoversClass(SecureHttpClientFactory::class)]
 final class SecureHttpClientFactoryTest extends TestCase
 {
+    use GuzzleClientConfigTrait;
+
     protected bool $resetSingletonInstances = true;
 
     private SecureHttpClientFactory $factory;
@@ -178,6 +181,45 @@ final class SecureHttpClientFactoryTest extends TestCase
 
         // Should not throw and use defaults
         self::assertInstanceOf(ClientInterface::class, $client);
+    }
+
+    #[Test]
+    public function createAppliesPositiveTimeoutOverride(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP'] = [
+            'timeout' => 60,
+            'connect_timeout' => 5,
+        ];
+
+        $config = $this->getGuzzleConfig($this->factory->create(300));
+
+        self::assertSame(300, $config['timeout']);
+        // connect_timeout stays platform-managed: the override bounds the
+        // whole transfer, not connection establishment.
+        self::assertSame(5, $config['connect_timeout']);
+    }
+
+    #[Test]
+    #[DataProvider('noTimeoutOverrideProvider')]
+    public function createKeepsPlatformTimeoutWithoutPositiveOverride(?int $timeoutSeconds): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP'] = [
+            'timeout' => 60,
+        ];
+
+        $config = $this->getGuzzleConfig($this->factory->create($timeoutSeconds));
+
+        self::assertSame(60, $config['timeout']);
+    }
+
+    /**
+     * @return iterable<string, array{int|null}>
+     */
+    public static function noTimeoutOverrideProvider(): iterable
+    {
+        yield 'null (no override requested)' => [null];
+        yield 'zero' => [0];
+        yield 'negative' => [-10];
     }
 
     #[Test]

--- a/Tests/Unit/Http/VaultHttpClientTest.php
+++ b/Tests/Unit/Http/VaultHttpClientTest.php
@@ -20,11 +20,13 @@ use Netresearch\NrVault\Exception\VaultException;
 use Netresearch\NrVault\Http\OAuth\OAuthConfig;
 use Netresearch\NrVault\Http\OAuth\OAuthTokenManager;
 use Netresearch\NrVault\Http\SecretPlacement;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Http\VaultHttpClient;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Client\ClientExceptionInterface;
@@ -36,6 +38,8 @@ use ReflectionClass;
 #[AllowMockObjectsWithoutExpectations]
 final class VaultHttpClientTest extends TestCase
 {
+    use GuzzleClientConfigTrait;
+
     private const API_URL = 'https://api.example.com/data';
 
     private const TOKEN_ENDPOINT = 'https://auth.example.com/token';
@@ -461,6 +465,106 @@ final class VaultHttpClientTest extends TestCase
 
         $request = new Request('GET', self::API_URL);
         $authenticatedClient->sendRequest($request);
+    }
+
+    #[Test]
+    public function withTimeoutReturnsNewInstanceAndLeavesOriginalUntouched(): void
+    {
+        $this->innerClient
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn(new Response(200));
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $timeoutClient = $client->withTimeout(300);
+
+        self::assertNotSame($client, $timeoutClient);
+        self::assertInstanceOf(VaultHttpClient::class, $timeoutClient);
+
+        // The original instance still sends through the injected inner client.
+        $response = $client->sendRequest(new Request('GET', self::API_URL));
+        self::assertSame(200, $response->getStatusCode());
+    }
+
+    #[Test]
+    public function withTimeoutAppliesOverrideToInnerClientOptions(): void
+    {
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $config = $this->getInnerGuzzleConfig($client->withTimeout(300));
+
+        self::assertSame(300, $config['timeout']);
+    }
+
+    #[Test]
+    #[DataProvider('nonPositiveTimeoutProvider')]
+    public function withTimeoutNonPositiveFallsBackToPlatformDefault(int $seconds): void
+    {
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $platformConfig = $this->getGuzzleConfig((new SecureHttpClientFactory())->create());
+        $config = $this->getInnerGuzzleConfig($client->withTimeout($seconds));
+
+        self::assertSame($platformConfig['timeout'], $config['timeout']);
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function nonPositiveTimeoutProvider(): iterable
+    {
+        yield 'zero' => [0];
+        yield 'negative' => [-300];
+    }
+
+    #[Test]
+    public function withTimeoutSurvivesSubsequentWitherCalls(): void
+    {
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $chained = $client
+            ->withTimeout(300)
+            ->withAuthentication('my_key', SecretPlacement::Bearer)
+            ->withReason('Long-running generation');
+
+        $config = $this->getInnerGuzzleConfig($chained);
+
+        self::assertSame(300, $config['timeout']);
+    }
+
+    #[Test]
+    public function withTimeoutPreservesAuthenticationConfiguration(): void
+    {
+        $client = (new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        ))
+            ->withAuthentication('my_key', SecretPlacement::Bearer, ['reason' => 'API call'])
+            ->withTimeout(300);
+
+        $reflection = new ReflectionClass(VaultHttpClient::class);
+
+        self::assertSame('my_key', $reflection->getProperty('secretIdentifier')->getValue($client));
+        self::assertSame(SecretPlacement::Bearer, $reflection->getProperty('placement')->getValue($client));
+        self::assertSame('API call', $reflection->getProperty('reason')->getValue($client));
     }
 
     #[Test]
@@ -1235,6 +1339,23 @@ final class VaultHttpClientTest extends TestCase
             $this->extractOAuthManager($afterChain),
             'withReason() (after withOAuth) must forward the same OAuthTokenManager — token cache is dead if this fails',
         );
+    }
+
+    /**
+     * Read the request-option configuration of the inner Guzzle client that
+     * withTimeout() bakes into a VaultHttpClient instance.
+     *
+     * @return array<string, mixed>
+     */
+    private function getInnerGuzzleConfig(VaultHttpClient $client): array
+    {
+        $inner = (new ReflectionClass(VaultHttpClient::class))
+            ->getProperty('innerClient')
+            ->getValue($client);
+
+        self::assertInstanceOf(ClientInterface::class, $inner);
+
+        return $this->getGuzzleConfig($inner);
     }
 
     private function extractOAuthManager(VaultHttpClient $client): OAuthTokenManager


### PR DESCRIPTION
## Summary

`VaultHttpClient` is PSR-18 and rides the instance-wide TYPO3 Guzzle options — consumers could not set a per-request timeout, and a long-running gpt-image-2 generation in nr-llm died at the instance's global 180s.

This adds the frozen contract nr-llm is built against next:

- **`VaultHttpClientInterface::withTimeout(int $seconds): static`** — immutable wither following the existing `withReason()` / `withAuthentication()` pattern.
- **Semantics:** applies Guzzle's `timeout` request option (total request duration) to every request sent through the returned instance, authenticated or not. Non-positive values mean "no override" (platform default from `$GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout']`).
- **Layer:** PSR-18 `sendRequest()` carries no per-request options, so the override is baked into the inner Guzzle client config — `SecureHttpClientFactory::create(?int $timeoutSeconds = null)` gains the optional override, and `withTimeout()` rebuilds the hardened inner client (SSRF DNS pinning, debug off, redirects off) through the shared factory. All send paths through the instance honour it.
- **`connect_timeout` deliberately stays platform-managed** — the override bounds the whole transfer, not the TCP/TLS handshake (a slow response never justifies waiting longer for the connect).
- **OAuth:** the forwarded token manager keeps its own platform-default client, preserving the token cache across the clone; the override governs the API call, not the token-endpoint round trip.
- **Audit:** call sites untouched; timeout is plain transport metadata and `HttpCallContext` has no matching field, so the context is not extended. No secrets in logs.
- **Docs:** `withTimeout()` documented in the `VaultHttpClientInterface` section of `Documentation/Developer/Api.rst`.

## Test plan

- [x] `withTimeoutReturnsNewInstanceAndLeavesOriginalUntouched` — wither immutability, original keeps its inner client
- [x] `withTimeoutAppliesOverrideToInnerClientOptions` — `timeout: 300` baked into the inner Guzzle config
- [x] `withTimeoutNonPositiveFallsBackToPlatformDefault` (0, -300) — no override
- [x] `withTimeoutSurvivesSubsequentWitherCalls` — `withTimeout()->withAuthentication()->withReason()` keeps the override
- [x] `withTimeoutPreservesAuthenticationConfiguration` — auth/reason state forwarded
- [x] Factory: `createAppliesPositiveTimeoutOverride` (incl. `connect_timeout` untouched), `createKeepsPlatformTimeoutWithoutPositiveOverride` (null/0/-10)
- [x] Local: PHPStan `[OK] No errors`, php-cs-fixer dry-run clean, unit 1850 tests / 7366 assertions pass, fuzz 1514 tests pass, arch + doc-cli OK (`make lint` fails on the unmodified tree — known runTests container issue; `php -l` clean on all changed files)
