### PR TITLE
feat(dashboard): admin-only secrets count and audit activity widgets

### DIFF
--- a/Classes/Widgets/AdminOnlyBarChartWidget.php
+++ b/Classes/Widgets/AdminOnlyBarChartWidget.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Widgets;
+
+use TYPO3\CMS\Dashboard\Widgets\AdminOnlyWidgetInterface;
+use TYPO3\CMS\Dashboard\Widgets\BarChartWidget;
+
+/**
+ * Admin-only variant of the core BarChart widget.
+ *
+ * See {@see AdminOnlyNumberWithIconWidget} for why the marker interface has
+ * to live on the registered widget class: DashboardWidgetPass derives the
+ * `adminOnly` flag from the class of the tagged service, and the core widget
+ * classes do not implement AdminOnlyWidgetInterface themselves.
+ *
+ * TYPO3 v14 only — see {@see AdminOnlyNumberWithIconWidget} for the v13.4
+ * fallback and PHPStan exclusion rationale.
+ */
+final class AdminOnlyBarChartWidget extends BarChartWidget implements AdminOnlyWidgetInterface {}

--- a/Classes/Widgets/AdminOnlyNumberWithIconWidget.php
+++ b/Classes/Widgets/AdminOnlyNumberWithIconWidget.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Widgets;
+
+use TYPO3\CMS\Dashboard\Widgets\AdminOnlyWidgetInterface;
+use TYPO3\CMS\Dashboard\Widgets\NumberWithIconWidget;
+
+/**
+ * Admin-only variant of the core NumberWithIcon widget.
+ *
+ * The core dashboard marks a widget as admin-only via the registered widget
+ * CLASS: DashboardWidgetPass sets the `adminOnly` tag attribute from
+ * `is_a($class, AdminOnlyWidgetInterface::class)`. The core widget classes do
+ * not implement that marker interface, so this empty subclass exists solely
+ * to add it — vault statistics must never be assignable to non-admin users,
+ * matching the admin-scoped vault backend module (`'access' => 'admin'`).
+ *
+ * TYPO3 v14 only: AdminOnlyWidgetInterface does not exist in v13.4, so
+ * Services.Dashboard.php registers this class only when the interface is
+ * present (v13 falls back to the plain core widget class) and the file is
+ * excluded from PHPStan analysis on the v13 matrix (see phpstan.neon).
+ */
+final class AdminOnlyNumberWithIconWidget extends NumberWithIconWidget implements AdminOnlyWidgetInterface {}

--- a/Classes/Widgets/DataProvider/ActiveSecretCountDataProvider.php
+++ b/Classes/Widgets/DataProvider/ActiveSecretCountDataProvider.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Widgets\DataProvider;
+
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Dashboard\Widgets\NumberWithIconDataProviderInterface;
+
+/**
+ * Data provider for the "Vault secrets" NumberWithIcon dashboard widget.
+ *
+ * Counts active secrets in tx_nrvault_secret with a single aggregate query.
+ * "Active" means neither soft-deleted nor hidden; the flags are filtered
+ * explicitly (restrictions removed) so the count does not silently change
+ * with TCA enable-column configuration.
+ */
+final readonly class ActiveSecretCountDataProvider implements NumberWithIconDataProviderInterface
+{
+    private const TABLE = 'tx_nrvault_secret';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+    ) {}
+
+    public function getNumber(): int
+    {
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $count = $queryBuilder
+            ->count('uid')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'deleted',
+                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT),
+                ),
+                $queryBuilder->expr()->eq(
+                    'hidden',
+                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT),
+                ),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($count) ? (int) $count : 0;
+    }
+}

--- a/Classes/Widgets/DataProvider/AuditActivityDataProvider.php
+++ b/Classes/Widgets/DataProvider/AuditActivityDataProvider.php
@@ -1,0 +1,112 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Widgets\DataProvider;
+
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Dashboard\Widgets\ChartDataProviderInterface;
+
+/**
+ * Chart.js bar-chart data provider for "vault audit activity (last 14 days)".
+ *
+ * Aggregates tx_nrvault_audit_log rows into per-day event counts with a
+ * single GROUP BY query on `crdate`. Days are bucketed as UTC calendar days
+ * (`crdate - (crdate % 86400)`) — an at-a-glance activity trend, not an
+ * audit report; exact per-entry timestamps live in the audit log module.
+ */
+final readonly class AuditActivityDataProvider implements ChartDataProviderInterface
+{
+    private const TABLE = 'tx_nrvault_audit_log';
+
+    private const DEFAULT_DAYS = 14;
+
+    private const SECONDS_PER_DAY = 86400;
+
+    private const BAR_COLOR = '#2F99A4';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+        private int $days = self::DEFAULT_DAYS,
+    ) {}
+
+    /**
+     * @return array{labels: list<string>, datasets: list<array{label: string, data: list<int>, backgroundColor: list<string>}>}
+     */
+    public function getChartData(): array
+    {
+        $days = max(1, $this->days);
+        $todayStart = intdiv(time(), self::SECONDS_PER_DAY) * self::SECONDS_PER_DAY;
+        $firstDayStart = $todayStart - (($days - 1) * self::SECONDS_PER_DAY);
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $rows = $queryBuilder
+            ->addSelectLiteral('(crdate - (crdate % 86400)) AS day_start')
+            ->addSelectLiteral('COUNT(*) AS entry_count')
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->gte(
+                    'crdate',
+                    $queryBuilder->createNamedParameter($firstDayStart, Connection::PARAM_INT),
+                ),
+            )
+            ->groupBy('day_start')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        return self::shapeChartData($rows, $firstDayStart, $days);
+    }
+
+    /**
+     * Shape the SQL rows into chart.js bar-chart format, zero-filling days
+     * without audit activity so the time axis stays continuous.
+     *
+     * Extracted as a pure static method for unit-testability — the
+     * ConnectionPool-driven query path is exercised via mocks.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     *
+     * @return array{labels: list<string>, datasets: list<array{label: string, data: list<int>, backgroundColor: list<string>}>}
+     */
+    public static function shapeChartData(array $rows, int $firstDayStart, int $days): array
+    {
+        $countPerDay = [];
+
+        foreach ($rows as $row) {
+            $bucket = $row['day_start'] ?? null;
+            if (!is_numeric($bucket)) {
+                continue;
+            }
+
+            $count = $row['entry_count'] ?? 0;
+
+            $countPerDay[(int) $bucket] = is_numeric($count) ? (int) $count : 0;
+        }
+
+        $labels = [];
+        $data = [];
+
+        for ($i = 0; $i < $days; ++$i) {
+            $dayStart = $firstDayStart + ($i * self::SECONDS_PER_DAY);
+            $labels[] = gmdate('Y-m-d', $dayStart);
+            $data[] = $countPerDay[$dayStart] ?? 0;
+        }
+
+        return [
+            'labels' => $labels,
+            'datasets' => [
+                [
+                    'label' => 'Audit events',
+                    'data' => $data,
+                    'backgroundColor' => array_fill(0, \count($data), self::BAR_COLOR),
+                ],
+            ],
+        ];
+    }
+}

--- a/Configuration/Backend/DashboardWidgetGroups.php
+++ b/Configuration/Backend/DashboardWidgetGroups.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+/**
+ * Dashboard widget group for nr-vault widgets.
+ *
+ * Only evaluated when EXT:dashboard is installed — TYPO3 reads this file
+ * from the dashboard extension's boot code, so no guard is needed here.
+ */
+return [
+    'nrvault' => [
+        'title' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_dashboard.xlf:widget_group.nrvault',
+    ],
+];

--- a/Configuration/Services.Dashboard.php
+++ b/Configuration/Services.Dashboard.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+use Netresearch\NrVault\Widgets\AdminOnlyBarChartWidget;
+use Netresearch\NrVault\Widgets\AdminOnlyNumberWithIconWidget;
+use Netresearch\NrVault\Widgets\DataProvider\ActiveSecretCountDataProvider;
+use Netresearch\NrVault\Widgets\DataProvider\AuditActivityDataProvider;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use TYPO3\CMS\Dashboard\Widgets\AdminOnlyWidgetInterface;
+use TYPO3\CMS\Dashboard\Widgets\BarChartWidget;
+use TYPO3\CMS\Dashboard\Widgets\NumberWithIconWidget;
+
+use function Symfony\Component\DependencyInjection\Loader\Configurator\service;
+
+/*
+ * Dashboard widget registration for nr-vault.
+ *
+ * Imported conditionally from Configuration/Services.php only when
+ * typo3/cms-dashboard is installed. This is a PHP config file (not YAML)
+ * because TYPO3 loads Configuration/Services.php with a standalone Symfony
+ * PhpFileLoader that has no YAML loader in its resolver, so a `.yaml` import
+ * cannot be resolved from there.
+ *
+ * Vault statistics are admin-scoped (matching the vault backend module's
+ * 'access' => 'admin') and must not be assignable to non-admin backend
+ * users. On TYPO3 v14 the AdminOnly* widget subclasses enforce this via
+ * AdminOnlyWidgetInterface; the interface does not exist in v13.4 (added in
+ * v14), so v13 falls back to the plain core widget classes — there, widgets
+ * are invisible to non-admins anyway unless a group explicitly grants them
+ * in its access list.
+ */
+return static function (ContainerConfigurator $containerConfigurator): void {
+    $services = $containerConfigurator->services();
+
+    $services->defaults()
+        ->autowire()
+        ->autoconfigure()
+        ->private();
+
+    $adminOnlySupported = interface_exists(AdminOnlyWidgetInterface::class);
+    $numberWidgetClass = $adminOnlySupported ? AdminOnlyNumberWithIconWidget::class : NumberWithIconWidget::class;
+    $barWidgetClass = $adminOnlySupported ? AdminOnlyBarChartWidget::class : BarChartWidget::class;
+
+    $services->set(ActiveSecretCountDataProvider::class);
+    $services->set(AuditActivityDataProvider::class);
+
+    $services->set('dashboard.widget.nrvault.secrets', $numberWidgetClass)
+        ->arg('$dataProvider', service(ActiveSecretCountDataProvider::class))
+        ->arg('$options', [
+            'icon' => 'vault-secret',
+            'title' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_dashboard.xlf:widget.secrets.title',
+            'subtitle' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_dashboard.xlf:widget.secrets.subtitle',
+        ])
+        ->tag('dashboard.widget', [
+            'identifier' => 'nrvault-secrets',
+            'groupNames' => 'nrvault',
+            'title' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_dashboard.xlf:widget.secrets.title',
+            'description' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_dashboard.xlf:widget.secrets.description',
+            'iconIdentifier' => 'vault-secret',
+            'height' => 'small',
+            'width' => 'small',
+        ]);
+
+    $services->set('dashboard.widget.nrvault.audit_activity', $barWidgetClass)
+        ->arg('$dataProvider', service(AuditActivityDataProvider::class))
+        ->tag('dashboard.widget', [
+            'identifier' => 'nrvault-audit-activity',
+            'groupNames' => 'nrvault',
+            'title' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_dashboard.xlf:widget.audit_activity.title',
+            'description' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_dashboard.xlf:widget.audit_activity.description',
+            'iconIdentifier' => 'module-vault',
+            'height' => 'medium',
+            'width' => 'medium',
+        ]);
+};

--- a/Configuration/Services.php
+++ b/Configuration/Services.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
+use TYPO3\CMS\Dashboard\Widgets\WidgetInterface;
+
+return static function (ContainerConfigurator $containerConfigurator, ContainerBuilder $containerBuilder): void {
+    // Dashboard widgets ship only when typo3/cms-dashboard is installed
+    // (composer "suggest", not a hard requirement). Guarding here keeps TYPO3
+    // installs without the dashboard from blowing up on unresolvable class
+    // references during container compile. WidgetInterface is an interface,
+    // so the guard must use interface_exists() (class_exists() returns false
+    // for interfaces). The imported file is PHP, not YAML, because the loader
+    // handling Services.php cannot resolve a YAML import.
+    if (interface_exists(WidgetInterface::class)) {
+        $containerConfigurator->import(__DIR__ . '/Services.Dashboard.php');
+    }
+};

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -11,6 +11,10 @@ services:
       - '../Classes/Exception/*'
       - '../Classes/Http/OAuth/OAuthConfig.php'
       - '../Classes/Security/TechnicalActor.php'
+      # Widgets depend on typo3/cms-dashboard classes (a "suggest", not a
+      # requirement) — they are registered by Services.Dashboard.php, imported
+      # from Services.php only when EXT:dashboard is installed.
+      - '../Classes/Widgets/*'
 
   # ----- Interface aliases -------------------------------------------------
   # Symfony's `autoconfigure` auto-aliases an interface to its single

--- a/Resources/Private/Language/locallang_dashboard.xlf
+++ b/Resources/Private/Language/locallang_dashboard.xlf
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xliff version="1.2" xmlns="urn:oasis:names:tc:xliff:document:1.2">
+    <file source-language="en" datatype="plaintext" original="messages" date="2026-07-21T00:00:00Z" product-name="nr_vault">
+        <header/>
+        <body>
+            <trans-unit id="widget_group.nrvault">
+                <source>Vault</source>
+            </trans-unit>
+            <trans-unit id="widget.secrets.title">
+                <source>Vault secrets</source>
+            </trans-unit>
+            <trans-unit id="widget.secrets.subtitle">
+                <source>Active secrets (not deleted or hidden)</source>
+            </trans-unit>
+            <trans-unit id="widget.secrets.description">
+                <source>Number of active secrets currently stored in the vault. Deleted and hidden secrets are excluded.</source>
+            </trans-unit>
+            <trans-unit id="widget.audit_activity.title">
+                <source>Vault audit activity</source>
+            </trans-unit>
+            <trans-unit id="widget.audit_activity.description">
+                <source>Bar chart of vault audit-log events per day over the last 14 days, covering reads, writes, rotations, and deletions.</source>
+            </trans-unit>
+        </body>
+    </file>
+</xliff>

--- a/Tests/Unit/Widgets/DataProvider/ActiveSecretCountDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/ActiveSecretCountDataProviderTest.php
@@ -1,0 +1,100 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Widgets\DataProvider;
+
+use Doctrine\DBAL\Result;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Widgets\DataProvider\ActiveSecretCountDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface;
+
+/**
+ * Unit tests for {@see ActiveSecretCountDataProvider}.
+ */
+#[CoversClass(ActiveSecretCountDataProvider::class)]
+final class ActiveSecretCountDataProviderTest extends TestCase
+{
+    /**
+     * Field names passed to ExpressionBuilder::eq(), captured per test.
+     *
+     * @var list<string>
+     */
+    private array $eqFields = [];
+
+    #[Test]
+    #[DataProvider('countResultProvider')]
+    public function getNumberNormalizesFetchOneResult(mixed $fetchOneResult, int $expected): void
+    {
+        $subject = new ActiveSecretCountDataProvider(
+            $this->createConnectionPoolStub($fetchOneResult),
+        );
+
+        self::assertSame($expected, $subject->getNumber());
+    }
+
+    /**
+     * @return iterable<string, array{0: mixed, 1: int}>
+     */
+    public static function countResultProvider(): iterable
+    {
+        yield 'integer count' => [5, 5];
+        yield 'numeric-string count (MySQL aggregate)' => ['12', 12];
+        yield 'zero rows' => [0, 0];
+        yield 'false (no result row)' => [false, 0];
+        yield 'null' => [null, 0];
+    }
+
+    #[Test]
+    public function getNumberFiltersOnDeletedAndHiddenFlags(): void
+    {
+        $subject = new ActiveSecretCountDataProvider(
+            $this->createConnectionPoolStub(3),
+        );
+        $subject->getNumber();
+
+        self::assertSame(['deleted', 'hidden'], $this->eqFields);
+    }
+
+    private function createConnectionPoolStub(mixed $fetchOneResult): ConnectionPool
+    {
+        $result = $this->createStub(Result::class);
+        $result->method('fetchOne')->willReturn($fetchOneResult);
+
+        $expressionBuilder = $this->createStub(ExpressionBuilder::class);
+        $expressionBuilder->method('eq')->willReturnCallback(
+            function (string $field): string {
+                $this->eqFields[] = $field;
+
+                return $field . ' = ?';
+            },
+        );
+
+        $restrictions = $this->createStub(QueryRestrictionContainerInterface::class);
+
+        $queryBuilder = $this->createStub(QueryBuilder::class);
+        $queryBuilder->method('getRestrictions')->willReturn($restrictions);
+        $queryBuilder->method('count')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('expr')->willReturn($expressionBuilder);
+        $queryBuilder->method('createNamedParameter')->willReturn(':dcValue1');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $connectionPool = $this->createStub(ConnectionPool::class);
+        $connectionPool->method('getQueryBuilderForTable')->willReturn($queryBuilder);
+
+        return $connectionPool;
+    }
+}

--- a/Tests/Unit/Widgets/DataProvider/AuditActivityDataProviderTest.php
+++ b/Tests/Unit/Widgets/DataProvider/AuditActivityDataProviderTest.php
@@ -1,0 +1,136 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Widgets\DataProvider;
+
+use Doctrine\DBAL\Result;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Widgets\DataProvider\AuditActivityDataProvider;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+
+/**
+ * Unit tests for {@see AuditActivityDataProvider}.
+ */
+#[CoversClass(AuditActivityDataProvider::class)]
+final class AuditActivityDataProviderTest extends TestCase
+{
+    private const DAY = 86400;
+
+    /** 2026-07-01T00:00:00Z — a fixed UTC day-start for deterministic buckets. */
+    private const FIRST_DAY = 1_782_864_000;
+
+    #[Test]
+    public function shapeChartDataZeroFillsDaysWithoutActivity(): void
+    {
+        $shaped = AuditActivityDataProvider::shapeChartData(
+            [
+                ['day_start' => self::FIRST_DAY, 'entry_count' => 4],
+                ['day_start' => self::FIRST_DAY + (2 * self::DAY), 'entry_count' => 7],
+            ],
+            self::FIRST_DAY,
+            4,
+        );
+
+        self::assertSame(['2026-07-01', '2026-07-02', '2026-07-03', '2026-07-04'], $shaped['labels']);
+        self::assertCount(1, $shaped['datasets']);
+        self::assertSame('Audit events', $shaped['datasets'][0]['label']);
+        self::assertSame([4, 0, 7, 0], $shaped['datasets'][0]['data']);
+        self::assertCount(4, $shaped['datasets'][0]['backgroundColor']);
+    }
+
+    #[Test]
+    public function shapeChartDataCastsNumericStringAggregates(): void
+    {
+        // MySQL COUNT(*) and the day_start literal can come back as strings.
+        $shaped = AuditActivityDataProvider::shapeChartData(
+            [
+                ['day_start' => (string) self::FIRST_DAY, 'entry_count' => '42'],
+            ],
+            self::FIRST_DAY,
+            1,
+        );
+
+        self::assertSame([42], $shaped['datasets'][0]['data']);
+    }
+
+    #[Test]
+    public function shapeChartDataSkipsRowsWithNonNumericDayStart(): void
+    {
+        $shaped = AuditActivityDataProvider::shapeChartData(
+            [
+                ['day_start' => null, 'entry_count' => 50],
+                ['day_start' => 'not-a-timestamp', 'entry_count' => 60],
+                ['day_start' => self::FIRST_DAY, 'entry_count' => 3],
+            ],
+            self::FIRST_DAY,
+            2,
+        );
+
+        self::assertSame([3, 0], $shaped['datasets'][0]['data']);
+    }
+
+    #[Test]
+    public function shapeChartDataTreatsMissingEntryCountAsZero(): void
+    {
+        $shaped = AuditActivityDataProvider::shapeChartData(
+            [
+                ['day_start' => self::FIRST_DAY],
+            ],
+            self::FIRST_DAY,
+            1,
+        );
+
+        self::assertSame([0], $shaped['datasets'][0]['data']);
+    }
+
+    #[Test]
+    public function shapeChartDataIgnoresRowsOutsideTheWindow(): void
+    {
+        $shaped = AuditActivityDataProvider::shapeChartData(
+            [
+                ['day_start' => self::FIRST_DAY - self::DAY, 'entry_count' => 99],
+            ],
+            self::FIRST_DAY,
+            2,
+        );
+
+        self::assertSame([0, 0], $shaped['datasets'][0]['data']);
+    }
+
+    #[Test]
+    public function getChartDataRunsSingleGroupedQueryAndCoversConfiguredDays(): void
+    {
+        $result = $this->createStub(Result::class);
+        $result->method('fetchAllAssociative')->willReturn([]);
+
+        $expressionBuilder = $this->createStub(ExpressionBuilder::class);
+        $expressionBuilder->method('gte')->willReturn('crdate >= ?');
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('addSelectLiteral')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('groupBy')->willReturnSelf();
+        $queryBuilder->method('expr')->willReturn($expressionBuilder);
+        $queryBuilder->method('createNamedParameter')->willReturn(':dcValue1');
+        $queryBuilder->expects(self::once())->method('executeQuery')->willReturn($result);
+
+        $connectionPool = $this->createStub(ConnectionPool::class);
+        $connectionPool->method('getQueryBuilderForTable')->willReturn($queryBuilder);
+
+        $shaped = (new AuditActivityDataProvider($connectionPool, 14))->getChartData();
+
+        self::assertCount(14, $shaped['labels']);
+        self::assertSame(array_fill(0, 14, 0), $shaped['datasets'][0]['data']);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,11 @@
         "mikey179/vfsstream": "^1.6",
         "netresearch/typo3-ci-workflows": "^1.0",
         "roave/security-advisories": "dev-latest",
+        "typo3/cms-dashboard": "^13.4 || ^14.3",
         "typo3/cms-scheduler": "^13.4 || ^14.3"
+    },
+    "suggest": {
+        "typo3/cms-dashboard": "Adds vault secret count and audit activity widgets to the TYPO3 dashboard"
     },
     "autoload": {
         "psr-4": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -33,6 +33,11 @@ parameters:
             # UpgradeWizardInterface moved from cms-install to cms-core in v14.
             # The wizard only runs in v14+ where the interface exists.
             - Classes/Upgrades/AuditHmacMigrationWizard.php
+            # AdminOnlyWidgetInterface was added in TYPO3 v14 (absent in v13.4).
+            # These empty marker subclasses are only registered in the DI
+            # container when the interface exists (Services.Dashboard.php).
+            - Classes/Widgets/AdminOnlyNumberWithIconWidget.php
+            - Classes/Widgets/AdminOnlyBarChartWidget.php
     reportUnmatchedIgnoredErrors: false
 
     ignoreErrors:


### PR DESCRIPTION
## What

Adds two admin-only TYPO3 dashboard widgets in a new **`nrvault` ("Vault")** widget group:

| Identifier | Widget | Data | Size |
|---|---|---|---|
| `nrvault-secrets` | core `NumberWithIconWidget` (icon `vault-secret`) | Count of active secrets in `tx_nrvault_secret` (`deleted=0 AND hidden=0`, filtered explicitly with restrictions removed) | small/small |
| `nrvault-audit-activity` | core `BarChartWidget` (icon `module-vault`) | `tx_nrvault_audit_log` events per UTC day over the last 14 days — one `GROUP BY (crdate - (crdate % 86400))` aggregate query, zero-filled days | medium/medium |

## Why

Admins get an at-a-glance vault health view (secret inventory + audit activity trend) on the standard TYPO3 dashboard, without opening the vault module.

## Design decisions

- **Optional dependency, guarded registration** (same pattern as [netresearch/t3x-nr-llm](https://github.com/netresearch/t3x-nr-llm)): `typo3/cms-dashboard` is a composer `suggest` (plus `require-dev` for tests/PHPStan), NOT a hard requirement. `Configuration/Services.php` imports `Services.Dashboard.php` only when `WidgetInterface` exists, and `Classes/Widgets/*` is excluded from the `Services.yaml` resource glob so installs without EXT:dashboard keep compiling.
- **Admin-only enforcement**: core's `DashboardWidgetPass` derives the `adminOnly` tag attribute from `is_a($widgetClass, AdminOnlyWidgetInterface::class)` — the marker must live on the registered widget class. Since the core widget classes don't implement it, two empty subclasses (`AdminOnlyNumberWithIconWidget`, `AdminOnlyBarChartWidget`) add the interface, matching the vault backend module's `'access' => 'admin'` scope.
- **v13.4 compatibility**: `AdminOnlyWidgetInterface` was added in TYPO3 v14 and does not exist in v13.4. `Services.Dashboard.php` therefore registers the AdminOnly subclasses only when the interface exists and falls back to the plain core widget classes on v13 (where widgets reach non-admins only via explicit group access lists anyway). The two marker subclasses are excluded from PHPStan analysis, mirroring the existing v14-only `AuditHmacMigrationWizard` exclusion.
- **Cheap queries only**: each data provider issues exactly one aggregate `QueryBuilder` query (COUNT / GROUP BY); chart shaping is a pure static method for unit-testability.
- Titles/descriptions are translatable via a new `locallang_dashboard.xlf`; icons reuse the already-registered `vault-secret` / `module-vault` identifiers.

## Test evidence

- CI on this PR: all 51 checks green across PHP 8.2–8.5 × TYPO3 ^13.4/^14.3 (unit, functional SQLite, PHPStan, Rector, CGL, CodeQL, license, security) — see [checks](https://github.com/netresearch/t3x-nr-vault/pull/212/checks)
- Local (PHP 8.5): `phpunit --testsuite Unit` OK (1921 tests, incl. 12 new widget tests), `--testsuite Fuzz` OK (1514), PHPStan level 10 clean, `php-cs-fixer --dry-run` clean, `rector --dry-run` clean, `check-test-base-class.php` / `check-cli-docs.php` OK

No version bump / CHANGELOG (release flow is separate).
