### PR TITLE
Enforce vault delete ACL on DataHandler deletes

### DIFF
--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -9,7 +9,10 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Hook;
 
+use Netresearch\NrVault\Audit\AuditAction;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Domain\Model\Secret;
+use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Throwable;
@@ -62,10 +65,21 @@ final class SecretTcaHook
      */
     private array $pendingSecrets = [];
 
+    /**
+     * Record UIDs whose delete command failed the vault ACL in
+     * processCmdmap_preProcess(), to be cancelled in processCmdmap(). Entries
+     * are consumed (unset) when the cancel is applied so a DI-shared hook
+     * instance cannot leak a stale denial across DataHandler runs.
+     *
+     * @var array<int, true>
+     */
+    private array $deniedDeletions = [];
+
     public function __construct(
         private readonly VaultServiceInterface $vaultService,
         private readonly AuditLogServiceInterface $auditService,
         private readonly AccessControlServiceInterface $accessControlService,
+        private readonly SecretRepositoryInterface $secretRepository,
     ) {}
 
     /**
@@ -255,38 +269,111 @@ final class SecretTcaHook
     }
 
     /**
-     * Called before record deletion.
-     * Logs deletion to audit log.
+     * Called before a command (here: delete) is processed. Enforces the vault
+     * delete ACL (F5 / CWE-862) and records the audit entry.
+     *
+     * DataHandler's own table permissions are NOT the vault ACL, so the gate
+     * lives here — mirroring VaultService::delete()'s canDelete() check (the
+     * most restrictive tier: owner / admin / system maintainer only, ADR-005).
+     * A denied delete is flagged for cancellation in processCmdmap() and logged
+     * as access_denied; only an authorized delete records a delete success.
+     *
+     * The extra $value/$dataHandler parameters are supplied by core
+     * (DataHandler passes six positional args); they are optional so the
+     * pre-existing three-argument unit-test calls still bind.
      */
     public function processCmdmap_preProcess(// NOSONAR: TYPO3 DataHandler hook method name (fixed API contract)
         string $command,
         string $table,
         string|int $id,
+        mixed $value = null,
+        ?DataHandler $dataHandler = null,
     ): void {
         if ($table !== self::TABLE || $command !== 'delete') {
             return;
         }
 
-        $record = BackendUtility::getRecord(self::TABLE, (int) $id, 'identifier');
-        if ($record === null) {
+        $uid = is_numeric($id) ? (int) $id : 0;
+        $secret = $this->secretRepository->findByUid($uid);
+        if (!$secret instanceof Secret) {
             return;
         }
 
-        $recordIdentifier = \is_string($record['identifier'] ?? null) ? $record['identifier'] : '';
-        if ($recordIdentifier === '') {
+        $identifier = $secret->getIdentifier();
+
+        // Write-path authorization (CWE-862): only the owner, an admin or a
+        // system maintainer may delete a secret. A non-owner non-admin editor
+        // with generic table-modify rights must be stopped here.
+        if (!$this->accessControlService->canDelete($secret)) {
+            $this->deniedDeletions[$uid] = true;
+
+            try {
+                $this->auditService->log(
+                    $identifier,
+                    AuditAction::AccessDenied->value,
+                    false,
+                    'Delete access denied',
+                    'FormEngine delete denied',
+                );
+            } catch (Throwable) {
+                // A failed audit write must not mask the denial.
+            }
+
+            /** @phpstan-ignore method.internal */
+            $dataHandler?->log(
+                self::TABLE,
+                $uid,
+                2,
+                null,
+                1,
+                'Vault secret can only be deleted by its owner or an administrator',
+            );
+
             return;
         }
 
+        // Authorized delete: record the audit entry now, while the identifier
+        // is still resolvable (core removes the row afterwards).
         try {
             $this->auditService->log(
-                $recordIdentifier,
-                'delete',
+                $identifier,
+                AuditAction::Delete->value,
                 true,
                 null,
                 'Deleted via FormEngine',
             );
         } catch (Throwable) {
             // Don't fail the delete if audit logging fails
+        }
+    }
+
+    /**
+     * Cancels a delete command that failed the vault ACL in
+     * processCmdmap_preProcess(). Setting $commandIsProcessed = true makes core
+     * skip its own deleteAction() (DataHandler runs this hook before the
+     * command switch), so the record is preserved.
+     *
+     * The denial flag is consumed so a DI-shared hook instance cannot leak a
+     * stale denial into a later DataHandler run (same discipline as
+     * $pendingSecrets).
+     */
+    public function processCmdmap(// NOSONAR: TYPO3 DataHandler hook method name (fixed API contract)
+        string $command,
+        string $table,
+        string|int $id,
+        mixed $value,
+        bool &$commandIsProcessed,
+        DataHandler $dataHandler,
+        mixed $pasteUpdate,
+    ): void {
+        if ($table !== self::TABLE || $command !== 'delete') {
+            return;
+        }
+
+        $uid = is_numeric($id) ? (int) $id : 0;
+        if (($this->deniedDeletions[$uid] ?? false) === true) {
+            unset($this->deniedDeletions[$uid]);
+            $commandIsProcessed = true;
         }
     }
 

--- a/Tests/Functional/Hook/SecretTcaHookDeleteAclTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookDeleteAclTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Hook;
+
+use Netresearch\NrVault\Audit\AuditAction;
+use Netresearch\NrVault\Hook\SecretTcaHook;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for the delete-command write-path authorization in
+ * SecretTcaHook (F5, CWE-862).
+ *
+ * A DataHandler `delete` on tx_nrvault_secret must enforce the vault
+ * canDelete ACL (owner / admin / system-maintainer only). A non-owner
+ * non-admin editor with generic table-modify rights must NOT be able to
+ * delete another user's secret.
+ */
+#[CoversClass(SecretTcaHook::class)]
+final class SecretTcaHookDeleteAclTest extends AbstractVaultFunctionalTestCase
+{
+    private const SECRET_TABLE = 'tx_nrvault_secret';
+
+    private const AUDIT_TABLE = 'tx_nrvault_audit_log';
+
+    /** Admin backend user (uid 1 in the fixture). */
+    private const ADMIN_UID = 1;
+
+    /** Non-admin editor (uid 2 in the fixture). */
+    private const EDITOR_UID = 2;
+
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_acl.csv';
+
+    /** Log in explicitly per test — different actors per scenario. */
+    protected ?int $backendUserUid = null;
+
+    #[Test]
+    public function nonOwnerNonAdminDeleteIsBlocked(): void
+    {
+        $this->setUpBackendUser(self::EDITOR_UID);
+        [$uid, $identifier] = $this->seedSecret(self::ADMIN_UID);
+
+        // Drive the hook contract directly rather than DataHandler::process_cmdmap():
+        // core's own table-permission check (checkModifyAccessList) would block a
+        // group-less editor BEFORE the hook runs, masking the vault gate under test.
+        // The direct call isolates the vault ACL, which is the finding.
+        $commandIsProcessed = $this->runDeleteHook($uid);
+
+        // The vault gate must cancel the delete (commandIsProcessed=true makes core
+        // skip its deleteAction) AND record an access_denied audit entry — the
+        // fingerprint that the HOOK, not core's table permissions, blocked it.
+        self::assertTrue(
+            $commandIsProcessed,
+            'The vault gate must cancel a non-owner non-admin delete (commandIsProcessed=true).',
+        );
+        self::assertSame(
+            1,
+            $this->countAudit($identifier, AuditAction::AccessDenied->value, 0),
+            'A failed access_denied audit entry must be recorded for the denied delete.',
+        );
+        self::assertSame(
+            0,
+            $this->countAudit($identifier, AuditAction::Delete->value, 1),
+            'No successful delete audit entry may be written for a denied delete.',
+        );
+    }
+
+    #[Test]
+    public function nonAdminOwnerDeleteIsAllowedByVaultGate(): void
+    {
+        $this->setUpBackendUser(self::EDITOR_UID);
+        [$uid, $identifier] = $this->seedSecret(self::EDITOR_UID);
+
+        $commandIsProcessed = $this->runDeleteHook($uid);
+
+        self::assertFalse($commandIsProcessed, 'The owner must not be blocked by the vault delete gate.');
+        self::assertSame(
+            1,
+            $this->countAudit($identifier, AuditAction::Delete->value, 1),
+            'The authorized delete must record a successful delete audit entry.',
+        );
+    }
+
+    #[Test]
+    public function adminDeleteIsAllowedByVaultGate(): void
+    {
+        $this->setUpBackendUser(self::ADMIN_UID);
+        [$uid, $identifier] = $this->seedSecret(self::EDITOR_UID);
+
+        $commandIsProcessed = $this->runDeleteHook($uid);
+
+        self::assertFalse($commandIsProcessed, 'An admin must not be blocked by the vault delete gate.');
+        self::assertSame(
+            1,
+            $this->countAudit($identifier, AuditAction::Delete->value, 1),
+            'The authorized delete must record a successful delete audit entry.',
+        );
+    }
+
+    /**
+     * Drive the hook contract directly (preProcess decision + processCmdmap
+     * cancellation) so the vault gate is isolated from core DataHandler's own
+     * table-permission system — which would otherwise block a permission-less
+     * non-admin owner and mask the result.
+     */
+    private function runDeleteHook(int $uid): bool
+    {
+        $hook = $this->get(SecretTcaHook::class);
+        self::assertInstanceOf(SecretTcaHook::class, $hook);
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+
+        $hook->processCmdmap_preProcess('delete', self::SECRET_TABLE, $uid, dataHandler: $dataHandler);
+
+        $commandIsProcessed = false;
+        $hook->processCmdmap('delete', self::SECRET_TABLE, $uid, '', $commandIsProcessed, $dataHandler, false);
+
+        return $commandIsProcessed;
+    }
+
+    /**
+     * @return array{0: int, 1: string} [secret uid, identifier]
+     */
+    private function seedSecret(int $ownerUid): array
+    {
+        $identifier = 'del_acl_' . bin2hex(random_bytes(4));
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::SECRET_TABLE);
+        $connection->insert(self::SECRET_TABLE, [
+            'pid' => 0,
+            'identifier' => $identifier,
+            'owner_uid' => $ownerUid,
+            'frontend_accessible' => 0,
+            'deleted' => 0,
+        ]);
+
+        return [(int) $connection->lastInsertId(), $identifier];
+    }
+
+    private function countAudit(string $identifier, string $action, int $success): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::AUDIT_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $count = $queryBuilder
+            ->count('uid')
+            ->from(self::AUDIT_TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('secret_identifier', $queryBuilder->createNamedParameter($identifier)),
+                $queryBuilder->expr()->eq('action', $queryBuilder->createNamedParameter($action)),
+                $queryBuilder->expr()->eq('success', $queryBuilder->createNamedParameter($success, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($count) ? (int) $count : 0;
+    }
+}

--- a/Tests/Unit/Hook/SecretTcaHookTest.php
+++ b/Tests/Unit/Hook/SecretTcaHookTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Hook;
 
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
 use Netresearch\NrVault\Hook\SecretTcaHook;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
@@ -31,6 +32,8 @@ final class SecretTcaHookTest extends TestCase
 
     private AccessControlServiceInterface&MockObject $accessControlService;
 
+    private SecretRepositoryInterface&MockObject $secretRepository;
+
     private SecretTcaHook $hook;
 
     protected function setUp(): void
@@ -40,6 +43,7 @@ final class SecretTcaHookTest extends TestCase
         $this->vaultService = $this->createMock(VaultServiceInterface::class);
         $this->auditService = $this->createMock(AuditLogServiceInterface::class);
         $this->accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        $this->secretRepository = $this->createMock(SecretRepositoryInterface::class);
 
         // Default to an admin actor so the pre-existing field-normalisation
         // tests (NEW records, owner/scope extraction) are not coerced by the
@@ -50,6 +54,7 @@ final class SecretTcaHookTest extends TestCase
             $this->vaultService,
             $this->auditService,
             $this->accessControlService,
+            $this->secretRepository,
         );
     }
 
@@ -305,6 +310,7 @@ final class SecretTcaHookTest extends TestCase
             $this->vaultService,
             $this->auditService,
             $accessControl,
+            $this->secretRepository,
         );
 
         $fieldArray = [
@@ -340,6 +346,7 @@ final class SecretTcaHookTest extends TestCase
             $this->vaultService,
             $this->auditService,
             $accessControl,
+            $this->secretRepository,
         );
 
         $fieldArray = [


### PR DESCRIPTION
## Summary

Deleting a `tx_nrvault_secret` record via DataHandler (FormEngine, list module) only wrote an audit entry — it never enforced the vault's `canDelete` ACL. A non-admin backend user granted generic table-modify rights could delete secrets they do not own (CWE-862).

`SecretTcaHook::processCmdmap_preProcess` now loads the `Secret` and enforces `AccessControlService::canDelete` (owner / admin / system-maintainer only, ADR-005). A denied delete is flagged, audited as `access_denied`, and cancelled in a new `processCmdmap` method by setting `$commandIsProcessed = true` — verified against core `DataHandler.php:3234-3241`, which skips its own `deleteAction` when the flag is set. The denial flag is consumed per run so a DI-shared hook instance cannot leak a stale denial. Only an authorized delete records a delete-success entry.

## Finding

Found by a Claude Security scan (`max` effort), confirmed by a 3-voter panel and re-verified after the fix (closes the finding; cancellation mechanism, DI autowiring of the new dependency, and all three unit-test construction sites verified).

## Tests

`SecretTcaHookDeleteAclTest` drives the hook contract directly (isolating the vault gate from core's own table-permission layer, which would otherwise block a group-less editor first): a non-owner non-admin delete is cancelled and audited `access_denied`; owner and admin deletes pass the gate.