### PR TITLE
docs: add missed security fixes (#185, #186) to 0.10.1 CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   unaffected.
 
 - **Privileged secret ACL columns are now authorization-gated** (#186). On the
-  secret FormEngine write path the `owner_uid`, `allowed_groups`,
+  secret FormEngine write path, the `owner_uid`, `allowed_groups`,
   `write_groups`, `frontend_accessible` and `scope_pid` columns of
   `tx_nrvault_secret` carried no `exclude` flag and no admin gate, so a
   non-admin editor could widen a secret's ACL or reassign ownership
@@ -33,9 +33,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Audit hash-chain tamper-evidence hardened** (#185). Two forgery paths
   reachable by the documented in-scope database attacker (a principal with
   `UPDATE`/`DELETE` on `tx_nrvault_audit_log`) are closed: an epoch-downgrade
-  that let the tail row be rewritten under a keyless SHA-256 epoch because the
-  `hmac_key_epoch` was bound into no payload (CWE-345 / CWE-757), and an
-  attribution forgery. Both are now detected by `verifyHashChain()`.
+  that allowed the tail row to be rewritten under a keyless SHA-256 epoch
+  because the `hmac_key_epoch` was not bound into any hashed payload
+  (CWE-345 / CWE-757), and an attribution forgery. Both are now detected by
+  `verifyHashChain()`.
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   allowlists the exact literal; the canonical dotted-quad / IPv6 form is
   unaffected.
 
+- **Privileged secret ACL columns are now authorization-gated** (#186). On the
+  secret FormEngine write path the `owner_uid`, `allowed_groups`,
+  `write_groups`, `frontend_accessible` and `scope_pid` columns of
+  `tx_nrvault_secret` carried no `exclude` flag and no admin gate, so a
+  non-admin editor could widen a secret's ACL or reassign ownership
+  (privilege escalation, CWE-639 / CWE-269). The write path now enforces
+  owner/admin authorization on those privileged columns (also closes a minor
+  in-memory cleartext exposure, CWE-316).
+
+- **Audit hash-chain tamper-evidence hardened** (#185). Two forgery paths
+  reachable by the documented in-scope database attacker (a principal with
+  `UPDATE`/`DELETE` on `tx_nrvault_audit_log`) are closed: an epoch-downgrade
+  that let the tail row be rewritten under a keyless SHA-256 epoch because the
+  `hmac_key_epoch` was bound into no payload (CWE-345 / CWE-757), and an
+  attribution forgery. Both are now detected by `verifyHashChain()`.
+
 ### Fixed
 
 - **The `vaultSecret` field description no longer renders twice on v14** (#189).


### PR DESCRIPTION
Completes the 0.10.1 release notes. `git log v0.10.0..main` surfaced two HIGH-severity security fixes that merged after v0.10.0 but were never added to the CHANGELOG `[Unreleased]` section:

- **#186** — privileged secret ACL columns (`owner_uid`, `allowed_groups`, `write_groups`, `frontend_accessible`, `scope_pid`) were writable through the FormEngine element without an owner/admin gate (privilege escalation / ACL-widening, CWE-639 / CWE-269).
- **#185** — audit hash-chain epoch-downgrade + attribution forgery (tamper-evidence bypass reachable by a DB-level attacker, CWE-345 / CWE-757).

Both are documented under `[0.10.1]` now. Version stays 0.10.1 (fixes/security only, no features or breaking changes). After merge: tag `v0.10.1` (signed) on the merge commit.