### PR TITLE
fix: pin all resolved addresses in one CURLOPT_RESOLVE entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Dual-stack hosts are reachable again from IPv6-less environments** (#190).
+  The DNS-rebinding defence pinned each resolved address as a separate
+  `CURLOPT_RESOLVE` entry, but curl keeps only the last entry per `host:port`
+  — so effectively only the final DNS record (typically the AAAA) was pinned.
+  On hosts without IPv6 connectivity every request to a dual-stack host
+  (e.g. `api.github.com`) failed with `cURL error 7` and no IPv4 fallback;
+  all-IPv4 multi-record hosts silently lost their fallback addresses too.
+  All safe resolved addresses now travel comma-joined in a single resolve
+  entry (curl's multi-address form, curl ≥ 7.59), restoring curl's native
+  cross-family/cross-address connect fallback while keeping the pin: every
+  usable address is still one the defence resolved and vetted.
+
 ## [0.10.0] - 2026-06-11
 
 ### Added

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -292,17 +292,31 @@ final class SecureHttpClientFactory
     }
 
     /**
-     * Resolve `$host` to one or more IP addresses and convert each safe entry
-     * into the `host:port:ip` form curl expects for `CURLOPT_RESOLVE`.
+     * Resolve `$host` to one or more IP addresses and convert ALL safe
+     * addresses into a SINGLE `host:port:addr1[,addr2,...]` entry for curl's
+     * `CURLOPT_RESOLVE` (the multi-address form, curl >= 7.59.0).
+     *
+     * ONE entry, not one per address: for duplicate `host:port` resolve
+     * entries curl keeps only the LAST one (each entry replaces the previous
+     * cache slot). Emitting one entry per record therefore pinned only the
+     * final DNS record — on a dual-stack host that is typically the AAAA, so
+     * a host without IPv6 connectivity failed with cURL error 7 and never
+     * fell back to the (discarded) IPv4 pin, and even all-IPv4 multi-record
+     * hosts lost every fallback address (issue #190). With the comma-joined
+     * form curl has the full vetted address list in its cache slot and does
+     * its normal cross-family/cross-address connect fallback — the rebind pin
+     * is unchanged, since every usable address is still one we resolved and
+     * checked here.
      *
      * Returns:
      *  - `null` if the host resolved to AT LEAST ONE dangerous IP and is NOT
      *    explicitly allowlisted (the entire request must be rejected — even if
      *    some A records look safe, the presence of a dangerous answer signals
      *    an active rebinding attempt).
-     *  - `[]` if the host is an IP literal (no pin needed) OR if resolution
-     *    failed entirely (let curl handle the error path).
-     *  - `list<string>` of pin entries to add to `CURLOPT_RESOLVE` for safe
+     *  - `[]` if the host is an IP literal (no pin needed), if resolution
+     *    failed entirely, or if it yielded no usable A/AAAA address (let curl
+     *    handle the error path).
+     *  - a single-element `list<string>` carrying the pin entry for safe
      *    multi-record hosts.
      *
      * @param bool $allowlisted When the host carries a literal `allowed_hosts`
@@ -327,10 +341,15 @@ final class SecureHttpClientFactory
             return [];
         }
 
-        $entries = [];
+        $addresses = [];
         foreach ($records as $record) {
             $ip = $record['ip'] ?? $record['ipv6'] ?? null;
-            if (!\is_string($ip)) {
+            // Only well-formed IPs may enter the pin: curl discards the ENTIRE
+            // comma-joined entry when any one token is unparseable (fail-open
+            // to re-resolution). DefaultDnsResolver always yields canonical
+            // IPs, but DnsResolverInterface is a public seam — keep the entry
+            // valid by construction.
+            if (!\is_string($ip) || filter_var($ip, FILTER_VALIDATE_IP) === false) {
                 continue;
             }
             if (!$allowlisted && $this->isDangerousIpLiteral($ip)) {
@@ -342,14 +361,20 @@ final class SecureHttpClientFactory
                 // remains blocked.
                 return null;
             }
-            // libcurl's CURLOPT_RESOLVE format is `host:port:address`. IPv6
-            // addresses contain colons, so they MUST be bracketed or curl
-            // misparses the entry (see curl docs / CVE-2025-* class of bugs).
-            $formattedIp = str_contains($ip, ':') ? '[' . $ip . ']' : $ip;
-            $entries[] = \sprintf('%s:%d:%s', $host, $port, $formattedIp);
+            // IPv6 addresses contain colons, so they MUST be bracketed inside
+            // the resolve entry or curl misparses it (brackets supported since
+            // curl 7.57.0; see curl docs / CVE-2025-* class of bugs).
+            $addresses[] = str_contains($ip, ':') ? '[' . $ip . ']' : $ip;
         }
 
-        return $entries;
+        if ($addresses === []) {
+            return [];
+        }
+
+        // One entry with every safe address (see the method docblock): a later
+        // entry for the same host:port would REPLACE this one in curl's cache,
+        // so all fallback addresses must travel in a single entry.
+        return [\sprintf('%s:%d:%s', $host, $port, implode(',', array_unique($addresses)))];
     }
 
     /**

--- a/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
@@ -46,6 +46,8 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
 
     private const PUBLIC_IP = '93.184.216.34';
 
+    private const PUBLIC_IP_SECONDARY = '93.184.216.35';
+
     private SecureHttpClientFactory $subject;
 
     private InMemoryDnsResolver $dnsResolver;
@@ -110,6 +112,56 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
         $entries = $this->callBuildResolveEntries('v6.example.com', 443);
 
         self::assertSame(['v6.example.com:443:[2001:db8::1]'], $entries);
+    }
+
+    #[Test]
+    public function buildResolveEntriesJoinsDualStackRecordsIntoOneEntry(): void
+    {
+        // Regression for #190: curl keeps only the LAST resolve entry for a
+        // given host:port (later entries replace earlier ones in its cache).
+        // One entry per record therefore pinned only the final DNS record —
+        // typically the AAAA — so a host without IPv6 connectivity failed
+        // with cURL error 7 and never fell back to the discarded IPv4 pin.
+        // All safe addresses must travel comma-joined in a SINGLE entry
+        // (curl's multi-address form) so curl can fall back across families.
+        $this->dnsResolver->program('dual.example.com', [
+            ['ip' => self::PUBLIC_IP],
+            ['ipv6' => '2001:db8::1'],
+        ]);
+
+        $entries = $this->callBuildResolveEntries('dual.example.com', 443);
+
+        self::assertSame(['dual.example.com:443:93.184.216.34,[2001:db8::1]'], $entries);
+    }
+
+    #[Test]
+    public function buildResolveEntriesJoinsMultipleARecordsIntoOneEntry(): void
+    {
+        // Same last-entry-wins rationale for an all-IPv4 multi-record host:
+        // separate entries would silently discard every fallback address.
+        $this->dnsResolver->program('multi.example.com', [
+            ['ip' => self::PUBLIC_IP],
+            ['ip' => self::PUBLIC_IP_SECONDARY],
+        ]);
+
+        $entries = $this->callBuildResolveEntries('multi.example.com', 443);
+
+        self::assertSame(['multi.example.com:443:93.184.216.34,93.184.216.35'], $entries);
+    }
+
+    #[Test]
+    public function buildResolveEntriesDeduplicatesRepeatedAddresses(): void
+    {
+        // Some resolvers return the same address more than once; the pin
+        // entry must not repeat it.
+        $this->dnsResolver->program('dup.example.com', [
+            ['ip' => self::PUBLIC_IP],
+            ['ip' => self::PUBLIC_IP],
+        ]);
+
+        $entries = $this->callBuildResolveEntries('dup.example.com', 443);
+
+        self::assertSame(['dup.example.com:443:93.184.216.34'], $entries);
     }
 
     #[Test]
@@ -237,6 +289,30 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
         self::assertIsArray($curlOpts);
         self::assertArrayHasKey(\CURLOPT_RESOLVE, $curlOpts);
         self::assertSame(['safe.example:443:93.184.216.34'], $curlOpts[\CURLOPT_RESOLVE]);
+    }
+
+    #[Test]
+    public function middlewarePinsDualStackHostAsSingleJoinedEntry(): void
+    {
+        // Regression for #190 at the layer curl actually sees: the option
+        // array must carry ONE entry with both addresses — two entries for
+        // the same host:port would make curl keep only the last (typically
+        // the AAAA), breaking IPv4 fallback on IPv6-less hosts.
+        $this->dnsResolver->program('dualstack.example', [
+            ['ip' => self::PUBLIC_IP],
+            ['ipv6' => '2001:db8::1'],
+        ]);
+        $client = $this->buildCapturingClient($capturedOptions);
+
+        $client->get('https://dualstack.example/api');
+
+        $curlOpts = $capturedOptions['curl'] ?? null;
+        self::assertIsArray($curlOpts);
+        self::assertArrayHasKey(\CURLOPT_RESOLVE, $curlOpts);
+        self::assertSame(
+            ['dualstack.example:443:93.184.216.34,[2001:db8::1]'],
+            $curlOpts[\CURLOPT_RESOLVE],
+        );
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #190.

## Root cause — deeper than the issue described

The DNS-rebinding defence pinned each resolved address as a **separate** `CURLOPT_RESOLVE` entry for the same `host:port`. But curl keeps only the **last** entry per `host:port` — each later entry replaces the earlier cache slot. So effectively **only the final DNS record was ever pinned** (typically the AAAA, given `dns_get_record`'s A-then-AAAA ordering):

- On a host **without IPv6 connectivity**, every request to a dual-stack host (`api.github.com`, `raw.githubusercontent.com`, …) failed with `cURL error 7` and never fell back to the discarded IPv4 pin → #190.
- Even **all-IPv4 multi-record hosts** silently lost their fallback addresses — reduced availability nobody noticed.

### Empirical proof (IPv6-less container, curl 8.14)

| Entries | Result |
|---|---|
| `host:443:v4`, `host:443:[v6]` (current code's order) | **errno 7** — v4 pin replaced by v6 |
| `host:443:[v6]`, `host:443:v4` | 200 via v4 — last wins |
| `host:443:[v6],v4` (single joined entry) | **200 via v4 fallback** |

## Fix

`buildResolveEntries()` now emits **one** entry with every safe address comma-joined (curl's multi-address form, curl ≥ 7.59.0; IPv6 stays bracketed; deduped). curl gets the full vetted address list in one cache slot and performs its normal cross-family / cross-address connect fallback.

**The rebind pin is unchanged:** every address curl may use is still one the defence resolved and vetted; split-horizon rejection (`null` on any dangerous record) and the literal-allowlist opt-in behave exactly as before. This needs no config knob and no `CURLOPT_IPRESOLVE` forcing (which would have broken IPv6-only deployments).

Hardening (from adversarial review): each address is additionally gated by `FILTER_VALIDATE_IP` before joining — curl discards the *whole* entry if any one token is unparseable, and `DnsResolverInterface` is a public constructor seam that could feed non-canonical values. The pin string is now valid by construction.

### curl floor note

Bracketed-IPv6 pinning already required curl ≥ 7.57; the multi-address form moves the floor to 7.59 (March 2018). Any platform running PHP ≥ 8.2 ships far newer curl. On older curl the entry is skipped and the request proceeds unpinned but still guarded by the pre-connect dangerous-IP rejection — the same degraded posture as the documented StreamHandler fallback.

## Tests

- 4 new tests: dual-stack single-joined-entry (regression for #190, fails on old code), multi-A-record joining, address dedup, and a **middleware-level** dual-stack assertion on `$options['curl'][CURLOPT_RESOLVE]` (pins the fix at the layer curl actually sees).
- Existing single-record assertions unchanged — the entry string is identical for one address.

## Verification

- Unit: **1862 tests / 7399 assertions green** (18 in the rebinding suite)
- PHPStan: no errors; CGL: clean
- **Live end-to-end:** deployed into a TYPO3 v14.3 ddev container *without IPv6 routing* — EXT:nr_llm's skill sync (60+ HTTPS fetches to dual-stack GitHub hosts through `$vault->http()`) completed `status=ok, errors=[]`, where it previously died on the first request with cURL 7.

Two **pre-existing** issues surfaced during adversarial review (not introduced or changed here) will be filed separately: non-canonical numeric IP literals (`http://2130706433/`) bypass `isDangerousIpLiteral`, and the middleware references `\CURLOPT_RESOLVE` without ext-curl despite `create()`'s graceful-degradation warning.
