### PR TITLE
Close umask race on secret and key file writes

### DIFF
--- a/Classes/Command/VaultInitCommand.php
+++ b/Classes/Command/VaultInitCommand.php
@@ -144,16 +144,33 @@ final class VaultInitCommand extends Command
             return Command::FAILURE;
         }
 
-        // Write key to file with restrictive permissions
-        $result = file_put_contents($outputFilePath, $masterKey);
+        // Eliminate the umask race: tighten umask before the write so the file
+        // is created 0600, then chmod to enforce it even when the file already
+        // existed. The previous order (file_put_contents -> chmod) left a brief
+        // window where a freshly created key file was world-readable on hosts
+        // with permissive umasks, and a permanent 0644 file if the process was
+        // interrupted before the chmod. Mirrors
+        // FileMasterKeyProvider::storeMasterKey().
+        $previousUmask = umask(0o077);
+
+        try {
+            $result = file_put_contents($outputFilePath, $masterKey);
+        } finally {
+            umask($previousUmask);
+        }
         if ($result === false) {
             $io->error(\sprintf('Failed to write master key to: %s', $outputFilePath));
 
             return Command::FAILURE;
         }
 
-        // Set restrictive permissions (owner read/write only)
-        chmod($outputFilePath, 0o600);
+        // Enforce restrictive permissions (owner read/write only), also on a
+        // pre-existing file, and fail loudly if it cannot be secured
+        if (!chmod($outputFilePath, 0o600)) {
+            $io->error(\sprintf('Failed to set permissions on master key file: %s', $outputFilePath));
+
+            return Command::FAILURE;
+        }
 
         $io->success(\sprintf('Master key generated and saved to: %s', $outputFilePath));
         $io->table(

--- a/Classes/Command/VaultRetrieveCommand.php
+++ b/Classes/Command/VaultRetrieveCommand.php
@@ -88,8 +88,21 @@ final class VaultRetrieveCommand extends Command
                     return Command::FAILURE;
                 }
 
-                // Write to file with restricted permissions
-                $result = file_put_contents($outputFile, $value);
+                // Eliminate the umask race: tighten umask before the write so
+                // the file is created 0600, then chmod to enforce it even when
+                // the file already existed. The previous order
+                // (file_put_contents -> chmod) left a brief window where a
+                // freshly created file was world-readable on hosts with
+                // permissive umasks, and a permanent 0644 file if the process
+                // was interrupted before the chmod. Mirrors
+                // FileMasterKeyProvider::storeMasterKey().
+                $previousUmask = umask(0o077);
+
+                try {
+                    $result = file_put_contents($outputFile, $value);
+                } finally {
+                    umask($previousUmask);
+                }
                 if ($result === false) {
                     $io->error(\sprintf('Failed to write to file: %s', $outputFile));
                     sodium_memzero($value);
@@ -97,8 +110,14 @@ final class VaultRetrieveCommand extends Command
                     return Command::FAILURE;
                 }
 
-                // Set restrictive permissions
-                chmod($outputFile, 0o600);
+                // Enforce restrictive permissions (also tightens a pre-existing
+                // file, which umask cannot) and fail loudly if it cannot be set
+                if (!chmod($outputFile, 0o600)) {
+                    $io->error(\sprintf('Failed to set permissions on file: %s', $outputFile));
+                    sodium_memzero($value);
+
+                    return Command::FAILURE;
+                }
 
                 $io->success(\sprintf('Secret written to: %s', $outputFile));
             } else {

--- a/Tests/Unit/Command/VaultInitCommandTest.php
+++ b/Tests/Unit/Command/VaultInitCommandTest.php
@@ -19,6 +19,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 #[CoversClass(VaultInitCommand::class)]
 #[AllowMockObjectsWithoutExpectations]
@@ -29,6 +30,9 @@ final class VaultInitCommandTest extends TestCase
     private ExtensionConfigurationInterface&MockObject $configuration;
 
     private CommandTester $commandTester;
+
+    /** @var list<string> */
+    private array $tempPaths = [];
 
     protected function setUp(): void
     {
@@ -42,6 +46,16 @@ final class VaultInitCommandTest extends TestCase
         $application->addCommand($command);
 
         $this->commandTester = new CommandTester($command);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempPaths as $path) {
+            GeneralUtility::rmdir($path, true);
+        }
+        $this->tempPaths = [];
+
+        parent::tearDown();
     }
 
     #[Test]
@@ -214,5 +228,53 @@ final class VaultInitCommandTest extends TestCase
         self::assertStringContainsString('IMPORTANT SECURITY NOTES', $display);
         self::assertStringContainsString('Back up this key', $display);
         self::assertStringContainsString('XSalsa20-Poly1305', $display);
+    }
+
+    #[Test]
+    public function generatesKeyToFileWithRestrictivePermissions(): void
+    {
+        $this->configuration->method('getMasterKeyProvider')->willReturn('file');
+        $this->configuration->method('getMasterKeySource')->willReturn('');
+
+        $outputFile = $this->createTempDir() . '/master.key';
+
+        $previousUmask = umask(0o000);
+
+        try {
+            $exitCode = $this->commandTester->execute(['--output' => $outputFile]);
+        } finally {
+            umask($previousUmask);
+        }
+
+        self::assertSame(0, $exitCode);
+        self::assertFileExists($outputFile);
+        self::assertSame(0o600, fileperms($outputFile) & 0o777);
+    }
+
+    #[Test]
+    public function overwritesExistingKeyFileAndTightensPermissions(): void
+    {
+        $this->configuration->method('getMasterKeyProvider')->willReturn('file');
+
+        $outputFile = $this->createTempDir() . '/master.key';
+        file_put_contents($outputFile, str_repeat('x', 32));
+        chmod($outputFile, 0o644);
+
+        $exitCode = $this->commandTester->execute([
+            '--output' => $outputFile,
+            '--force' => true,
+        ]);
+
+        self::assertSame(0, $exitCode);
+        self::assertSame(0o600, fileperms($outputFile) & 0o777);
+    }
+
+    private function createTempDir(): string
+    {
+        $dir = sys_get_temp_dir() . '/nr-vault-init-' . bin2hex(random_bytes(6));
+        mkdir($dir, 0o700);
+        $this->tempPaths[] = $dir;
+
+        return $dir;
     }
 }

--- a/Tests/Unit/Command/VaultRetrieveCommandTest.php
+++ b/Tests/Unit/Command/VaultRetrieveCommandTest.php
@@ -21,6 +21,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 #[CoversClass(VaultRetrieveCommand::class)]
 #[AllowMockObjectsWithoutExpectations]
@@ -29,6 +30,9 @@ final class VaultRetrieveCommandTest extends TestCase
     private VaultServiceInterface&MockObject $vaultService;
 
     private CommandTester $commandTester;
+
+    /** @var list<string> */
+    private array $tempPaths = [];
 
     protected function setUp(): void
     {
@@ -42,6 +46,16 @@ final class VaultRetrieveCommandTest extends TestCase
         $application->addCommand($command);
 
         $this->commandTester = new CommandTester($command);
+    }
+
+    protected function tearDown(): void
+    {
+        foreach ($this->tempPaths as $path) {
+            GeneralUtility::rmdir($path, true);
+        }
+        $this->tempPaths = [];
+
+        parent::tearDown();
     }
 
     #[Test]
@@ -202,5 +216,61 @@ final class VaultRetrieveCommandTest extends TestCase
 
         self::assertSame(1, $exitCode);
         self::assertStringContainsString('Failed to write to file', $this->commandTester->getDisplay());
+    }
+
+    #[Test]
+    public function writesSecretToFileWithRestrictivePermissions(): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturn('file-content-123');
+
+        $outputFile = $this->createTempDir() . '/secret.txt';
+
+        $previousUmask = umask(0o000);
+
+        try {
+            $exitCode = $this->commandTester->execute([
+                'identifier' => 'file-secret',
+                '--output' => $outputFile,
+            ]);
+        } finally {
+            umask($previousUmask);
+        }
+
+        self::assertSame(0, $exitCode);
+        self::assertFileExists($outputFile);
+        self::assertSame('file-content-123', file_get_contents($outputFile));
+        self::assertSame(0o600, fileperms($outputFile) & 0o777);
+    }
+
+    #[Test]
+    public function overwritesExistingFileAndTightensPermissions(): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturn('new-content');
+
+        $outputFile = $this->createTempDir() . '/existing.txt';
+        file_put_contents($outputFile, 'stale');
+        chmod($outputFile, 0o644);
+
+        $exitCode = $this->commandTester->execute([
+            'identifier' => 'file-secret',
+            '--output' => $outputFile,
+        ]);
+
+        self::assertSame(0, $exitCode);
+        self::assertSame('new-content', file_get_contents($outputFile));
+        self::assertSame(0o600, fileperms($outputFile) & 0o777);
+    }
+
+    private function createTempDir(): string
+    {
+        $dir = sys_get_temp_dir() . '/nr-vault-retrieve-' . bin2hex(random_bytes(6));
+        mkdir($dir, 0o700);
+        $this->tempPaths[] = $dir;
+
+        return $dir;
     }
 }


### PR DESCRIPTION
## Summary

`vault:retrieve --output` and `vault:init` wrote the decrypted secret / master key with `file_put_contents()` and only `chmod`'d `0600` afterwards, leaving a world/group-readable window on permissive-umask hosts (and a permanent `0644` file if the process was interrupted before the chmod) — CWE-377.

Both paths now tighten `umask(0o077)` around the write (restored in `finally`) so the file is created `0600`, keep the `chmod` to also tighten a pre-existing file, and fail loudly (`Command::FAILURE`) if the chmod cannot be applied. This mirrors the existing `FileMasterKeyProvider::storeMasterKey()` pattern.

The `vault:init` path is included as defense-in-depth: the same write-then-chmod pattern on master-key material. (The scan flagged it too but it was rated non-exploitable because init creates its target directory `0700` first; the one-line hardening is applied regardless.)

## Finding

Found by a Claude Security scan (`max` effort), confirmed by a 3-voter panel. Post-fix adversarial review confirmed both sinks are patched.

## Tests

`writesSecretToFileWithRestrictivePermissions` / `overwritesExistingFileAndTightensPermissions` (and the init equivalents) assert the resulting file mode is `0600`, using a real temp dir since vfsStream cannot model POSIX modes or umask.

## Limitation

The tests assert the end-state mode; the transient race window itself is not directly unit-testable while the `chmod` remains. The fix is the umask-based creation, verified by mirroring the established provider pattern.