### PR TITLE
fix: accept array $pasteUpdate in FlexFormVaultHook too

### DIFF
--- a/Classes/Hook/FlexFormVaultHook.php
+++ b/Classes/Hook/FlexFormVaultHook.php
@@ -182,6 +182,13 @@ final class FlexFormVaultHook
     /**
      * Called after record copy.
      * Copies FlexForm vault secrets to the new record with fresh UUIDs.
+     *
+     * @param bool|array<string, mixed> $pasteUpdate TYPO3 core defaults this to `false`
+     *                                               but reassigns it to `$value['update']`
+     *                                               (an array) on the localize / copy-to-
+     *                                               language path, so the type must accept
+     *                                               both to avoid a TypeError before the
+     *                                               command guard below runs.
      */
     public function processCmdmap_postProcess(// NOSONAR: TYPO3 DataHandler hook method name (fixed API contract)
         string $command,
@@ -189,7 +196,7 @@ final class FlexFormVaultHook
         string|int $id,
         mixed $value,
         DataHandler $dataHandler,
-        bool $pasteUpdate,
+        bool|array $pasteUpdate,
     ): void {
         if ($command !== 'copy') {
             return;

--- a/Tests/Unit/Hook/FlexFormVaultHookTest.php
+++ b/Tests/Unit/Hook/FlexFormVaultHookTest.php
@@ -677,6 +677,27 @@ final class FlexFormVaultHookTest extends TestCase
     }
 
     #[Test]
+    public function postProcessAcceptsArrayPasteUpdate(): void
+    {
+        // Regression for #207: on the localize / copy-to-language path TYPO3 core
+        // reassigns $pasteUpdate from its `false` default to `$value['update']` (an
+        // array) before invoking the hook. A `bool`-typed parameter threw a
+        // TypeError at the signature, before the command guard could run.
+        $this->dataHandler->copyMappingArray = [];
+
+        $this->vaultService->expects(self::never())->method('retrieve');
+
+        $this->subject->processCmdmap_postProcess(
+            'copy',
+            'tt_content',
+            42,
+            null,
+            $this->dataHandler,
+            ['colPos' => 0, 'sys_language_uid' => 1],
+        );
+    }
+
+    #[Test]
     public function postProcessSkipsCopyForTableWithoutFlexFields(): void
     {
         $this->dataHandler->copyMappingArray = ['tx_test' => [42 => 100]];


### PR DESCRIPTION
## Problem

Follow-up on #207: the reporter confirmed the copy-mode translation TypeError also occurs through `FlexFormVaultHook`. #208 / v0.11.1 fixed only `DataHandlerHook`.

## Fix

`FlexFormVaultHook::processCmdmap_postProcess` still typed its sixth parameter `bool $pasteUpdate`; TYPO3 core passes an array on the localize / copy-to-language path, so PHP threw before the `if ($command !== 'copy') return` guard ran. Widened to `bool|array`, matching core's runtime contract. The parameter is unused in the body — behaviour-neutral.

An exhaustive sweep (`grep -rn pasteUpdate Classes/`) confirms this was the **last** `bool`-typed `$pasteUpdate` in the extension: `processCmdmap_deleteAction` follows a different core contract without that parameter (core calls it with 5 args), and `SecretTcaHook::processCmdmap_preProcess` declares only three parameters, so PHP ignores the extra args.

## Tests

`postProcessAcceptsArrayPasteUpdate` added to `Tests/Unit/Hook/FlexFormVaultHookTest.php` — reproduces the exact reported TypeError against the unpatched signature and passes with the fix. Full unit suite (1909), PHPStan level 10, CGL green.

Fixes #207
