### PR TITLE
Enforce owner/admin authorization on secret ACL columns

### DIFF
--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Hook;
 
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -29,6 +30,32 @@ final class SecretTcaHook
     private const TABLE = 'tx_nrvault_secret';
 
     /**
+     * Scalar ACL columns whose submitted value is reverted to the stored
+     * value for a non-owner, non-admin editor (CWE-639/CWE-269). These are
+     * plain row columns, so the prior value can be read back and re-written.
+     *
+     * @var list<string>
+     */
+    private const PRIVILEGED_SCALAR_COLUMNS = [
+        'owner_uid',
+        'frontend_accessible',
+        'scope_pid',
+    ];
+
+    /**
+     * Privileged ACL columns backed by MM relation tables. The row column
+     * only holds the relation COUNT, so it cannot be reverted by writing a
+     * value back — the submitted change is instead dropped from $fieldArray
+     * entirely, leaving DataHandler to keep the existing MM relations.
+     *
+     * @var list<string>
+     */
+    private const PRIVILEGED_MM_COLUMNS = [
+        'allowed_groups',
+        'write_groups',
+    ];
+
+    /**
      * Pending secrets to store after database operations.
      *
      * @var array<string, mixed> Map of temporary ID => secret value
@@ -38,6 +65,7 @@ final class SecretTcaHook
     public function __construct(
         private readonly VaultServiceInterface $vaultService,
         private readonly AuditLogServiceInterface $auditService,
+        private readonly AccessControlServiceInterface $accessControlService,
     ) {}
 
     /**
@@ -55,6 +83,12 @@ final class SecretTcaHook
         if ($table !== self::TABLE) {
             return;
         }
+
+        // Authorize privileged ACL columns BEFORE DataHandler persists them.
+        // The VaultService coercion (resolveOwnerUid/resolveFrontendAccessible)
+        // only runs on the programmatic store($options) path; the FormEngine
+        // path writes the raw columns directly, so the gate must live here.
+        $this->enforcePrivilegedColumnPolicy($fieldArray, $id, $dataHandler);
 
         // For existing records, prevent identifier changes
         if (!str_starts_with((string) $id, 'NEW') && isset($fieldArray['identifier'])) {
@@ -135,6 +169,11 @@ final class SecretTcaHook
         // Handle pending secret encryption
         if (isset($this->pendingSecrets[$originalId])) {
             $secretValue = $this->pendingSecrets[$originalId];
+            // Drop the property's copy; $secretValue keeps the only remaining
+            // reference and is wiped with sodium_memzero() in the finally block
+            // below, once it has been consumed. Wiping the property here would,
+            // via copy-on-write, also zero $secretValue before it is stored —
+            // so the cleartext is scrubbed (CWE-316) without corrupting it.
             unset($this->pendingSecrets[$originalId]);
 
             // Ensure secretValue is a string
@@ -169,6 +208,11 @@ final class SecretTcaHook
                         1,
                         'Failed to store secret: ' . $e->getMessage(),
                     );
+                } finally {
+                    // Scrub the local plaintext copy (success or failure).
+                    // $secretValue is a guaranteed non-empty string in this
+                    // branch, so no emptiness guard is needed.
+                    sodium_memzero($secretValue);
                 }
             }
         }
@@ -243,6 +287,123 @@ final class SecretTcaHook
             );
         } catch (Throwable) {
             // Don't fail the delete if audit logging fails
+        }
+    }
+
+    /**
+     * Enforce that only the secret's owner (or an admin/system maintainer)
+     * may set or change the privileged ACL columns: owner_uid,
+     * frontend_accessible, scope_pid (scalar) and allowed_groups, write_groups
+     * (MM relations). This is the write-path authorization layer for
+     * CWE-639/CWE-269 — the TCA `exclude` flag is the complementary
+     * form-permission layer.
+     *
+     * Policy (default-DENY for the ambiguous delegation case):
+     *  - Admin / system maintainer: unrestricted (no coercion).
+     *  - NEW record by a non-admin: owner_uid is forced to the current backend
+     *    user (the submitted value is not trusted); the other privileged
+     *    columns are left as submitted (a creator legitimately scopes the
+     *    secret they own).
+     *  - EXISTING record edited by the owner: unrestricted.
+     *  - EXISTING record edited by a non-owner non-admin: every privileged
+     *    column change is reverted (scalar columns) or dropped (MM columns),
+     *    and the attempt is logged.
+     *
+     * @param array<string, mixed> $fieldArray
+     */
+    private function enforcePrivilegedColumnPolicy(
+        array &$fieldArray,
+        string|int $id,
+        DataHandler $dataHandler,
+    ): void {
+        // Admins and system maintainers are trusted on this path. Non-backend
+        // actors (CLI/scheduler/api) do not reach DataHandler form edits with a
+        // BE user, so they are treated as non-privileged here and fall through
+        // to the owner check (which yields actor UID 0 => not owner).
+        if ($this->accessControlService->isCurrentActorAdmin()) {
+            return;
+        }
+
+        $isNew = str_starts_with((string) $id, 'NEW');
+
+        if ($isNew) {
+            // A non-admin creator owns what they create: force owner_uid to the
+            // current backend user. Set it unconditionally — owner_uid is an
+            // excludefield, so a creator lacking that grant submits no value at
+            // all, and a conditional set would leave the column 0 (ownerless),
+            // locking the creator out of managing their own new secret.
+            $fieldArray['owner_uid'] = $this->accessControlService->getCurrentActorUid();
+
+            return;
+        }
+
+        $uid = is_numeric($id) ? (int) $id : 0;
+        $original = BackendUtility::getRecord(
+            self::TABLE,
+            $uid,
+            'owner_uid,frontend_accessible,scope_pid',
+        );
+        if ($original === null) {
+            return;
+        }
+
+        $storedOwner = is_numeric($original['owner_uid'] ?? null) ? (int) $original['owner_uid'] : 0;
+        $actorUid = $this->accessControlService->getCurrentActorUid();
+
+        // The owner may freely manage their own secret's ACL.
+        if ($actorUid !== 0 && $actorUid === $storedOwner) {
+            return;
+        }
+
+        // Non-owner, non-admin: revert any privileged change. Scalar columns
+        // are restored to their stored value; MM columns are dropped so
+        // DataHandler leaves the existing relation rows untouched.
+        $reverted = false;
+
+        foreach (self::PRIVILEGED_SCALAR_COLUMNS as $column) {
+            if (!\array_key_exists($column, $fieldArray)) {
+                continue;
+            }
+            // Group fields (owner_uid, scope_pid) arrive as "be_users_12" /
+            // "pages_100" strings while the stored value is an int; normalise
+            // before comparing so an unchanged ACL on an ordinary save by a
+            // non-owner is not treated as tampering (which would revert it and
+            // log a spurious warning). frontend_accessible is already 0/1.
+            $submitted = $fieldArray[$column];
+            $submittedStr = \is_scalar($submitted) ? (string) $submitted : '';
+            $submittedUid = ($column === 'owner_uid' || $column === 'scope_pid')
+                ? $this->extractUidFromGroupValue($submittedStr)
+                : (int) $submittedStr;
+            $storedUid = is_numeric($original[$column] ?? null) ? (int) $original[$column] : 0;
+            if ($submittedUid === $storedUid) {
+                continue;
+            }
+            $fieldArray[$column] = $original[$column] ?? null;
+            $reverted = true;
+        }
+
+        foreach (self::PRIVILEGED_MM_COLUMNS as $column) {
+            if (!\array_key_exists($column, $fieldArray)) {
+                continue;
+            }
+            // MM-backed group field: the row column holds only the relation
+            // count, so it cannot be reverted by writing a value back. Drop the
+            // submitted value entirely — DataHandler then preserves the
+            // existing MM relations instead of replacing them.
+            unset($fieldArray[$column]);
+            $reverted = true;
+        }
+
+        if ($reverted) {
+            /** @phpstan-ignore method.internal */
+            $dataHandler->log(
+                self::TABLE,
+                $uid,
+                2,
+                null,
+                1,
+                'Vault secret ACL columns can only be changed by the secret owner or an administrator',
+            );
         }
     }
 

--- a/Configuration/TCA/tx_nrvault_secret.php
+++ b/Configuration/TCA/tx_nrvault_secret.php
@@ -94,6 +94,11 @@ return [
         'owner_uid' => [
             'label' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.owner_uid',
             'description' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.owner_uid.description',
+            // Privileged ACL column: editable only by BE groups explicitly
+            // granted this excludefield (and admins). SecretTcaHook enforces a
+            // second, write-path layer (owner/admin-only) so a stray grant
+            // still cannot widen another user's ACL.
+            'exclude' => true,
             'config' => [
                 'type' => 'group',
                 'allowed' => 'be_users',
@@ -112,6 +117,8 @@ return [
         'allowed_groups' => [
             'label' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.allowed_groups',
             'description' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.allowed_groups.description',
+            // Privileged ACL column (read tier). See owner_uid note.
+            'exclude' => true,
             'config' => [
                 'type' => 'group',
                 'allowed' => 'be_groups',
@@ -130,6 +137,8 @@ return [
         'write_groups' => [
             'label' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.write_groups',
             'description' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.write_groups.description',
+            // Privileged ACL column (write tier). See owner_uid note.
+            'exclude' => true,
             'config' => [
                 'type' => 'group',
                 'allowed' => 'be_groups',
@@ -160,6 +169,9 @@ return [
         'frontend_accessible' => [
             'label' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.frontend_accessible',
             'description' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.frontend_accessible.description',
+            // Privileged column: flips a secret from ACL-gated to world-readable
+            // by the frontend. See owner_uid note.
+            'exclude' => true,
             'config' => [
                 'type' => 'check',
                 'renderType' => 'checkboxToggle',
@@ -191,6 +203,9 @@ return [
         'scope_pid' => [
             'label' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.scope_pid',
             'description' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_tca.xlf:tx_nrvault_secret.scope_pid.description',
+            // Privileged column: constrains which page scope a secret resolves
+            // under. See owner_uid note.
+            'exclude' => true,
             'config' => [
                 'type' => 'group',
                 'allowed' => 'pages',

--- a/Tests/Functional/Hook/Fixtures/be_users_acl.csv
+++ b/Tests/Functional/Hook/Fixtures/be_users_acl.csv
@@ -1,0 +1,4 @@
+"be_users"
+,"uid","username","password","admin","disable","starttime","endtime"
+,1,"admin","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",1,0,0,0
+,2,"editor","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0

--- a/Tests/Functional/Hook/SecretTcaHookAclTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookAclTest.php
@@ -1,0 +1,215 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Hook;
+
+use Netresearch\NrVault\Hook\SecretTcaHook;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for the privileged-ACL-column write-path authorization in
+ * SecretTcaHook (CWE-639/CWE-269).
+ *
+ * A non-admin, non-owner backend editor with table-modify rights on
+ * tx_nrvault_secret must NOT be able to widen another user's ACL or reassign
+ * ownership / frontend-accessibility through the FormEngine path.
+ */
+#[CoversClass(SecretTcaHook::class)]
+final class SecretTcaHookAclTest extends AbstractVaultFunctionalTestCase
+{
+    private const SECRET_TABLE = 'tx_nrvault_secret';
+
+    private const READ_MM_TABLE = 'tx_nrvault_secret_begroups_mm';
+
+    private const WRITE_MM_TABLE = 'tx_nrvault_secret_writegroups_mm';
+
+    /** Owner of the seeded secret (a different user than the editor). */
+    private const OWNER_UID = 1;
+
+    /** Non-admin editor performing the malicious edit. */
+    private const EDITOR_UID = 2;
+
+    /** Pre-existing read-tier group on the secret. */
+    private const EXISTING_READ_GROUP = 10;
+
+    /** Pre-existing write-tier group on the secret. */
+    private const EXISTING_WRITE_GROUP = 20;
+
+    /** Group the attacker tries to inject (e.g. one they belong to). */
+    private const ATTACKER_GROUP = 99;
+
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_acl.csv';
+
+    /** Log in as the non-admin editor (uid 2), not the default admin. */
+    protected ?int $backendUserUid = self::EDITOR_UID;
+
+    #[Test]
+    public function nonOwnerEditorCannotWidenMmGroupAcls(): void
+    {
+        $secretUid = $this->seedSecretOwnedByOther();
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+        $dataHandler->start(
+            [
+                self::SECRET_TABLE => [
+                    $secretUid => [
+                        // Attacker appends their own group to BOTH tiers.
+                        'allowed_groups' => self::EXISTING_READ_GROUP . ',' . self::ATTACKER_GROUP,
+                        'write_groups' => self::EXISTING_WRITE_GROUP . ',' . self::ATTACKER_GROUP,
+                    ],
+                ],
+            ],
+            [],
+        );
+        $dataHandler->process_datamap();
+
+        // The MM relations must be exactly what was seeded — the attacker group
+        // must NOT have been added to either tier.
+        self::assertSame(
+            [self::EXISTING_READ_GROUP],
+            $this->loadMmGroups(self::READ_MM_TABLE, $secretUid),
+            'Read-tier MM relations must be unchanged by a non-owner editor.',
+        );
+        self::assertSame(
+            [self::EXISTING_WRITE_GROUP],
+            $this->loadMmGroups(self::WRITE_MM_TABLE, $secretUid),
+            'Write-tier MM relations must be unchanged by a non-owner editor.',
+        );
+    }
+
+    #[Test]
+    public function nonOwnerEditorCannotReassignOwnerOrFrontendAccess(): void
+    {
+        $secretUid = $this->seedSecretOwnedByOther();
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+        $dataHandler->start(
+            [
+                self::SECRET_TABLE => [
+                    $secretUid => [
+                        // Attacker grabs ownership and flips frontend exposure.
+                        'owner_uid' => self::EDITOR_UID,
+                        'frontend_accessible' => 1,
+                    ],
+                ],
+            ],
+            [],
+        );
+        $dataHandler->process_datamap();
+
+        $record = $this->loadSecretRow($secretUid);
+        self::assertSame(
+            self::OWNER_UID,
+            (int) $record['owner_uid'],
+            'owner_uid must remain the original owner.',
+        );
+        self::assertSame(
+            0,
+            (int) $record['frontend_accessible'],
+            'frontend_accessible must remain disabled.',
+        );
+    }
+
+    /**
+     * Seed a secret owned by OWNER_UID with one read-tier and one write-tier
+     * MM relation, not frontend-accessible.
+     *
+     * @return int The new secret UID
+     */
+    private function seedSecretOwnedByOther(): int
+    {
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::SECRET_TABLE);
+        $connection->insert(self::SECRET_TABLE, [
+            'pid' => 0,
+            'identifier' => 'acl_secret_' . bin2hex(random_bytes(4)),
+            'owner_uid' => self::OWNER_UID,
+            'frontend_accessible' => 0,
+            // DataHandler stores the relation count in the row column.
+            'allowed_groups' => 1,
+            'write_groups' => 1,
+        ]);
+        $secretUid = (int) $connection->lastInsertId();
+
+        $this->insertMmRelation(self::READ_MM_TABLE, $secretUid, self::EXISTING_READ_GROUP);
+        $this->insertMmRelation(self::WRITE_MM_TABLE, $secretUid, self::EXISTING_WRITE_GROUP);
+
+        return $secretUid;
+    }
+
+    private function insertMmRelation(string $mmTable, int $secretUid, int $groupUid): void
+    {
+        $this->getConnectionPool()
+            ->getConnectionForTable($mmTable)
+            ->insert($mmTable, [
+                'uid_local' => $secretUid,
+                'uid_foreign' => $groupUid,
+                'sorting' => 1,
+                'sorting_foreign' => 0,
+            ]);
+    }
+
+    /**
+     * @return list<int> Group UIDs related to the secret, ascending
+     */
+    private function loadMmGroups(string $mmTable, int $secretUid): array
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable($mmTable);
+        $queryBuilder->getRestrictions()->removeAll();
+        $rows = $queryBuilder
+            ->select('uid_foreign')
+            ->from($mmTable)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'uid_local',
+                    $queryBuilder->createNamedParameter($secretUid, Connection::PARAM_INT),
+                ),
+            )
+            ->orderBy('uid_foreign', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $groups = [];
+        foreach ($rows as $row) {
+            $groups[] = (int) $row['uid_foreign'];
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function loadSecretRow(int $secretUid): array
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::SECRET_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $record = $queryBuilder
+            ->select('owner_uid', 'frontend_accessible')
+            ->from(self::SECRET_TABLE)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'uid',
+                    $queryBuilder->createNamedParameter($secretUid, Connection::PARAM_INT),
+                ),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        self::assertIsArray($record);
+
+        return $record;
+    }
+}

--- a/Tests/Unit/Hook/SecretTcaHookTest.php
+++ b/Tests/Unit/Hook/SecretTcaHookTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrVault\Tests\Unit\Hook;
 
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Hook\SecretTcaHook;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -28,6 +29,8 @@ final class SecretTcaHookTest extends TestCase
 
     private AuditLogServiceInterface&MockObject $auditService;
 
+    private AccessControlServiceInterface&MockObject $accessControlService;
+
     private SecretTcaHook $hook;
 
     protected function setUp(): void
@@ -36,10 +39,17 @@ final class SecretTcaHookTest extends TestCase
 
         $this->vaultService = $this->createMock(VaultServiceInterface::class);
         $this->auditService = $this->createMock(AuditLogServiceInterface::class);
+        $this->accessControlService = $this->createMock(AccessControlServiceInterface::class);
+
+        // Default to an admin actor so the pre-existing field-normalisation
+        // tests (NEW records, owner/scope extraction) are not coerced by the
+        // privileged-column policy. Policy-specific tests override this.
+        $this->accessControlService->method('isCurrentActorAdmin')->willReturn(true);
 
         $this->hook = new SecretTcaHook(
             $this->vaultService,
             $this->auditService,
+            $this->accessControlService,
         );
     }
 
@@ -281,6 +291,91 @@ final class SecretTcaHookTest extends TestCase
         // Test non-numeric string
         self::assertSame(0, $method->invoke($this->hook, 'not_a_number'));
         self::assertSame(0, $method->invoke($this->hook, ''));
+    }
+
+    #[Test]
+    public function nonAdminCreatingNewRecordCannotAssignForeignOwnerUid(): void
+    {
+        // Fresh hook with a NON-admin actor (uid 7); setUp() defaults to admin.
+        $accessControl = $this->createMock(AccessControlServiceInterface::class);
+        $accessControl->method('isCurrentActorAdmin')->willReturn(false);
+        $accessControl->method('getCurrentActorUid')->willReturn(7);
+
+        $hook = new SecretTcaHook(
+            $this->vaultService,
+            $this->auditService,
+            $accessControl,
+        );
+
+        $fieldArray = [
+            'identifier' => 'test-secret',
+            // Attempt to plant the secret as owned by user 42.
+            'owner_uid' => 'be_users_42',
+        ];
+        $dataHandler = $this->createMock(DataHandler::class);
+
+        $hook->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            'tx_nrvault_secret',
+            'NEW123',
+            $dataHandler,
+        );
+
+        // owner_uid must be forced to the current backend user (7), not 42.
+        self::assertSame(7, $fieldArray['owner_uid']);
+    }
+
+    #[Test]
+    public function nonAdminCreatingNewRecordWithoutOwnerUidStillGetsForcedOwnership(): void
+    {
+        // Regression: owner_uid is an excludefield, so a non-admin creator who
+        // lacks that grant submits no owner_uid at all. The hook must STILL
+        // force ownership to the current user — otherwise the column defaults
+        // to 0 (ownerless) and the creator cannot manage their own secret.
+        $accessControl = $this->createMock(AccessControlServiceInterface::class);
+        $accessControl->method('isCurrentActorAdmin')->willReturn(false);
+        $accessControl->method('getCurrentActorUid')->willReturn(7);
+
+        $hook = new SecretTcaHook(
+            $this->vaultService,
+            $this->auditService,
+            $accessControl,
+        );
+
+        $fieldArray = [
+            'identifier' => 'test-secret',
+            // No owner_uid submitted (excludefield absent for this user).
+        ];
+        $dataHandler = $this->createMock(DataHandler::class);
+
+        $hook->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            'tx_nrvault_secret',
+            'NEW123',
+            $dataHandler,
+        );
+
+        self::assertSame(7, $fieldArray['owner_uid']);
+    }
+
+    #[Test]
+    public function adminCreatingNewRecordKeepsSubmittedOwnerUid(): void
+    {
+        // setUp() default actor is admin → no coercion.
+        $fieldArray = [
+            'identifier' => 'test-secret',
+            'owner_uid' => 'be_users_42',
+        ];
+        $dataHandler = $this->createMock(DataHandler::class);
+
+        $this->hook->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            'tx_nrvault_secret',
+            'NEW123',
+            $dataHandler,
+        );
+
+        self::assertSame(42, $fieldArray['owner_uid']);
     }
 
     #[Test]


### PR DESCRIPTION
## Summary

Fixes a privilege-escalation / ACL-widening path (HIGH, CWE-639 / CWE-269) plus a minor in-memory cleartext issue (LOW, CWE-316) on the secret FormEngine write path.

### Finding — Privileged ACL columns writable without authorization (HIGH)
`owner_uid`, `allowed_groups`, `write_groups`, `frontend_accessible`, `scope_pid` on `tx_nrvault_secret` carried no `exclude` flag and the table had no admin gate; `SecretTcaHook` called `VaultService::store()/rotate()` with **no options**, so the `resolveOwnerUid` / `resolveFrontendAccessible` coercion never ran on the FormEngine path — DataHandler persisted the raw submitted ACL values. A non-admin editor with table-modify rights could reassign ownership, widen read/write groups to their own, or flip a secret to frontend-accessible. This is precisely the delegated-management use case those columns exist for, which makes it the realistic worst case, not a contrived one.

### Finding — plaintext not zeroed (LOW, CWE-316)
The `secret_input` plaintext was `unset()` without `sodium_memzero()`.

## Fix
- The five privileged ACL columns are now `exclude` fields (form-permission layer).
- Write-path authorization gate in `SecretTcaHook`: admins / system maintainers unrestricted; a non-admin creating a record is forced to own it; a non-owner non-admin editing a record has scalar ACL changes reverted and MM-group changes dropped, with a DataHandler log entry.
- Plaintext `secret_input` is scrubbed with `sodium_memzero()` after storage — wiping the single remaining reference in the `finally` block (wiping the property earlier would, via copy-on-write, zero the value before it is stored).

## Verification (local)

| Gate | Result |
|---|---|
| PHPStan (`Build/phpstan.no-plugins.neon`) | ✅ No errors |
| cgl | ✅ |
| Unit (incl. new owner-coercion tests) | ✅ |
| Fuzz | ✅ |
| Functional (mariadb) | 169 tests (2 new) — same 11 errors / 2 failures as unmodified `main@841947a` → **0 regressions**; new `SecretTcaHookAclTest` passes |

> The 11 errors / 2 failures are pre-existing local test-infra issues (SQLite DDL on MariaDB; OAuth sidecar), identical on unmodified `main`. CI is the authoritative functional gate.

## Reviewer decisions
1. **Default-DENY delegation:** there is no non-admin "secrets-manager" role that may manage others' ACLs. If one is intended, it needs an explicit policy extension.
2. System maintainers who are not admins fall through to the owner check (`isCurrentActorAdmin()` checks `isAdmin()` only).
3. MM-group reverts **drop** the submitted change (DataHandler keeps existing relations) rather than re-emitting the stored UIDs.

Found via a security audit of the extension. Sibling PR hardens the audit hash chain.
