### PR TITLE
Neutralize CSV formula injection in audit exports

### DIFF
--- a/Classes/Command/VaultAuditCommand.php
+++ b/Classes/Command/VaultAuditCommand.php
@@ -15,6 +15,7 @@ use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Audit\AuditLogFilter;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Exception\VaultException;
+use Netresearch\NrVault\Utility\CsvFormulaSanitizer;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -279,13 +280,13 @@ final class VaultAuditCommand extends Command
             $output->writeln(\sprintf(
                 '%s,%s,%s,%d,%s,%s,%s,%s',
                 date('Y-m-d H:i:s', $entry->crdate),
-                $this->escapeCsv($entry->secretIdentifier),
-                $entry->action,
+                CsvFormulaSanitizer::escapeField($entry->secretIdentifier),
+                CsvFormulaSanitizer::escapeField($entry->action),
                 $entry->success ? 1 : 0,
-                $this->escapeCsv($entry->actorUsername),
-                $entry->actorType,
-                $entry->ipAddress,
-                $entry->entryHash,
+                CsvFormulaSanitizer::escapeField($entry->actorUsername),
+                CsvFormulaSanitizer::escapeField($entry->actorType),
+                CsvFormulaSanitizer::escapeField($entry->ipAddress),
+                CsvFormulaSanitizer::escapeField($entry->entryHash),
             ));
         }
     }
@@ -338,7 +339,7 @@ final class VaultAuditCommand extends Command
                 static fn (mixed $v): bool|float|int|string|null => \is_scalar($v) || $v === null ? $v : json_encode($v),
                 $row,
             );
-            fputcsv($output, $csvRow, escape: '\\');
+            fputcsv($output, CsvFormulaSanitizer::neutralizeRow($csvRow), escape: '\\');
         }
 
         rewind($output);
@@ -346,14 +347,5 @@ final class VaultAuditCommand extends Command
         fclose($output);
 
         return $csv;
-    }
-
-    private function escapeCsv(string $value): string
-    {
-        if (str_contains($value, ',') || str_contains($value, '"') || str_contains($value, "\n")) {
-            return '"' . str_replace('"', '""', $value) . '"';
-        }
-
-        return $value;
     }
 }

--- a/Classes/Command/VaultListCommand.php
+++ b/Classes/Command/VaultListCommand.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrVault\Command;
 use Netresearch\NrVault\Domain\Dto\SecretMetadata;
 use Netresearch\NrVault\Exception\VaultException;
 use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Utility\CsvFormulaSanitizer;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -148,7 +149,7 @@ final class VaultListCommand extends Command
         foreach ($secrets as $secret) {
             $output->writeln(\sprintf(
                 '%s,%d,%s,%s,%d,%s',
-                $this->escapeCsv($secret->identifier),
+                CsvFormulaSanitizer::escapeField($secret->identifier),
                 $secret->ownerUid,
                 date(self::DATE_FORMAT_LONG, $secret->createdAt),
                 date(self::DATE_FORMAT_LONG, $secret->updatedAt),
@@ -156,14 +157,5 @@ final class VaultListCommand extends Command
                 $secret->lastReadAt !== null ? date(self::DATE_FORMAT_LONG, $secret->lastReadAt) : '',
             ));
         }
-    }
-
-    private function escapeCsv(string $value): string
-    {
-        if (str_contains($value, ',') || str_contains($value, '"') || str_contains($value, "\n")) {
-            return '"' . str_replace('"', '""', $value) . '"';
-        }
-
-        return $value;
     }
 }

--- a/Classes/Controller/AuditController.php
+++ b/Classes/Controller/AuditController.php
@@ -15,6 +15,7 @@ use Netresearch\NrVault\Audit\AuditAction;
 use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Audit\AuditLogFilter;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Utility\CsvFormulaSanitizer;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use TYPO3\CMS\Backend\Attribute\AsController;
@@ -352,7 +353,7 @@ final readonly class AuditController
                 }
                 /** @var array<int, bool|float|int|string|null> $values */
                 $values = array_values($row);
-                fputcsv($output, $values, escape: '\\');
+                fputcsv($output, CsvFormulaSanitizer::neutralizeRow($values), escape: '\\');
             }
         }
 

--- a/Classes/Utility/CsvFormulaSanitizer.php
+++ b/Classes/Utility/CsvFormulaSanitizer.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Utility;
+
+/**
+ * Neutralizes spreadsheet-formula leaders in CSV cells (CWE-1236).
+ *
+ * CSV quoting (fputcsv / RFC 4180) protects the CSV grammar but not the
+ * consuming spreadsheet application: a cell whose first character is one of
+ * = + - @ TAB CR is interpreted as a formula by Excel / LibreOffice / Google
+ * Sheets. Attacker-controlled audit data (User-Agent, request id, identifiers)
+ * must therefore be neutralized before it is written to any CSV export.
+ */
+final class CsvFormulaSanitizer
+{
+    /**
+     * Characters that trigger formula evaluation when they are a cell's first
+     * byte. Includes TAB (0x09) and CR (0x0D), which some parsers strip before
+     * evaluating the following leader.
+     *
+     * @var list<string>
+     */
+    private const FORMULA_LEADERS = ['=', '+', '-', '@', "\t", "\r"];
+
+    /**
+     * Neutralize a single CSV cell.
+     *
+     * Prefixes a leading single quote when the first byte is a formula leader;
+     * otherwise the value is returned byte-identical. Intended to be applied
+     * before the value is handed to fputcsv() (which adds RFC-4180 quoting).
+     */
+    public static function neutralizeCell(string $value): string
+    {
+        if ($value === '') {
+            return $value;
+        }
+
+        if (\in_array($value[0], self::FORMULA_LEADERS, true)) {
+            return "'" . $value;
+        }
+
+        return $value;
+    }
+
+    /**
+     * Neutralize every string cell of a row for fputcsv().
+     *
+     * Non-string cells (bool/int/float/null) are passed through unchanged; keys
+     * are preserved.
+     *
+     * @param array<int|string, bool|float|int|string|null> $row
+     *
+     * @return array<int|string, bool|float|int|string|null>
+     */
+    public static function neutralizeRow(array $row): array
+    {
+        return array_map(
+            static fn (bool|float|int|string|null $cell): bool|float|int|string|null
+                => \is_string($cell) ? self::neutralizeCell($cell) : $cell,
+            $row,
+        );
+    }
+
+    /**
+     * Escape a field for hand-rolled (non-fputcsv) CSV assembly.
+     *
+     * Neutralizes formula leaders, then applies RFC-4180 quoting when the value
+     * contains a comma, double quote or newline.
+     */
+    public static function escapeField(string $value): string
+    {
+        $value = self::neutralizeCell($value);
+
+        if (str_contains($value, ',') || str_contains($value, '"') || str_contains($value, "\n")) {
+            return '"' . str_replace('"', '""', $value) . '"';
+        }
+
+        return $value;
+    }
+}

--- a/Tests/Unit/Command/VaultAuditCommandTest.php
+++ b/Tests/Unit/Command/VaultAuditCommandTest.php
@@ -540,4 +540,79 @@ final class VaultAuditCommandTest extends TestCase
         $content = file_get_contents($exportFile);
         self::assertStringContainsString('csv-export', $content);
     }
+
+    #[Test]
+    public function csvConsoleOutputNeutralizesFormulaInjection(): void
+    {
+        $entry = AuditLogEntry::fromDatabaseRow([
+            'uid' => 1,
+            'crdate' => 1704067200,
+            'secret_identifier' => '=1+1',
+            'action' => 'read',
+            'success' => 1,
+            'actor_uid' => 1,
+            'actor_username' => '@SUM(A1)',
+            'actor_type' => 'be_user',
+            'ip_address' => '10.0.0.1',
+            'entry_hash' => 'csvhash',
+            'previous_hash' => '',
+            'context' => '{}',
+        ]);
+
+        $this->auditLogService
+            ->method('query')
+            ->willReturn([$entry]);
+
+        $exitCode = $this->commandTester->execute([
+            '--format' => 'csv',
+        ]);
+
+        self::assertSame(0, $exitCode);
+        $display = $this->commandTester->getDisplay();
+        self::assertStringContainsString("'=1+1", $display);
+        self::assertStringContainsString("'@SUM(A1)", $display);
+        self::assertStringNotContainsString(',=1+1', $display);
+        self::assertStringNotContainsString(',@SUM(A1)', $display);
+    }
+
+    #[Test]
+    public function csvExportFileNeutralizesFormulaInUserAgentAndRequestId(): void
+    {
+        vfsStream::setup('exports');
+
+        $entry = AuditLogEntry::fromDatabaseRow([
+            'uid' => 1,
+            'crdate' => 1704067200,
+            'secret_identifier' => 'benign_id',
+            'action' => 'read',
+            'success' => 1,
+            'actor_uid' => 1,
+            'actor_username' => 'admin',
+            'actor_type' => 'be_user',
+            'ip_address' => '10.0.0.1',
+            'user_agent' => "=cmd|'/c calc'!A1",
+            'request_id' => '@SUM(1+1)',
+            'entry_hash' => 'hash',
+            'previous_hash' => '',
+            'context' => '{}',
+        ]);
+
+        $this->auditLogService
+            ->method('query')
+            ->willReturn([$entry]);
+
+        $exportFile = vfsStream::url('exports/audit.csv');
+
+        $exitCode = $this->commandTester->execute([
+            '--export' => $exportFile,
+            '--format' => 'csv',
+        ]);
+
+        self::assertSame(0, $exitCode);
+        $content = (string) file_get_contents($exportFile);
+        self::assertStringContainsString("'=cmd|'/c calc'!A1", $content);
+        self::assertStringContainsString("'@SUM(1+1)", $content);
+        self::assertStringContainsString('benign_id', $content);
+        self::assertStringNotContainsString("'benign_id", $content);
+    }
 }

--- a/Tests/Unit/Command/VaultListCommandTest.php
+++ b/Tests/Unit/Command/VaultListCommandTest.php
@@ -412,4 +412,34 @@ final class VaultListCommandTest extends TestCase
         // Last read shows "-" when never read
         self::assertStringContainsString('-', $display);
     }
+
+    #[Test]
+    public function outputCsvNeutralizesFormulaInIdentifier(): void
+    {
+        $secrets = [
+            new SecretMetadata(
+                identifier: '=cmd',
+                ownerUid: 1,
+                createdAt: 1704067200,
+                updatedAt: 1704153600,
+                readCount: 0,
+                lastReadAt: null,
+                description: '',
+                version: 1,
+            ),
+        ];
+
+        $this->vaultService
+            ->method('list')
+            ->willReturn($secrets);
+
+        $exitCode = $this->commandTester->execute([
+            '--format' => 'csv',
+        ]);
+
+        self::assertSame(0, $exitCode);
+        $display = $this->commandTester->getDisplay();
+        self::assertStringContainsString("'=cmd", $display);
+        self::assertStringNotContainsString("\n=cmd", $display);
+    }
 }

--- a/Tests/Unit/Utility/CsvFormulaSanitizerTest.php
+++ b/Tests/Unit/Utility/CsvFormulaSanitizerTest.php
@@ -1,0 +1,93 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Utility;
+
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Utility\CsvFormulaSanitizer;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(CsvFormulaSanitizer::class)]
+final class CsvFormulaSanitizerTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function formulaLeaderProvider(): iterable
+    {
+        yield 'equals' => ['=1+1', "'=1+1"];
+        yield 'plus' => ['+1+1', "'+1+1"];
+        yield 'minus' => ['-1+1', "'-1+1"];
+        yield 'at' => ['@SUM(A1)', "'@SUM(A1)"];
+        yield 'tab' => ["\t=1", "'\t=1"];
+        yield 'carriage-return' => ["\r=1", "'\r=1"];
+        yield 'dde-payload' => ["=cmd|'/c calc'!A1", "'=cmd|'/c calc'!A1"];
+    }
+
+    #[Test]
+    #[DataProvider('formulaLeaderProvider')]
+    public function neutralizeCellPrefixesFormulaLeaders(string $input, string $expected): void
+    {
+        self::assertSame($expected, CsvFormulaSanitizer::neutralizeCell($input));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function benignValueProvider(): iterable
+    {
+        yield 'plain' => ['hello'];
+        yield 'identifier' => ['my_api_key'];
+        yield 'hex-hash' => ['abc123def456'];
+        yield 'ip' => ['127.0.0.1'];
+        yield 'iso-date' => ['2024-01-01T00:00:00+00:00'];
+        yield 'empty' => [''];
+        yield 'leader-not-first' => ['a=b'];
+    }
+
+    #[Test]
+    #[DataProvider('benignValueProvider')]
+    public function neutralizeCellLeavesBenignValuesByteIdentical(string $input): void
+    {
+        self::assertSame($input, CsvFormulaSanitizer::neutralizeCell($input));
+    }
+
+    #[Test]
+    public function neutralizeRowNeutralizesStringsAndPreservesOtherTypes(): void
+    {
+        $row = [
+            'id' => '=cmd',
+            'count' => 5,
+            'ratio' => 1.5,
+            'ok' => true,
+            'empty' => null,
+            'benign' => 'read',
+        ];
+
+        self::assertSame([
+            'id' => "'=cmd",
+            'count' => 5,
+            'ratio' => 1.5,
+            'ok' => true,
+            'empty' => null,
+            'benign' => 'read',
+        ], CsvFormulaSanitizer::neutralizeRow($row));
+    }
+
+    #[Test]
+    public function escapeFieldNeutralizesThenQuotesWhenNeeded(): void
+    {
+        self::assertSame("\"'=cmd,evil\"", CsvFormulaSanitizer::escapeField('=cmd,evil'));
+        self::assertSame("'=cmd", CsvFormulaSanitizer::escapeField('=cmd'));
+        self::assertSame('"a,b"', CsvFormulaSanitizer::escapeField('a,b'));
+        self::assertSame('plain', CsvFormulaSanitizer::escapeField('plain'));
+    }
+}


### PR DESCRIPTION
## Summary

Attacker-controlled audit fields (`User-Agent`, `request_id`, identifiers) were written to CSV exports without neutralizing spreadsheet formula leaders (`= + - @` TAB CR). Opening such an export in Excel/LibreOffice evaluates the crafted cell as a formula in the operator's context (CWE-1236), crossing a low-privilege → admin boundary.

A shared `CsvFormulaSanitizer` now guards **all four** CSV sinks: `AuditController::exportAsCsv`, `VaultAuditCommand` console + file export, and `VaultListCommand`. A leading single quote is prefixed only when the first byte is a formula leader; benign values are byte-identical. The two duplicated quote-only `escapeCsv` helpers (which did not defend against formula injection) are consolidated into it.

## Finding

Found by a Claude Security scan (`max` effort); the finding cited two sinks, the class-of-bug sweep found four. Confirmed by a 3-voter panel and re-verified after the fix (SHIP: closes the finding, no sink missed, no dangling `escapeCsv`, CS/PHPStan-clean).

## Tests

- `CsvFormulaSanitizerTest` — exhaustive: every leader + a DDE payload neutralized, benign values byte-identical, `neutralizeRow`/`escapeField` combinations.
- `VaultAuditCommandTest` — console and export-file sinks.
- `VaultListCommandTest` — identifier sink.

The `AuditController` backend-export sink calls the same unit-tested `neutralizeRow` primitive as the CLI export; a controller-level functional test was omitted to avoid coupling to backend-auth scaffolding.