### PR TITLE
fix: accept array $pasteUpdate in DataHandler cmdmap hooks

### DIFF
--- a/Classes/Hook/DataHandlerHook.php
+++ b/Classes/Hook/DataHandlerHook.php
@@ -160,6 +160,13 @@ final class DataHandlerHook
     /**
      * Called before record deletion.
      * Removes associated vault secrets.
+     *
+     * @param bool|array<string, mixed> $pasteUpdate TYPO3 core defaults this to `false`
+     *                                               but reassigns it to `$value['update']`
+     *                                               (an array) on the localize / copy-to-
+     *                                               language path, so the type must accept
+     *                                               both to avoid a TypeError before the
+     *                                               command guard below runs.
      */
     public function processCmdmap_preProcess(// NOSONAR: TYPO3 DataHandler hook method name (fixed API contract)
         string $command,
@@ -167,7 +174,7 @@ final class DataHandlerHook
         string|int $id,
         mixed $value,
         DataHandler $dataHandler,
-        bool $pasteUpdate,
+        bool|array $pasteUpdate,
     ): void {
         if ($command !== 'delete') {
             return;
@@ -220,6 +227,13 @@ final class DataHandlerHook
     /**
      * Called after record copy.
      * Copies vault secrets to the new record with new UUIDs.
+     *
+     * @param bool|array<string, mixed> $pasteUpdate TYPO3 core defaults this to `false`
+     *                                               but reassigns it to `$value['update']`
+     *                                               (an array) on the localize / copy-to-
+     *                                               language path, so the type must accept
+     *                                               both to avoid a TypeError before the
+     *                                               command guard below runs.
      */
     public function processCmdmap_postProcess(// NOSONAR: TYPO3 DataHandler hook method name (fixed API contract)
         string $command,
@@ -227,7 +241,7 @@ final class DataHandlerHook
         string|int $id,
         mixed $value,
         DataHandler $dataHandler,
-        bool $pasteUpdate,
+        bool|array $pasteUpdate,
     ): void {
         if ($command !== 'copy') {
             return;

--- a/Tests/Unit/Hook/DataHandlerHookTest.php
+++ b/Tests/Unit/Hook/DataHandlerHookTest.php
@@ -581,6 +581,47 @@ final class DataHandlerHookTest extends TestCase
     }
 
     #[Test]
+    public function cmdmapPreProcessAcceptsArrayPasteUpdate(): void
+    {
+        // Regression for #207: on the localize / copy-to-language path TYPO3 core
+        // reassigns $pasteUpdate from its `false` default to `$value['update']` (an
+        // array) before invoking the hook. A `bool`-typed parameter threw a
+        // TypeError at the signature, before the command guard could run.
+        $this->vaultService
+            ->expects(self::never())
+            ->method('delete');
+
+        $this->subject->processCmdmap_preProcess(
+            'localize',
+            'tt_content',
+            42,
+            null,
+            $this->dataHandler,
+            ['colPos' => 0, 'sys_language_uid' => 1],
+        );
+    }
+
+    #[Test]
+    public function cmdmapPostProcessAcceptsArrayPasteUpdate(): void
+    {
+        // Regression for #207: the copy path receives the same array $pasteUpdate.
+        $this->dataHandler->copyMappingArray = [];
+
+        $this->vaultService
+            ->expects(self::never())
+            ->method('retrieve');
+
+        $this->subject->processCmdmap_postProcess(
+            'copy',
+            'tt_content',
+            42,
+            null,
+            $this->dataHandler,
+            ['colPos' => 0, 'sys_language_uid' => 1],
+        );
+    }
+
+    #[Test]
     public function cmdmapPostProcessSkipsWhenNoNewIdFound(): void
     {
         $this->mockTcaSchemaForTable('tx_test', [


### PR DESCRIPTION
## Problem

Translating a content element to another language in **copy mode** (the `records/localize` AJAX endpoint) threw:

```
Netresearch\NrVault\Hook\DataHandlerHook::processCmdmap_preProcess():
Argument #6 ($pasteUpdate) must be of type bool, array given,
called in .../typo3/cms-core/Classes/DataHandling/DataHandler.php on line 3335
```

## Root cause

TYPO3 core (`DataHandler`) initialises `$pasteUpdate = false` but reassigns it to `$value['update']` — an **array** — on the localize / copy-to-language path before invoking the `processCmdmap_preProcess` / `processCmdmap_postProcess` hooks. The hook methods typed the sixth parameter as `bool`, so PHP raised a `TypeError` at the signature, before the `if ($command !== 'delete'/'copy') return` guard could even run.

## Fix

Widen the parameter to `bool|array` on both hook methods, matching core's runtime contract. `$pasteUpdate` is unused in both method bodies, so the change is behaviour-neutral.

## Tests

Added `cmdmapPreProcessAcceptsArrayPasteUpdate` and `cmdmapPostProcessAcceptsArrayPasteUpdate` to `Tests/Unit/Hook/DataHandlerHookTest.php`, exercising the array `$pasteUpdate` contract. Verified they reproduce the exact `TypeError` against the unpatched signature and pass with the fix. Full unit suite (1908 tests), PHPStan level 10, and CGL are green.

Fixes #207
