### PR TITLE
Add SecurityProfile with fail-closed master key provider selection

### DIFF
--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrVault\Configuration;
 
 use Netresearch\NrVault\Configuration\Dto\AwsSecretsConfig;
 use Netresearch\NrVault\Configuration\Dto\VaultServerConfig;
+use Netresearch\NrVault\Exception\ConfigurationException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration as Typo3ExtensionConfiguration;
 use TYPO3\CMS\Core\Core\Environment;
 use TYPO3\CMS\Core\SingletonInterface;
@@ -21,6 +22,8 @@ use TYPO3\CMS\Core\SingletonInterface;
 final class ExtensionConfiguration implements ExtensionConfigurationInterface, SingletonInterface
 {
     // Default values as constants for maintainability
+    public const DEFAULT_SECURITY_PROFILE = 'standard';
+
     public const DEFAULT_STORAGE_ADAPTER = 'local';
 
     public const DEFAULT_MASTER_KEY_PROVIDER = 'typo3';
@@ -82,6 +85,26 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
         /** @var array<string, mixed> $configArray */
         $configArray = \is_array($config) ? $config : [];
         $this->configuration = $configArray;
+    }
+
+    /**
+     * Get the configured security profile.
+     *
+     * Fail-closed: an unknown profile value throws instead of silently
+     * degrading to Standard — a typo in a hardened deployment must never
+     * weaken the effective policy.
+     *
+     * @throws ConfigurationException
+     */
+    public function getSecurityProfile(): SecurityProfile
+    {
+        $val = $this->configuration['securityProfile'] ?? self::DEFAULT_SECURITY_PROFILE;
+        if (!\is_string($val) || $val === '') {
+            $val = self::DEFAULT_SECURITY_PROFILE;
+        }
+
+        return SecurityProfile::tryFrom($val)
+            ?? throw ConfigurationException::invalidSecurityProfile($val);
     }
 
     /**

--- a/Classes/Configuration/ExtensionConfigurationInterface.php
+++ b/Classes/Configuration/ExtensionConfigurationInterface.php
@@ -18,6 +18,15 @@ use Netresearch\NrVault\Configuration\Dto\VaultServerConfig;
 interface ExtensionConfigurationInterface
 {
     /**
+     * Get the configured security profile.
+     *
+     * @throws \Netresearch\NrVault\Exception\ConfigurationException if the
+     *                                                               configured value is not a valid profile (fail-closed: an
+     *                                                               unknown profile must never silently degrade to Standard)
+     */
+    public function getSecurityProfile(): SecurityProfile;
+
+    /**
      * Get storage adapter identifier (local, hashicorp, aws).
      */
     public function getStorageAdapter(): string;

--- a/Classes/Configuration/ExtensionConfigurationInterface.php
+++ b/Classes/Configuration/ExtensionConfigurationInterface.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrVault\Configuration;
 
 use Netresearch\NrVault\Configuration\Dto\AwsSecretsConfig;
 use Netresearch\NrVault\Configuration\Dto\VaultServerConfig;
+use Netresearch\NrVault\Exception\ConfigurationException;
 
 /**
  * Interface for extension configuration access.
@@ -20,9 +21,9 @@ interface ExtensionConfigurationInterface
     /**
      * Get the configured security profile.
      *
-     * @throws \Netresearch\NrVault\Exception\ConfigurationException if the
-     *                                                               configured value is not a valid profile (fail-closed: an
-     *                                                               unknown profile must never silently degrade to Standard)
+     * @throws ConfigurationException if the configured value is not a valid
+     *                                profile (fail-closed: an unknown profile
+     *                                must never silently degrade to Standard)
      */
     public function getSecurityProfile(): SecurityProfile;
 

--- a/Classes/Configuration/SecurityProfile.php
+++ b/Classes/Configuration/SecurityProfile.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Configuration;
+
+/**
+ * Operating profile of the vault.
+ *
+ * A profile is a single, internally consistent security policy — not a bag of
+ * independent toggles. Enforcement happens in code (provider selection, access
+ * control, audit anchoring), never only in documentation.
+ *
+ * - Standard: secure defaults with zero-configuration TYPO3 integration.
+ * - Hardened: fail-closed, audit-ready configuration for regulated
+ *   environments. Requires an explicit external master-key provider,
+ *   forbids provider auto-detection and any fallback to the TYPO3
+ *   encryption key.
+ */
+enum SecurityProfile: string
+{
+    case Standard = 'standard';
+
+    case Hardened = 'hardened';
+
+    public function isHardened(): bool
+    {
+        return $this === self::Hardened;
+    }
+}

--- a/Classes/Crypto/MasterKeyProviderFactory.php
+++ b/Classes/Crypto/MasterKeyProviderFactory.php
@@ -25,6 +25,10 @@ final readonly class MasterKeyProviderFactory implements MasterKeyProviderFactor
     {
         $provider = $this->configuration->getMasterKeyProvider();
 
+        if ($provider === 'typo3' && $this->configuration->getSecurityProfile()->isHardened()) {
+            throw ConfigurationException::providerForbiddenInHardenedProfile($provider);
+        }
+
         return match ($provider) {
             'typo3' => new Typo3MasterKeyProvider(),
             'file' => new FileMasterKeyProvider($this->configuration),
@@ -35,9 +39,19 @@ final readonly class MasterKeyProviderFactory implements MasterKeyProviderFactor
 
     /**
      * Get the configured provider, falling back to auto-detection.
+     *
+     * In the hardened profile there is NO auto-detection and NO fallback:
+     * the explicitly configured provider is returned even when it is not
+     * available (its getMasterKey() then fails loudly), and configuration
+     * errors propagate. A misconfigured hardened vault must stop, never
+     * silently continue on the TYPO3 encryption key.
      */
     public function getAvailableProvider(): MasterKeyProviderInterface
     {
+        if ($this->configuration->getSecurityProfile()->isHardened()) {
+            return $this->create();
+        }
+
         // Try configured provider first
         try {
             $provider = $this->create();

--- a/Classes/Crypto/MasterKeyProviderFactoryInterface.php
+++ b/Classes/Crypto/MasterKeyProviderFactoryInterface.php
@@ -19,12 +19,21 @@ interface MasterKeyProviderFactoryInterface
     /**
      * Create a master key provider based on configuration.
      *
-     * @throws ConfigurationException If provider is invalid
+     * @throws ConfigurationException If the provider is invalid, or if the
+     *                                hardened security profile forbids the
+     *                                configured provider (e.g. 'typo3')
      */
     public function create(): MasterKeyProviderInterface;
 
     /**
      * Get the configured provider, falling back to auto-detection.
+     *
+     * Auto-detection applies to the Standard profile only. In the Hardened
+     * profile this behaves exactly like {@see create()}: no fallback, no
+     * auto-detection — configuration errors propagate (fail-closed).
+     *
+     * @throws ConfigurationException In the hardened profile, if the
+     *                                configured provider is invalid or forbidden
      */
     public function getAvailableProvider(): MasterKeyProviderInterface;
 }

--- a/Classes/Exception/ConfigurationException.php
+++ b/Classes/Exception/ConfigurationException.php
@@ -37,4 +37,29 @@ final class ConfigurationException extends VaultException
             1703800017,
         );
     }
+
+    public static function invalidSecurityProfile(string $profile): self
+    {
+        return new self(
+            \sprintf(
+                'Unknown security profile "%s". Valid profiles: standard, hardened. '
+                . 'Refusing to fall back to a weaker profile.',
+                $profile,
+            ),
+            1753900001,
+        );
+    }
+
+    public static function providerForbiddenInHardenedProfile(string $provider): self
+    {
+        return new self(
+            \sprintf(
+                'Master key provider "%s" is not permitted in the hardened security profile. '
+                . 'Configure an explicit external provider (file, env) — the TYPO3 encryption '
+                . 'key must not protect vault secrets in hardened deployments.',
+                $provider,
+            ),
+            1753900002,
+        );
+    }
 }

--- a/Tests/Unit/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/Configuration/ExtensionConfigurationTest.php
@@ -12,6 +12,8 @@ namespace Netresearch\NrVault\Tests\Unit\Configuration;
 use Netresearch\NrVault\Configuration\Dto\AwsSecretsConfig;
 use Netresearch\NrVault\Configuration\Dto\VaultServerConfig;
 use Netresearch\NrVault\Configuration\ExtensionConfiguration;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Exception\ConfigurationException;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -544,5 +546,64 @@ final class ExtensionConfigurationTest extends TestCase
         self::assertContains(1, $result);
         self::assertContains(3, $result);
         self::assertNotContains(0, $result);
+    }
+
+    #[Test]
+    public function getSecurityProfileReturnsStandardWhenNotConfigured(): void
+    {
+        $this->typo3Config->method('get')
+            ->willReturn([]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame(SecurityProfile::Standard, $config->getSecurityProfile());
+    }
+
+    #[Test]
+    public function getSecurityProfileReturnsStandardForEmptyString(): void
+    {
+        $this->typo3Config->method('get')
+            ->willReturn(['securityProfile' => '']);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame(SecurityProfile::Standard, $config->getSecurityProfile());
+    }
+
+    #[Test]
+    public function getSecurityProfileReturnsHardenedWhenConfigured(): void
+    {
+        $this->typo3Config->method('get')
+            ->willReturn(['securityProfile' => 'hardened']);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame(SecurityProfile::Hardened, $config->getSecurityProfile());
+    }
+
+    #[Test]
+    public function getSecurityProfileThrowsForUnknownProfileInsteadOfDegrading(): void
+    {
+        // Fail-closed: a typo like "hardned" must never silently become Standard.
+        $this->typo3Config->method('get')
+            ->willReturn(['securityProfile' => 'hardned']);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionCode(1753900001);
+
+        $config->getSecurityProfile();
+    }
+
+    #[Test]
+    public function getSecurityProfileFallsBackToStandardForNonStringValue(): void
+    {
+        $this->typo3Config->method('get')
+            ->willReturn(['securityProfile' => 1]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame(SecurityProfile::Standard, $config->getSecurityProfile());
     }
 }

--- a/Tests/Unit/Configuration/SecurityProfileTest.php
+++ b/Tests/Unit/Configuration/SecurityProfileTest.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Configuration;
+
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(SecurityProfile::class)]
+final class SecurityProfileTest extends TestCase
+{
+    #[Test]
+    public function standardIsNotHardened(): void
+    {
+        self::assertFalse(SecurityProfile::Standard->isHardened());
+    }
+
+    #[Test]
+    public function hardenedIsHardened(): void
+    {
+        self::assertTrue(SecurityProfile::Hardened->isHardened());
+    }
+
+    #[Test]
+    public function profilesAreBackedByStableConfigurationValues(): void
+    {
+        self::assertSame('standard', SecurityProfile::Standard->value);
+        self::assertSame('hardened', SecurityProfile::Hardened->value);
+    }
+
+    #[Test]
+    public function unknownValueIsNotAProfile(): void
+    {
+        self::assertNull(SecurityProfile::tryFrom('military-grade'));
+    }
+}

--- a/Tests/Unit/Crypto/MasterKeyProviderFactoryTest.php
+++ b/Tests/Unit/Crypto/MasterKeyProviderFactoryTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Crypto;
 
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
 use Netresearch\NrVault\Crypto\EnvironmentMasterKeyProvider;
 use Netresearch\NrVault\Crypto\FileMasterKeyProvider;
 use Netresearch\NrVault\Crypto\MasterKeyProviderFactory;
@@ -35,6 +36,9 @@ final class MasterKeyProviderFactoryTest extends TestCase
         parent::setUp();
 
         $this->configuration = $this->createMock(ExtensionConfigurationInterface::class);
+        $this->configuration
+            ->method('getSecurityProfile')
+            ->willReturn(SecurityProfile::Standard);
         $this->subject = new MasterKeyProviderFactory($this->configuration);
     }
 
@@ -98,5 +102,98 @@ final class MasterKeyProviderFactoryTest extends TestCase
         $result = $this->subject->getAvailableProvider();
 
         self::assertInstanceOf(MasterKeyProviderInterface::class, $result);
+    }
+
+    #[Test]
+    public function createThrowsWhenHardenedProfileUsesTypo3Provider(): void
+    {
+        $factory = $this->createHardenedFactory('typo3');
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionCode(1753900002);
+
+        $factory->create();
+    }
+
+    #[Test]
+    public function getAvailableProviderThrowsWhenHardenedProfileUsesTypo3Provider(): void
+    {
+        $factory = $this->createHardenedFactory('typo3');
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionCode(1753900002);
+
+        $factory->getAvailableProvider();
+    }
+
+    #[Test]
+    public function getAvailableProviderThrowsWhenHardenedProfileUsesUnknownProvider(): void
+    {
+        // Hardened: no auto-detection may paper over an invalid provider name.
+        $factory = $this->createHardenedFactory('invalid');
+
+        $this->expectException(ConfigurationException::class);
+        $this->expectExceptionCode(1703800015);
+
+        $factory->getAvailableProvider();
+    }
+
+    #[Test]
+    public function getAvailableProviderDoesNotFallBackWhenHardenedProviderIsUnavailable(): void
+    {
+        // The configured file provider points at a nonexistent key file. In the
+        // hardened profile the factory must still return THAT provider (whose
+        // getMasterKey() fails loudly) — never a typo3/env substitute.
+        $factory = $this->createHardenedFactory('file');
+
+        $result = $factory->getAvailableProvider();
+
+        self::assertInstanceOf(FileMasterKeyProvider::class, $result);
+        self::assertFalse($result->isAvailable());
+    }
+
+    #[Test]
+    public function createAllowsFileProviderInHardenedProfile(): void
+    {
+        $factory = $this->createHardenedFactory('file');
+
+        self::assertInstanceOf(FileMasterKeyProvider::class, $factory->create());
+    }
+
+    #[Test]
+    public function createAllowsEnvProviderInHardenedProfile(): void
+    {
+        $factory = $this->createHardenedFactory('env');
+
+        self::assertInstanceOf(EnvironmentMasterKeyProvider::class, $factory->create());
+    }
+
+    #[Test]
+    public function createAllowsTypo3ProviderInStandardProfile(): void
+    {
+        $this->configuration
+            ->method('getMasterKeyProvider')
+            ->willReturn('typo3');
+
+        self::assertInstanceOf(Typo3MasterKeyProvider::class, $this->subject->create());
+    }
+
+    /**
+     * Build a factory whose configuration uses the hardened profile.
+     */
+    private function createHardenedFactory(string $provider): MasterKeyProviderFactory
+    {
+        $configuration = $this->createMock(ExtensionConfigurationInterface::class);
+        $configuration
+            ->method('getSecurityProfile')
+            ->willReturn(SecurityProfile::Hardened);
+        $configuration
+            ->method('getMasterKeyProvider')
+            ->willReturn($provider);
+        $configuration
+            ->method('getMasterKeySource')
+            ->willReturn('/nonexistent/hardened-test.key');
+
+        return new MasterKeyProviderFactory($configuration);
     }
 }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -30,6 +30,9 @@ encryptionAlgorithm =
 ### SECURITY ###
 #################
 
+# cat=Security; type=options[standard=Standard (secure defaults),hardened=Hardened (fail-closed, audit-ready)]; label=Security Profile: "standard" keeps zero-configuration defaults. "hardened" enforces a fail-closed policy: an explicit external master key provider (file or env) is required, provider auto-detection and any fallback to the TYPO3 encryption key are disabled, and vault operations refuse to run on a misconfigured or unavailable provider.
+securityProfile = standard
+
 # cat=Security; type=boolean; label=Allow CLI Access: Enable secret access via CLI commands (requires proper authentication)
 allowCliAccess = 0
 


### PR DESCRIPTION
## Summary

First step of the hardened-profile roadmap (P0 item 1): a technically enforced `SecurityProfile` (`standard` | `hardened`) with fail-closed master key provider selection.

- New `SecurityProfile` enum + `securityProfile` extension configuration (default `standard`, no behavior change for existing installations).
- **Hardened profile**:
  - `masterKeyProvider = typo3` is a configuration error (`ConfigurationException`, code 1753900002) — vault secrets must not be protected by the TYPO3 encryption key.
  - `getAvailableProvider()` performs **no auto-detection and no fallback**: the configured provider is returned even when unavailable, so `getMasterKey()` fails loudly instead of silently degrading (previously it fell back typo3 → env → file).
  - Unknown `securityProfile` values throw instead of degrading to `standard` (a typo must never weaken the effective policy).
- `VaultHealthService` and `vault:rotate-master-key` consume the same factory path, so misconfiguration surfaces in the system status and blocks rotation.

## Acceptance criteria (from the roadmap)

```
Configured provider unavailable => no fallback            ✔ getAvailableProviderDoesNotFallBackWhenHardenedProviderIsUnavailable
Configured provider unavailable => vault operations fail  ✔ provider getMasterKey() throws; DI path uses create()
Hardened + provider=typo3      => configuration error     ✔ createThrowsWhenHardenedProfileUsesTypo3Provider
```

## Test plan

- `composer ci` green locally: 2209 unit tests, 1514 fuzz tests, PHPStan level 10, CGL, architecture + CLI-doc checks.
- New tests: `SecurityProfileTest`, 5 `ExtensionConfigurationTest` cases, 7 `MasterKeyProviderFactoryTest` cases covering all hardened/fail-closed paths.

Part of the security-hardening roadmap (PR 1 of 10). Follow-ups: reveal lifecycle (PR 2), operation-based permissions (PR 3), break-glass (PR 4), audit sinks (PR 5), `vault:doctor` (PR 6).
