### PR TITLE
fix(form): render the vaultSecret field description exactly once on v13 and v14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The `vaultSecret` field description no longer renders twice on v14** (#189).
+  TYPO3 v14's `AbstractFormElement::renderLabel()` emits the TCA `description`
+  itself (via `renderDescription()`), so `VaultSecretElement`'s own copy became
+  a duplicate. The element now renders its own description only on v13, where
+  the label does not — so it appears exactly once on both v13 and v14.
+
 - **The SSRF middleware no longer fatals without ext-curl** (#192). It
   referenced the curl-only `CURLOPT_RESOLVE` constant unconditionally, so the
   first pinned request on a curl-less install raised `Error: Undefined

--- a/Classes/Form/Element/VaultSecretElement.php
+++ b/Classes/Form/Element/VaultSecretElement.php
@@ -16,6 +16,7 @@ use Throwable;
 use TYPO3\CMS\Backend\Form\Element\AbstractFormElement;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Page\JavaScriptModuleInstruction;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\StringUtility;
@@ -59,9 +60,15 @@ final class VaultSecretElement extends AbstractFormElement
         /** @var array<string, mixed> $resultArray */
         $resultArray = $this->mergeChildReturnIntoExistingResult($resultArray, $fieldInformationResult, false);
 
-        $descriptionHtml = $this->renderVaultDescription($context['fieldConf']);
-        if ($descriptionHtml !== '') {
-            $html[] = $descriptionHtml;
+        // TYPO3 v14's AbstractFormElement::renderLabel() already emits the TCA
+        // `description` (via renderDescription()); v13's does not. Render our own
+        // copy only on v13 — otherwise the description appears twice on v14, or
+        // not at all on v13.
+        if ((new Typo3Version())->getMajorVersion() < 14) {
+            $descriptionHtml = $this->renderVaultDescription($context['fieldConf']);
+            if ($descriptionHtml !== '') {
+                $html[] = $descriptionHtml;
+            }
         }
 
         $html[] = '<div class="form-wizards-wrap">';
@@ -244,6 +251,9 @@ final class VaultSecretElement extends AbstractFormElement
 
     /**
      * Optional field description from TCA — empty string if none.
+     *
+     * Only used on TYPO3 versions whose AbstractFormElement::renderLabel() does
+     * not already render the description (v13); on v14+ the label renders it.
      *
      * @param array<string, mixed> $fieldConf
      */

--- a/Tests/Unit/Form/Element/VaultSecretElementTest.php
+++ b/Tests/Unit/Form/Element/VaultSecretElementTest.php
@@ -150,8 +150,14 @@ final class VaultSecretElementTest extends TestCase
     }
 
     #[Test]
-    public function renderOutputContainsDescriptionWhenPresent(): void
+    public function renderOutputContainsDescriptionExactlyOnce(): void
     {
+        // On TYPO3 v14 AbstractFormElement::renderLabel() emits the TCA
+        // `description` (via renderDescription()); the element must NOT render a
+        // second copy, or it appears twice. On v13 renderLabel() emits nothing,
+        // so the element renders it itself. Either way the description must
+        // appear exactly once — this is the discriminator the CI matrix
+        // (^13.4 + ^14.3) exercises.
         $langService = $this->createMock(LanguageService::class);
         $langService->method('sL')->willReturnCallback(
             static fn (string $key): string => $key === self::FIELD_DESCRIPTION ? self::FIELD_DESCRIPTION : '',
@@ -173,8 +179,9 @@ final class VaultSecretElementTest extends TestCase
         $result = $this->subject->render();
 
         self::assertIsString($result['html']);
-        self::assertStringContainsString('form-description', $result['html']);
         self::assertStringContainsString(self::FIELD_DESCRIPTION, $result['html']);
+        // Exactly one description block — not the pre-fix duplicate.
+        self::assertSame(1, substr_count($result['html'], 'form-description'));
     }
 
     #[Test]


### PR DESCRIPTION
## Problem
A `vaultSecret` field with a TCA `description` (e.g. a consumer's *API Key* field) rendered the description text **twice** — on TYPO3 **v14**.

## Cause (version-specific)
- **v14**: `AbstractFormElement::renderLabel()` now emits the TCA `description` itself via the new `renderDescription()`. `VaultSecretElement` *also* rendered its own `renderVaultDescription()` block → duplicate.
- **v13**: `renderLabel()` does **not** emit the description, so the element's own copy is the only one — removing it unconditionally (the first attempt) made the description vanish on 13.4 (the ^13.4 CI matrix caught this: 0 occurrences).

## Fix
Render the element's own description **only on v13** (`(new Typo3Version())->getMajorVersion() < 14`), where the label doesn't. On v14 the label's single copy shows; on v13 the element's single copy shows. Exactly once on both.

A runtime `Typo3Version` check (rather than `method_exists`) is used so PHPStan keeps both branches live across the ^13.4/^14.3 analysis matrix.

## Verification
- v14 unit suite green (1870 tests); `renderOutputContainsDescriptionExactlyOnce` asserts `substr_count(..., 'form-description') === 1`.
- Root cause confirmed against both versions' `AbstractFormElement`: v14 `renderLabel()` calls `renderDescription()`; v13's does not.
- PHPStan, CGL, Rector clean. The ^13.4 matrix is the authoritative cross-version check.