### PR TITLE
Strip URL query strings from audit error messages

### DIFF
--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -750,6 +750,22 @@ final readonly class AuditLogService implements AuditLogServiceInterface
         // Collapse any control characters / newlines to single spaces so a
         // multi-line stack fragment cannot bloat or break the forensic row.
         $clean = (string) preg_replace('/[\x00-\x1F\x7F]+/', ' ', $errorMessage);
+
+        // Strip URL query strings before the message is sealed into the
+        // tamper-evident row (F4 / CWE-532). A transport error from an
+        // outbound HTTP call surfaces the effective request URI in the
+        // driver's exception message; for SecretPlacement::QueryParam that
+        // URI carries the injected secret as `?<param>=<secret>`. The secret's
+        // parameter name is caller-configurable, so we drop the ENTIRE query
+        // component of every embedded http(s) URL and keep only scheme/host/
+        // path. Bounded, delimiter-anchored classes (no `.*?`, no nested
+        // quantifiers) — linear time, no catastrophic backtracking.
+        $clean = (string) preg_replace(
+            '~(https?://[^\s?#"\'<>]+)\?[^\s"\'<>]*~i',
+            '${1}?[REDACTED]',
+            $clean,
+        );
+
         $clean = trim($clean);
 
         // Bound the length: forensic value is in the category of failure, not

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -2332,6 +2332,52 @@ final class AuditLogServiceTest extends TestCase
         self::assertSame([2, 3, 4], $verification->missingUids);
     }
 
+    #[Test]
+    public function logStripsUrlQueryStringFromTransportErrorMessage(): void
+    {
+        // F4 / CWE-532: a SecretPlacement::QueryParam request whose transport
+        // throws surfaces the effective URI — including `?api_key=<secret>` —
+        // in the ClientExceptionInterface message. VaultHttpClient forwards
+        // that message verbatim to log(); the sanitizer MUST strip the query
+        // string so the live secret is never sealed into the audit row.
+        $this->setupDatabaseMocks();
+
+        $secret = 'SUPERSECRET123';
+        $message = 'cURL error 6: Could not resolve host: api.example.com '
+            . 'for https://api.example.com/data?api_key=' . $secret;
+
+        $captured = null;
+        $this->connection
+            ->method('insert')
+            ->with(
+                'tx_nrvault_audit_log',
+                self::callback(static function (array $data) use (&$captured): bool {
+                    $captured = $data['error_message'];
+
+                    return true;
+                }),
+            );
+
+        $this->getSubject()->log('api_creds', 'http_call', false, $message);
+
+        self::assertIsString($captured);
+        self::assertStringNotContainsString(
+            $secret,
+            $captured,
+            'The live secret must NOT be persisted in the audit row',
+        );
+        self::assertStringContainsString(
+            '[REDACTED]',
+            $captured,
+            'The stripped query must be marked [REDACTED]',
+        );
+        self::assertStringContainsString(
+            'https://api.example.com/data',
+            $captured,
+            'Scheme/host/path forensics are retained',
+        );
+    }
+
     /**
      * Build a raw DB row (snake_case keys, mixed types) suitable for
      * extractV2HashRow() input. Used by tests that exercise the extractor


### PR DESCRIPTION
## Summary

A `SecretPlacement::QueryParam` outbound request places the secret in the URL query string. On a transport error, the driver's exception message — which embeds the effective request URI — was logged verbatim into the audit log `error_message`, persisting the live secret in cleartext (CWE-532).

`AuditLogService::sanitizeErrorMessage()` now strips the query component of every embedded `http(s)` URL before the message is sealed into the tamper-evident row, keeping scheme/host/path for forensics. This is the single chokepoint every logged error message traverses.

The audit URL/context field is **not** a second sink: `HttpCallContext::fromRequest()` keeps only host+path (`parse_url` drops the query), and `logHttpCall` receives the pre-injection URI.

## Finding

Found by a Claude Security scan (whole-repo, `max` effort), confirmed by a 3-voter adversarial panel, and re-verified after the fix (SHIP verdict: closes the finding, no new issue, CS/PHPStan-clean).

## Tests

`logStripsUrlQueryStringFromTransportErrorMessage` asserts the secret is absent, `[REDACTED]` present, and scheme/host/path retained. The redaction regex is delimiter-anchored and linear-time.