### PR TITLE
Fix invalid commit-msg hook configuration

### DIFF
--- a/captainhook.json
+++ b/captainhook.json
@@ -10,13 +10,10 @@
             {
                 "action": "\\CaptainHook\\App\\Hook\\Message\\Action\\Rules",
                 "options": [
-                    [
-                        "\\CaptainHook\\App\\Hook\\Message\\Rule\\CapitalizeSubject",
-                        "\\CaptainHook\\App\\Hook\\Message\\Rule\\LimitSubjectLength",
-                        "\\CaptainHook\\App\\Hook\\Message\\Rule\\MsgNotEmpty",
-                        "\\CaptainHook\\App\\Hook\\Message\\Rule\\NoPeriodOnSubjectEnd",
-                        "\\Ergebnis\\CaptainHook\\Rules\\Rule\\SubjectMustUseImperativeMood"
-                    ]
+                    "\\CaptainHook\\App\\Hook\\Message\\Rule\\CapitalizeSubject",
+                    "\\CaptainHook\\App\\Hook\\Message\\Rule\\LimitSubjectLength",
+                    "\\CaptainHook\\App\\Hook\\Message\\Rule\\MsgNotEmpty",
+                    "\\CaptainHook\\App\\Hook\\Message\\Rule\\NoPeriodOnSubjectEnd"
                 ]
             }
         ]


### PR DESCRIPTION
## Problem

The `commit-msg` Rules action in `captainhook.json` is unusable in two independent ways:

1. **Double-nested `options`** (`[[ … ]]`) → CaptainHook throws `Invalid rule configuration` before evaluating any rule.
2. It references **`\Ergebnis\CaptainHook\Rules\Rule\SubjectMustUseImperativeMood`** from `ergebnis/captainhook-rules` — **a package that does not exist**: 404 on Packagist and on GitHub; the `ergebnis` vendor ships only `phpstan-rules` and `rector-rules`. Even after flattening, CaptainHook reports `Unknown rule`.

It went unnoticed because hooks were never actually installed here — CaptainHook's installer can't write into this repo's git-worktree checkout layout (`invalid .git path`), so the broken config was never exercised. Any plain clone that ran `captainhook install` would have had **every commit blocked**.

## Fix

- Flatten `options` to a single list.
- Drop the non-existent `SubjectMustUseImperativeMood` rule.
- Keep the four built-in rules: `CapitalizeSubject`, `LimitSubjectLength`, `MsgNotEmpty`, `NoPeriodOnSubjectEnd`.

These enforce four of the five subject conventions documented in `AGENTS.md` (capitalized, length-limited, non-empty, no trailing period). **Imperative-mood** stays a documented convention rather than a machine-enforced rule — no installable CaptainHook package provides it (verified against Packagist/GitHub). The repo's own history already follows it.

## Verification

```
$ .Build/bin/captainhook hook:commit-msg --configuration=captainhook.json --bootstrap=.Build/vendor/autoload.php -- <msg>
commit-msg:
 - \CaptainHook\App\Hook\Message\Action\Rules : done
captainhook executed all actions successfully
```

https://claude.ai/code/session_015Myeo4imGJGskBMto9BVAm