### PR TITLE
fix(security): route unauthenticated CLI user to CLI access rules

### DIFF
--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -69,6 +69,13 @@ final class AccessControlService implements AccessControlServiceInterface
     {
         $backendUser = $this->getBackendUser();
 
+        // An unauthenticated CommandLineUserAuthentication (messenger worker,
+        // scheduler CLI run) must not pass as a backend user — the CLI access
+        // configuration decides. See hasAccess() for the full rationale.
+        if ($this->isUnauthenticatedCommandLineUser($backendUser)) {
+            return $this->configuration->isCliAccessAllowed();
+        }
+
         // Backend user takes precedence
         if ($backendUser instanceof BackendUserAuthentication) {
             // Defence-in-depth: disabled users must not create secrets,
@@ -243,6 +250,23 @@ final class AccessControlService implements AccessControlServiceInterface
     {
         $backendUser = $this->getBackendUser();
 
+        // An UNAUTHENTICATED CommandLineUserAuthentication must not take the
+        // backend-user precedence branch: the TYPO3 CLI bootstrap
+        // (CommandApplication::run() — console commands, Symfony Messenger
+        // workers, scheduler runs) places one in $GLOBALS['BE_USER'] "not
+        // logged in yet", i.e. without a user record. Treating it as a
+        // backend user both shadows the configured CLI access rules (every
+        // group/admin/maintainer check fails on the empty record) AND lets
+        // its default uid 0 match ownerUid=0 secrets via the owner check.
+        // A CommandLineUserAuthentication only ever exists in CLI context
+        // (its constructor throws otherwise — see also getCurrentActorType()),
+        // so the CLI access rules apply directly. An AUTHENTICATED CLI user
+        // (after Bootstrap::initializeBackendAuthentication()) keeps its
+        // user-based access semantics below.
+        if ($this->isUnauthenticatedCommandLineUser($backendUser)) {
+            return $this->hasCliAccess($secret, $permission);
+        }
+
         // Backend user takes precedence
         if ($backendUser instanceof BackendUserAuthentication) {
             return $this->hasBackendUserAccess($backendUser, $secret, $permission);
@@ -250,27 +274,7 @@ final class AccessControlService implements AccessControlServiceInterface
 
         // CLI access control (only when no backend user)
         if ($this->isRealCliContext()) {
-            if (!$this->configuration->isCliAccessAllowed()) {
-                return false;
-            }
-
-            // Check CLI access groups if configured
-            $cliAccessGroups = $this->configuration->getCliAccessGroups();
-            if ($cliAccessGroups !== []) {
-                // The trusted CLI operator is scoped to the configured
-                // groups. The applicable secret-group set widens with the
-                // permission tier: read may match read- OR write-tier
-                // groups, write only write-tier groups, delete has no group
-                // tier at all (owner/admin/maintainer-only — none of which a
-                // CLI actor is — so group-restricted CLI cannot delete).
-                $secretGroups = $this->secretGroupsForPermission($secret, $permission);
-
-                return array_intersect($secretGroups, $cliAccessGroups) !== [];
-            }
-
-            // CLI allowed and no group restrictions: trusted operator gets
-            // the requested tier.
-            return true;
+            return $this->hasCliAccess($secret, $permission);
         }
 
         // Frontend access for secrets explicitly marked as frontend_accessible.
@@ -282,6 +286,71 @@ final class AccessControlService implements AccessControlServiceInterface
         }
 
         return $secret->isFrontendAccessible();
+    }
+
+    /**
+     * Check access for the trusted CLI operator (no authenticated backend
+     * user) against the CLI access configuration.
+     *
+     * @param self::PERMISSION_* $permission
+     */
+    private function hasCliAccess(Secret $secret, string $permission): bool
+    {
+        if (!$this->configuration->isCliAccessAllowed()) {
+            return false;
+        }
+
+        // Check CLI access groups if configured
+        $cliAccessGroups = $this->configuration->getCliAccessGroups();
+        if ($cliAccessGroups !== []) {
+            // The trusted CLI operator is scoped to the configured
+            // groups. The applicable secret-group set widens with the
+            // permission tier: read may match read- OR write-tier
+            // groups, write only write-tier groups, delete has no group
+            // tier at all (owner/admin/maintainer-only — none of which a
+            // CLI actor is — so group-restricted CLI cannot delete).
+            $secretGroups = $this->secretGroupsForPermission($secret, $permission);
+
+            return array_intersect($secretGroups, $cliAccessGroups) !== [];
+        }
+
+        // CLI allowed and no group restrictions: trusted operator gets
+        // the requested tier.
+        return true;
+    }
+
+    /**
+     * Detect the unauthenticated CommandLineUserAuthentication placeholder
+     * that the TYPO3 CLI bootstrap puts into $GLOBALS['BE_USER'] before any
+     * authentication happens (console commands, Symfony Messenger workers,
+     * scheduler runs). It carries no user record (uid), so no user-based
+     * access semantics can apply — CLI access rules must be used instead.
+     * Once authenticate() / Bootstrap::initializeBackendAuthentication() has
+     * loaded the `_cli_` user record, this returns false and the user-based
+     * semantics take over.
+     */
+    private function isUnauthenticatedCommandLineUser(?BackendUserAuthentication $backendUser): bool
+    {
+        if (!$backendUser instanceof CommandLineUserAuthentication) {
+            return false;
+        }
+
+        /** @phpstan-ignore property.internal */
+        $userRecord = $backendUser->user;
+        /** @var array<string, mixed> $userRecordTyped */
+        $userRecordTyped = \is_array($userRecord) ? $userRecord : [];
+        $uid = $userRecordTyped['uid'] ?? null;
+
+        if (\is_int($uid)) {
+            return $uid <= 0;
+        }
+
+        if (is_numeric($uid)) {
+            return (int) $uid <= 0;
+        }
+
+        // No usable uid at all: not authenticated.
+        return true;
     }
 
     /**

--- a/Tests/Unit/Security/AccessControlServiceTest.php
+++ b/Tests/Unit/Security/AccessControlServiceTest.php
@@ -647,6 +647,146 @@ final class AccessControlServiceTest extends TestCase
         );
     }
 
+    #[Test]
+    public function unauthenticatedCliUserFollowsCliAccessRulesWhenAllowed(): void
+    {
+        // BUG FIX verification (messenger-worker CLI access): the TYPO3 CLI
+        // bootstrap (CommandApplication::run() — console commands, Symfony
+        // Messenger workers, scheduler runs) sets BE_USER to a
+        // CommandLineUserAuthentication "not logged in yet" (user record
+        // null). That placeholder used to take the backend-user precedence
+        // branch in hasAccess(), where every check fails on the empty user
+        // record — shadowing the configured CLI access rules entirely.
+        // With CLI access allowed and no group restrictions, the trusted
+        // CLI operator gets every tier.
+        $this->configuration->method('isCliAccessAllowed')->willReturn(true);
+        $this->configuration->method('getCliAccessGroups')->willReturn([]);
+        $this->setUnauthenticatedCommandLineUser();
+        $secret = $this->createSecret(ownerUid: 42);
+
+        self::assertTrue($this->subject->canRead($secret), 'CLI access allowed: read granted');
+        self::assertTrue($this->subject->canWrite($secret), 'CLI access allowed: write granted');
+        self::assertTrue($this->subject->canDelete($secret), 'CLI access allowed: delete granted');
+    }
+
+    #[Test]
+    public function unauthenticatedCliUserIsDeniedWhenCliAccessDisabled(): void
+    {
+        $this->configuration->method('isCliAccessAllowed')->willReturn(false);
+        $this->setUnauthenticatedCommandLineUser();
+        $secret = $this->createSecret(ownerUid: 42);
+
+        self::assertFalse($this->subject->canRead($secret), 'CLI access off: read denied');
+        self::assertFalse($this->subject->canWrite($secret), 'CLI access off: write denied');
+        self::assertFalse($this->subject->canDelete($secret), 'CLI access off: delete denied');
+    }
+
+    #[Test]
+    public function unauthenticatedCliUserIsScopedToConfiguredCliAccessGroups(): void
+    {
+        // Group-scoped CLI access: read may match read- OR write-tier groups,
+        // write only write-tier groups, delete has no group tier at all.
+        $this->configuration->method('isCliAccessAllowed')->willReturn(true);
+        $this->configuration->method('getCliAccessGroups')->willReturn([5]);
+        $this->setUnauthenticatedCommandLineUser();
+
+        $inScope = $this->createSecret(ownerUid: 42, allowedGroups: [5]);
+        $outOfScope = $this->createSecret(ownerUid: 42, allowedGroups: [7]);
+        $writable = $this->createSecret(ownerUid: 42, writeGroups: [5]);
+
+        self::assertTrue($this->subject->canRead($inScope), 'read-tier group in CLI scope: read granted');
+        self::assertFalse($this->subject->canWrite($inScope), 'read-tier group only: write denied');
+        self::assertFalse($this->subject->canRead($outOfScope), 'group outside CLI scope: read denied');
+        self::assertTrue($this->subject->canWrite($writable), 'write-tier group in CLI scope: write granted');
+        self::assertFalse($this->subject->canDelete($writable), 'group-scoped CLI cannot delete');
+    }
+
+    #[Test]
+    public function unauthenticatedCliUserDoesNotOwnOwnerUidZeroSecrets(): void
+    {
+        // BUG FIX verification: the placeholder's missing user record used to
+        // default to uid 0 in the backend-user branch and MATCH ownerUid=0
+        // secrets via the owner check — granting full access (including
+        // delete) even with CLI access disabled. CLI rules apply instead.
+        $this->configuration->method('isCliAccessAllowed')->willReturn(false);
+        $this->setUnauthenticatedCommandLineUser();
+        $secret = $this->createSecret(ownerUid: 0);
+
+        self::assertFalse($this->subject->canRead($secret), 'ownerUid=0 must not grant read to placeholder');
+        self::assertFalse($this->subject->canWrite($secret), 'ownerUid=0 must not grant write to placeholder');
+        self::assertFalse($this->subject->canDelete($secret), 'ownerUid=0 must not grant delete to placeholder');
+    }
+
+    #[Test]
+    public function unauthenticatedCliUserCanCreateFollowsCliAccessConfig(): void
+    {
+        // BUG FIX verification: canCreate() used to treat the placeholder as
+        // an enabled backend user and returned true regardless of the CLI
+        // access configuration.
+        $this->configuration->method('isCliAccessAllowed')->willReturn(false);
+        $this->setUnauthenticatedCommandLineUser();
+
+        self::assertFalse($this->subject->canCreate(), 'CLI access off: create denied');
+    }
+
+    #[Test]
+    public function unauthenticatedCliUserCanCreateWhenCliAccessAllowed(): void
+    {
+        $this->configuration->method('isCliAccessAllowed')->willReturn(true);
+        $this->setUnauthenticatedCommandLineUser();
+
+        self::assertTrue($this->subject->canCreate(), 'CLI access on: create granted');
+    }
+
+    #[Test]
+    public function authenticatedCliUserKeepsUserBasedAccessSemantics(): void
+    {
+        // An AUTHENTICATED CLI user (after Bootstrap::initializeBackendAuthentication()
+        // loaded the `_cli_` record — an admin in TYPO3) keeps the user-based
+        // precedence: user semantics decide, the CLI access config does not
+        // apply. isCliAccessAllowed() must not even be consulted.
+        $this->configuration->expects(self::never())->method('isCliAccessAllowed');
+
+        $commandLineUser = $this->createMock(CommandLineUserAuthentication::class);
+        $commandLineUser->user = [
+            'uid' => 1,
+            'username' => '_cli_',
+            'disable' => 0,
+        ];
+        $commandLineUser->userGroupsUID = [];
+        $commandLineUser->method('isAdmin')->willReturn(true);
+        $GLOBALS['BE_USER'] = $commandLineUser;
+
+        $secret = $this->createSecret(ownerUid: 42);
+
+        self::assertTrue($this->subject->canRead($secret), 'authenticated _cli_ admin: read via user semantics');
+        self::assertTrue($this->subject->canDelete($secret), 'authenticated _cli_ admin: delete via user semantics');
+        self::assertTrue($this->subject->canCreate(), 'authenticated _cli_ admin: create via user semantics');
+    }
+
+    #[Test]
+    public function unauthenticatedCliUserIsClassifiedAsCliActor(): void
+    {
+        // Audit classification for the messenger-worker placeholder stays 'cli'.
+        $this->setUnauthenticatedCommandLineUser();
+
+        self::assertSame('cli', $this->subject->getCurrentActorType());
+    }
+
+    /**
+     * Set up a mock CLI backend user WITHOUT an authenticated user record, as
+     * present in Symfony Messenger workers and scheduler CLI runs: the TYPO3
+     * CLI bootstrap (CommandApplication::run() -> Bootstrap::initializeBackendUser())
+     * creates the BE_USER "not logged in yet" — `user` stays null unless a
+     * command calls Bootstrap::initializeBackendAuthentication().
+     */
+    private function setUnauthenticatedCommandLineUser(): void
+    {
+        $commandLineUser = $this->createMock(CommandLineUserAuthentication::class);
+        // Deliberately NO $commandLineUser->user assignment: stays null.
+        $GLOBALS['BE_USER'] = $commandLineUser;
+    }
+
     /**
      * Create a test Secret with specified properties.
      *


### PR DESCRIPTION
## Problem (confirmed by characterization tests before fixing)

TYPO3's CLI bootstrap (`CommandApplication`) puts an **unauthenticated** `CommandLineUserAuthentication` — "not logged in yet", no user record — into `$GLOBALS['BE_USER']` for console commands, Symfony Messenger workers and scheduler runs. `AccessControlService` treated it as a backend user, with two consequences:

1. **CLI access config unreachable from workers**: the backend-user precedence branch swallows the CLI branch, so `cliAccessAllowed`/`cliAccessGroups` never applied — every group/admin/maintainer check fails on the empty record. (This forced consumers like nr-ai-search into `BE_USER`-impersonation workarounds — see nr-llm ADR-052.)
2. **Permissive hole**: the placeholder's default uid `0` matched `ownerUid=0` secrets via the owner check → full read/delete on those secrets *even with CLI access disabled*, and `canCreate()` returned true ("not a disabled user").

## Fix

`hasAccess()` and `canCreate()` detect the unauthenticated placeholder (`CommandLineUserAuthentication` + no uid > 0) and route it to the CLI access rules **before** the backend-user precedence branch. The CLI-branch body is extracted verbatim into `hasCliAccess()` (shared with the unchanged no-BE_USER path).

- authenticated `_cli_` user (after `Bootstrap::initializeBackendAuthentication()`) → unchanged user-based semantics
- web requests → structurally unaffected (`CommandLineUserAuthentication` constructor throws outside CLI)

## Tests

3 characterization tests reproduced the broken behavior first; 8 regression tests pin the fixed matrix (cliAccessAllowed on/off × read/delete/create, group scoping, authenticated-CLI passthrough). unit+fuzz, phpstan L10, cgl, arch, doc-cli green locally; functional suite left to CI.

Maintainers may want to assess whether the uid-0/ownerUid-0 hole warrants an advisory; exploitation requires local CLI execution.

Design alternative recorded but not implemented: a first-class `TechnicalActorContext::runAs()` vault API (would remove consumers' `$GLOBALS['BE_USER']` mutation workarounds entirely) — follow-up issue.