### PR TITLE
Close audit hash-chain epoch-downgrade and attribution forgery

### DIFF
--- a/Classes/Audit/AuditChainRekeyService.php
+++ b/Classes/Audit/AuditChainRekeyService.php
@@ -104,7 +104,8 @@ final readonly class AuditChainRekeyService implements AuditChainRekeyServiceInt
         // Epoch-aware dispatch, mirroring verifyHashChain():
         //   0  → legacy keyless SHA-256 (identity fields only)
         //   1  → HMAC-SHA256 (identity fields only)
-        //   2+ → HMAC-SHA256 (extended forensic payload)
+        //   2  → HMAC-SHA256 (extended forensic payload)
+        //   3+ → HMAC-SHA256 (forensic payload + epoch selector + attribution)
         $expectedHash = match (true) {
             $entry['epoch'] === 0 => AuditLogService::calculateHash(
                 $entry['uid'],
@@ -123,8 +124,13 @@ final readonly class AuditChainRekeyService implements AuditChainRekeyServiceInt
                 $previousHash,
                 $hmacKey,
             ),
-            default => AuditLogService::calculateHashV2(
+            $entry['epoch'] === 2 => AuditLogService::calculateHashV2(
                 AuditLogService::extractV2HashRow($row),
+                $previousHash,
+                $hmacKey,
+            ),
+            default => AuditLogService::calculateHashV3(
+                AuditLogService::extractV3HashRow($row),
                 $previousHash,
                 $hmacKey,
             ),

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -257,8 +257,26 @@ final readonly class AuditLogService implements AuditLogServiceInterface
 
                 $previousUid = $uid;
 
-                // Detect epoch boundary and report warning
-                if ($previousEpoch >= 0 && $epoch !== $previousEpoch) {
+                // Detect epoch transitions.
+                //
+                // The per-row hmac_key_epoch selects which algorithm verifies
+                // the row, including the keyless epoch-0 SHA-256. A DB-write
+                // attacker who downgrades a row (e.g. tail row 2 -> 0) could
+                // otherwise re-sign it without the HMAC key and have the chain
+                // still report valid. A legitimate chain only ever INCREASES
+                // the epoch (a partial migration leaves older rows at a lower
+                // epoch ahead of newer rows): a DECREASE between consecutive
+                // rows is therefore a tamper signal, recorded as an ERROR so
+                // `valid` (errors === []) flips to false. Increases stay a
+                // non-fatal warning, preserving backward compatibility for
+                // mid-migration chains.
+                if ($previousEpoch >= 0 && $epoch < $previousEpoch) {
+                    $errors[$uid] = \sprintf(
+                        'HMAC key epoch downgrade detected: %d -> %d (possible algorithm-downgrade forgery)',
+                        $previousEpoch,
+                        $epoch,
+                    );
+                } elseif ($previousEpoch >= 0 && $epoch !== $previousEpoch) {
                     $warnings[$uid] = \sprintf(
                         'HMAC key epoch boundary: %d -> %d',
                         $previousEpoch,
@@ -271,11 +289,14 @@ final readonly class AuditLogService implements AuditLogServiceInterface
                 // Epoch-aware hash dispatch:
                 //   0 → legacy SHA-256 (identity fields only)
                 //   1 → HMAC-SHA256 (identity fields only)
-                //   2+ → HMAC-SHA256 (extended forensic payload)
+                //   2 → HMAC-SHA256 (extended forensic payload)
+                //   3+ → HMAC-SHA256 (forensic payload + epoch selector +
+                //        human-readable attribution fields)
                 $expectedHash = match (true) {
                     $epoch === 0 => self::calculateHash($uid, $secretId, $actionStr, $actorUid, $crdate, $previousHash),
                     $epoch === 1 => self::calculateHash($uid, $secretId, $actionStr, $actorUid, $crdate, $previousHash, $hmacKey),
-                    default => self::calculateHashV2(self::extractV2HashRow($row), $previousHash, $hmacKey),
+                    $epoch === 2 => self::calculateHashV2(self::extractV2HashRow($row), $previousHash, $hmacKey),
+                    default => self::calculateHashV3(self::extractV3HashRow($row), $previousHash, $hmacKey),
                 };
 
                 // Verify previous_hash matches. Use hash_equals() for the
@@ -393,22 +414,72 @@ final readonly class AuditLogService implements AuditLogServiceInterface
         #[SensitiveParameter]
         string $hmacKey,
     ): string {
-        $payload = json_encode([
-            'uid' => (int) $row['uid'],
-            'secret_identifier' => (string) $row['secret_identifier'],
-            'action' => (string) $row['action'],
-            'success' => (int) (bool) $row['success'],
-            'actor_uid' => (int) $row['actor_uid'],
-            'crdate' => (int) $row['crdate'],
-            'previous_hash' => $previousHash,
-            'error_message' => (string) $row['error_message'],
-            'reason' => (string) $row['reason'],
-            'ip_address' => (string) $row['ip_address'],
-            'user_agent' => (string) $row['user_agent'],
-            'hash_before' => (string) $row['hash_before'],
-            'hash_after' => (string) $row['hash_after'],
-            'context' => (string) $row['context'],
-        ], JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $payload = json_encode(
+            self::forensicPayloadV2($row, $previousHash),
+            JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        );
+
+        return hash_hmac('sha256', $payload, $hmacKey);
+    }
+
+    /**
+     * Calculate an audit log entry hash with the v3 payload.
+     *
+     * Extends the v2 forensic payload with two integrity-critical additions:
+     *
+     *  1. `hmac_key_epoch` — the algorithm selector itself. At epoch 0-2 the
+     *     epoch was read from the row but never bound into any hash, so a
+     *     DB-write attacker could downgrade the (keyless-verifiable) algorithm
+     *     by flipping the column and re-signing without the HMAC key. Binding
+     *     the epoch makes any such re-sign mismatch the stored entry_hash.
+     *  2. The human-readable attribution fields `actor_type`,
+     *     `actor_username`, `actor_role` and the `request_id` — surfaced in the
+     *     backend audit list and CSV export but excluded from the v2 payload,
+     *     so blame could previously be reassigned on any row without breaking
+     *     the chain.
+     *
+     * Payload keys (ordered for deterministic JSON): the v2 keys, then
+     * hmac_key_epoch, actor_type, actor_username, actor_role, request_id.
+     *
+     * @param array{
+     *     uid: int,
+     *     secret_identifier: string,
+     *     action: string,
+     *     success: bool|int,
+     *     actor_uid: int,
+     *     crdate: int,
+     *     error_message: string,
+     *     reason: string,
+     *     ip_address: string,
+     *     user_agent: string,
+     *     hash_before: string,
+     *     hash_after: string,
+     *     context: string,
+     *     hmac_key_epoch: int,
+     *     actor_type: string,
+     *     actor_username: string,
+     *     actor_role: string,
+     *     request_id: string,
+     * } $row
+     */
+    public static function calculateHashV3(
+        array $row,
+        string $previousHash,
+        #[SensitiveParameter]
+        string $hmacKey,
+    ): string {
+        $payload = json_encode(
+            self::forensicPayloadV2($row, $previousHash) + [
+                // v3 additions — authenticate the algorithm selector and the
+                // human-facing attribution surface.
+                'hmac_key_epoch' => (int) $row['hmac_key_epoch'],
+                'actor_type' => (string) $row['actor_type'],
+                'actor_username' => (string) $row['actor_username'],
+                'actor_role' => (string) $row['actor_role'],
+                'request_id' => (string) $row['request_id'],
+            ],
+            JSON_THROW_ON_ERROR | JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        );
 
         return hash_hmac('sha256', $payload, $hmacKey);
     }
@@ -484,6 +555,47 @@ final readonly class AuditLogService implements AuditLogServiceInterface
     }
 
     /**
+     * Type-safe extraction of the audit-row fields for the v3 hash payload
+     * (`calculateHashV3()`). Adds, on top of the v2 fields, the algorithm
+     * selector `hmac_key_epoch` and the four human-readable attribution
+     * fields (actor_type, actor_username, actor_role, request_id) that v2
+     * does not bind into the chain.
+     *
+     * @param array<string, mixed> $row
+     *
+     * @return array{
+     *     uid: int,
+     *     secret_identifier: string,
+     *     action: string,
+     *     success: int,
+     *     actor_uid: int,
+     *     crdate: int,
+     *     error_message: string,
+     *     reason: string,
+     *     ip_address: string,
+     *     user_agent: string,
+     *     hash_before: string,
+     *     hash_after: string,
+     *     context: string,
+     *     hmac_key_epoch: int,
+     *     actor_type: string,
+     *     actor_username: string,
+     *     actor_role: string,
+     *     request_id: string,
+     * }
+     */
+    public static function extractV3HashRow(array $row): array
+    {
+        return self::extractV2HashRow($row) + [
+            'hmac_key_epoch' => is_numeric($row['hmac_key_epoch'] ?? null) ? (int) $row['hmac_key_epoch'] : 0,
+            'actor_type' => \is_string($row['actor_type'] ?? null) ? $row['actor_type'] : '',
+            'actor_username' => \is_string($row['actor_username'] ?? null) ? $row['actor_username'] : '',
+            'actor_role' => \is_string($row['actor_role'] ?? null) ? $row['actor_role'] : '',
+            'request_id' => \is_string($row['request_id'] ?? null) ? $row['request_id'] : '',
+        ];
+    }
+
+    /**
      * Derive the HMAC key from the master key via HKDF.
      *
      * Uses a distinct info string to ensure the HMAC key is separate from the encryption key.
@@ -515,6 +627,50 @@ final readonly class AuditLogService implements AuditLogServiceInterface
     public static function deriveHmacKeyFromMasterKey(#[SensitiveParameter] string $masterKey): string
     {
         return hash_hkdf('sha256', $masterKey, 32, 'nr-vault-audit-hmac-v1');
+    }
+
+    /**
+     * Build the ordered v2 forensic payload shared by calculateHashV2() and
+     * calculateHashV3(), so the v3 payload does not duplicate the v2 key set.
+     * The key order is load-bearing for hash stability — do not reorder.
+     *
+     * @param array{
+     *     uid: int,
+     *     secret_identifier: string,
+     *     action: string,
+     *     success: bool|int,
+     *     actor_uid: int,
+     *     crdate: int,
+     *     error_message: string,
+     *     reason: string,
+     *     ip_address: string,
+     *     user_agent: string,
+     *     hash_before: string,
+     *     hash_after: string,
+     *     context: string,
+     *     ...
+     * } $row
+     *
+     * @return array<string, int|string>
+     */
+    private static function forensicPayloadV2(array $row, string $previousHash): array
+    {
+        return [
+            'uid' => (int) $row['uid'],
+            'secret_identifier' => (string) $row['secret_identifier'],
+            'action' => (string) $row['action'],
+            'success' => (int) (bool) $row['success'],
+            'actor_uid' => (int) $row['actor_uid'],
+            'crdate' => (int) $row['crdate'],
+            'previous_hash' => $previousHash,
+            'error_message' => (string) $row['error_message'],
+            'reason' => (string) $row['reason'],
+            'ip_address' => (string) $row['ip_address'],
+            'user_agent' => (string) $row['user_agent'],
+            'hash_before' => (string) $row['hash_before'],
+            'hash_after' => (string) $row['hash_after'],
+            'context' => (string) $row['context'],
+        ];
     }
 
     /**
@@ -639,10 +795,14 @@ final readonly class AuditLogService implements AuditLogServiceInterface
      *   - epoch 2 → HMAC-SHA256 over identity + forensic fields (success,
      *               error_message, reason, ip_address, user_agent,
      *               hash_before, hash_after, context)
+     *   - epoch 3 → HMAC-SHA256 over the epoch-2 payload plus the algorithm
+     *               selector (hmac_key_epoch) and the attribution fields
+     *               (actor_type, actor_username, actor_role, request_id)
      *
      * @param array<string, mixed> $row Must contain `hmac_key_epoch`; epoch
      *                                  2 also requires the forensic fields
-     *                                  (see `extractV2HashRow()`).
+     *                                  (see `extractV2HashRow()`), epoch 3 the
+     *                                  attribution fields (see `extractV3HashRow()`).
      */
     private function calculateEntryHashFromRow(array $row, string $previousHash): string
     {
@@ -675,8 +835,13 @@ final readonly class AuditLogService implements AuditLogServiceInterface
                 );
             }
 
-            // Epoch 2+: extended payload that covers forensic fields too.
-            return self::calculateHashV2(self::extractV2HashRow($row), $previousHash, $hmacKey);
+            if ($epoch === 2) {
+                // Extended payload that covers forensic fields too.
+                return self::calculateHashV2(self::extractV2HashRow($row), $previousHash, $hmacKey);
+            }
+
+            // Epoch 3+: also binds the epoch selector and attribution fields.
+            return self::calculateHashV3(self::extractV3HashRow($row), $previousHash, $hmacKey);
         } finally {
             sodium_memzero($hmacKey);
         }

--- a/Classes/Command/VaultAuditMigrateCommand.php
+++ b/Classes/Command/VaultAuditMigrateCommand.php
@@ -165,14 +165,26 @@ final class VaultAuditMigrateCommand extends Command
 
                 // Re-hash ALL entries to maintain chain integrity. Dispatch by
                 // target epoch: v1 covers identity fields only, v2 adds the
-                // forensic fields (success/error_message/reason/ip/UA/context).
-                $newHash = $targetEpoch >= 2
-                    ? AuditLogService::calculateHashV2(
+                // forensic fields (success/error_message/reason/ip/UA/context),
+                // v3 also binds the epoch selector (hmac_key_epoch) and the
+                // attribution fields (actor_type/actor_username/actor_role/
+                // request_id). extractV3HashRow() reads hmac_key_epoch from the
+                // row, so seed it with the target epoch before extraction.
+                if ($targetEpoch >= 3) {
+                    $row['hmac_key_epoch'] = $targetEpoch;
+                    $newHash = AuditLogService::calculateHashV3(
+                        AuditLogService::extractV3HashRow($row),
+                        $previousHash,
+                        $hmacKey,
+                    );
+                } elseif ($targetEpoch >= 2) {
+                    $newHash = AuditLogService::calculateHashV2(
                         AuditLogService::extractV2HashRow($row),
                         $previousHash,
                         $hmacKey,
-                    )
-                    : AuditLogService::calculateHash(
+                    );
+                } else {
+                    $newHash = AuditLogService::calculateHash(
                         $uid,
                         $entry['secretId'],
                         $entry['action'],
@@ -181,6 +193,7 @@ final class VaultAuditMigrateCommand extends Command
                         $previousHash,
                         $hmacKey,
                     );
+                }
 
                 if (!$dryRun) {
                     $connection->update(

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -50,14 +50,19 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
      *  - 2: HMAC-SHA256 over identity + forensic fields (success,
      *       error_message, reason, ip_address, user_agent, hash_before,
      *       hash_after, context).
+     *  - 3: HMAC-SHA256 over the epoch-2 payload PLUS the algorithm selector
+     *       (hmac_key_epoch) and the attribution fields (actor_type,
+     *       actor_username, actor_role, request_id).
      *
-     * Default 2 binds the forensic surface into the chain — an attacker
-     * with DB-write privileges can no longer flip `success: false → true`
-     * or rewrite `error_message`/`reason`/etc. without breaking the chain.
-     * Existing epoch-0/epoch-1 entries continue to verify under their
-     * stored epoch until `AuditHmacMigrationWizard` rehashes them.
+     * Default 3 additionally binds the epoch selector into the chain — so a
+     * DB-write attacker can no longer downgrade a row's hmac_key_epoch to the
+     * keyless SHA-256 path and re-sign it without the HMAC key — and the
+     * human-readable attribution columns, so blame can no longer be reassigned
+     * on a row without breaking the chain. Existing epoch-0/1/2 entries
+     * continue to verify under their stored epoch until
+     * `AuditHmacMigrationWizard` rehashes them.
      */
-    public const DEFAULT_AUDIT_HMAC_EPOCH = 2;
+    public const DEFAULT_AUDIT_HMAC_EPOCH = 3;
 
     public const DEFAULT_STALE_NEVER_READ_DAYS = 30;
 

--- a/Classes/Seeder/AuditChainSeeder.php
+++ b/Classes/Seeder/AuditChainSeeder.php
@@ -24,7 +24,7 @@ final readonly class AuditChainSeeder
 {
     private const TABLE = 'tx_nrvault_audit_log';
 
-    private const SUPPORTED_EPOCHS = [0, 1, 2];
+    private const SUPPORTED_EPOCHS = [0, 1, 2, 3];
 
     public function __construct(
         private ConnectionPool $connectionPool,
@@ -41,7 +41,7 @@ final readonly class AuditChainSeeder
         $epoch = $this->extensionConfiguration->getAuditHmacEpoch();
         if (!\in_array($epoch, self::SUPPORTED_EPOCHS, true)) {
             throw new ConfigurationException(
-                \sprintf('Demo seeder supports audit epoch 0/1/2; configured epoch is %d.', $epoch),
+                \sprintf('Demo seeder supports audit epoch 0/1/2/3; configured epoch is %d.', $epoch),
                 1_748_736_000,
             );
         }
@@ -129,6 +129,10 @@ final readonly class AuditChainSeeder
             return AuditLogService::calculateHash($v1['uid'], $v1['secretId'], $v1['action'], $v1['actorUid'], $v1['crdate'], $previousHash, $hmacKey);
         }
 
-        return AuditLogService::calculateHashV2(AuditLogService::extractV2HashRow($row), $previousHash, $hmacKey);
+        if ($epoch === 2) {
+            return AuditLogService::calculateHashV2(AuditLogService::extractV2HashRow($row), $previousHash, $hmacKey);
+        }
+
+        return AuditLogService::calculateHashV3(AuditLogService::extractV3HashRow($row), $previousHash, $hmacKey);
     }
 }

--- a/Classes/Upgrades/AuditHmacMigrationWizard.php
+++ b/Classes/Upgrades/AuditHmacMigrationWizard.php
@@ -69,7 +69,10 @@ final class AuditHmacMigrationWizard implements UpgradeWizardInterface, LoggerAw
             . 'resistance against DB-privileged attackers). Epoch 2 extends '
             . 'the HMAC payload to cover forensic fields (success, '
             . 'error_message, reason, ip_address, user_agent, context) so '
-            . 'they too become tamper-evident. '
+            . 'they too become tamper-evident. Epoch 3 additionally binds the '
+            . 'epoch selector (hmac_key_epoch) — closing the algorithm-downgrade '
+            . 'forgery — and the attribution fields (actor_type, actor_username, '
+            . 'actor_role, request_id). '
             . 'The migration re-hashes all entries while maintaining chain integrity. '
             . 'Runs under an advisory lock and a single transaction — concurrent '
             . 'audit writes are serialised and partial failure rolls back.';
@@ -179,14 +182,27 @@ final class AuditHmacMigrationWizard implements UpgradeWizardInterface, LoggerAw
 
             // Dispatch by target epoch: v1 covers identity fields only, v2
             // adds the forensic fields (success / error_message / reason /
-            // ip_address / user_agent / hash_before / hash_after / context).
-            $newHash = $targetEpoch >= 2
-                ? AuditLogService::calculateHashV2(
+            // ip_address / user_agent / hash_before / hash_after / context),
+            // v3 also binds the epoch selector (hmac_key_epoch) and the
+            // attribution fields (actor_type / actor_username / actor_role /
+            // request_id). extractV3HashRow() reads hmac_key_epoch from the
+            // row, so seed it with the target epoch the row is being rehashed
+            // to before extraction.
+            if ($targetEpoch >= 3) {
+                $row['hmac_key_epoch'] = $targetEpoch;
+                $newHash = AuditLogService::calculateHashV3(
+                    AuditLogService::extractV3HashRow($row),
+                    $previousHash,
+                    $hmacKey,
+                );
+            } elseif ($targetEpoch >= 2) {
+                $newHash = AuditLogService::calculateHashV2(
                     AuditLogService::extractV2HashRow($row),
                     $previousHash,
                     $hmacKey,
-                )
-                : AuditLogService::calculateHash(
+                );
+            } else {
+                $newHash = AuditLogService::calculateHash(
                     $entry['uid'],
                     $entry['secretId'],
                     $entry['action'],
@@ -195,6 +211,7 @@ final class AuditHmacMigrationWizard implements UpgradeWizardInterface, LoggerAw
                     $previousHash,
                     $hmacKey,
                 );
+            }
 
             $connection->update(
                 self::TABLE_NAME,

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -17,6 +17,7 @@ use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Audit\AuditLogFilter;
 use Netresearch\NrVault\Audit\AuditLogService;
 use Netresearch\NrVault\Audit\GenericContext;
+use Netresearch\NrVault\Audit\HashChainVerificationResult;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
 use Netresearch\NrVault\Exception\AuditWriteException;
@@ -1137,6 +1138,178 @@ final class AuditLogServiceTest extends TestCase
         );
     }
 
+    // =========================================================================
+    // Epoch 3 — also binds the algorithm selector (hmac_key_epoch) and the
+    // human-readable attribution fields (actor_type / actor_username /
+    // actor_role / request_id).
+    //
+    // Finding audit-integrity-1 (epoch-downgrade forgery): the per-row
+    // hmac_key_epoch selects the verifying algorithm but was itself
+    // unauthenticated, so a DB-write attacker could downgrade the tail row to
+    // keyless epoch-0 SHA-256 and re-sign it without the HMAC key.
+    // Finding audit-integrity-2 (attribution forgery): actor_username/role/
+    // type and request_id were excluded from the v2 HMAC payload.
+    // =========================================================================
+
+    #[Test]
+    public function verifyHashChainRejectsTailRowDowngradedToEpochZeroAndKeylessResigned(): void
+    {
+        // A two-row chain: row 1 stays epoch-3 HMAC-protected; the attacker
+        // takes the tail row, sets hmac_key_epoch=0, rewrites identity fields,
+        // and recomputes a VALID keyless SHA-256 entry_hash WITHOUT the HMAC
+        // key. The downgrade (3 -> 0) MUST be reported as invalid, not merely
+        // warned — otherwise the keyless tail-row forgery succeeds silently.
+        $masterKey = str_repeat("\x01", 32);
+        $hmacKey = hash_hkdf('sha256', $masterKey, 32, 'nr-vault-audit-hmac-v1');
+
+        $row1 = $this->makeV3Row(uid: 1, secretIdentifier: 'secret-a', action: 'create');
+        $hash1 = AuditLogService::calculateHashV3($row1, '', $hmacKey);
+
+        // Attacker's forged tail row: downgraded to epoch 0, keyless re-sign.
+        $forgedPrevHash = $hash1;
+        $forgedEntryHash = AuditLogService::calculateHash(
+            2,
+            'attacker-rewritten',
+            'read',
+            999,
+            1704153600,
+            $forgedPrevHash,
+        );
+
+        $rows = [
+            array_merge($row1, [
+                'previous_hash' => '',
+                'entry_hash' => $hash1,
+                'hmac_key_epoch' => 3,
+            ]),
+            [
+                'uid' => 2,
+                'secret_identifier' => 'attacker-rewritten',
+                'action' => 'read',
+                'actor_uid' => 999,
+                'crdate' => 1704153600,
+                'previous_hash' => $forgedPrevHash,
+                'entry_hash' => $forgedEntryHash,
+                'hmac_key_epoch' => 0,
+            ],
+        ];
+
+        $verification = $this->runVerifyOverRows($rows);
+
+        self::assertFalse(
+            $verification->isValid(),
+            'A tail row downgraded to epoch 0 and keyless-resigned MUST be reported INVALID, not just warned',
+        );
+        self::assertArrayHasKey(2, $verification->errors, 'The downgrade error must be recorded against the forged tail row');
+        self::assertStringContainsString('downgrade', $verification->errors[2]);
+    }
+
+    #[Test]
+    public function verifyHashChainEpoch3DetectsActorUsernameTampering(): void
+    {
+        // The entry_hash binds the original actor_username; the attacker
+        // rewrites the stored column to reassign blame but cannot recompute the
+        // HMAC. verifyHashChain() MUST flag the entry hash mismatch.
+        $masterKey = str_repeat("\x01", 32);
+        $hmacKey = hash_hkdf('sha256', $masterKey, 32, 'nr-vault-audit-hmac-v1');
+
+        $row = $this->makeV3Row(actorUsername: 'alice');
+        $validHash = AuditLogService::calculateHashV3($row, '', $hmacKey);
+
+        $tamperedRow = array_merge($row, [
+            'actor_username' => 'bob',
+            'previous_hash' => '',
+            'entry_hash' => $validHash,
+            'hmac_key_epoch' => 3,
+        ]);
+
+        $verification = $this->runVerifyOverRows([$tamperedRow]);
+
+        self::assertFalse(
+            $verification->isValid(),
+            'verifyHashChain MUST detect actor_username tampering when epoch=3',
+        );
+    }
+
+    #[Test]
+    public function calculateHashV2AndV3ProduceStableGoldenHashes(): void
+    {
+        // Golden-hash guard: pins the exact byte serialisation of the v2 and v3
+        // HMAC payloads. If a future refactor (e.g. of the shared
+        // forensicPayloadV2 builder) changes key order or casting, the hash of
+        // every already-stored audit row would change and the chain would fail
+        // to verify after deployment. Captured from the pre-refactor code.
+        $key = str_repeat("\x02", 32);
+        $row = [
+            'uid' => 1, 'secret_identifier' => 'göld/en', 'action' => 'read',
+            'success' => 1, 'actor_uid' => 7, 'crdate' => 1704067200,
+            'error_message' => 'e', 'reason' => 'r', 'ip_address' => 'ip-test',
+            'user_agent' => 'ua', 'hash_before' => 'hb', 'hash_after' => 'ha',
+            'context' => '{"k":"v"}', 'hmac_key_epoch' => 3, 'actor_type' => 'backend',
+            'actor_username' => 'alice', 'actor_role' => 'groups:1', 'request_id' => 'req-1',
+        ];
+
+        self::assertSame(
+            'fca84c88f4120f3b3cc534913d61afe33ce2ecce84993b52c5f5969ec65f05a4',
+            AuditLogService::calculateHashV2(AuditLogService::extractV2HashRow($row), 'PREVHASH', $key),
+            'v2 payload serialisation changed - existing epoch-2 rows would no longer verify',
+        );
+        self::assertSame(
+            'a6d2b90cfcedcb39d46bef63401b96257319988b0540fc66982f114c66a8a569',
+            AuditLogService::calculateHashV3(AuditLogService::extractV3HashRow($row), 'PREVHASH', $key),
+            'v3 payload serialisation changed',
+        );
+    }
+
+    #[Test]
+    public function verifyHashChainEpoch3RoundTripIsValid(): void
+    {
+        // Backward-compat/forward-compat sanity: an untampered epoch-3 chain
+        // verifies valid.
+        $masterKey = str_repeat("\x01", 32);
+        $hmacKey = hash_hkdf('sha256', $masterKey, 32, 'nr-vault-audit-hmac-v1');
+
+        $row1 = $this->makeV3Row(uid: 1, secretIdentifier: 'secret-a', action: 'create');
+        $hash1 = AuditLogService::calculateHashV3($row1, '', $hmacKey);
+        $row2 = $this->makeV3Row(uid: 2, secretIdentifier: 'secret-b', action: 'read', crdate: 1704153600);
+        $hash2 = AuditLogService::calculateHashV3($row2, $hash1, $hmacKey);
+
+        $rows = [
+            array_merge($row1, ['previous_hash' => '', 'entry_hash' => $hash1, 'hmac_key_epoch' => 3]),
+            array_merge($row2, ['previous_hash' => $hash1, 'entry_hash' => $hash2, 'hmac_key_epoch' => 3]),
+        ];
+
+        $verification = $this->runVerifyOverRows($rows);
+
+        self::assertTrue($verification->isValid(), 'An untampered epoch-3 chain must verify valid');
+        self::assertSame([], $verification->errors);
+    }
+
+    #[Test]
+    public function verifyHashChainAllowsMonotonicEpochIncrease(): void
+    {
+        // A partially-migrated chain (epoch 2 row followed by an epoch 3 row)
+        // is a legitimate INCREASE and must stay valid — only the increase
+        // warning is recorded, never an error.
+        $masterKey = str_repeat("\x01", 32);
+        $hmacKey = hash_hkdf('sha256', $masterKey, 32, 'nr-vault-audit-hmac-v1');
+
+        $row1 = $this->makeV3Row(uid: 1, secretIdentifier: 'secret-a', action: 'create');
+        $hash1 = AuditLogService::calculateHashV2(AuditLogService::extractV2HashRow($row1), '', $hmacKey);
+        $row2 = $this->makeV3Row(uid: 2, secretIdentifier: 'secret-b', action: 'read', crdate: 1704153600);
+        $hash2 = AuditLogService::calculateHashV3($row2, $hash1, $hmacKey);
+
+        $rows = [
+            array_merge($row1, ['previous_hash' => '', 'entry_hash' => $hash1, 'hmac_key_epoch' => 2]),
+            array_merge($row2, ['previous_hash' => $hash1, 'entry_hash' => $hash2, 'hmac_key_epoch' => 3]),
+        ];
+
+        $verification = $this->runVerifyOverRows($rows);
+
+        self::assertTrue($verification->isValid(), 'A monotonically increasing epoch chain (2 -> 3) must stay valid');
+        self::assertArrayHasKey(2, $verification->warnings, 'The increase must still be reported as a (non-fatal) warning');
+    }
+
     #[Test]
     public function extractV2HashRowAcceptsBooleanSuccess(): void
     {
@@ -2186,6 +2359,61 @@ final class AuditLogServiceTest extends TestCase
             'hash_after' => $hashAfter,
             'context' => $context,
         ];
+    }
+
+    /**
+     * Build a v3 hash row (v2 fields plus the epoch selector and the four
+     * attribution fields) with sensible defaults; override individual fields
+     * via named parameters.
+     *
+     * @return array{
+     *     uid: int, secret_identifier: string, action: string, success: int,
+     *     actor_uid: int, crdate: int, error_message: string, reason: string,
+     *     ip_address: string, user_agent: string, hash_before: string,
+     *     hash_after: string, context: string, hmac_key_epoch: int,
+     *     actor_type: string, actor_username: string, actor_role: string,
+     *     request_id: string,
+     * }
+     */
+    private function makeV3Row(
+        int $uid = 1,
+        string $secretIdentifier = 'sek',
+        string $action = 'read',
+        int $success = 1,
+        int $actorUid = 1,
+        int $crdate = 1704067200,
+        string $actorType = 'backend',
+        string $actorUsername = 'admin',
+        string $actorRole = 'groups:1',
+        string $requestId = 'req-0001',
+    ): array {
+        return $this->makeV2Row(
+            uid: $uid,
+            secretIdentifier: $secretIdentifier,
+            action: $action,
+            success: $success,
+            actorUid: $actorUid,
+            crdate: $crdate,
+        ) + [
+            'hmac_key_epoch' => 3,
+            'actor_type' => $actorType,
+            'actor_username' => $actorUsername,
+            'actor_role' => $actorRole,
+            'request_id' => $requestId,
+        ];
+    }
+
+    /**
+     * Wire the verify-path query mocks over the given rows and run
+     * verifyHashChain() on the default subject.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     */
+    private function runVerifyOverRows(array $rows): HashChainVerificationResult
+    {
+        $this->setupQueryMocks($rows);
+
+        return $this->getSubject()->verifyHashChain();
     }
 
     private function getSubject(): AuditLogService

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -42,8 +42,8 @@ auditLogRetention = 365
 # cat=Security; type=boolean; label=Audit Read Operations: Log every secret read to the audit log. Disable for high-throughput scenarios where read logging is not required.
 auditReads = 1
 
-# cat=Security; type=int+; label=Audit HMAC Epoch: Hash algorithm version marker for the audit log hash chain (0 = legacy SHA-256 without HMAC, 1 = HMAC-SHA256 over identity fields only, 2 = HMAC-SHA256 over identity + forensic fields including success/error_message/reason/ip_address/user_agent/context). Default 2 binds the forensic surface into the chain so a DB-write attacker cannot flip success or rewrite error_message without breaking the chain. Run the install-tool "Migrate audit hash chain" wizard after bumping.
-auditHmacEpoch = 2
+# cat=Security; type=int+; label=Audit HMAC Epoch: Hash algorithm version marker for the audit log hash chain (0 = legacy SHA-256 without HMAC, 1 = HMAC-SHA256 over identity fields only, 2 = HMAC-SHA256 over identity + forensic fields including success/error_message/reason/ip_address/user_agent/context, 3 = additionally binds the epoch selector hmac_key_epoch plus the attribution fields actor_type/actor_username/actor_role/request_id). Default 3 closes the algorithm-downgrade forgery (a DB-write attacker can no longer downgrade a row to keyless SHA-256 and re-sign it) and makes actor attribution tamper-evident. Run the install-tool "Migrate audit hash chain" wizard after bumping.
+auditHmacEpoch = 3
 
 ##################
 ### PERFORMANCE ###


### PR DESCRIPTION
## Summary

Closes two tamper-evidence bypasses in the audit hash chain. Both are reachable by the **documented in-scope attacker** in `SECURITY.md` — a database principal with `UPDATE`/`DELETE` on `tx_nrvault_audit_log` (SQLi elsewhere, leaked DB creds, hostile DBA) — and both defeat the "any in-place edit … is detected by `verifyHashChain()`" guarantee.

### Finding 1 — Epoch-downgrade forgery (HIGH, CWE-345 / CWE-757)
`verifyHashChain()` picks the hash algorithm from each row's `hmac_key_epoch`, but the epoch was bound into no payload. An attacker downgrades the tail row to keyless epoch-0 SHA-256, rewrites it, and recomputes a valid hash **without the HMAC key**; verification still returned `valid` (the epoch change was only a warning). This re-opened the keyless-recompute class the HMAC migration was meant to close.

### Finding 2 — Attribution forgery (MEDIUM, CWE-345)
The epoch-2 HMAC payload omitted `actor_username`, `actor_role`, `actor_type`, `request_id` — the "who did it" columns rendered in the backend audit list and CSV export. They could be rewritten on any row without breaking the chain.

## Fix
- New **HMAC epoch 3** (`calculateHashV3` / `extractV3HashRow`) binds `hmac_key_epoch` **and** the four attribution fields into the payload.
- `verifyHashChain()` now treats an epoch **decrease** between consecutive rows as an **error** (a legitimate chain only ever increases); increases stay a non-fatal warning, so mid-migration chains still verify.
- Default `DEFAULT_AUDIT_HMAC_EPOCH` → 3; migration wizard, rekey service, seeder and migrate command route to epoch 3. Existing epoch 0/1/2 rows keep verifying under their stored epoch until rehashed.
- Unit regression tests added: downgrade rejection, attribution-tamper detection, epoch-3 round-trip, monotonic-increase backward compat.

## Verification (local)

| Gate | Result |
|---|---|
| PHPStan (`Build/phpstan.no-plugins.neon`) | ✅ No errors |
| cgl | ✅ |
| Unit (incl. new regression tests) | ✅ |
| Fuzz | ✅ |
| Functional (mariadb) | 167 tests — same 11 errors / 2 failures as unmodified `main@841947a` → **0 regressions** |

> The 11 errors / 2 failures are pre-existing local test-infra issues (SQLite-flavoured DDL in `TcaIntegrationTest` on MariaDB; OAuth mock sidecar) and are identical on unmodified `main`. CI is the authoritative functional gate.

## Reviewer decision

**Residual risk:** decrease-rejection closes the tail-row downgrade but not a *uniform full-chain* downgrade (every row set to epoch 0 + keyless re-sign). That needs the out-of-band chain-tip persistence already recommended in `SECURITY.md`, or an opt-in hard epoch floor — deliberately **not** added here because it would invalidate legitimate pre-migration epoch 0/1/2 rows. Please confirm this is acceptable.

Found via a security audit of the extension. Sibling PR hardens the secret TCA write path.
