### PR TITLE
security: reject legacy numeric IP forms; guard SSRF pin without ext-curl

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **Legacy numeric IP-literal SSRF bypass closed** (#192). curl's resolver
+  accepts `inet_aton()` forms — dword (`2130706433`), octal (`0177.0.0.1`),
+  hex (`0x7f.0.0.1`) and partial-dot (`127.1`) — that all reach `127.0.0.1`,
+  but PHP's `inet_pton()` / `FILTER_VALIDATE_IP` reject them, so they slipped
+  through the dangerous-IP guard as pseudo-hostnames (no DNS record, no pin)
+  and curl derived the internal IP itself. Such forms are now rejected both in
+  `isHostAllowed()` and in the request-time SSRF middleware unless the operator
+  allowlists the exact literal; the canonical dotted-quad / IPv6 form is
+  unaffected.
+
 ### Fixed
+
+- **The SSRF middleware no longer fatals without ext-curl** (#192). It
+  referenced the curl-only `CURLOPT_RESOLVE` constant unconditionally, so the
+  first pinned request on a curl-less install raised `Error: Undefined
+  constant "CURLOPT_RESOLVE"` — contradicting `create()`'s documented
+  StreamHandler-fallback warning. The pin is now attached only when
+  `curl_init()` exists; the dangerous-IP rejections still run.
 
 - **Dual-stack hosts are reachable again from IPv6-less environments** (#190).
   The DNS-rebinding defence pinned each resolved address as a separate

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -261,6 +261,24 @@ final class SecureHttpClientFactory
                     $this->resolveAllowedHostsList(),
                 );
 
+                // Legacy inet_aton() forms ("2130706433", "0177.0.0.1",
+                // "0x7f.0.0.1", "127.1") are IPs to curl but pseudo-hostnames
+                // to PHP's strict parsers: no DNS record, no pin, and curl
+                // then derives the (possibly loopback/internal) IP itself.
+                // Reject the ambiguous form outright unless the operator
+                // explicitly allowlisted that exact literal.
+                if (!$allowlisted && $this->isLegacyNumericIpForm($host)) {
+                    throw new RequestException(
+                        \sprintf(
+                            'Refused to send request: host "%s" is a non-canonical numeric IP form '
+                            . '(curl would interpret it as an IP address, bypassing the IP range '
+                            . 'checks). Use the canonical dotted-quad or IPv6 form.',
+                            $host,
+                        ),
+                        $request,
+                    );
+                }
+
                 $resolveEntries = $this->buildResolveEntries($host, $port, $allowlisted);
 
                 if ($resolveEntries === null) {
@@ -274,7 +292,13 @@ final class SecureHttpClientFactory
                     );
                 }
 
-                if ($resolveEntries !== []) {
+                // Attach the pin only when ext-curl exists: without it the
+                // `\CURLOPT_RESOLVE` constant is undefined (referencing it
+                // fatals) and the StreamHandler ignores/deprecates the `curl`
+                // option anyway. The dangerous-IP rejections above still ran —
+                // this is exactly the degraded-but-working posture create()'s
+                // missing-ext-curl warning documents.
+                if ($resolveEntries !== [] && \function_exists('curl_init')) {
                     $curlOptions = \is_array($options['curl'] ?? null) ? $options['curl'] : [];
                     /** @var list<string> $existing */
                     $existing = \is_array($curlOptions[\CURLOPT_RESOLVE] ?? null)
@@ -462,6 +486,41 @@ final class SecureHttpClientFactory
     }
 
     /**
+     * Detect a legacy `inet_aton()` numeric address form that curl accepts but
+     * PHP's strict IP parsers do not — so it would otherwise slip through the
+     * dangerous-IP guard as a pseudo-hostname.
+     *
+     * `inet_aton()` (and therefore curl's getaddrinfo path) parses 1–4
+     * dot-separated parts where each part is decimal, octal (leading `0`) or
+     * hex (`0x`). All of these reach 127.0.0.1:
+     *   2130706433, 0x7f000001, 0177.0.0.1, 0x7f.0.0.1, 127.1
+     * while `filter_var(FILTER_VALIDATE_IP)` / `inet_pton()` reject them.
+     *
+     * A canonical dotted-quad or IPv6 literal returns false here (those go
+     * through the normal `inet_pton()` path). Anything containing a non-numeric
+     * label (a real hostname like `example.com` or `163.com`) fails the grammar
+     * and returns false too. Only the genuinely ambiguous numeric forms match.
+     */
+    private function isLegacyNumericIpForm(string $host): bool
+    {
+        if ($host === '') {
+            return false;
+        }
+
+        // A canonical IP is unambiguous — leave it to the inet_pton() path.
+        if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            return false;
+        }
+
+        // 1–4 dot-separated parts, each decimal/octal (a digit run) or hex
+        // (`0x…`). Value-range overflow (e.g. an out-of-range part) is left to
+        // fail closed: over-matching only refuses an already-suspect request.
+        $part = '(?:0[xX][0-9a-fA-F]+|[0-9]+)';
+
+        return preg_match('/^' . $part . '(?:\.' . $part . '){0,3}$/', $host) === 1;
+    }
+
+    /**
      * Reject IP literals in private/link-local/loopback/multicast/metadata ranges.
      *
      * The check combines:
@@ -486,6 +545,19 @@ final class SecureHttpClientFactory
      */
     private function isDangerousIpLiteral(string $host): bool
     {
+        // curl's resolver accepts legacy inet_aton() forms that PHP's strict
+        // parsers reject — dword ("2130706433"), octal ("0177.0.0.1"), hex
+        // ("0x7f.0.0.1") and partial-dot ("127.1") all connect to 127.0.0.1
+        // while inet_pton()/FILTER_VALIDATE_IP call them "not an IP". Left
+        // unchecked they sail past this guard as pseudo-hostnames (no DNS
+        // record, no pin) and curl then derives the IP itself → SSRF into
+        // loopback/internal ranges. Treat every such ambiguous form as
+        // dangerous; the request-time middleware rejects it outright, and the
+        // canonical dotted-quad remains available to operators.
+        if ($this->isLegacyNumericIpForm($host)) {
+            return true;
+        }
+
         $packed = inet_pton($host);
         if ($packed === false) {
             return false;

--- a/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
@@ -278,6 +278,20 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
     }
 
     #[Test]
+    public function middlewareRejectsLegacyNumericIpFormHost(): void
+    {
+        // "2130706433" is 127.0.0.1 to curl but a pseudo-hostname to PHP —
+        // the middleware must reject it BEFORE the socket opens (#192), not
+        // hand it to curl to resolve internally.
+        $client = $this->buildCapturingClient($capturedOptions);
+
+        $this->expectException(RequestException::class);
+        $this->expectExceptionMessageMatches('/non-canonical numeric IP form/i');
+
+        $client->get('http://2130706433/');
+    }
+
+    #[Test]
     public function middlewareAddsCurlResolvePinForResolvedHost(): void
     {
         $this->dnsResolver->program('safe.example', [['ip' => self::PUBLIC_IP]]);

--- a/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
@@ -106,6 +106,47 @@ final class SecureHttpClientFactorySsrfTest extends TestCase
     }
 
     #[Test]
+    #[DataProvider('legacyNumericIpFormProvider')]
+    public function isHostAllowedRejectsLegacyNumericIpForms(string $host): void
+    {
+        // curl's resolver accepts these inet_aton() forms and derives an IP
+        // from them (most map to 127.0.0.1; 010.010.010.010 is octal → 8.8.8.8),
+        // but inet_pton()/FILTER_VALIDATE_IP reject them. The danger is the
+        // ambiguity: without the guard they slip through as pseudo-hostnames,
+        // dodge the IP-range checks entirely, and curl connects to whatever IP
+        // it decodes. They must be blocked (#192).
+        self::assertFalse(
+            $this->subject->isHostAllowed($host),
+            \sprintf('Expected legacy numeric IP form %s to be blocked, but it was allowed.', $host),
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function legacyNumericIpFormProvider(): array
+    {
+        return [
+            'dword loopback' => ['2130706433'],       // -> 127.0.0.1
+            'hex dword loopback' => ['0x7f000001'],   // -> 127.0.0.1
+            'octal dotted loopback' => ['0177.0.0.1'],
+            'hex dotted loopback' => ['0x7f.0.0.1'],
+            'partial-dot loopback' => ['127.1'],      // -> 127.0.0.1
+            'octal dotted public-looking' => ['010.010.010.010'], // -> 8.8.8.8
+        ];
+    }
+
+    #[Test]
+    public function explicitAllowlistEntryOverridesLegacyNumericForm(): void
+    {
+        // An operator who deliberately allowlists the exact literal opts back in
+        // (the guard is fail-closed, not a hard ban).
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'] = ['2130706433'];
+
+        self::assertTrue($this->subject->isHostAllowed('2130706433'));
+    }
+
+    #[Test]
     public function isHostAllowedReturnsFalseForEmptyHost(): void
     {
         self::assertFalse($this->subject->isHostAllowed(''));


### PR DESCRIPTION
Fixes #192. Both gaps pre-dated #190/#191 and were surfaced by that PR's adversarial review.

## 1. Legacy numeric IP-literal SSRF bypass (security)

curl's resolver accepts `inet_aton()` address forms that PHP's strict parsers reject. All of these connect to **127.0.0.1** (verified, curl 8.14):

| Form | Example | `FILTER_VALIDATE_IP` | curl resolves to |
|---|---|---|---|
| dword | `2130706433` | ✗ rejects | 127.0.0.1 |
| hex dword | `0x7f000001` | ✗ | 127.0.0.1 |
| octal dotted | `0177.0.0.1` | ✗ | 127.0.0.1 |
| hex dotted | `0x7f.0.0.1` | ✗ | 127.0.0.1 |
| partial-dot | `127.1` | ✗ | 127.0.0.1 |
| octal all | `010.010.010.010` | ✗ | 8.8.8.8 |

Because `inet_pton()`/`FILTER_VALIDATE_IP` call them "not an IP", they slipped through `isDangerousIpLiteral()` as **pseudo-hostnames**: `dns_get_record` returns nothing → no `CURLOPT_RESOLVE` pin → curl derives the internal IP itself → **SSRF past the range guard** into loopback/RFC1918/metadata.

**Fix:** a new `isLegacyNumericIpForm()` recognises the `inet_aton` grammar (1–4 dot-separated decimal/octal/hex parts) for any string that isn't already a canonical IP. `isDangerousIpLiteral()` treats such forms as dangerous, and the request-time SSRF middleware rejects them outright with a clear `RequestException` — **unless the operator allowlisted the exact literal** (fail-closed, not a hard ban). Canonical dotted-quad / IPv6 literals are untouched (they take the `inet_pton()` path); real hostnames (`example.com`, `163.com`) fail the numeric grammar and are unaffected.

## 2. ext-curl-absent fatal

The middleware referenced the curl-only `\CURLOPT_RESOLVE` constant **unconditionally**, so the first pinned request on a curl-less install raised `Error: Undefined constant "CURLOPT_RESOLVE"` — contradicting `create()`'s documented "falls back to the stream handler" warning (`composer.json` requires only ext-sodium/ext-json). The pin is now attached only when `curl_init()` exists, mirroring `create()`'s guard; the dangerous-IP rejections still run, so the documented degraded-but-working posture holds.

## Tests & verification

- New: 6-case `isHostAllowed` data-provider for the numeric forms, allowlist-override case, and a middleware-level rejection test (`middlewareRejectsLegacyNumericIpFormHost`). `isLegacyNumericIpForm` classification validated against 20 inputs (all flag/keep correct).
- Full unit suite **1870 tests green**; PHPStan clean; CGL clean.
- **Live regression guard:** deployed into the same IPv6-less TYPO3 v14.3 ddev container — EXT:nr_llm skill sync (dual-stack GitHub over `$vault->http()`) still completes `status=ok, updated=60, errors=[]`, so the new guard doesn't disturb the normal path fixed in #191.

Stacked on #191 (merged); rebased onto `main`.
