### PR TITLE
Add missing metadata_update audit action

### DIFF
--- a/Classes/Audit/AuditAction.php
+++ b/Classes/Audit/AuditAction.php
@@ -29,6 +29,7 @@ enum AuditAction: string
     case Update = 'update';
     case Delete = 'delete';
     case Rotate = 'rotate';
+    case MetadataUpdate = 'metadata_update';
     case AccessDenied = 'access_denied';
     case HttpCall = 'http_call';
     case MasterKeyRotateStart = 'master_key_rotate_start';

--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -239,11 +239,11 @@ final class SecretTcaHook
 
         try {
             // Determine action type
-            $action = 'metadata_update';
+            $action = AuditAction::MetadataUpdate->value;
             if ($status === 'new') {
-                $action = 'create';
+                $action = AuditAction::Create->value;
             } elseif ($secretStored) {
-                $action = 'rotate';
+                $action = AuditAction::Rotate->value;
             }
 
             // Log the operation

--- a/Tests/E2E/tca/formengine.spec.ts
+++ b/Tests/E2E/tca/formengine.spec.ts
@@ -165,5 +165,53 @@ test.describe('TYPO3 FormEngine/TCA Integration', () => {
       await expect(frame.locator('text=str_starts_with')).not.toBeVisible();
       await expect(frame.locator('text=Oops, an error occurred')).not.toBeVisible();
     });
+
+    test('re-saving an existing record does not raise an audit logging error', async ({ authenticatedPage: page }) => {
+      // Regression test for https://github.com/netresearch/t3x-nr-vault/issues/227:
+      // a metadata-only re-save (secret untouched) logged the unknown audit
+      // action "metadata_update" and surfaced "Audit logging failed" to the editor.
+      const testIdentifier = generateTestId();
+
+      // Create a secret via the module's create form (FormEngine)
+      await page.goto('/typo3/module/admin/vault/secrets/create');
+      await waitForModuleContent(page);
+
+      let frame = getModuleFrame(page);
+      await frame.locator('input[data-formengine-input-name*="identifier"]').fill(testIdentifier);
+      await frame.locator('input[data-vault-is-new="1"]').first().fill('resave-test-secret');
+      await frame.locator('button[name="_savedok"], button:has-text("Save")').first().click();
+      await page.waitForLoadState('networkidle');
+
+      // Re-open the record via the filtered list
+      await page.goto('/typo3/module/admin/vault/secrets');
+      await waitForModuleContent(page);
+      frame = getModuleFrame(page);
+      await frame.getByRole('textbox', { name: 'Identifier' }).fill(testIdentifier);
+      const filterResp = page.waitForResponse(
+        (resp) => resp.url().includes('admin_vault_secrets') && resp.status() === 200,
+        { timeout: 10000 },
+      );
+      await frame.locator('button:has-text("Filter")').click();
+      await filterResp.catch(() => undefined);
+
+      frame = getModuleFrame(page);
+      await frame.locator('table tbody tr button[title*="Edit"], table tbody tr a[title*="Edit"]').first().click();
+      await waitForModuleContent(page);
+
+      // Hit save without touching anything — the issue #227 reproduction
+      frame = getModuleFrame(page);
+      await frame.locator('button[name="_savedok"], button:has-text("Save")').first().click();
+      await page.waitForLoadState('networkidle');
+
+      // The form must still render (save succeeded) …
+      frame = getModuleFrame(page);
+      const tabs = frame.locator('[role="tablist"], .nav-tabs');
+      await expect(tabs.first()).toBeVisible();
+
+      // … and no audit logging error may surface to the editor
+      await expect(frame.locator('text=Audit logging failed')).not.toBeVisible();
+      await expect(page.locator('text=Audit logging failed')).not.toBeVisible();
+      await expect(frame.locator('text=Oops, an error occurred')).not.toBeVisible();
+    });
   });
 });

--- a/Tests/Functional/Hook/SecretTcaHookTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookTest.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Functional\Hook;
 
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Audit\AuditLogFilter;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Hook\SecretTcaHook;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
@@ -255,6 +258,63 @@ final class SecretTcaHookTest extends AbstractVaultFunctionalTestCase
 
         // Cleanup
         $vaultService->delete($identifier, self::DELETE_REASON_CLEANUP);
+    }
+
+    #[Test]
+    public function metadataOnlyUpdateLogsMetadataUpdateAuditEntry(): void
+    {
+        $identifier = 'test_metadata_update_' . bin2hex(random_bytes(4));
+
+        // Create the record with a secret
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start(
+            [
+                'tx_nrvault_secret' => [
+                    'NEW1' => [
+                        'pid' => 0,
+                        'identifier' => $identifier,
+                        'description' => 'Before metadata update',
+                        'secret_input' => 'metadata-update-secret',
+                    ],
+                ],
+            ],
+            [],
+        );
+        $dataHandler->process_datamap();
+
+        $recordUid = $dataHandler->substNEWwithIDs['NEW1'] ?? 0;
+        self::assertGreaterThan(0, $recordUid);
+
+        // Re-save with a metadata-only change (no secret_input submitted) —
+        // the untouched re-save from the backend edit form (issue #227).
+        $updateHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $updateHandler->start(
+            [
+                'tx_nrvault_secret' => [
+                    $recordUid => [
+                        'description' => 'After metadata update',
+                    ],
+                ],
+            ],
+            [],
+        );
+        $updateHandler->process_datamap();
+
+        self::assertEmpty(
+            $updateHandler->errorLog,
+            'Metadata-only update must not produce DataHandler errors: ' . implode(', ', $updateHandler->errorLog),
+        );
+
+        // The metadata change must be sealed into the audit chain
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $actions = array_map(
+            static fn (AuditLogEntry $entry): string => $entry->action,
+            $auditService->query(AuditLogFilter::forSecret($identifier)),
+        );
+        self::assertContains('metadata_update', $actions);
+
+        // Cleanup
+        $this->get(VaultServiceInterface::class)->delete($identifier, self::DELETE_REASON_CLEANUP);
     }
 
     #[Test]


### PR DESCRIPTION
Fixes #227.

## Problem

Saving an existing secret record without retyping the secret showed:

> 1: Audit logging failed: Unknown audit action "metadata_update"; must be one of AuditAction::cases().

`SecretTcaHook` defaults the audit action to `metadata_update` for a metadata-only update, but the `AuditAction` enum never had that case, so `AuditLogService::log()` rejected it. The save itself succeeded, but the audit entry for the metadata change was silently never written — a gap in the tamper-evident chain, not just a cosmetic error.

The path became reachable with the v0.12.1 untouched-re-save fix (#225): before it, an untouched re-save never ended in the metadata-only branch.

## Fix

- Add `AuditAction::MetadataUpdate = 'metadata_update'`.
- Derive the hook's action strings (`create` / `rotate` / `metadata_update`) from the enum instead of string literals, matching the rest of the file — an unknown-action drift now fails at compile time instead of at runtime in the editor's face.

The audit-module filter dropdown and badge rendering pick the new case up automatically (`cases()` + `label()`, badge `match` has a default arm).

## Tests

Both written first and watched fail with the exact reported error before the fix:

- **Functional** (`SecretTcaHookTest::metadataOnlyUpdateLogsMetadataUpdateAuditEntry`): creates a secret via DataHandler, re-saves with a metadata-only change, asserts a clean `errorLog` and a sealed `metadata_update` audit entry. Runs in CI — this is the net that was missing.
- **E2E** (`formengine.spec.ts`): replays the reported backend flow — create, reopen, hit save untouched — and asserts no "Audit logging failed" notification. Verified red/green locally on chromium + firefox (webkit lacks host GTK libs in my environment; E2E is not part of CI).

Local runs: unit + fuzz 1514 tests OK, full functional suite 174 tests OK, PHPStan clean, php-cs-fixer clean.
