### PR TITLE
fix(http): pin all resolved IPs in one CURLOPT_RESOLVE entry (address-family fallback)

### DIFF
--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -327,7 +327,7 @@ final class SecureHttpClientFactory
             return [];
         }
 
-        $entries = [];
+        $formattedIps = [];
         foreach ($records as $record) {
             $ip = $record['ip'] ?? $record['ipv6'] ?? null;
             if (!\is_string($ip)) {
@@ -345,11 +345,25 @@ final class SecureHttpClientFactory
             // libcurl's CURLOPT_RESOLVE format is `host:port:address`. IPv6
             // addresses contain colons, so they MUST be bracketed or curl
             // misparses the entry (see curl docs / CVE-2025-* class of bugs).
-            $formattedIp = str_contains($ip, ':') ? '[' . $ip . ']' : $ip;
-            $entries[] = \sprintf('%s:%d:%s', $host, $port, $formattedIp);
+            $formattedIps[] = str_contains($ip, ':') ? '[' . $ip . ']' : $ip;
         }
 
-        return $entries;
+        if ($formattedIps === []) {
+            return [];
+        }
+
+        // Pin ALL validated addresses in a SINGLE comma-separated
+        // CURLOPT_RESOLVE entry (`host:port:ip1,ip2,[ipv6],…`) rather than one
+        // entry per IP. curl performs Happy-Eyeballs fall-back across the
+        // addresses of a single entry, so a host that resolves to an
+        // unreachable address family (e.g. an AAAA record on an IPv4-only
+        // network, or an A record on an IPv6-only one) still connects via a
+        // reachable pinned address. Separate per-IP entries defeat that
+        // fall-back and fail with "could not connect".
+        //
+        // This remains rebinding-proof: curl may still only connect to these
+        // pinned, already-validated addresses — it cannot re-resolve.
+        return [\sprintf('%s:%d:%s', $host, $port, implode(',', $formattedIps))];
     }
 
     /**

--- a/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
@@ -113,6 +113,26 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
     }
 
     #[Test]
+    public function buildResolveEntriesPinsAllAddressesInOneEntry(): void
+    {
+        // A host resolving to several addresses (here IPv4 + IPv6) must be
+        // pinned as ONE comma-separated CURLOPT_RESOLVE entry, not one entry
+        // per IP: curl only performs Happy-Eyeballs fall-back across the
+        // addresses of a single entry. With separate entries, a host whose DNS
+        // returns an unreachable address family (e.g. an AAAA record on an
+        // IPv4-only network) fails with "could not connect" instead of falling
+        // back to a reachable pinned address. The IPv6 address stays bracketed.
+        $this->dnsResolver->program('dual.example.com', [
+            ['ip' => self::PUBLIC_IP],
+            ['ipv6' => '2001:db8::1'],
+        ]);
+
+        $entries = $this->callBuildResolveEntries('dual.example.com', 443);
+
+        self::assertSame(['dual.example.com:443:93.184.216.34,[2001:db8::1]'], $entries);
+    }
+
+    #[Test]
     public function buildResolveEntriesReturnsNullWhenAnyRecordIsDangerous(): void
     {
         // Split-horizon: resolver returns one public + one internal IP. ANY


### PR DESCRIPTION
## Problem
The SSRF DNS-rebinding defence pins the resolved+validated IPs via `CURLOPT_RESOLVE`, building **one array element per IP** (`host:port:ip1`, `host:port:ip2`, …).

curl only performs **Happy-Eyeballs fall-back across the addresses of a single entry**. With separate entries, a host whose DNS returns an **unreachable address family** — an `AAAA` record on an IPv4-only network, or an `A` record on an IPv6-only one — fails with `cURL error 7: Failed to connect … after 0 ms: Could not connect to server`, instead of falling back to a reachable pinned address. Plain curl (system resolver) doesn't hit this because it fans out over all addresses itself, so the secured client is *less* robust than an unsecured one.

## Reproduction (real, in a container)
`raw.githubusercontent.com` resolves to both A and AAAA; the container had **no IPv6 egress**. Evidence:
- Pin IPv4 alone → `HTTP 200`
- Pin IPv6 alone → `cURL 7 (0 ms)`
- Pin both as **separate** entries → **fails** (curl stuck on the dead IPv6)
- Pin both in **one comma-separated** entry → `HTTP 200` ✅ (curl falls back)

A consumer extension's GitHub skill sync failed exactly this way.

## Fix
Combine the validated IPs into **one** comma-separated entry (`host:port:ip1,ip2,[ipv6],…`). curl then does proper Happy-Eyeballs across all of them.

**Still fully rebinding-proof:** curl may only connect to the pinned, already-validated addresses and cannot re-resolve. Single-address hosts are unaffected (one IP → one entry). The dangerous-IP rejection and the allowlist opt-in paths are unchanged.

## Tests
- New `buildResolveEntriesPinsAllAddressesInOneEntry` asserts the single comma-separated entry (IPv6 bracketed).
- Existing single-IP / IPv6-bracket / rebinding-rejection / allowlist tests unchanged and green (71 tests).