### PR TITLE
fix(hook): preserve vault secret on an untouched re-save (#223)

### DIFF
--- a/Classes/Hook/FlexFormVaultHook.php
+++ b/Classes/Hook/FlexFormVaultHook.php
@@ -376,31 +376,60 @@ final class FlexFormVaultHook
             $originalChecksum = '';
         }
 
-        if ($secretValue === '' && $originalChecksum === '') {
+        // A new plaintext value was entered: store it as a new secret or rotate
+        // the existing one. See PendingSecretExtractor::extract() for the full
+        // empty-value rationale — this mirrors it for FlexForm-embedded fields.
+        if ($secretValue !== '') {
+            $isNewSecret = $existingIdentifier === '' || $originalChecksum === '';
+            $vaultIdentifier = $isNewSecret ? IdentifierValidator::generateUuid() : $existingIdentifier;
+
+            $this->pendingFlexSecrets[$table][$id][] = $isNewSecret
+                ? FlexFormPendingSecret::createNew(
+                    $flexFieldName,
+                    $sheetName,
+                    $fieldPath,
+                    $secretValue,
+                    $vaultIdentifier,
+                )
+                : FlexFormPendingSecret::createUpdate(
+                    $flexFieldName,
+                    $sheetName,
+                    $fieldPath,
+                    $secretValue,
+                    $vaultIdentifier,
+                    $originalChecksum,
+                );
+
+            $fieldData['vDEF'] = $vaultIdentifier;
+
             return;
         }
 
-        $isNewSecret = $existingIdentifier === '' || $originalChecksum === '';
-        $vaultIdentifier = $isNewSecret ? IdentifierValidator::generateUuid() : $existingIdentifier;
+        // Empty value with the checksum still present: the field was left
+        // untouched (the plaintext is never rendered into the form), so keep the
+        // stored secret and collapse the submitted array back to its identifier
+        // (issue #223 — a plain re-save must not wipe the key).
+        if ($originalChecksum !== '') {
+            $fieldData['vDEF'] = $existingIdentifier;
 
-        $this->pendingFlexSecrets[$table][$id][] = $isNewSecret
-            ? FlexFormPendingSecret::createNew(
+            return;
+        }
+
+        // Empty value and no checksum: the clear control blanked the checksum. An
+        // identifier still present means the user explicitly cleared the field,
+        // so delete the stored secret.
+        if ($existingIdentifier !== '') {
+            $this->pendingFlexSecrets[$table][$id][] = FlexFormPendingSecret::createUpdate(
                 $flexFieldName,
                 $sheetName,
                 $fieldPath,
-                $secretValue,
-                $vaultIdentifier,
-            )
-            : FlexFormPendingSecret::createUpdate(
-                $flexFieldName,
-                $sheetName,
-                $fieldPath,
-                $secretValue,
-                $vaultIdentifier,
-                $originalChecksum,
+                '',
+                $existingIdentifier,
+                '',
             );
 
-        $fieldData['vDEF'] = $secretValue !== '' ? $vaultIdentifier : '';
+            $fieldData['vDEF'] = '';
+        }
     }
 
     /**
@@ -480,7 +509,9 @@ final class FlexFormVaultHook
     ): void {
         try {
             if ($pending->value === '') {
-                if ($pending->originalChecksum !== '') {
+                // The identifier — not the checksum, which the clear control
+                // blanks — is the reliable "a secret existed" signal (issue #223).
+                if ($pending->identifier !== '') {
                     $this->vaultService->delete($pending->identifier, 'FlexForm field cleared');
                 }
             } elseif ($pending->isNew) {

--- a/Classes/Hook/PendingSecretExtractor.php
+++ b/Classes/Hook/PendingSecretExtractor.php
@@ -26,11 +26,21 @@ final class PendingSecretExtractor
     /**
      * Extract a pending secret from a raw field value.
      *
+     * The secret plaintext is never rendered back into the edit form, so an
+     * empty submitted value does NOT by itself mean "clear this secret". The
+     * vault FormEngine element submits a checksum alongside an existing secret
+     * and blanks that checksum when its clear control is used — that
+     * presence/absence is what distinguishes an untouched re-save from an
+     * explicit clear.
+     *
      * Returns:
-     * - a {@see PendingSecret} with a non-empty value for a new/updated secret,
-     * - a {@see PendingSecret} with an empty value (and a prior checksum) when
-     *   the field was cleared and the secret must be deleted,
-     * - null when there is nothing to do (empty value and no prior secret).
+     * - a {@see PendingSecret} with a non-empty value for a new / rotated secret,
+     * - a {@see PendingSecret} with an empty value to DELETE the secret, but only
+     *   when the field was explicitly cleared (checksum blanked while an
+     *   identifier is still present),
+     * - null when there is nothing to do: either an untouched existing secret,
+     *   which must be kept (issue #223 — a plain re-save must never wipe the
+     *   key), or an empty field that never held a secret.
      *
      * @param mixed $value The raw field value (string, int, or the array shape
      *                     emitted by the vault FormEngine element)
@@ -39,17 +49,34 @@ final class PendingSecretExtractor
     {
         ['value' => $secretValue, 'identifier' => $existingIdentifier, 'checksum' => $originalChecksum] = $this->classifyValue($value);
 
-        // Nothing to do: empty value and no prior secret.
-        if ($secretValue === '' && $originalChecksum === '') {
+        // A new plaintext value was entered: store it as a new secret, or rotate
+        // the existing one when an identifier + checksum are present.
+        if ($secretValue !== '') {
+            $isNewSecret = $existingIdentifier === '' || $originalChecksum === '';
+            $vaultIdentifier = $isNewSecret ? IdentifierValidator::generateUuid() : $existingIdentifier;
+
+            return $isNewSecret
+                ? PendingSecret::createNew($secretValue, $vaultIdentifier)
+                : PendingSecret::createUpdate($secretValue, $vaultIdentifier, $originalChecksum);
+        }
+
+        // The submitted value is empty. Because the stored secret is never shown
+        // in the form, an untouched save also arrives empty — so a present
+        // checksum means "left untouched": keep the secret intact by doing
+        // nothing (the DataHandler hook leaves the DB field as-is on null).
+        if ($originalChecksum !== '') {
             return null;
         }
 
-        $isNewSecret = $existingIdentifier === '' || $originalChecksum === '';
-        $vaultIdentifier = $isNewSecret ? IdentifierValidator::generateUuid() : $existingIdentifier;
+        // Empty value and no checksum: the clear control blanked the checksum. If
+        // an identifier still remains, the user explicitly cleared the field, so
+        // delete the stored secret (empty-value PendingSecret => delete).
+        if ($existingIdentifier !== '') {
+            return PendingSecret::createUpdate('', $existingIdentifier, '');
+        }
 
-        return $isNewSecret
-            ? PendingSecret::createNew($secretValue, $vaultIdentifier)
-            : PendingSecret::createUpdate($secretValue, $vaultIdentifier, $originalChecksum);
+        // Empty field that never held a secret — nothing to do.
+        return null;
     }
 
     /**

--- a/Classes/Hook/PendingSecretPersister.php
+++ b/Classes/Hook/PendingSecretPersister.php
@@ -59,8 +59,12 @@ final readonly class PendingSecretPersister
     ): ?Throwable {
         try {
             if ($pending->value === '') {
-                // Empty value means delete the secret (only if one existed).
-                if ($pending->originalChecksum !== '') {
+                // Empty value means delete the secret — but only when one existed.
+                // The extractor only emits an empty-value pending for an explicit
+                // clear, which always carries the existing identifier; the
+                // identifier (not the checksum, which the clear control blanks)
+                // is the reliable "a secret existed" signal (issue #223).
+                if ($pending->identifier !== '') {
                     $this->vaultService->delete($pending->identifier, $deleteReason);
                 }
             } elseif ($pending->isNew) {

--- a/Tests/Functional/Hook/DataHandlerHookTest.php
+++ b/Tests/Functional/Hook/DataHandlerHookTest.php
@@ -114,6 +114,46 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
         }
     }
 
+    /**
+     * Regression for issue #223: re-saving a record without retyping the masked
+     * secret (empty value, checksum still present) must preserve the stored
+     * secret in the vault — not delete it.
+     */
+    #[Test]
+    public function hookKeepsExistingSecretWhenFieldLeftUntouched(): void
+    {
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $hook = $this->createHookWithVaultFields('tx_test', ['secret_field']);
+
+        $vaultIdentifier = $this->generateUuidV7();
+        $originalValue = 'keep-me-secret';
+        $vaultService->store($vaultIdentifier, $originalValue);
+
+        try {
+            // Untouched re-save: empty value but the checksum the element renders
+            // for an existing secret is still present.
+            $fieldArray = [
+                'secret_field' => [
+                    'value' => '',
+                    '_vault_identifier' => $vaultIdentifier,
+                    '_vault_checksum' => hash('sha256', $vaultIdentifier),
+                ],
+            ];
+
+            $hook->processDatamap_preProcessFieldArray($fieldArray, 'tx_test', 99);
+            // An untouched field is dropped from the datamap, so the DB keeps it.
+            self::assertArrayNotHasKey('secret_field', $fieldArray, 'Untouched secret must not be rewritten');
+
+            $hook->processDatamap_afterDatabaseOperations('update', 'tx_test', 99, $fieldArray, $this->createDataHandler());
+
+            $vaultService->clearCache();
+            $retrieved = $vaultService->retrieve($vaultIdentifier);
+            self::assertSame($originalValue, $retrieved, 'Vault secret must survive an untouched save (issue #223)');
+        } finally {
+            $this->safeDelete($vaultService, $vaultIdentifier);
+        }
+    }
+
     #[Test]
     public function hookClearsFieldWhenEmptyValueProvided(): void
     {

--- a/Tests/Unit/Hook/DataHandlerHookTest.php
+++ b/Tests/Unit/Hook/DataHandlerHookTest.php
@@ -291,7 +291,53 @@ final class DataHandlerHookTest extends TestCase
     }
 
     #[Test]
-    public function afterDatabaseOperationsDeletesSecretWhenCleared(): void
+    public function afterDatabaseOperationsDeletesSecretWhenExplicitlyCleared(): void
+    {
+        $this->mockTcaSchemaForTable('tx_test', [
+            'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+        ]);
+
+        $existingUuid = self::EXISTING_UUID;
+        // The clear control blanks the checksum while keeping the identifier —
+        // that is what distinguishes an explicit clear from an untouched re-save.
+        $fieldArray = [
+            'api_key' => [
+                'value' => '',
+                '_vault_identifier' => $existingUuid,
+                '_vault_checksum' => '',
+            ],
+        ];
+
+        $this->subject->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            'tx_test',
+            42,
+        );
+
+        $this->vaultService
+            ->expects(self::once())
+            ->method('delete')
+            ->with(
+                $existingUuid,
+                'TCA field cleared',
+            );
+
+        $this->subject->processDatamap_afterDatabaseOperations(
+            'update',
+            'tx_test',
+            42,
+            $fieldArray,
+            $this->dataHandler,
+        );
+    }
+
+    /**
+     * Regression for issue #223: re-saving a record without retyping the masked
+     * secret submits an empty value but the checksum is still present. The stored
+     * secret must be kept, not wiped from the record or the vault.
+     */
+    #[Test]
+    public function afterDatabaseOperationsKeepsSecretWhenFieldLeftUntouched(): void
     {
         $this->mockTcaSchemaForTable('tx_test', [
             'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
@@ -312,13 +358,13 @@ final class DataHandlerHookTest extends TestCase
             42,
         );
 
+        // The untouched field is dropped from the datamap, so the database keeps
+        // its existing identifier untouched.
+        self::assertArrayNotHasKey('api_key', $fieldArray, 'Untouched secret field must be left unchanged');
+
         $this->vaultService
-            ->expects(self::once())
-            ->method('delete')
-            ->with(
-                $existingUuid,
-                'TCA field cleared',
-            );
+            ->expects(self::never())
+            ->method('delete');
 
         $this->subject->processDatamap_afterDatabaseOperations(
             'update',
@@ -741,11 +787,12 @@ final class DataHandlerHookTest extends TestCase
         ]);
 
         $existingUuid = self::EXISTING_UUID;
+        // Explicit clear: the clear control blanks the checksum.
         $fieldArray = [
             'api_key' => [
                 'value' => '',
                 '_vault_identifier' => $existingUuid,
-                '_vault_checksum' => 'existing-checksum',
+                '_vault_checksum' => '',
             ],
         ];
 
@@ -755,7 +802,7 @@ final class DataHandlerHookTest extends TestCase
             42,
         );
 
-        // Should be empty string when clearing
+        // Should be empty string when explicitly cleared
         self::assertSame('', $fieldArray['api_key']);
     }
 

--- a/Tests/Unit/Hook/FlexFormVaultHookTest.php
+++ b/Tests/Unit/Hook/FlexFormVaultHookTest.php
@@ -919,7 +919,7 @@ final class FlexFormVaultHookTest extends TestCase
     }
 
     #[Test]
-    public function afterDatabaseOperationsDeletesSecretWhenValueCleared(): void
+    public function afterDatabaseOperationsDeletesSecretWhenExplicitlyCleared(): void
     {
         $this->dataHandler->substNEWwithIDs = [];
 
@@ -931,10 +931,10 @@ final class FlexFormVaultHookTest extends TestCase
             'sheets' => ['sDEF' => ['ROOT' => ['el' => ['settings.token' => ['config' => ['type' => 'input', 'renderType' => 'vaultSecret']]]]]],
         ]);
 
-        // Empty value with existing checksum → delete
+        // Empty value with a blanked checksum (the clear control) → delete.
         $fieldArray = [
             'pi_flexform' => [
-                'data' => ['sDEF' => ['lDEF' => ['settings.token' => ['vDEF' => ['value' => '', '_vault_identifier' => $existingUuid, '_vault_checksum' => 'abc123']]]]],
+                'data' => ['sDEF' => ['lDEF' => ['settings.token' => ['vDEF' => ['value' => '', '_vault_identifier' => $existingUuid, '_vault_checksum' => '']]]]],
             ],
         ];
 
@@ -944,6 +944,42 @@ final class FlexFormVaultHookTest extends TestCase
             ->expects(self::once())
             ->method('delete')
             ->with($existingUuid, 'FlexForm field cleared');
+
+        $this->subject->processDatamap_afterDatabaseOperations('update', 'tt_content', 15, [], $this->dataHandler);
+    }
+
+    /**
+     * Regression for issue #223 (FlexForm-embedded vault field): an untouched
+     * re-save submits an empty value but keeps the checksum. The stored secret
+     * must be preserved, not deleted.
+     */
+    #[Test]
+    public function afterDatabaseOperationsKeepsSecretWhenFieldLeftUntouched(): void
+    {
+        $this->dataHandler->substNEWwithIDs = [];
+
+        $existingUuid = self::EXISTING_UUID;
+
+        $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
+        $this->flexFormTools->method('getDataStructureIdentifier')->willReturn('test-ds');
+        $this->flexFormTools->method('parseDataStructureByIdentifier')->willReturn([
+            'sheets' => ['sDEF' => ['ROOT' => ['el' => ['settings.token' => ['config' => ['type' => 'input', 'renderType' => 'vaultSecret']]]]]],
+        ]);
+
+        // Empty value but the checksum is still present → left untouched.
+        $fieldArray = [
+            'pi_flexform' => [
+                'data' => ['sDEF' => ['lDEF' => ['settings.token' => ['vDEF' => ['value' => '', '_vault_identifier' => $existingUuid, '_vault_checksum' => 'abc123']]]]],
+            ],
+        ];
+
+        $this->subject->processDatamap_preProcessFieldArray($fieldArray, 'tt_content', 15);
+
+        // The submitted array collapses back to the existing identifier, and the
+        // vault is left untouched.
+        self::assertSame($existingUuid, $fieldArray['pi_flexform']['data']['sDEF']['lDEF']['settings.token']['vDEF']);
+        $this->vaultService->expects(self::never())->method('delete');
+        $this->vaultService->expects(self::never())->method('rotate');
 
         $this->subject->processDatamap_afterDatabaseOperations('update', 'tt_content', 15, [], $this->dataHandler);
     }
@@ -1527,7 +1563,7 @@ final class FlexFormVaultHookTest extends TestCase
 
         $fieldArray = [
             'pi_flexform' => [
-                'data' => ['sDEF' => ['lDEF' => ['k' => ['vDEF' => ['value' => '', '_vault_identifier' => $uuid, '_vault_checksum' => 'cs']]]]],
+                'data' => ['sDEF' => ['lDEF' => ['k' => ['vDEF' => ['value' => '', '_vault_identifier' => $uuid, '_vault_checksum' => '']]]]],
             ],
         ];
 


### PR DESCRIPTION
## Problem

Saving a record that holds a vault secret (e.g. a provider's API key) **without retyping the key** wiped it — from both the record and the vault (reported by @lradloff in #223). A plain "save & close" on an unchanged record removed the secret.

## Root cause

The secret plaintext is never rendered back into the edit form (`VaultSecretElement` shows `••••••••` as a placeholder, value empty). So an **untouched** re-save submits an empty value, but with the change-detection `_vault_checksum` still present.

`PendingSecretExtractor::extract()` (and the parallel inline logic in `FlexFormVaultHook`) treated *empty value + present checksum* as **delete**, and the persisters gated the delete on the checksum. Meanwhile the JS clear control **blanks** the checksum to signal a clear — the exact opposite. The result:

- untouched re-save (empty value, checksum present) → **deleted the secret** (the bug), and
- the clear button (empty value, checksum blanked) → **did nothing**.

## Fix

Correct the empty-value handling in **both** the regular and the FlexForm path, so the checksum's presence has consistent meaning:

- **checksum present** ⇒ field left untouched ⇒ **keep** the secret (emit no pending secret; the DataHandler hook then leaves the DB field unchanged) — issue #223,
- **checksum blanked but an identifier remains** ⇒ the clear control was used ⇒ **delete**,
- the persisters (`PendingSecretPersister` and `FlexFormVaultHook`) gate the delete on the **identifier** — the reliable "a secret existed" signal — rather than the checksum the clear control blanks.

This fixes the data loss **and** repairs the clear control (which previously never deleted).

## Tests

- `DataHandlerHookTest` (unit + functional) and `FlexFormVaultHookTest` (unit): added *keep-on-untouched* regressions and corrected the *explicit-clear* cases to model a blanked checksum. The functional test stores a real secret, simulates an untouched save, and asserts it is still retrievable.
- Full local unit suite green (1942 tests). PHPStan/functional validated in CI (this box's local phpstan config + SQLite functional env are pre-existing local-only blockers).

Fixes #223
