### PR TITLE
Reject epoch-downgrade forgery in the audit chain

### DIFF
--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -168,8 +168,16 @@ final readonly class AuditLogService implements AuditLogServiceInterface
         } while (\count($chunk) === $chunkSize);
     }
 
-    public function verifyHashChain(?int $fromUid = null, ?int $toUid = null): HashChainVerificationResult
+    public function verifyHashChain(?int $fromUid = null, ?int $toUid = null, ?int $minEpoch = null): HashChainVerificationResult
     {
+        // Epoch floor: the lowest per-row epoch the chain may legitimately carry.
+        // Defaults to the configured audit HMAC epoch so a DB-write attacker cannot
+        // relabel an HMAC-migrated chain down to keyless epoch-0 (which needs no HMAC
+        // key to re-sign) and have the recomputed keyless chain still report valid.
+        // Callers that must verify a not-yet-migrated chain under its own stored
+        // epochs (the HMAC migration) pass 0 to disable the configured floor.
+        $epochFloor = $minEpoch ?? $this->getCurrentEpoch();
+
         $queryBuilder = $this->getConnection()->createQueryBuilder();
         $queryBuilder
             ->select('*')
@@ -199,6 +207,9 @@ final readonly class AuditLogService implements AuditLogServiceInterface
         $missingUidCount = 0;
         $previousHash = '';
         $previousEpoch = -1;
+        // Highest epoch observed across the chain (the "high-water mark"). Stays
+        // -1 for an empty chain so the epoch-floor check below is skipped.
+        $maxEpoch = -1;
         // When the caller specified $fromUid, treat $fromUid-1 as the
         // previous UID so a leading gap (first row > $fromUid) is still
         // detected. Otherwise start at -1 meaning "no prior row yet".
@@ -285,6 +296,9 @@ final readonly class AuditLogService implements AuditLogServiceInterface
                 }
 
                 $previousEpoch = $epoch;
+                if ($epoch > $maxEpoch) {
+                    $maxEpoch = $epoch;
+                }
 
                 // Epoch-aware hash dispatch:
                 //   0 → legacy SHA-256 (identity fields only)
@@ -319,9 +333,51 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             sodium_memzero($hmacKey);
         }
 
+        // Chain-level epoch-floor check (finding audit-chain-integrity, F3).
+        //
+        // The per-row consecutive-epoch check above catches a PARTIAL downgrade
+        // (a DECREASE between adjacent rows), but a DB-write attacker can relabel
+        // EVERY row uniformly to keyless epoch-0 and recompute a fully self-
+        // consistent SHA-256 chain — no decrease, every previous_hash links, every
+        // entry_hash matches. The only tell is external: the installation is
+        // configured for HMAC, so the chain's highest epoch must reach the floor.
+        // A high-water mark below the floor means the algorithm selector was
+        // downgraded below the configured protection level. Applied only to a
+        // full-chain pass ($fromUid/$toUid null) — a bounded sub-range may
+        // legitimately exclude the higher-epoch rows. $maxEpoch === -1 means an
+        // empty chain, which has nothing to downgrade.
+        if ($fromUid === null && $toUid === null && $maxEpoch !== -1 && $maxEpoch < $epochFloor) {
+            $errors[0] = \sprintf(
+                'HMAC key epoch downgrade detected: chain high-water epoch %d is below the configured floor %d (possible algorithm-downgrade forgery)',
+                $maxEpoch,
+                $epochFloor,
+            );
+        }
+
         return $errors === []
             ? HashChainVerificationResult::valid($warnings, $missingUids, $missingUidCount)
             : HashChainVerificationResult::invalid($errors, $warnings, $missingUids, $missingUidCount);
+    }
+
+    public function verifyChainForReseal(): ?HashChainVerificationResult
+    {
+        // Genuinely-legacy keyless epoch-0 chains carry no tamper evidence to
+        // check — re-sealing them is exactly how they FIRST gain HMAC protection,
+        // so there is nothing to launder and nothing to verify. Proceed.
+        if (!$this->chainHasHmacRows()) {
+            return null;
+        }
+
+        // The chain is (at least partly) HMAC-protected. Verify it under its OWN
+        // stored epochs (floor 0 — the chain may legitimately sit below the
+        // migration target, e.g. an epoch-1 chain migrating to epoch 2). A
+        // DB-write attacker cannot forge a valid HMAC without the key, so any
+        // tampering of an HMAC row surfaces here. Re-sealing a tampered chain
+        // would rewrite every hash under the current key and launder the
+        // tampering into a freshly valid chain — so report it for refusal.
+        $result = $this->verifyHashChain(minEpoch: 0);
+
+        return $result->isValid() ? null : $result;
     }
 
     public function getLatestHash(): ?string
@@ -627,6 +683,29 @@ final readonly class AuditLogService implements AuditLogServiceInterface
     public static function deriveHmacKeyFromMasterKey(#[SensitiveParameter] string $masterKey): string
     {
         return hash_hkdf('sha256', $masterKey, 32, 'nr-vault-audit-hmac-v1');
+    }
+
+    /**
+     * Whether any row is already HMAC-protected (epoch >= 1). Distinguishes a
+     * genuinely-legacy keyless chain (nothing to authenticate) from one that
+     * carries HMAC tamper evidence worth verifying before a re-seal.
+     */
+    private function chainHasHmacRows(): bool
+    {
+        $queryBuilder = $this->getConnection()->createQueryBuilder();
+        $count = $queryBuilder
+            ->count('uid')
+            ->from(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->gte(
+                    'hmac_key_epoch',
+                    $queryBuilder->createNamedParameter(1, Connection::PARAM_INT),
+                ),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($count) && (int) $count > 0;
     }
 
     /**

--- a/Classes/Audit/AuditLogServiceInterface.php
+++ b/Classes/Audit/AuditLogServiceInterface.php
@@ -69,8 +69,30 @@ interface AuditLogServiceInterface
 
     /**
      * Verify hash chain integrity.
+     *
+     * @param int|null $minEpoch Lowest acceptable per-row `hmac_key_epoch`. When null
+     *                           (the default for all production callers) the configured
+     *                           audit HMAC epoch is used as the floor, so a chain whose
+     *                           highest epoch was downgraded below the configured level
+     *                           (e.g. relabelled to keyless epoch-0 SHA-256) fails
+     *                           verification. Pass 0 to verify a chain under its own
+     *                           stored epochs without the configured-epoch floor (used by
+     *                           the HMAC migration to check a not-yet-migrated chain).
      */
-    public function verifyHashChain(?int $fromUid = null, ?int $toUid = null): HashChainVerificationResult;
+    public function verifyHashChain(?int $fromUid = null, ?int $toUid = null, ?int $minEpoch = null): HashChainVerificationResult;
+
+    /**
+     * Verify that the existing chain is safe to re-seal before the HMAC migration
+     * rewrites every entry hash.
+     *
+     * Returns null when it is safe to proceed — either the chain verifies under its
+     * own stored epochs, or it is a genuinely-legacy keyless epoch-0 chain that
+     * carries no tamper evidence to check (re-sealing is how it GAINS protection).
+     * Returns the failed {@see HashChainVerificationResult} when the chain is
+     * HMAC-protected and fails verification, so callers can refuse to re-seal a
+     * tampered chain (which would launder the tampering into a fresh valid chain).
+     */
+    public function verifyChainForReseal(): ?HashChainVerificationResult;
 
     /**
      * Get the hash of the most recent audit log entry.

--- a/Classes/Command/VaultAuditMigrateCommand.php
+++ b/Classes/Command/VaultAuditMigrateCommand.php
@@ -12,6 +12,8 @@ namespace Netresearch\NrVault\Command;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Netresearch\NrVault\Audit\AuditChainLockTrait;
 use Netresearch\NrVault\Audit\AuditLogService;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\HashChainVerificationResult;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -42,6 +44,7 @@ final class VaultAuditMigrateCommand extends Command
         private readonly ConnectionPool $connectionPool,
         private readonly MasterKeyProviderInterface $masterKeyProvider,
         private readonly ExtensionConfigurationInterface $extensionConfiguration,
+        private readonly AuditLogServiceInterface $auditLogService,
     ) {
         parent::__construct();
     }
@@ -102,6 +105,23 @@ final class VaultAuditMigrateCommand extends Command
             ));
 
             return Command::SUCCESS;
+        }
+
+        // Before re-sealing every row under the current key, verify the existing
+        // chain (finding audit-chain-integrity, F6). Re-hashing a tampered
+        // HMAC-protected chain would launder the tampering into a freshly valid
+        // chain and destroy the evidence. A genuinely-legacy keyless epoch-0 chain
+        // has no tamper evidence to check and is allowed through — this is exactly
+        // the migration that first adds protection.
+        $failedVerification = $this->auditLogService->verifyChainForReseal();
+        if ($failedVerification instanceof HashChainVerificationResult) {
+            $io->error([
+                'Audit hash chain verification FAILED — migration refused.',
+                'Re-sealing a tampered chain would launder the tampering into a valid chain.',
+                'Investigate with vault:audit --verify before migrating.',
+            ]);
+
+            return Command::FAILURE;
         }
 
         // Count total entries (we must re-hash ALL to maintain chain integrity)

--- a/Classes/Upgrades/AuditHmacMigrationWizard.php
+++ b/Classes/Upgrades/AuditHmacMigrationWizard.php
@@ -12,6 +12,8 @@ namespace Netresearch\NrVault\Upgrades;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Netresearch\NrVault\Audit\AuditChainLockTrait;
 use Netresearch\NrVault\Audit\AuditLogService;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\HashChainVerificationResult;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
 use Psr\Log\LoggerAwareInterface;
@@ -53,6 +55,7 @@ final class AuditHmacMigrationWizard implements UpgradeWizardInterface, LoggerAw
         private readonly ConnectionPool $connectionPool,
         private readonly MasterKeyProviderInterface $masterKeyProvider,
         private readonly ExtensionConfigurationInterface $extensionConfiguration,
+        private readonly AuditLogServiceInterface $auditLogService,
     ) {
         $this->logger = new NullLogger();
     }
@@ -96,6 +99,21 @@ final class AuditHmacMigrationWizard implements UpgradeWizardInterface, LoggerAw
         }
 
         $connection = $this->connectionPool->getConnectionForTable(self::TABLE_NAME);
+
+        // Verify the existing chain before re-sealing it (finding
+        // audit-chain-integrity, F6): re-hashing a tampered HMAC chain would
+        // launder the tampering into a freshly valid chain. Legacy keyless
+        // epoch-0 chains carry no tamper evidence and are allowed through.
+        $failedVerification = $this->auditLogService->verifyChainForReseal();
+        if ($failedVerification instanceof HashChainVerificationResult) {
+            $this->logger->error(
+                'AuditHmacMigrationWizard: existing audit chain failed verification; refusing to re-seal',
+                ['errorCount' => $failedVerification->getErrorCount()],
+            );
+
+            return false;
+        }
+
         $hmacKey = AuditLogService::deriveHmacKey($this->masterKeyProvider);
 
         try {

--- a/Tests/Functional/Audit/AuditLogServiceTest.php
+++ b/Tests/Functional/Audit/AuditLogServiceTest.php
@@ -477,4 +477,53 @@ final class AuditLogServiceTest extends AbstractVaultFunctionalTestCase
             }
         }
     }
+
+    #[Test]
+    public function verifyHashChainRejectsFullEpochZeroRelabelOfHmacChain(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $vaultService = $this->get(VaultServiceInterface::class);
+
+        $identifier = $this->generateUuidV7();
+        $vaultService->store($identifier, 'relabel-test-value');
+        $vaultService->retrieve($identifier);
+        $vaultService->delete($identifier, 'cleanup');
+
+        self::assertTrue($auditService->verifyHashChain()->isValid(), 'Precondition: chain valid before relabel');
+
+        // Attacker relabels EVERY row to keyless epoch-0 and recomputes a valid
+        // keyless SHA-256 chain (identity fields only) in UID order.
+        $connection = $this->getConnectionPool()->getConnectionForTable('tx_nrvault_audit_log');
+        $rows = $connection->createQueryBuilder()
+            ->select('uid', 'secret_identifier', 'action', 'actor_uid', 'crdate')
+            ->from('tx_nrvault_audit_log')
+            ->orderBy('uid', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $previousHash = '';
+        foreach ($rows as $row) {
+            $entryHash = AuditLogService::calculateHash(
+                (int) $row['uid'],
+                (string) $row['secret_identifier'],
+                (string) $row['action'],
+                (int) $row['actor_uid'],
+                (int) $row['crdate'],
+                $previousHash,
+            );
+            $connection->update(
+                'tx_nrvault_audit_log',
+                ['previous_hash' => $previousHash, 'entry_hash' => $entryHash, 'hmac_key_epoch' => 0],
+                ['uid' => (int) $row['uid']],
+            );
+            $previousHash = $entryHash;
+        }
+
+        $result = $auditService->verifyHashChain();
+
+        self::assertFalse(
+            $result->isValid(),
+            'A uniform relabel to keyless epoch-0 on an HMAC-configured install must be rejected',
+        );
+    }
 }

--- a/Tests/Functional/Service/VaultServiceAtomicityTest.php
+++ b/Tests/Functional/Service/VaultServiceAtomicityTest.php
@@ -216,9 +216,14 @@ final class VaultServiceAtomicityTest extends AbstractVaultFunctionalTestCase
                 return [];
             }
 
-            public function verifyHashChain(?int $fromUid = null, ?int $toUid = null): HashChainVerificationResult
+            public function verifyHashChain(?int $fromUid = null, ?int $toUid = null, ?int $minEpoch = null): HashChainVerificationResult
             {
                 return new HashChainVerificationResult(true);
+            }
+
+            public function verifyChainForReseal(): ?HashChainVerificationResult
+            {
+                return null;
             }
 
             public function getLatestHash(): ?string

--- a/Tests/Functional/Upgrades/AuditHmacMigrationWizardTest.php
+++ b/Tests/Functional/Upgrades/AuditHmacMigrationWizardTest.php
@@ -143,6 +143,7 @@ final class AuditHmacMigrationWizardTest extends AbstractVaultFunctionalTestCase
             $this->get(ConnectionPool::class),
             $this->get(MasterKeyProviderInterface::class),
             new ExtensionConfiguration(new Typo3ExtensionConfiguration()),
+            $this->get(AuditLogServiceInterface::class),
         );
 
         self::assertTrue(
@@ -303,6 +304,7 @@ final class AuditHmacMigrationWizardTest extends AbstractVaultFunctionalTestCase
             $this->get(ConnectionPool::class),
             $this->get(MasterKeyProviderInterface::class),
             $this->get(ExtensionConfigurationInterface::class),
+            $this->get(AuditLogServiceInterface::class),
         );
     }
 

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -2378,6 +2378,33 @@ final class AuditLogServiceTest extends TestCase
         );
     }
 
+    #[Test]
+    public function verifyHashChainRejectsUniformEpochZeroRelabelOnHmacInstall(): void
+    {
+        // F3 (audit-chain-integrity): a DB-write attacker relabels EVERY row of an
+        // HMAC-migrated chain down to keyless epoch-0 and recomputes a fully valid
+        // keyless SHA-256 chain. Per-row hash checks, previous_hash links and the
+        // consecutive-epoch check all pass (every row is epoch 0, no DECREASE);
+        // only the configured-epoch high-water floor exposes the downgrade. The
+        // setUp() subject is configured for HMAC (epoch 1).
+        $hash1 = AuditLogService::calculateHash(1, 'a', 'create', 1, 100, '');
+        $hash2 = AuditLogService::calculateHash(2, 'b', 'read', 1, 200, $hash1);
+
+        $rows = [
+            ['uid' => 1, 'secret_identifier' => 'a', 'action' => 'create', 'actor_uid' => 1, 'crdate' => 100, 'previous_hash' => '', 'entry_hash' => $hash1, 'hmac_key_epoch' => 0],
+            ['uid' => 2, 'secret_identifier' => 'b', 'action' => 'read', 'actor_uid' => 1, 'crdate' => 200, 'previous_hash' => $hash1, 'entry_hash' => $hash2, 'hmac_key_epoch' => 0],
+        ];
+
+        $verification = $this->runVerifyOverRows($rows);
+
+        self::assertFalse(
+            $verification->isValid(),
+            'A chain relabelled entirely to keyless epoch 0 on an HMAC-configured install MUST be rejected',
+        );
+        self::assertArrayHasKey(0, $verification->errors, 'The chain-level epoch-floor error must be recorded');
+        self::assertStringContainsString('floor', $verification->errors[0]);
+    }
+
     /**
      * Build a raw DB row (snake_case keys, mixed types) suitable for
      * extractV2HashRow() input. Used by tests that exercise the extractor

--- a/Tests/Unit/Command/VaultAuditMigrateCommandTest.php
+++ b/Tests/Unit/Command/VaultAuditMigrateCommandTest.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Command;
 
 use Doctrine\DBAL\Result;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\HashChainVerificationResult;
 use Netresearch\NrVault\Command\VaultAuditMigrateCommand;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
@@ -33,6 +35,8 @@ final class VaultAuditMigrateCommandTest extends TestCase
 
     private ExtensionConfigurationInterface $extensionConfiguration;
 
+    private AuditLogServiceInterface $auditLogService;
+
     private QueryBuilder $queryBuilder;
 
     private CommandTester $commandTester;
@@ -44,6 +48,8 @@ final class VaultAuditMigrateCommandTest extends TestCase
         $this->connectionPool = $this->createStub(ConnectionPool::class);
         $this->masterKeyProvider = $this->createStub(MasterKeyProviderInterface::class);
         $this->extensionConfiguration = $this->createStub(ExtensionConfigurationInterface::class);
+        // Default: chain is safe to re-seal (verifyChainForReseal() returns null).
+        $this->auditLogService = $this->createStub(AuditLogServiceInterface::class);
         $this->queryBuilder = $this->createStub(QueryBuilder::class);
 
         $this->masterKeyProvider
@@ -62,6 +68,7 @@ final class VaultAuditMigrateCommandTest extends TestCase
             $this->connectionPool,
             $this->masterKeyProvider,
             $this->extensionConfiguration,
+            $this->auditLogService,
         );
 
         $application = new Application();
@@ -77,6 +84,7 @@ final class VaultAuditMigrateCommandTest extends TestCase
             $this->connectionPool,
             $this->masterKeyProvider,
             $this->extensionConfiguration,
+            $this->auditLogService,
         );
 
         self::assertSame('vault:audit-migrate-hmac', $command->getName());
@@ -222,6 +230,7 @@ final class VaultAuditMigrateCommandTest extends TestCase
             $this->connectionPool,
             $this->masterKeyProvider,
             $extensionConfig,
+            $this->auditLogService,
         );
 
         $application = new Application();
@@ -232,6 +241,44 @@ final class VaultAuditMigrateCommandTest extends TestCase
 
         self::assertSame(1, $exitCode);
         self::assertStringContainsString('Cannot migrate to epoch 0', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function migrationAbortsWhenExistingChainFailsVerification(): void
+    {
+        // One outdated row so the command reaches the pre-reseal verification.
+        $countResult = $this->createStub(Result::class);
+        $countResult->method('fetchOne')->willReturn(1);
+
+        $this->queryBuilder->method('count')->willReturnSelf();
+        $this->queryBuilder->method('from')->willReturnSelf();
+        $this->queryBuilder->method('where')->willReturnSelf();
+        $this->queryBuilder->method('createNamedParameter')->willReturn('0');
+        $this->queryBuilder->method('executeQuery')->willReturn($countResult);
+
+        // The existing chain is reported unsafe to re-seal.
+        $auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $auditLogService->method('verifyChainForReseal')
+            ->willReturn(HashChainVerificationResult::invalid([0 => 'HMAC key epoch downgrade detected']));
+
+        $command = new VaultAuditMigrateCommand(
+            $this->connectionPool,
+            $this->masterKeyProvider,
+            $this->extensionConfiguration,
+            $auditLogService,
+        );
+
+        // update() must never be called — nothing is re-sealed.
+        $connection = $this->wireConnectionMock();
+        $connection->expects(self::never())->method('update');
+
+        $application = new Application();
+        $application->addCommand($command);
+        $tester = new CommandTester($command);
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('verification FAILED', $tester->getDisplay());
     }
 
     /**

--- a/Tests/Unit/Upgrades/AuditHmacMigrationWizardTest.php
+++ b/Tests/Unit/Upgrades/AuditHmacMigrationWizardTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrVault\Tests\Unit\Upgrades;
 
 use Doctrine\DBAL\Platforms\MySQLPlatform;
 use Doctrine\DBAL\Result;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
@@ -46,11 +47,14 @@ final class AuditHmacMigrationWizardTest extends TestCase
         $this->connectionPool = $this->createStub(ConnectionPool::class);
         $this->masterKeyProvider = $this->createStub(MasterKeyProviderInterface::class);
         $this->configuration = $this->createStub(ExtensionConfigurationInterface::class);
+        // Default: chain is safe to re-seal (verifyChainForReseal() returns null).
+        $auditLogService = $this->createStub(AuditLogServiceInterface::class);
 
         $this->subject = new AuditHmacMigrationWizard(
             $this->connectionPool,
             $this->masterKeyProvider,
             $this->configuration,
+            $auditLogService,
         );
     }
 


### PR DESCRIPTION
## Summary

Two gaps let a database-write attacker (SQL injection elsewhere, a compromised DB account, or a second app sharing the database) defeat the tamper-evident audit hash chain (CWE-345).

**F3 — algorithm downgrade.** `verifyHashChain()` selected each row's hash algorithm from the attacker-writable `hmac_key_epoch` column and accepted keyless epoch-0 SHA-256. An attacker could relabel every row of an HMAC-migrated chain to epoch 0 and recompute a self-consistent keyless chain that still verified (per-row hashes link, no consecutive decrease). Fix: a chain-level **high-water-mark epoch floor** — on a full-chain pass the highest epoch must reach the configured audit HMAC epoch, so a uniform downgrade below the configured level is rejected. Legitimate monotonic epoch-0→N transitions still pass (this is why a naive per-row floor is wrong).

**F6 — reseal laundering.** The HMAC migration (`vault:audit-migrate-hmac` and the install-tool wizard) re-sealed every row without first verifying the chain, laundering prior tampering into a fresh valid chain. Fix: `verifyChainForReseal()` runs before any re-seal and refuses on failure. Genuinely-legacy keyless epoch-0 chains carry no tamper evidence and still migrate.

## Interface change

`verifyHashChain()` gains an optional `?int $minEpoch = null` (default = configured floor; pass `0` to verify under stored epochs), and a new `verifyChainForReseal()` method — both added to the interface and its sole hand-written implementation.

## Finding

Found by a Claude Security scan (`max` effort), confirmed by a 3-voter panel.

## Tests

- Unit: `verifyHashChainRejectsUniformEpochZeroRelabelOnHmacInstall` (F3 floor); `migrationAbortsWhenExistingChainFailsVerification` (F6 abort, version-agnostic).
- Functional: `verifyHashChainRejectsFullEpochZeroRelabelOfHmacChain` — end-to-end relabel of a real VaultService-generated chain.

Existing verify/migration tests are unaffected: the default configured epoch (1) matches their HMAC rows, epoch-0 tests use a local epoch-0 config, and the injected reseal-verifier stub returns null (proceed) by default.