### PR TITLE
feat(security): scoped TechnicalActorContext::runAs() for headless consumers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -126,6 +126,10 @@ EncryptionServiceInterface::calculateChecksum(string $plaintext): string
 // Master key — Classes/Crypto/MasterKeyProviderInterface.php
 MasterKeyProviderInterface::getMasterKey(): string
 
+// Technical actor (headless runAs) — Classes/Security/TechnicalActorContextInterface.php
+TechnicalActorContextInterface::runAs(int $beUserUid, callable $fn): mixed
+TechnicalActorContextInterface::getCurrentActor(): ?TechnicalActor
+
 // Audit logging — Classes/Audit/AuditLogServiceInterface.php
 AuditLogServiceInterface::log(
     string $secretIdentifier, string $action, bool $success,

--- a/Classes/Exception/TechnicalActorException.php
+++ b/Classes/Exception/TechnicalActorException.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Exception;
+
+/**
+ * Thrown when a technical-actor identity cannot be established.
+ *
+ * Every refusal is fail-closed: `TechnicalActorContext::runAs()` never
+ * executes the callable when the requested backend user cannot act as a
+ * valid, enabled identity.
+ */
+final class TechnicalActorException extends VaultException
+{
+    public static function invalidUid(int $beUserUid): self
+    {
+        return new self(
+            \sprintf('Technical actor uid must be a positive integer, got %d', $beUserUid),
+            1784000001,
+        );
+    }
+
+    public static function userNotFound(int $beUserUid): self
+    {
+        return new self(
+            \sprintf('Technical actor uid %d does not resolve to a non-deleted be_users record', $beUserUid),
+            1784000002,
+        );
+    }
+
+    public static function userDisabled(int $beUserUid): self
+    {
+        return new self(
+            \sprintf('Technical actor uid %d refers to a disabled be_users record', $beUserUid),
+            1784000003,
+        );
+    }
+
+    public static function userNotActive(int $beUserUid): self
+    {
+        return new self(
+            \sprintf('Technical actor uid %d refers to a be_users record outside its start/end time window', $beUserUid),
+            1784000004,
+        );
+    }
+}

--- a/Classes/Exception/TechnicalActorException.php
+++ b/Classes/Exception/TechnicalActorException.php
@@ -49,4 +49,12 @@ final class TechnicalActorException extends VaultException
             1784000004,
         );
     }
+
+    public static function userNotAtRootLevel(int $beUserUid): self
+    {
+        return new self(
+            \sprintf('Technical actor uid %d refers to a be_users record outside the root level (pid != 0)', $beUserUid),
+            1784000005,
+        );
+    }
 }

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -48,6 +48,7 @@ final class AccessControlService implements AccessControlServiceInterface
     public function __construct(
         private readonly ExtensionConfigurationInterface $configuration,
         private readonly ?ConnectionPool $connectionPool = null,
+        private readonly ?TechnicalActorContextInterface $technicalActorContext = null,
     ) {}
 
     public function canRead(Secret $secret): bool
@@ -67,6 +68,13 @@ final class AccessControlService implements AccessControlServiceInterface
 
     public function canCreate(): bool
     {
+        // An active technical actor was validated as a real, enabled backend
+        // user when its runAs() scope was established — same outcome as the
+        // authenticated-BE-user branch below (any enabled user can create).
+        if ($this->getTechnicalActor() instanceof TechnicalActor) {
+            return true;
+        }
+
         $backendUser = $this->getBackendUser();
 
         // An unauthenticated CommandLineUserAuthentication (messenger worker,
@@ -95,6 +103,11 @@ final class AccessControlService implements AccessControlServiceInterface
 
     public function isCurrentActorAdmin(): bool
     {
+        $technicalActor = $this->getTechnicalActor();
+        if ($technicalActor instanceof TechnicalActor) {
+            return $technicalActor->admin;
+        }
+
         $backendUser = $this->getBackendUser();
         if (!$backendUser instanceof BackendUserAuthentication) {
             return false;
@@ -108,6 +121,11 @@ final class AccessControlService implements AccessControlServiceInterface
 
     public function getCurrentActorUid(): int
     {
+        $technicalActor = $this->getTechnicalActor();
+        if ($technicalActor instanceof TechnicalActor) {
+            return $technicalActor->uid;
+        }
+
         $backendUser = $this->getBackendUser();
         if (!$backendUser instanceof BackendUserAuthentication) {
             return 0;
@@ -123,6 +141,13 @@ final class AccessControlService implements AccessControlServiceInterface
 
     public function getCurrentActorType(): string
     {
+        // The technical actor supersedes even CLI detection: a runAs() scope
+        // typically runs INSIDE a CLI worker, and the audit log must record
+        // the named technical identity — not the anonymous CLI operator.
+        if ($this->getTechnicalActor() instanceof TechnicalActor) {
+            return 'technical';
+        }
+
         // CLI detection must run BEFORE the backend-user check: the TYPO3 CLI
         // bootstrap (console commands, messenger workers) sets
         // $GLOBALS['BE_USER'] to a CommandLineUserAuthentication instance —
@@ -154,6 +179,11 @@ final class AccessControlService implements AccessControlServiceInterface
 
     public function getCurrentActorUsername(): string
     {
+        $technicalActor = $this->getTechnicalActor();
+        if ($technicalActor instanceof TechnicalActor) {
+            return $technicalActor->username;
+        }
+
         $backendUser = $this->getBackendUser();
         if ($backendUser instanceof BackendUserAuthentication) {
             /** @phpstan-ignore property.internal */
@@ -174,6 +204,11 @@ final class AccessControlService implements AccessControlServiceInterface
 
     public function getCurrentUserGroups(): array
     {
+        $technicalActor = $this->getTechnicalActor();
+        if ($technicalActor instanceof TechnicalActor) {
+            return $technicalActor->groupIds;
+        }
+
         $backendUser = $this->getBackendUser();
         if (!$backendUser instanceof BackendUserAuthentication) {
             return [];
@@ -248,6 +283,17 @@ final class AccessControlService implements AccessControlServiceInterface
      */
     private function hasAccess(Secret $secret, string $permission): bool
     {
+        // An active TechnicalActorContext::runAs() scope supersedes every
+        // ambient branch below (the unauthenticated CLI placeholder, a
+        // hypothetical $GLOBALS['BE_USER'], the frontend fallback): the
+        // caller explicitly asked to be evaluated as that named backend
+        // user. Without an active scope this is a no-op and the ambient
+        // behaviour is unchanged.
+        $technicalActor = $this->getTechnicalActor();
+        if ($technicalActor instanceof TechnicalActor) {
+            return $this->hasTechnicalActorAccess($technicalActor, $secret, $permission);
+        }
+
         $backendUser = $this->getBackendUser();
 
         // An UNAUTHENTICATED CommandLineUserAuthentication must not take the
@@ -351,6 +397,51 @@ final class AccessControlService implements AccessControlServiceInterface
 
         // No usable uid at all: not authenticated.
         return true;
+    }
+
+    /**
+     * Check access for a validated technical actor — the SAME user-based
+     * semantics an authenticated backend user gets in
+     * `hasBackendUserAccess()`, evaluated against the actor's snapshot:
+     *
+     * - admin → full access to every tier (this also covers the system
+     *   maintainer, because `isSystemMaintainer()` implies the admin flag);
+     * - owner → full access to every tier;
+     * - group tier per ADR-005, with the same stale-group filtering.
+     *
+     * No disabled-user re-check: `TechnicalActorContext::runAs()` refuses
+     * deleted/disabled/time-restricted users before the scope starts.
+     *
+     * @param self::PERMISSION_* $permission
+     */
+    private function hasTechnicalActorAccess(
+        TechnicalActor $actor,
+        Secret $secret,
+        string $permission,
+    ): bool {
+        if ($actor->admin) {
+            return true;
+        }
+
+        if ($secret->getOwnerUid() === $actor->uid) {
+            return true;
+        }
+
+        $secretGroups = $this->secretGroupsForPermission($secret, $permission);
+        if ($secretGroups !== []) {
+            $userGroups = $this->filterExistingGroupIds($actor->groupIds);
+
+            if (array_intersect($secretGroups, $userGroups) !== []) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function getTechnicalActor(): ?TechnicalActor
+    {
+        return $this->technicalActorContext?->getCurrentActor();
     }
 
     /**

--- a/Classes/Security/AccessControlServiceInterface.php
+++ b/Classes/Security/AccessControlServiceInterface.php
@@ -69,7 +69,11 @@ interface AccessControlServiceInterface
     /**
      * Get the current actor type.
      *
-     * @return string One of: 'backend', 'cli', 'api', 'scheduler'
+     * 'technical' marks an active `TechnicalActorContext::runAs()` scope
+     * and supersedes all ambient detection — the audit log records the
+     * named technical identity, not the CLI operator it runs under.
+     *
+     * @return string One of: 'backend', 'cli', 'api', 'scheduler', 'technical'
      */
     public function getCurrentActorType(): string;
 

--- a/Classes/Security/TechnicalActor.php
+++ b/Classes/Security/TechnicalActor.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Security;
+
+/**
+ * Immutable snapshot of a validated technical-actor identity.
+ *
+ * Built exclusively by `TechnicalActorContext` from a real, enabled,
+ * non-deleted `be_users` record; consumers (notably `AccessControlService`)
+ * treat it as equivalent to an authenticated backend user for the duration
+ * of a `runAs()` scope.
+ */
+final readonly class TechnicalActor
+{
+    /**
+     * @param positive-int $uid be_users uid the actor acts as
+     * @param string $username be_users username (audit attribution)
+     * @param bool $admin be_users admin flag
+     * @param list<int> $groupIds resolved be_groups uids (incl. subgroups)
+     */
+    public function __construct(
+        public int $uid,
+        public string $username,
+        public bool $admin,
+        public array $groupIds,
+    ) {}
+}

--- a/Classes/Security/TechnicalActorContext.php
+++ b/Classes/Security/TechnicalActorContext.php
@@ -1,0 +1,179 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Security;
+
+use Netresearch\NrVault\Exception\TechnicalActorException;
+use TYPO3\CMS\Core\Authentication\GroupResolver;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Technical actor context implementation.
+ *
+ * State is a plain per-service-instance stack: with TYPO3's shared DI
+ * services that means per-request (web) or per-process (CLI worker).
+ * Scopes are strictly LIFO via try/finally; the stack is NOT keyed per
+ * fiber — concurrent fibers sharing one instance would observe each
+ * other's actor, so `runAs()` scopes must not span fiber suspension
+ * points.
+ */
+final class TechnicalActorContext implements TechnicalActorContextInterface
+{
+    /** @var list<TechnicalActor> */
+    private array $actorStack = [];
+
+    public function __construct(
+        private readonly ConnectionPool $connectionPool,
+        // GroupResolver is what BackendUserAuthentication::fetchGroupData()
+        // itself uses; no non-internal API reproduces core's group semantics.
+        // @phpstan-ignore parameter.internalClass, property.internalClass
+        private readonly GroupResolver $groupResolver,
+    ) {}
+
+    public function runAs(int $beUserUid, callable $fn): mixed
+    {
+        $actor = $this->resolveActor($beUserUid);
+
+        $this->actorStack[] = $actor;
+
+        try {
+            return $fn();
+        } finally {
+            array_pop($this->actorStack);
+        }
+    }
+
+    public function getCurrentActor(): ?TechnicalActor
+    {
+        return $this->actorStack === [] ? null : $this->actorStack[array_key_last($this->actorStack)];
+    }
+
+    /**
+     * Load and validate the be_users record for the requested actor.
+     *
+     * Mirrors the enable-column semantics of a real backend login
+     * (`deleted`, `disable`, `starttime`, `endtime`): a user who could not
+     * authenticate interactively must not be usable as a technical actor
+     * either. Fail-closed — every rejection throws before the caller's
+     * callable runs.
+     *
+     * @param positive-int $beUserUid
+     *
+     * @throws TechnicalActorException
+     */
+    private function resolveActor(int $beUserUid): TechnicalActor
+    {
+        if ($beUserUid <= 0) {
+            throw TechnicalActorException::invalidUid($beUserUid);
+        }
+
+        $record = $this->loadUserRecord($beUserUid);
+        if ($record === null) {
+            throw TechnicalActorException::userNotFound($beUserUid);
+        }
+
+        if ($this->toInt($record['disable'] ?? 0) !== 0) {
+            throw TechnicalActorException::userDisabled($beUserUid);
+        }
+
+        $now = time();
+        $starttime = $this->toInt($record['starttime'] ?? 0);
+        $endtime = $this->toInt($record['endtime'] ?? 0);
+        if ($starttime > $now || ($endtime !== 0 && $endtime <= $now)) {
+            throw TechnicalActorException::userNotActive($beUserUid);
+        }
+
+        $username = $record['username'] ?? '';
+
+        return new TechnicalActor(
+            uid: $beUserUid,
+            username: \is_string($username) ? $username : '',
+            admin: $this->toInt($record['admin'] ?? 0) !== 0,
+            groupIds: $this->resolveGroupIds($record),
+        );
+    }
+
+    /**
+     * Fetch the raw, non-deleted be_users row.
+     *
+     * Restrictions are removed deliberately: the enable columns are
+     * evaluated explicitly in `resolveActor()` so each rejection carries a
+     * distinct, typed exception instead of a generic "not found".
+     *
+     * @return array<string, mixed>|null
+     */
+    private function loadUserRecord(int $beUserUid): ?array
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable('be_users');
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $row = $queryBuilder
+            ->select('*')
+            ->from('be_users')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'uid',
+                    $queryBuilder->createNamedParameter($beUserUid, Connection::PARAM_INT),
+                ),
+                $queryBuilder->expr()->eq(
+                    'deleted',
+                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT),
+                ),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if (!\is_array($row)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $row */
+        return $row;
+    }
+
+    /**
+     * Resolve the actor's be_groups uids exactly as a real backend login
+     * would (subgroup expansion, enable-column filtering, PSR-14
+     * AfterGroupsResolvedEvent).
+     *
+     * @param array<string, mixed> $userRecord
+     *
+     * @return list<int>
+     */
+    private function resolveGroupIds(array $userRecord): array
+    {
+        // GroupResolver is what BackendUserAuthentication::fetchGroupData()
+        // itself uses; there is no non-internal API that reproduces core's
+        // group semantics (subgroup recursion + restrictions + event).
+        // @phpstan-ignore method.internalClass (no non-internal alternative exists)
+        $groups = $this->groupResolver->resolveGroupsForUser($userRecord, 'be_groups');
+
+        $groupIds = [];
+        foreach ($groups as $group) {
+            $uid = \is_array($group) ? ($group['uid'] ?? null) : null;
+            if (\is_int($uid)) {
+                $groupIds[] = $uid;
+            } elseif (is_numeric($uid)) {
+                $groupIds[] = (int) $uid;
+            }
+        }
+
+        return $groupIds;
+    }
+
+    private function toInt(mixed $value): int
+    {
+        if (\is_int($value)) {
+            return $value;
+        }
+
+        return is_numeric($value) ? (int) $value : 0;
+    }
+}

--- a/Classes/Security/TechnicalActorContext.php
+++ b/Classes/Security/TechnicalActorContext.php
@@ -59,10 +59,11 @@ final class TechnicalActorContext implements TechnicalActorContextInterface
      * Load and validate the be_users record for the requested actor.
      *
      * Mirrors the enable-column semantics of a real backend login
-     * (`deleted`, `disable`, `starttime`, `endtime`): a user who could not
-     * authenticate interactively must not be usable as a technical actor
-     * either. Fail-closed — every rejection throws before the caller's
-     * callable runs.
+     * (`deleted`, `disable`, `starttime`, `endtime`) plus its rootLevel
+     * restriction (`pid` = 0): a user who could not authenticate
+     * interactively must not be usable as a technical actor either.
+     * Fail-closed — every rejection throws before the caller's callable
+     * runs.
      *
      * @param positive-int $beUserUid
      *
@@ -77,6 +78,10 @@ final class TechnicalActorContext implements TechnicalActorContextInterface
         $record = $this->loadUserRecord($beUserUid);
         if ($record === null) {
             throw TechnicalActorException::userNotFound($beUserUid);
+        }
+
+        if ($this->toInt($record['pid'] ?? 0) !== 0) {
+            throw TechnicalActorException::userNotAtRootLevel($beUserUid);
         }
 
         if ($this->toInt($record['disable'] ?? 0) !== 0) {

--- a/Classes/Security/TechnicalActorContextInterface.php
+++ b/Classes/Security/TechnicalActorContextInterface.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Security;
+
+use Netresearch\NrVault\Exception\TechnicalActorException;
+
+/**
+ * Scoped technical-actor identity for headless vault consumers.
+ *
+ * Messenger workers, scheduler runs, and CLI jobs that need vault-gated
+ * secrets under a NAMED backend-user identity (per-consumer audit
+ * attribution, group-scoped vault ACL) call `runAs()` instead of mutating
+ * `$GLOBALS['BE_USER']`. `AccessControlService` consults the active actor
+ * directly — before its BE_USER/CLI branches — so the ambient global is
+ * never touched and no privileged identity can leak past the scope.
+ *
+ * Trust model: `runAs()` is NOT an authentication mechanism. Any PHP code
+ * with access to this service can act as any enabled backend user — the
+ * same power `$GLOBALS['BE_USER']` mutation already grants every
+ * extension. The value of the API is scoping (identity always restored,
+ * even on exceptions), validation (deleted/disabled/time-restricted users
+ * are refused), and audit attribution (`actor_type` = `technical`).
+ */
+interface TechnicalActorContextInterface
+{
+    /**
+     * Run `$fn` while vault access checks evaluate as backend user `$beUserUid`.
+     *
+     * The user record is loaded and validated on entry; the callable never
+     * runs when validation fails. Nested calls stack: the innermost actor
+     * wins, and each scope restores the previous actor on exit — including
+     * when `$fn` throws.
+     *
+     * @template T
+     *
+     * @param positive-int $beUserUid be_users uid to act as
+     * @param callable(): T $fn
+     *
+     * @throws TechnicalActorException if `$beUserUid` is not positive, or the
+     *                                 record is missing/deleted, disabled, or
+     *                                 outside its start/end time window
+     *
+     * @return T
+     */
+    public function runAs(int $beUserUid, callable $fn): mixed;
+
+    /**
+     * The innermost active technical actor, or null outside any `runAs()` scope.
+     */
+    public function getCurrentActor(): ?TechnicalActor;
+}

--- a/Classes/Security/TechnicalActorContextInterface.php
+++ b/Classes/Security/TechnicalActorContextInterface.php
@@ -25,8 +25,9 @@ use Netresearch\NrVault\Exception\TechnicalActorException;
  * with access to this service can act as any enabled backend user — the
  * same power `$GLOBALS['BE_USER']` mutation already grants every
  * extension. The value of the API is scoping (identity always restored,
- * even on exceptions), validation (deleted/disabled/time-restricted users
- * are refused), and audit attribution (`actor_type` = `technical`).
+ * even on exceptions), validation (deleted/disabled/time-restricted/
+ * off-root users are refused), and audit attribution
+ * (`actor_type` = `technical`).
  */
 interface TechnicalActorContextInterface
 {
@@ -44,8 +45,9 @@ interface TechnicalActorContextInterface
      * @param callable(): T $fn
      *
      * @throws TechnicalActorException if `$beUserUid` is not positive, or the
-     *                                 record is missing/deleted, disabled, or
-     *                                 outside its start/end time window
+     *                                 record is missing/deleted, disabled,
+     *                                 outside its start/end time window, or
+     *                                 not at root level (`pid` != 0)
      *
      * @return T
      */

--- a/Classes/Service/Analytics/VaultAnalyticsService.php
+++ b/Classes/Service/Analytics/VaultAnalyticsService.php
@@ -28,7 +28,7 @@ final class VaultAnalyticsService implements VaultAnalyticsServiceInterface
     private const AUDIT_TABLE = 'tx_nrvault_audit_log';
 
     /** actor_type values that count as automated (machine) reads. */
-    private const AUTOMATED_ACTORS = ['cli', 'api', 'scheduler'];
+    private const AUTOMATED_ACTORS = ['cli', 'api', 'scheduler', 'technical'];
 
     /**
      * Request-scoped memo of the audit read-split, keyed by windowStart, so the

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -10,6 +10,7 @@ services:
       - '../Classes/Domain/Model/*'
       - '../Classes/Exception/*'
       - '../Classes/Http/OAuth/OAuthConfig.php'
+      - '../Classes/Security/TechnicalActor.php'
 
   # ----- Interface aliases -------------------------------------------------
   # Symfony's `autoconfigure` auto-aliases an interface to its single
@@ -45,6 +46,9 @@ services:
 
   Netresearch\NrVault\Security\AccessControlServiceInterface:
     alias: Netresearch\NrVault\Security\AccessControlService
+
+  Netresearch\NrVault\Security\TechnicalActorContextInterface:
+    alias: Netresearch\NrVault\Security\TechnicalActorContext
 
   Netresearch\NrVault\Audit\AuditLogServiceInterface:
     alias: Netresearch\NrVault\Audit\AuditLogService

--- a/Documentation/Developer/Adr/ADR-029-TechnicalActorContext.rst
+++ b/Documentation/Developer/Adr/ADR-029-TechnicalActorContext.rst
@@ -1,0 +1,93 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-029-technical-actor-context:
+
+=========================================================
+ADR-029: Scoped technical-actor identity for headless use
+=========================================================
+
+.. contents:: Table of contents
+   :local:
+   :depth: 2
+
+Status
+======
+
+Accepted
+
+Date
+====
+
+2026-07-17
+
+Context
+=======
+
+Headless consumers — Symfony Messenger workers, scheduler runs, CLI jobs —
+need vault-gated secrets under a **named** technical backend user:
+per-consumer audit attribution, group-scoped vault ACL, per-user budget
+windows in downstream extensions.
+The global CLI access configuration (``allowCliAccess`` +
+``cliAccessGroups``) is an all-or-nothing trusted-operator switch; it
+cannot express "this worker acts as technical user X".
+
+Because ``AccessControlService`` read only ``$GLOBALS['BE_USER']``,
+consumers worked around this by mutating the global themselves for the
+duration of a call (nr_ai_search ``BackendUserContext::runAs()``; nr_llm
+ADR-052 documents the same pattern as a workaround).
+That mutation is a footgun:
+
+-  a temporarily privileged identity is visible to **all** code sharing
+   the PHP process while the scope is open — from a shared frontend
+   request that is exploitable;
+-  every consumer re-implements hydration via ``@internal`` core APIs
+   (``setBeUserByUid()``, raw ``->user`` reads);
+-  restoration discipline (``finally``) is copied per consumer instead of
+   guaranteed centrally.
+
+Decision
+========
+
+Vault owns the impersonation seam:
+``Netresearch\NrVault\Security\TechnicalActorContext::runAs(int $beUserUid, callable $fn): mixed``.
+
+-  ``runAs()`` loads the ``be_users`` record itself (Doctrine
+   QueryBuilder), refuses ``uid <= 0`` and deleted, disabled, or
+   start/endtime-restricted users with typed
+   ``TechnicalActorException`` codes, resolves groups through core's
+   ``GroupResolver`` (the same resolution a real login gets, including
+   subgroup expansion), and snapshots the result into an immutable
+   ``TechnicalActor`` value object.
+-  The actor lives on a per-service-instance **stack**; nested ``runAs()``
+   calls stack cleanly with the innermost actor winning, and every scope
+   is popped in ``finally`` — the identity cannot leak past the scope,
+   including on exceptions.
+-  ``AccessControlService`` consults the active technical actor **before**
+   its BE_USER/CLI branches and evaluates it with the same user-based
+   semantics an authenticated backend user gets: admin override, owner
+   check, ADR-005 group tiers with stale-group filtering.
+   ``$GLOBALS['BE_USER']`` is never touched.
+-  Without an active scope every check falls through unchanged — ambient
+   web/CLI behaviour is bit-identical (guarded by characterization
+   tests).
+-  The audit log records the technical actor as such:
+   ``actor_type = 'technical'`` plus the actor's uid and username, sealed
+   into the HMAC chain like every other attribution field (epoch 3,
+   ADR-024).
+
+Consequences
+============
+
+-  Consumers replace their ``$GLOBALS['BE_USER']`` mutation with a single
+   ``TechnicalActorContextInterface::runAs()`` call; the ``@internal``
+   core API reads live in one reviewed place inside vault.
+-  ``runAs()`` is **not** authentication: any PHP code with DI access can
+   act as any enabled backend user — the same power global mutation
+   already grants every extension.
+   The API adds validation, scoping, and honest audit attribution, not a
+   new privilege boundary.
+-  The audit ``actor_type`` vocabulary grows by ``'technical'``;
+   analytics count it as an automated actor.
+-  The technical actor's group snapshot is taken at scope entry; group
+   changes during a long-running scope are not observed (same as a real
+   BE session).

--- a/Documentation/Developer/Adr/Index.rst
+++ b/Documentation/Developer/Adr/Index.rst
@@ -53,6 +53,7 @@ ADR      Title                                       Status
 026      :ref:`adr-026-dns-rebinding-defence`        Accepted
 027      :ref:`adr-027-oauth-client-unification`     Accepted
 028      :ref:`adr-028-phpat-http-client-lock`       Accepted
+029      :ref:`adr-029-technical-actor-context`      Accepted
 =======  ==========================================  ========
 
 .. toctree::
@@ -87,3 +88,4 @@ ADR      Title                                       Status
    ADR-026-DnsRebindingDefence
    ADR-027-OAuthClientUnification
    ADR-028-PhpatHttpClientLock
+   ADR-029-TechnicalActorContext

--- a/Documentation/Developer/Index.rst
+++ b/Documentation/Developer/Index.rst
@@ -13,6 +13,7 @@ Developer
    Commands
    TcaIntegration
    SecureOutbound
+   TechnicalActorContext
    Adr/Index
 
 .. _developer-architecture:

--- a/Documentation/Developer/TechnicalActorContext.rst
+++ b/Documentation/Developer/TechnicalActorContext.rst
@@ -60,6 +60,7 @@ Code         Refusal
 1784000002   no non-deleted ``be_users`` record with that uid
 1784000003   the user record is disabled
 1784000004   the user is outside its start/end time window
+1784000005   the user record is not at root level (``pid`` != 0)
 ===========  ==================================================
 
 The identity is **always** restored on scope exit — including when the

--- a/Documentation/Developer/TechnicalActorContext.rst
+++ b/Documentation/Developer/TechnicalActorContext.rst
@@ -1,0 +1,128 @@
+.. include:: /Includes.rst.txt
+
+.. _developer-technical-actor-context:
+
+=======================
+Technical actor context
+=======================
+
+Headless consumers — Symfony Messenger workers, scheduler runs, CLI
+jobs — often need vault-gated secrets under a **named** technical
+backend user: per-consumer audit attribution and group-scoped vault
+ACL instead of the all-or-nothing CLI access switch.
+
+:php:`Netresearch\NrVault\Security\TechnicalActorContextInterface`
+provides that as a scoped API (see
+:ref:`adr-029-technical-actor-context`):
+
+.. code-block:: php
+   :caption: EXT:my_extension/Classes/MessageHandler/IngestHandler.php
+
+   use Netresearch\NrVault\Security\TechnicalActorContextInterface;
+   use Netresearch\NrVault\Service\VaultServiceInterface;
+
+   final readonly class IngestHandler
+   {
+       public function __construct(
+           private TechnicalActorContextInterface $technicalActorContext,
+           private VaultServiceInterface $vaultService,
+       ) {}
+
+       public function __invoke(IngestMessage $message): void
+       {
+           $apiKey = $this->technicalActorContext->runAs(
+               $this->technicalBeUserUid,
+               fn (): ?string => $this->vaultService->retrieve('my_ext/embeddings_api_key'),
+           );
+           // ...
+       }
+   }
+
+Semantics
+=========
+
+While the callable runs, vault access checks evaluate as the given
+backend user with the same user-based semantics a real authenticated
+BE user gets: admin override, owner check, and the :ref:`ADR-005
+group tiers <adr-005-access-control>` (including stale-group
+filtering).
+Groups are resolved exactly like a real login, including subgroup
+expansion.
+
+Validation is fail-closed and happens **before** the callable runs.
+:php:`runAs()` throws a typed
+:php:`Netresearch\NrVault\Exception\TechnicalActorException` for:
+
+===========  ==================================================
+Code         Refusal
+===========  ==================================================
+1784000001   uid is not a positive integer
+1784000002   no non-deleted ``be_users`` record with that uid
+1784000003   the user record is disabled
+1784000004   the user is outside its start/end time window
+===========  ==================================================
+
+The identity is **always** restored on scope exit — including when the
+callable throws.
+Nested :php:`runAs()` calls stack; the innermost actor wins and each
+scope restores the previous one.
+
+The audit log records the scope honestly: entries written inside
+:php:`runAs()` carry the actor's uid and username with
+``actor_type = 'technical'``, sealed into the tamper-evident HMAC
+chain like every other attribution field.
+
+.. note::
+
+   :php:`runAs()` is **not** an authentication mechanism.
+   Any PHP code with DI access can act as any enabled backend user —
+   the same power that ``$GLOBALS['BE_USER']`` mutation already grants
+   every extension.
+   The API adds validation, guaranteed restoration, and honest audit
+   attribution; it does not add a privilege boundary.
+
+.. _developer-technical-actor-context-migration:
+
+Migrating from ``$GLOBALS['BE_USER']`` mutation
+===============================================
+
+Before this API, consumers impersonated a technical user by hydrating a
+:php:`BackendUserAuthentication` via the ``@internal``
+:php:`setBeUserByUid()` and swapping it into ``$GLOBALS['BE_USER']``
+(restoring it in a ``finally``) so that vault's access control — which
+read only that global — would see the identity:
+
+.. code-block:: php
+   :caption: Legacy consumer workaround (do not copy)
+
+   $backendUser = new BackendUserAuthentication();
+   $backendUser->setBeUserByUid($technicalBeUserUid); // @internal API
+
+   $previous = $GLOBALS['BE_USER'] ?? null;
+   $GLOBALS['BE_USER'] = $backendUser; // visible to ALL code in this process
+   try {
+       $result = $callback();
+   } finally {
+       $GLOBALS['BE_USER'] = $previous;
+   }
+
+That pattern is unsafe in any PHP process shared with a live visitor
+request: while the scope is open, **all** code in the process observes
+a fully privileged backend-user identity.
+It also spreads ``@internal`` core API usage across every consumer.
+
+Migration is mechanical:
+
+#. Inject :php:`TechnicalActorContextInterface` instead of constructing
+   :php:`BackendUserAuthentication` yourself.
+#. Replace the global swap with
+   :php:`$context->runAs($technicalBeUserUid, $callback)`.
+#. Drop any ``Context`` aspect swap done *solely* for vault — vault
+   never reads the ``backend.user`` aspect.
+   Keep it only if other collaborators in the callback need the aspect.
+#. Remove the record-validation code — :php:`runAs()` refuses missing,
+   deleted, disabled, and time-restricted users itself.
+
+``$GLOBALS['BE_USER']`` is never touched by :php:`runAs()`; an ambient
+backend user (or the CLI placeholder a messenger worker runs under)
+stays untouched and regains effect the moment the scope ends.

--- a/Documentation/Security/Index.rst
+++ b/Documentation/Security/Index.rst
@@ -196,6 +196,33 @@ Secret access is controlled at multiple levels:
    CLI access requires explicit configuration and can be restricted
    to specific groups.
 
+Technical actors
+----------------
+
+Headless code (messenger workers, scheduler runs) can act as a named
+technical backend user through the scoped
+:ref:`TechnicalActorContext::runAs() API
+<developer-technical-actor-context>` instead of the global CLI switch.
+
+Threat-model notes:
+
+-  ``runAs()`` is **not** an authentication boundary: any PHP code with
+   DI access can act as any enabled backend user — the same power that
+   ``$GLOBALS['BE_USER']`` mutation already grants every installed
+   extension.
+   Its security value is validation (deleted/disabled/time-restricted
+   users are refused), guaranteed scope restoration (also on
+   exceptions), and honest audit attribution.
+-  ``$GLOBALS['BE_USER']`` is never mutated, so a technical identity
+   cannot leak into other code sharing the PHP process.
+-  Audit entries written inside a scope carry ``actor_type =
+   'technical'`` plus the actor's uid and username, sealed into the
+   HMAC hash chain — impersonation is always attributable and
+   tamper-evident.
+-  Restrict the technical user like any backend account: no admin flag
+   unless required, minimal group membership, and monitor its
+   ``access_denied`` events.
+
 .. _security-best-practices:
 
 Security best practices

--- a/Tests/Functional/Security/Fixtures/technical_actors.csv
+++ b/Tests/Functional/Security/Fixtures/technical_actors.csv
@@ -2,6 +2,7 @@
 ,"uid","pid","tstamp","username","password","admin","disable","usergroup"
 ,10,0,1700000000,"tech_indexer","",0,0,"6"
 ,11,0,1700000000,"tech_disabled","",0,1,""
+,12,5,1700000000,"tech_offroot","",0,0,""
 "be_groups",,,,,
 ,"uid","pid","tstamp","title","subgroup"
 ,5,0,1700000000,"vault-readers",""

--- a/Tests/Functional/Security/Fixtures/technical_actors.csv
+++ b/Tests/Functional/Security/Fixtures/technical_actors.csv
@@ -1,0 +1,8 @@
+"be_users",,,,,,,,
+,"uid","pid","tstamp","username","password","admin","disable","usergroup"
+,10,0,1700000000,"tech_indexer","",0,0,"6"
+,11,0,1700000000,"tech_disabled","",0,1,""
+"be_groups",,,,,
+,"uid","pid","tstamp","title","subgroup"
+,5,0,1700000000,"vault-readers",""
+,6,0,1700000000,"indexers","5"

--- a/Tests/Functional/Security/TechnicalActorContextTest.php
+++ b/Tests/Functional/Security/TechnicalActorContextTest.php
@@ -27,7 +27,8 @@ use PHPUnit\Framework\Attributes\Test;
  * uses core semantics including subgroup expansion.
  *
  * Fixture: be_users 10 `tech_indexer` (usergroup 6), 11 `tech_disabled`
- * (disabled); be_groups 6 `indexers` with subgroup 5 `vault-readers`.
+ * (disabled), 12 `tech_offroot` (pid 5); be_groups 6 `indexers` with
+ * subgroup 5 `vault-readers`.
  */
 #[CoversClass(TechnicalActorContext::class)]
 final class TechnicalActorContextTest extends AbstractVaultFunctionalTestCase
@@ -83,6 +84,17 @@ final class TechnicalActorContextTest extends AbstractVaultFunctionalTestCase
         $this->expectExceptionCode(1784000003);
 
         $context->runAs(11, static fn (): bool => true);
+    }
+
+    #[Test]
+    public function runAsRefusesUserOutsideRootLevel(): void
+    {
+        $context = $this->get(TechnicalActorContextInterface::class);
+
+        $this->expectException(TechnicalActorException::class);
+        $this->expectExceptionCode(1784000005);
+
+        $context->runAs(12, static fn (): bool => true);
     }
 
     #[Test]

--- a/Tests/Functional/Security/TechnicalActorContextTest.php
+++ b/Tests/Functional/Security/TechnicalActorContextTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Security;
+
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Domain\Model\Secret;
+use Netresearch\NrVault\Exception\TechnicalActorException;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\TechnicalActorContext;
+use Netresearch\NrVault\Security\TechnicalActorContextInterface;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * End-to-end coverage of the technical-actor scope against the real DI
+ * container and database: proves the container actually injects the shared
+ * TechnicalActorContext into AccessControlService (the optional constructor
+ * argument must be autowired, not silently null) and that group resolution
+ * uses core semantics including subgroup expansion.
+ *
+ * Fixture: be_users 10 `tech_indexer` (usergroup 6), 11 `tech_disabled`
+ * (disabled); be_groups 6 `indexers` with subgroup 5 `vault-readers`.
+ */
+#[CoversClass(TechnicalActorContext::class)]
+final class TechnicalActorContextTest extends AbstractVaultFunctionalTestCase
+{
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/technical_actors.csv';
+
+    /** No ambient backend user: headless-worker reality. */
+    protected ?int $backendUserUid = null;
+
+    #[Test]
+    public function runAsGrantsOwnerAccessOnlyInsideTheScope(): void
+    {
+        $accessControl = $this->get(AccessControlServiceInterface::class);
+        $context = $this->get(TechnicalActorContextInterface::class);
+
+        $secret = new Secret(identifier: 'tech/owned', ownerUid: 10);
+
+        self::assertFalse($accessControl->canRead($secret), 'no ambient actor: denied');
+
+        $granted = $context->runAs(10, static fn (): bool => $accessControl->canRead($secret));
+        self::assertTrue($granted, 'owner semantics inside runAs()');
+
+        self::assertFalse($accessControl->canRead($secret), 'scope exit restores denial');
+    }
+
+    #[Test]
+    public function runAsResolvesGroupAclIncludingSubgroupExpansion(): void
+    {
+        $accessControl = $this->get(AccessControlServiceInterface::class);
+        $context = $this->get(TechnicalActorContextInterface::class);
+
+        // Readable via group 5, which user 10 only reaches through the
+        // subgroup relation of its direct group 6.
+        $secret = new Secret(identifier: 'tech/group-read', ownerUid: 999, allowedGroups: [5]);
+
+        $decisions = $context->runAs(10, static fn (): array => [
+            'read' => $accessControl->canRead($secret),
+            'write' => $accessControl->canWrite($secret),
+            'delete' => $accessControl->canDelete($secret),
+        ]);
+
+        self::assertTrue($decisions['read'], 'read-tier group via subgroup');
+        self::assertFalse($decisions['write'], 'read-tier group must not write');
+        self::assertFalse($decisions['delete'], 'group members never delete');
+    }
+
+    #[Test]
+    public function runAsRefusesDisabledUser(): void
+    {
+        $context = $this->get(TechnicalActorContextInterface::class);
+
+        $this->expectException(TechnicalActorException::class);
+        $this->expectExceptionCode(1784000003);
+
+        $context->runAs(11, static fn (): bool => true);
+    }
+
+    #[Test]
+    public function auditLogRecordsTheTechnicalActorAsSuch(): void
+    {
+        $context = $this->get(TechnicalActorContextInterface::class);
+        $auditLog = $this->get(AuditLogServiceInterface::class);
+
+        $context->runAs(10, static function () use ($auditLog): void {
+            $auditLog->log('tech/audited', 'read', true);
+        });
+
+        $entries = $auditLog->query();
+        self::assertNotSame([], $entries);
+
+        $entry = $entries[0];
+        self::assertSame('tech/audited', $entry->secretIdentifier);
+        self::assertSame(10, $entry->actorUid);
+        self::assertSame('technical', $entry->actorType);
+        self::assertSame('tech_indexer', $entry->actorUsername);
+    }
+}

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -122,6 +122,45 @@ final class AuditLogServiceTest extends TestCase
     }
 
     #[Test]
+    public function logRecordsTechnicalActorAttributionAsReportedByAccessControl(): void
+    {
+        // Inside a TechnicalActorContext::runAs() scope AccessControlService
+        // reports the named technical identity; the audit row must seal it
+        // (actor_type 'technical' marks the scope) instead of the ambient
+        // CLI/backend attribution.
+        $this->setupDatabaseMocks();
+
+        $accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        $accessControlService->method('getCurrentActorUid')->willReturn(42);
+        $accessControlService->method('getCurrentActorType')->willReturn('technical');
+        $accessControlService->method('getCurrentActorUsername')->willReturn('tech_indexer');
+        $accessControlService->method('getCurrentUserGroups')->willReturn([5]);
+
+        self::assertNotNull($this->connectionPool);
+        self::assertNotNull($this->masterKeyProvider);
+        self::assertNotNull($this->extensionConfiguration);
+        $subject = new AuditLogService(
+            $this->connectionPool,
+            $accessControlService,
+            $this->masterKeyProvider,
+            $this->extensionConfiguration,
+        );
+
+        $this->connection
+            ->expects(self::once())
+            ->method('insert')
+            ->with(
+                'tx_nrvault_audit_log',
+                self::callback(static fn (array $data): bool => $data['actor_uid'] === 42
+                    && $data['actor_type'] === 'technical'
+                    && $data['actor_username'] === 'tech_indexer'
+                    && $data['actor_role'] === 'groups:5'),
+            );
+
+        $subject->log('test_secret', 'read', true);
+    }
+
+    #[Test]
     public function logCreatesAuditEntryForReadAction(): void
     {
         $this->setupDatabaseMocks();

--- a/Tests/Unit/Security/AccessControlServiceTest.php
+++ b/Tests/Unit/Security/AccessControlServiceTest.php
@@ -13,6 +13,8 @@ use Doctrine\DBAL\Result;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Domain\Model\Secret;
 use Netresearch\NrVault\Security\AccessControlService;
+use Netresearch\NrVault\Security\TechnicalActor;
+use Netresearch\NrVault\Security\TechnicalActorContextInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -773,6 +775,215 @@ final class AccessControlServiceTest extends TestCase
         self::assertSame('cli', $this->subject->getCurrentActorType());
     }
 
+    // ----- TechnicalActorContext (scoped runAs identity) ---------------------
+
+    #[Test]
+    public function technicalActorAdminHasFullAccessToAnySecret(): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: true, groupIds: []),
+        );
+        $secret = $this->createSecret(ownerUid: 999);
+
+        self::assertTrue($subject->canRead($secret));
+        self::assertTrue($subject->canWrite($secret));
+        self::assertTrue($subject->canDelete($secret));
+    }
+
+    #[Test]
+    public function technicalActorOwnerHasFullAccessToOwnSecret(): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: false, groupIds: []),
+        );
+        $secret = $this->createSecret(ownerUid: 42);
+
+        self::assertTrue($subject->canRead($secret));
+        self::assertTrue($subject->canWrite($secret));
+        self::assertTrue($subject->canDelete($secret));
+    }
+
+    #[Test]
+    public function technicalActorIsDeniedOnUnrelatedSecret(): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: false, groupIds: []),
+        );
+        $secret = $this->createSecret(ownerUid: 999, allowedGroups: [7]);
+
+        self::assertFalse($subject->canRead($secret));
+        self::assertFalse($subject->canWrite($secret));
+        self::assertFalse($subject->canDelete($secret));
+    }
+
+    #[Test]
+    public function technicalActorReadTierGroupGrantsReadButNotWriteOrDelete(): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: false, groupIds: [5]),
+            existingGroupUids: [5],
+        );
+        $secret = $this->createSecret(ownerUid: 999, allowedGroups: [5]);
+
+        self::assertTrue($subject->canRead($secret));
+        self::assertFalse($subject->canWrite($secret));
+        self::assertFalse($subject->canDelete($secret));
+    }
+
+    #[Test]
+    public function technicalActorWriteTierGroupGrantsReadAndWriteButNotDelete(): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: false, groupIds: [5]),
+            existingGroupUids: [5],
+        );
+        $secret = $this->createSecret(ownerUid: 999, writeGroups: [5]);
+
+        self::assertTrue($subject->canRead($secret));
+        self::assertTrue($subject->canWrite($secret));
+        self::assertFalse($subject->canDelete($secret));
+    }
+
+    #[Test]
+    public function technicalActorStaleGroupDoesNotGrantAccess(): void
+    {
+        // Group 5 is in the actor's snapshot but no longer exists in
+        // be_groups — the same stale-group defence as for real BE users.
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: false, groupIds: [5]),
+            existingGroupUids: [],
+        );
+        $secret = $this->createSecret(ownerUid: 999, allowedGroups: [5]);
+
+        self::assertFalse($subject->canRead($secret));
+    }
+
+    #[Test]
+    public function technicalActorSupersedesUnauthenticatedCliPlaceholder(): void
+    {
+        // Messenger-worker reality: $GLOBALS['BE_USER'] holds the CLI
+        // placeholder and CLI access is disabled — the runAs() actor still
+        // gets its user-based semantics.
+        $this->setUnauthenticatedCommandLineUser();
+        $this->configuration->method('isCliAccessAllowed')->willReturn(false);
+
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: false, groupIds: []),
+        );
+        $secret = $this->createSecret(ownerUid: 42);
+
+        self::assertTrue($subject->canRead($secret));
+    }
+
+    #[Test]
+    public function technicalActorSupersedesAmbientBackendUser(): void
+    {
+        // The ambient admin session must NOT leak into a runAs() scope: the
+        // non-admin technical actor is denied on a foreign secret even while
+        // $GLOBALS['BE_USER'] is an admin.
+        $this->setBackendUser(uid: 1, isAdmin: true);
+
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: false, groupIds: []),
+        );
+        $secret = $this->createSecret(ownerUid: 999);
+
+        self::assertFalse($subject->canRead($secret));
+    }
+
+    #[Test]
+    public function technicalActorCanCreate(): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: false, groupIds: []),
+        );
+
+        self::assertTrue($subject->canCreate());
+    }
+
+    #[Test]
+    public function technicalActorIsReportedForAuditAttribution(): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech_indexer', admin: false, groupIds: [5, 7]),
+        );
+
+        self::assertSame('technical', $subject->getCurrentActorType());
+        self::assertSame(42, $subject->getCurrentActorUid());
+        self::assertSame('tech_indexer', $subject->getCurrentActorUsername());
+        self::assertSame([5, 7], $subject->getCurrentUserGroups());
+    }
+
+    #[Test]
+    public function technicalActorTypeSupersedesCliClassification(): void
+    {
+        $this->setUnauthenticatedCommandLineUser();
+
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: false, groupIds: []),
+        );
+
+        self::assertSame('technical', $subject->getCurrentActorType());
+    }
+
+    #[Test]
+    public function isCurrentActorAdminReflectsTheTechnicalActor(): void
+    {
+        $admin = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: true, groupIds: []),
+        );
+        $nonAdmin = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: false, groupIds: []),
+        );
+
+        self::assertTrue($admin->isCurrentActorAdmin());
+        self::assertFalse($nonAdmin->isCurrentActorAdmin());
+    }
+
+    // ----- Characterization: behaviour without an active runAs() scope ------
+
+    #[Test]
+    public function inactiveTechnicalActorContextKeepsWebBehaviourIdentical(): void
+    {
+        // A wired-but-inactive context (no runAs() scope) must not change a
+        // single ambient decision. Mirrors the pre-existing expectations of
+        // canReadReturnsFalseWithoutBackendUser / canReadReturnsTrueForAdmin /
+        // canReadReturnsTrueForOwner.
+        $subject = $this->createSubjectWithTechnicalActor(null);
+
+        $foreign = $this->createSecret(ownerUid: 1);
+        self::assertFalse($subject->canRead($foreign), 'no BE user: denied');
+        self::assertFalse($subject->canCreate(), 'no BE user: cannot create');
+        self::assertSame(0, $subject->getCurrentActorUid());
+
+        $this->setBackendUser(uid: 5, isAdmin: false);
+        $own = $this->createSecret(ownerUid: 5);
+        self::assertTrue($subject->canRead($own), 'owner: allowed');
+        self::assertFalse($subject->canRead($foreign), 'non-owner: denied');
+        self::assertSame('backend', $subject->getCurrentActorType());
+        self::assertSame(5, $subject->getCurrentActorUid());
+
+        $this->setBackendUser(uid: 1, isAdmin: true);
+        self::assertTrue($subject->canRead($foreign), 'admin: allowed');
+        self::assertTrue($subject->canDelete($foreign), 'admin: delete allowed');
+    }
+
+    #[Test]
+    public function inactiveTechnicalActorContextKeepsCliBehaviourIdentical(): void
+    {
+        // Mirrors unauthenticatedCliUserIsClassifiedAsCliActor and the CLI
+        // access-config routing with a wired-but-inactive context.
+        $this->setUnauthenticatedCommandLineUser();
+        $this->configuration->method('isCliAccessAllowed')->willReturn(false);
+
+        $subject = $this->createSubjectWithTechnicalActor(null);
+        $secret = $this->createSecret(ownerUid: 0);
+
+        self::assertSame('cli', $subject->getCurrentActorType());
+        self::assertFalse($subject->canRead($secret), 'CLI disabled: denied');
+        self::assertFalse($subject->canCreate(), 'CLI disabled: cannot create');
+    }
+
     /**
      * Set up a mock CLI backend user WITHOUT an authenticated user record, as
      * present in Symfony Messenger workers and scheduler CLI runs: the TYPO3
@@ -891,5 +1102,49 @@ final class AccessControlServiceTest extends TestCase
             ->willReturn($queryBuilder);
 
         return new AccessControlService($this->configuration, $connectionPool);
+    }
+
+    /**
+     * Build an AccessControlService wired to a TechnicalActorContext whose
+     * current actor is `$actor` (null = wired but no active runAs() scope).
+     *
+     * @param list<int>|null $existingGroupUids be_groups uids the ConnectionPool
+     *                                          reports as existing; null = no
+     *                                          ConnectionPool (group checks fail closed)
+     */
+    private function createSubjectWithTechnicalActor(
+        ?TechnicalActor $actor,
+        ?array $existingGroupUids = null,
+    ): AccessControlService {
+        $technicalActorContext = $this->createMock(TechnicalActorContextInterface::class);
+        $technicalActorContext->method('getCurrentActor')->willReturn($actor);
+
+        $connectionPool = null;
+        if ($existingGroupUids !== null) {
+            $rows = array_map(static fn (int $uid): array => ['uid' => $uid], $existingGroupUids);
+
+            $result = $this->createMock(Result::class);
+            $result->method('fetchAllAssociative')->willReturn($rows);
+
+            $expressionBuilder = $this->createMock(ExpressionBuilder::class);
+            $expressionBuilder->method('eq')->willReturn('deleted = 0');
+
+            $queryBuilder = $this->createMock(QueryBuilder::class);
+            $queryBuilder->method('getRestrictions')->willReturn($this->createMock(DefaultRestrictionContainer::class));
+            $queryBuilder->method('select')->willReturnSelf();
+            $queryBuilder->method('from')->willReturnSelf();
+            $queryBuilder->method('where')->willReturnSelf();
+            $queryBuilder->method('expr')->willReturn($expressionBuilder);
+            $queryBuilder->method('createNamedParameter')->willReturn(':dcValue1');
+            $queryBuilder->method('executeQuery')->willReturn($result);
+
+            $connectionPool = $this->createMock(ConnectionPool::class);
+            $connectionPool
+                ->method('getQueryBuilderForTable')
+                ->with('be_groups')
+                ->willReturn($queryBuilder);
+        }
+
+        return new AccessControlService($this->configuration, $connectionPool, $technicalActorContext);
     }
 }

--- a/Tests/Unit/Security/TechnicalActorContextTest.php
+++ b/Tests/Unit/Security/TechnicalActorContextTest.php
@@ -1,0 +1,312 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Security;
+
+use Doctrine\DBAL\Result;
+use Netresearch\NrVault\Exception\TechnicalActorException;
+use Netresearch\NrVault\Security\TechnicalActor;
+use Netresearch\NrVault\Security\TechnicalActorContext;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use RuntimeException;
+use TYPO3\CMS\Core\Authentication\GroupResolver;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\DefaultRestrictionContainer;
+
+#[CoversClass(TechnicalActorContext::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class TechnicalActorContextTest extends TestCase
+{
+    #[Test]
+    public function runAsRejectsZeroUidWithoutTouchingTheDatabase(): void
+    {
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool->expects(self::never())->method('getQueryBuilderForTable');
+
+        $subject = new TechnicalActorContext($connectionPool, $this->createGroupResolver([]));
+
+        $called = false;
+
+        try {
+            $subject->runAs(0, static function () use (&$called): void {
+                $called = true;
+            });
+            self::fail('Expected TechnicalActorException');
+        } catch (TechnicalActorException $exception) {
+            self::assertSame(1784000001, $exception->getCode());
+        }
+
+        self::assertFalse($called);
+    }
+
+    #[Test]
+    public function runAsRejectsNegativeUid(): void
+    {
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool->expects(self::never())->method('getQueryBuilderForTable');
+
+        $subject = new TechnicalActorContext($connectionPool, $this->createGroupResolver([]));
+
+        $this->expectException(TechnicalActorException::class);
+        $this->expectExceptionCode(1784000001);
+
+        $subject->runAs(-5, static fn (): bool => true);
+    }
+
+    #[Test]
+    public function runAsRejectsUnknownOrDeletedUid(): void
+    {
+        $subject = $this->createSubject([false]);
+
+        $called = false;
+
+        try {
+            $subject->runAs(42, static function () use (&$called): void {
+                $called = true;
+            });
+            self::fail('Expected TechnicalActorException');
+        } catch (TechnicalActorException $exception) {
+            self::assertSame(1784000002, $exception->getCode());
+        }
+
+        self::assertFalse($called);
+    }
+
+    #[Test]
+    public function runAsRejectsDisabledUser(): void
+    {
+        $subject = $this->createSubject([$this->userRow(uid: 42, disable: 1)]);
+
+        $this->expectException(TechnicalActorException::class);
+        $this->expectExceptionCode(1784000003);
+
+        $subject->runAs(42, static fn (): bool => true);
+    }
+
+    #[Test]
+    public function runAsRejectsUserBeforeStarttime(): void
+    {
+        $subject = $this->createSubject([$this->userRow(uid: 42, starttime: time() + 3600)]);
+
+        $this->expectException(TechnicalActorException::class);
+        $this->expectExceptionCode(1784000004);
+
+        $subject->runAs(42, static fn (): bool => true);
+    }
+
+    #[Test]
+    public function runAsRejectsUserAfterEndtime(): void
+    {
+        $subject = $this->createSubject([$this->userRow(uid: 42, endtime: time() - 3600)]);
+
+        $this->expectException(TechnicalActorException::class);
+        $this->expectExceptionCode(1784000004);
+
+        $subject->runAs(42, static fn (): bool => true);
+    }
+
+    #[Test]
+    public function runAsReturnsTheCallableResult(): void
+    {
+        $subject = $this->createSubject([$this->userRow(uid: 42)]);
+
+        $result = $subject->runAs(42, static fn (): string => 'secret-value');
+
+        self::assertSame('secret-value', $result);
+    }
+
+    #[Test]
+    public function getCurrentActorIsNullOutsideAnyScope(): void
+    {
+        $subject = $this->createSubject([]);
+
+        self::assertNull($subject->getCurrentActor());
+    }
+
+    #[Test]
+    public function runAsExposesTheValidatedActorInsideTheScope(): void
+    {
+        $subject = $this->createSubject([
+            $this->userRow(uid: 42, username: 'tech_indexer', admin: 1),
+        ]);
+
+        $subject->runAs(42, static function () use ($subject): void {
+            $actor = $subject->getCurrentActor();
+
+            self::assertInstanceOf(TechnicalActor::class, $actor);
+            self::assertSame(42, $actor->uid);
+            self::assertSame('tech_indexer', $actor->username);
+            self::assertTrue($actor->admin);
+            self::assertSame([], $actor->groupIds);
+        });
+
+        self::assertNull($subject->getCurrentActor());
+    }
+
+    #[Test]
+    public function runAsResolvesGroupIdsViaCoreGroupResolution(): void
+    {
+        $subject = $this->createSubject(
+            [$this->userRow(uid: 42, usergroup: '5,7')],
+            [
+                ['uid' => 5, 'subgroup' => ''],
+                ['uid' => 7, 'subgroup' => ''],
+            ],
+        );
+
+        $subject->runAs(42, static function () use ($subject): void {
+            $actor = $subject->getCurrentActor();
+
+            self::assertInstanceOf(TechnicalActor::class, $actor);
+            self::assertSame([5, 7], $actor->groupIds);
+        });
+    }
+
+    #[Test]
+    public function runAsRestoresThePreviousStateWhenTheCallableThrows(): void
+    {
+        $subject = $this->createSubject([$this->userRow(uid: 42)]);
+
+        try {
+            $subject->runAs(42, static function (): never {
+                throw new RuntimeException('boom', 1234);
+            });
+            self::fail('Expected RuntimeException');
+        } catch (RuntimeException $exception) {
+            self::assertSame('boom', $exception->getMessage());
+        }
+
+        self::assertNull($subject->getCurrentActor());
+    }
+
+    #[Test]
+    public function runAsNestsWithInnermostActorWinningAndOuterRestored(): void
+    {
+        $subject = $this->createSubject([
+            $this->userRow(uid: 42, username: 'outer'),
+            $this->userRow(uid: 43, username: 'inner'),
+        ]);
+
+        $subject->runAs(42, static function () use ($subject): void {
+            $outer = $subject->getCurrentActor();
+            self::assertInstanceOf(TechnicalActor::class, $outer);
+            self::assertSame(42, $outer->uid);
+
+            $subject->runAs(43, static function () use ($subject): void {
+                $inner = $subject->getCurrentActor();
+                self::assertInstanceOf(TechnicalActor::class, $inner);
+                self::assertSame(43, $inner->uid);
+            });
+
+            $restored = $subject->getCurrentActor();
+            self::assertInstanceOf(TechnicalActor::class, $restored);
+            self::assertSame(42, $restored->uid);
+        });
+
+        self::assertNull($subject->getCurrentActor());
+    }
+
+    /**
+     * Build a context whose be_users lookups return the given rows in order
+     * and whose group resolution sees the given be_groups rows.
+     *
+     * @param list<array<string, mixed>|false> $userRows
+     * @param list<array<string, mixed>> $groupRows
+     */
+    private function createSubject(array $userRows, array $groupRows = []): TechnicalActorContext
+    {
+        $userResult = $this->createMock(Result::class);
+        if ($userRows !== []) {
+            $userResult->method('fetchAssociative')->willReturnOnConsecutiveCalls(...$userRows);
+        }
+
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool
+            ->method('getQueryBuilderForTable')
+            ->with('be_users')
+            ->willReturn($this->createQueryBuilderMock($userResult));
+
+        return new TechnicalActorContext($connectionPool, $this->createGroupResolver($groupRows));
+    }
+
+    /**
+     * Real core GroupResolver over a mocked be_groups table: the resolution
+     * logic (subgroup recursion, event dispatch) runs for real, only the DB
+     * and the event dispatcher are doubles.
+     *
+     * @param list<array<string, mixed>> $groupRows
+     */
+    private function createGroupResolver(array $groupRows): GroupResolver
+    {
+        $groupResult = $this->createMock(Result::class);
+        $groupResult
+            ->method('fetchAssociative')
+            ->willReturnOnConsecutiveCalls(...[...$groupRows, false]);
+
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool
+            ->method('getQueryBuilderForTable')
+            ->with('be_groups')
+            ->willReturn($this->createQueryBuilderMock($groupResult));
+
+        $eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+        $eventDispatcher->method('dispatch')->willReturnArgument(0);
+
+        // @internal core class; see TechnicalActorContext::resolveGroupIds().
+        return new GroupResolver($eventDispatcher, $connectionPool);
+    }
+
+    private function createQueryBuilderMock(Result&MockObject $result): QueryBuilder&MockObject
+    {
+        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
+        $expressionBuilder->method('eq')->willReturn('field = :value');
+        $expressionBuilder->method('in')->willReturn('field IN (:value)');
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('getRestrictions')->willReturn($this->createMock(DefaultRestrictionContainer::class));
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('expr')->willReturn($expressionBuilder);
+        $queryBuilder->method('createNamedParameter')->willReturn(':dcValue1');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        return $queryBuilder;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function userRow(
+        int $uid,
+        string $username = 'technical_user',
+        int $admin = 0,
+        int $disable = 0,
+        int $starttime = 0,
+        int $endtime = 0,
+        string $usergroup = '',
+    ): array {
+        return [
+            'uid' => $uid,
+            'username' => $username,
+            'admin' => $admin,
+            'disable' => $disable,
+            'starttime' => $starttime,
+            'endtime' => $endtime,
+            'usergroup' => $usergroup,
+        ];
+    }
+}

--- a/Tests/Unit/Security/TechnicalActorContextTest.php
+++ b/Tests/Unit/Security/TechnicalActorContextTest.php
@@ -119,6 +119,17 @@ final class TechnicalActorContextTest extends TestCase
     }
 
     #[Test]
+    public function runAsRejectsUserOutsideRootLevel(): void
+    {
+        $subject = $this->createSubject([$this->userRow(uid: 42, pid: 5)]);
+
+        $this->expectException(TechnicalActorException::class);
+        $this->expectExceptionCode(1784000005);
+
+        $subject->runAs(42, static fn (): bool => true);
+    }
+
+    #[Test]
     public function runAsReturnsTheCallableResult(): void
     {
         $subject = $this->createSubject([$this->userRow(uid: 42)]);
@@ -292,6 +303,7 @@ final class TechnicalActorContextTest extends TestCase
      */
     private function userRow(
         int $uid,
+        int $pid = 0,
         string $username = 'technical_user',
         int $admin = 0,
         int $disable = 0,
@@ -301,6 +313,7 @@ final class TechnicalActorContextTest extends TestCase
     ): array {
         return [
             'uid' => $uid,
+            'pid' => $pid,
             'username' => $username,
             'admin' => $admin,
             'disable' => $disable,

--- a/Tests/Unit/Security/TechnicalActorContextTest.php
+++ b/Tests/Unit/Security/TechnicalActorContextTest.php
@@ -19,17 +19,27 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\EventDispatcher\EventDispatcherInterface;
+use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Core\Authentication\GroupResolver;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\DefaultRestrictionContainer;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 #[CoversClass(TechnicalActorContext::class)]
 #[AllowMockObjectsWithoutExpectations]
 final class TechnicalActorContextTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        // Remove ConnectionPool instances queued for v13's GroupResolver
+        // (see createGroupResolver()) that the test path did not consume.
+        GeneralUtility::purgeInstances();
+        parent::tearDown();
+    }
+
     #[Test]
     public function runAsRejectsZeroUidWithoutTouchingTheDatabase(): void
     {
@@ -277,7 +287,22 @@ final class TechnicalActorContextTest extends TestCase
         $eventDispatcher->method('dispatch')->willReturnArgument(0);
 
         // @internal core class; see TechnicalActorContext::resolveGroupIds().
-        return new GroupResolver($eventDispatcher, $connectionPool);
+        // v14 takes the ConnectionPool as a constructor argument, v13 fetches
+        // it via GeneralUtility::makeInstance() on every be_groups lookup.
+        $reflection = new ReflectionClass(GroupResolver::class);
+        if (($reflection->getConstructor()?->getNumberOfParameters() ?? 1) >= 2) {
+            return new GroupResolver($eventDispatcher, $connectionPool);
+        }
+
+        // One makeInstance() call per fetchRowsFromDatabase(): the initial
+        // lookup plus at most one recursion per group row with subgroups.
+        // Instances not consumed by the test path are purged in tearDown().
+        $poolLookups = \count($groupRows) + 1;
+        for ($i = 0; $i < $poolLookups; ++$i) {
+            GeneralUtility::addInstance(ConnectionPool::class, $connectionPool);
+        }
+
+        return $reflection->newInstance($eventDispatcher);
     }
 
     private function createQueryBuilderMock(Result&MockObject $result): QueryBuilder&MockObject


### PR DESCRIPTION
Resolves #202 (follow-up to #201).

## What

`Netresearch\NrVault\Security\TechnicalActorContextInterface::runAs(int $beUserUid, callable $fn): mixed` — a vault-owned scoped technical-actor identity that `AccessControlService` consults directly, replacing consumer-side `$GLOBALS['BE_USER']` mutation (nr-ai-search `BackendUserContext::runAs()`; nr-llm ADR-052 calls that pattern a workaround).

## Design

- **Validation before execution**: uid &lt;= 0, missing/deleted, disabled, and start/endtime-restricted `be_users` records are refused with typed `TechnicalActorException` codes (1784000001–1784000004); the callable never runs on refusal. Mirrors the enable-column semantics of a real backend login.
- **Same user semantics**: admin override, owner check, ADR-005 group tiers with the existing stale-group filtering; groups resolved via core `GroupResolver` (subgroup expansion, restrictions, PSR-14 event) — the same resolution `fetchGroupData()` uses. System-maintainer is covered by the admin branch (`isSystemMaintainer()` implies the admin flag).
- **Scoping**: per-service-instance LIFO stack, popped in `finally` — identity restored on exceptions; nesting stacks with the innermost actor winning (documented). Not fiber-keyed (documented constraint).
- **No ambient mutation**: `$GLOBALS['BE_USER']` is never touched; the technical actor supersedes the unauthenticated CLI placeholder and any ambient BE user only inside the scope.
- **Web/CLI behaviour without an active scope is unchanged** — every new branch is a no-op guard; characterization tests pin ambient web and CLI decisions with a wired-but-inactive context.
- **Audit**: attribution flows through the existing `AccessControlServiceInterface` getters — rows inside a scope carry `actor_type = 'technical'` + actor uid/username, sealed into the epoch-3 HMAC chain. `VaultAnalyticsService` counts `technical` as an automated actor.
- **Trust model** (ADR-029, Security docs): `runAs()` is not an authentication boundary — it adds validation, guaranteed restoration, and honest attribution over the power `$GLOBALS['BE_USER']` mutation already grants any extension.

## Docs

- `Documentation/Developer/Adr/ADR-029-TechnicalActorContext.rst`
- `Documentation/Developer/TechnicalActorContext.rst` — API + migration story from the global-mutation workaround
- `Documentation/Security/Index.rst` — technical-actor threat-model notes

## Tests

- Unit: `TechnicalActorContextTest` (refusals, scope restore on exception, nesting, group resolution), `AccessControlServiceTest` technical-actor semantics + ambient characterization, `AuditLogServiceTest` technical attribution.
- Functional (sqlite): real-container DI wiring (the optional `AccessControlService` constructor argument is autowired), subgroup-expansion group ACL, disabled-user refusal, audit `actor_type = 'technical'`.