### PR TITLE
Split vault access into operation-based permissions

### DIFF
--- a/Build/phpunit.xml
+++ b/Build/phpunit.xml
@@ -37,6 +37,10 @@
             <file>../Classes/Controller/MigrationController.php</file>
             <file>../Classes/Controller/OverviewController.php</file>
             <file>../Classes/Controller/SecretsController.php</file>
+            <!-- Module permission gate: renders a ModuleTemplate (final TYPO3
+                 classes) for the 403 response; its decision seams are unit
+                 tested, the render is covered functionally/E2E. -->
+            <file>../Classes/Controller/ModuleAccessGuard.php</file>
             <!-- Form elements: VaultSecretInputElement depends on final TYPO3 classes -->
             <file>../Classes/Form/Element/VaultSecretInputElement.php</file>
             <!-- Interfaces define contracts, not executable code -->
@@ -58,6 +62,7 @@
             <file>../Classes/Http/SecretPlacement.php</file>
             <file>../Classes/Service/Detection/Severity.php</file>
             <file>../Classes/Service/VaultFieldPermission.php</file>
+            <file>../Classes/Security/VaultPermission.php</file>
             <!-- Interfaces and enums added with ADR-031/032/033: no executable
                  code to cover, and declaring CoversClass on an excluded target
                  raises a warning that failOnWarning turns into a failure. -->

--- a/Classes/Command/VaultRetrieveCommand.php
+++ b/Classes/Command/VaultRetrieveCommand.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrVault\Command;
 
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Exception\VaultException;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -31,6 +33,7 @@ final class VaultRetrieveCommand extends Command
 {
     public function __construct(
         private readonly VaultServiceInterface $vaultService,
+        private readonly AccessControlServiceInterface $accessControlService,
     ) {
         parent::__construct();
     }
@@ -68,6 +71,20 @@ final class VaultRetrieveCommand extends Command
         $io = new SymfonyStyle($input, $output);
         $identifierArg = $input->getArgument('identifier');
         $identifier = \is_string($identifierArg) ? $identifierArg : '';
+
+        // This command prints plaintext to a terminal (or writes it to a file),
+        // so it is a reveal surface and needs `secret.reveal` on top of the
+        // per-secret read access VaultService::retrieve() asserts. For a
+        // trusted CLI operator the vault's `allowCliAccess` switch decides;
+        // when invoked as a backend user, that user's group grants do.
+        if (!$this->accessControlService->isGranted(VaultPermission::SecretReveal)) {
+            $io->error(\sprintf(
+                'Access denied: the "%s" permission is required to print a secret value.',
+                VaultPermission::SecretReveal->value,
+            ));
+
+            return Command::FAILURE;
+        }
 
         try {
             $value = $this->vaultService->retrieve($identifier);

--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -26,6 +26,7 @@ use Netresearch\NrVault\Event\MasterKeyRotatedEvent;
 use Netresearch\NrVault\Exception\EncryptionException;
 use Netresearch\NrVault\Exception\MasterKeyException;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use SensitiveParameter;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -117,6 +118,20 @@ final class VaultRotateMasterKeyCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $io = new SymfonyStyle($input, $output);
+
+        // Master-key rotation rewrites every envelope in the store and rekeys
+        // the audit chain — the most powerful vault operation, so it carries
+        // its own operation permission. For a trusted CLI operator the vault's
+        // `allowCliAccess` switch decides; invoked as a backend user, the
+        // admin override or that user's group grants do.
+        if (!$this->accessControlService->isGranted(VaultPermission::MasterKeyRotate)) {
+            $io->error(\sprintf(
+                'Access denied: the "%s" permission is required to rotate the master key.',
+                VaultPermission::MasterKeyRotate->value,
+            ));
+
+            return Command::FAILURE;
+        }
 
         try {
             $oldKeyPath = $input->getOption('old-key');

--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -21,6 +21,7 @@ use Netresearch\NrVault\Exception\SecretExpiredException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Exception\ValidationException;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -49,7 +50,14 @@ final readonly class AjaxController
      * Reveal a secret value.
      *
      * Accepts POST requests with a JSON body containing `identifier`.
-     * Admin-only and server-side re-checked (see SEC-ACCESS-6).
+     * Requires the `secret.reveal` operation permission, re-checked
+     * server-side (see SEC-ACCESS-6).
+     *
+     * A non-admin needs BOTH `secret.reveal` (asserted here — displaying
+     * plaintext to a human) AND `secret.use` (asserted in
+     * `VaultService::retrieve()` — consuming the plaintext at all), on top of
+     * per-secret read access. That is intentional: the two permissions answer
+     * different questions and neither implies the other.
      *
      * The response carries the plaintext secret and therefore must never be
      * stored by any cache (browser, proxy, service worker): every reveal
@@ -60,14 +68,16 @@ final readonly class AjaxController
     public function revealAction(ServerRequestInterface $request): ResponseInterface
     {
         // SEC-ACCESS-6: defense-in-depth — do not rely solely on the route's
-        // `methods => ['POST']` / `access => admin` config. Re-assert the POST
-        // method (mirroring rotateAction) and re-check admin server-side, so
-        // authorization holds even if the route config is later loosened.
+        // `methods => ['POST']` / `access` config. Re-assert the POST method
+        // (mirroring rotateAction) and re-check the operation permission
+        // server-side, so authorization holds even if the route config is
+        // later loosened. The route is `access => user` precisely because this
+        // check, not the route, is the authority.
         if ($request->getMethod() !== 'POST') {
             return $this->jsonError('Method not allowed', 405);
         }
 
-        if (!$this->accessControlService->isCurrentActorAdmin()) {
+        if (!$this->accessControlService->isGranted(VaultPermission::SecretReveal)) {
             return $this->jsonError(self::ERROR_ACCESS_DENIED, 403);
         }
 
@@ -123,8 +133,10 @@ final readonly class AjaxController
             return $this->jsonError('Method not allowed', 405);
         }
 
-        // SEC-ACCESS-6: defense-in-depth admin re-check (see revealAction).
-        if (!$this->accessControlService->isCurrentActorAdmin()) {
+        // SEC-ACCESS-6: defense-in-depth operation-permission re-check
+        // (see revealAction). Per-secret write access is asserted by
+        // VaultService::rotate() on top of this.
+        if (!$this->accessControlService->isGranted(VaultPermission::SecretRotate)) {
             return $this->jsonError(self::ERROR_ACCESS_DENIED, 403);
         }
 

--- a/Classes/Controller/AnalyticsController.php
+++ b/Classes/Controller/AnalyticsController.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Controller;
 
 use Netresearch\NrVault\Domain\Dto\StaleSecret;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\Analytics\VaultAnalyticsServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -37,10 +38,20 @@ final readonly class AnalyticsController
         private VaultAnalyticsServiceInterface $analyticsService,
         private BackendUriBuilder $backendUriBuilder,
         private PageRenderer $pageRenderer,
+        private ModuleAccessGuard $accessGuard,
     ) {}
 
+    /**
+     * Usage analytics are derived from the audit log (the automated/manual read
+     * split comes from `actor_type`), so they carry the same disclosure as the
+     * log itself and share its `audit.view` permission.
+     */
     public function indexAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (!$this->accessGuard->isGranted(VaultPermission::AuditView)) {
+            return $this->accessGuard->deniedResponse($request, VaultPermission::AuditView);
+        }
+
         $moduleTemplate = $this->moduleTemplateFactory->create($request);
         $moduleTemplate->makeDocHeaderModuleMenu();
         $this->pageRenderer->addCssFile('EXT:nr_vault/Resources/Public/Css/backend.css');

--- a/Classes/Controller/AuditController.php
+++ b/Classes/Controller/AuditController.php
@@ -15,6 +15,7 @@ use Netresearch\NrVault\Audit\AuditAction;
 use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Audit\AuditLogFilter;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Utility\CsvFormulaSanitizer;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -24,7 +25,6 @@ use TYPO3\CMS\Backend\Template\Components\ButtonBar;
 use TYPO3\CMS\Backend\Template\ModuleTemplate;
 use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 use TYPO3\CMS\Core\Http\JsonResponse;
-use TYPO3\CMS\Core\Http\RedirectResponse;
 use TYPO3\CMS\Core\Http\Response;
 use TYPO3\CMS\Core\Imaging\IconFactory;
 use TYPO3\CMS\Core\Imaging\IconSize;
@@ -49,6 +49,7 @@ final readonly class AuditController
         private PageRenderer $pageRenderer,
         private AuditLogServiceInterface $auditLogService,
         private UriBuilder $uriBuilder,
+        private ModuleAccessGuard $accessGuard,
     ) {}
 
     /**
@@ -56,6 +57,10 @@ final readonly class AuditController
      */
     public function listAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (!$this->accessGuard->isGranted(VaultPermission::AuditView)) {
+            return $this->accessGuard->deniedResponse($request, VaultPermission::AuditView);
+        }
+
         $moduleTemplate = $this->moduleTemplateFactory->create($request);
         $moduleTemplate->makeDocHeaderModuleMenu();
         /** @phpstan-ignore function.alreadyNarrowedType (v14-only method, not available in v13) */
@@ -144,7 +149,7 @@ final readonly class AuditController
             'totalPages' => $totalPages,
             'filters' => ['_form' => $formData],
             'pagination' => $pagination,
-            'isAdmin' => $this->isAdmin(),
+            'canExport' => $this->accessGuard->isGranted(VaultPermission::AuditExport),
             // Derive the action-filter list from the AuditAction enum so the UI
             // can never drift from the actions actually written to the chain
             // (the previous hard-coded list silently omitted master_key_* and
@@ -166,11 +171,11 @@ final readonly class AuditController
      */
     public function verifyChainAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (!$this->isAdmin()) {
-            /** @phpstan-ignore new.internalClass, method.internalClass */
-            return new RedirectResponse(
-                (string) $this->uriBuilder->buildUriFromRoute(self::MODULE_NAME),
-            );
+        // Verification is a read of the chain, so it shares `audit.view` with
+        // the listing. Replaces the previous silent redirect-on-non-admin with
+        // an explicit 403 that names the missing permission.
+        if (!$this->accessGuard->isGranted(VaultPermission::AuditView)) {
+            return $this->accessGuard->deniedResponse($request, VaultPermission::AuditView);
         }
 
         $moduleTemplate = $this->moduleTemplateFactory->create($request);
@@ -210,7 +215,10 @@ final readonly class AuditController
      */
     public function exportAction(ServerRequestInterface $request): ResponseInterface
     {
-        if (!$this->isAdmin()) {
+        // Export needs its own permission: the downloaded copy leaves the
+        // tamper-evident storage behind (no hash chain, no retention, no
+        // access control), which `audit.view` deliberately does not cover.
+        if (!$this->accessGuard->isGranted(VaultPermission::AuditExport)) {
             /** @phpstan-ignore new.internalClass, method.internalClass */
             return new JsonResponse(['success' => false, 'error' => 'Access denied'], 403);
         }
@@ -381,14 +389,18 @@ final readonly class AuditController
         $buttonBar = $moduleTemplate->getDocHeaderComponent()->getButtonBar();
         $lang = $this->getLanguageService();
 
-        if ($this->isAdmin()) {
+        // The buttons follow the same permissions the actions enforce, so the
+        // UI never offers an operation that would answer 403.
+        if ($this->accessGuard->isGranted(VaultPermission::AuditView)) {
             // Verify Chain button
             $verifyButton = $buttonBar->makeLinkButton()
                 ->setHref((string) $this->uriBuilder->buildUriFromRoute(self::MODULE_NAME . '.verifyChain'))
                 ->setTitle($lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.verify_chain'))
                 ->setIcon($this->iconFactory->getIcon('actions-check', IconSize::SMALL));
             $buttonBar->addButton($verifyButton, ButtonBar::BUTTON_POSITION_LEFT, 1);
+        }
 
+        if ($this->accessGuard->isGranted(VaultPermission::AuditExport)) {
             // Export JSON button
             $exportJsonButton = $buttonBar->makeLinkButton()
                 ->setHref((string) $this->uriBuilder->buildUriFromRoute(self::MODULE_NAME . '.export', ['format' => 'json']))
@@ -418,16 +430,6 @@ final readonly class AuditController
             'access_denied' => 'danger',
             default => 'secondary',
         };
-    }
-
-    private function isAdmin(): bool
-    {
-        $backendUser = $GLOBALS['BE_USER'] ?? null;
-        if (!\is_object($backendUser) || !method_exists($backendUser, 'isAdmin')) {
-            return false;
-        }
-
-        return (bool) $backendUser->isAdmin();
     }
 
     private function getLanguageService(): LanguageService

--- a/Classes/Controller/MigrationController.php
+++ b/Classes/Controller/MigrationController.php
@@ -14,6 +14,7 @@ use Doctrine\DBAL\Schema\Column;
 use Doctrine\DBAL\Schema\Table;
 use Exception;
 use Netresearch\NrVault\Domain\Dto\MigrationResult;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\SecretDetectionService;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Utility\IdentifierValidator;
@@ -69,13 +70,23 @@ final readonly class MigrationController
         private FlashMessageService $flashMessageService,
         private IconFactory $iconFactory,
         private PageRenderer $pageRenderer,
+        private ModuleAccessGuard $accessGuard,
     ) {}
 
     /**
      * Main entry point - dispatches to action methods based on ?action= query param.
+     *
+     * The whole wizard sits behind `vault.configure`: its scan step produces a
+     * map of exactly where plaintext credentials still sit in the database,
+     * and its execute step moves values into the vault. One gate here covers
+     * every dispatched step — the private actions are unreachable otherwise.
      */
     public function handleRequest(ServerRequestInterface $request): ResponseInterface
     {
+        if (!$this->accessGuard->isGranted(VaultPermission::VaultConfigure)) {
+            return $this->accessGuard->deniedResponse($request, VaultPermission::VaultConfigure);
+        }
+
         $this->pageRenderer->addCssFile('EXT:nr_vault/Resources/Public/Css/backend.css');
 
         $queryParams = $request->getQueryParams();

--- a/Classes/Controller/ModuleAccessGuard.php
+++ b/Classes/Controller/ModuleAccessGuard.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Controller;
+
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
+use TYPO3\CMS\Core\Localization\LanguageService;
+
+/**
+ * Per-action operation-permission gate for the vault backend modules.
+ *
+ * The vault modules are registered with `'access' => 'user'` so that a
+ * non-admin holding a vault permission can reach them at all; the actual
+ * authorization is asserted here, in the controller, for every single action
+ * (same defence-in-depth stance as SEC-ACCESS-6 for the AJAX endpoints — the
+ * module registration is a routing convenience, never the authority).
+ *
+ * Centralised in one collaborator rather than copied into five controllers so
+ * the denial response is byte-identical everywhere and the "which permission
+ * does this action need" decision has exactly one shape.
+ */
+final readonly class ModuleAccessGuard
+{
+    private const LL_PREFIX = 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:';
+
+    public function __construct(
+        private AccessControlServiceInterface $accessControlService,
+        private ModuleTemplateFactory $moduleTemplateFactory,
+    ) {}
+
+    /**
+     * Is the actor granted this single operation permission?
+     */
+    public function isGranted(VaultPermission $permission): bool
+    {
+        return $this->accessControlService->isGranted($permission);
+    }
+
+    /**
+     * Is the actor granted at least ONE of these operation permissions?
+     *
+     * Used for the "may this actor enter the module at all" gates, where any
+     * single permission from a set implies a legitimate reason to see the
+     * listing (the individual mutating actions re-check their own permission).
+     */
+    public function isAnyGranted(VaultPermission ...$permissions): bool
+    {
+        foreach ($permissions as $permission) {
+            if ($this->accessControlService->isGranted($permission)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Render the module-shaped 403 for a denied action.
+     *
+     * Keeps the backend chrome (module menu) so the operator can navigate to a
+     * submodule they *are* allowed to use, states which permission is missing,
+     * and carries a real 403 status rather than a 200 with an error body.
+     */
+    public function deniedResponse(
+        ServerRequestInterface $request,
+        VaultPermission $required,
+    ): ResponseInterface {
+        $lang = $this->getLanguageService();
+        $moduleTemplate = $this->moduleTemplateFactory->create($request);
+        $moduleTemplate->makeDocHeaderModuleMenu();
+        $moduleTemplate->setTitle($lang->sL(self::LL_PREFIX . 'accessDenied.title'));
+        $moduleTemplate->assignMultiple([
+            'requiredPermission' => $required->value,
+        ]);
+
+        return $moduleTemplate->renderResponse('AccessDenied')->withStatus(403);
+    }
+
+    private function getLanguageService(): LanguageService
+    {
+        \assert($GLOBALS['LANG'] instanceof LanguageService);
+
+        return $GLOBALS['LANG'];
+    }
+}

--- a/Classes/Controller/OverviewController.php
+++ b/Classes/Controller/OverviewController.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Controller;
 
 use Exception;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\VaultHealthServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -35,13 +36,22 @@ final readonly class OverviewController
         private VaultHealthServiceInterface $vaultHealthService,
         private BackendUriBuilder $backendUriBuilder,
         private PageRenderer $pageRenderer,
+        private ModuleAccessGuard $accessGuard,
     ) {}
 
     /**
      * Display vault overview with submodule cards and usage information.
+     *
+     * Reachable with ANY vault permission — it is the landing page of the
+     * module tree. The submodule cards are filtered to the ones the actor can
+     * actually open, so the overview never links into a 403.
      */
     public function indexAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (!$this->hasAnyVaultPermission()) {
+            return $this->accessGuard->deniedResponse($request, VaultPermission::SecretUse);
+        }
+
         $moduleTemplate = $this->moduleTemplateFactory->create($request);
         $moduleTemplate->makeDocHeaderModuleMenu();
         $this->buildDocHeaderTabMenu($moduleTemplate, 'dashboard');
@@ -67,32 +77,7 @@ final readonly class OverviewController
         $moduleTemplate->assignMultiple([
             'stats' => $stats,
             'healthChecks' => $healthChecks,
-            'submodules' => [
-                [
-                    'route' => 'admin_vault_secrets',
-                    'icon' => 'module-vault-secrets',
-                    'title' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.title'),
-                    'description' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.secrets.description'),
-                ],
-                [
-                    'route' => 'admin_vault_analytics',
-                    'icon' => 'module-vault-analytics',
-                    'title' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:analytics.title'),
-                    'description' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.analytics.description'),
-                ],
-                [
-                    'route' => 'admin_vault_audit',
-                    'icon' => 'module-vault-audit',
-                    'title' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:audit.title'),
-                    'description' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.audit.description'),
-                ],
-                [
-                    'route' => 'admin_vault_migration',
-                    'icon' => 'module-vault-migration',
-                    'title' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:migration.title'),
-                    'description' => $lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.migration.description'),
-                ],
-            ],
+            'submodules' => $this->getAccessibleSubmodules($lang),
         ]);
 
         return $moduleTemplate->renderResponse('Overview/Index');
@@ -103,6 +88,10 @@ final readonly class OverviewController
      */
     public function helpAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (!$this->hasAnyVaultPermission()) {
+            return $this->accessGuard->deniedResponse($request, VaultPermission::SecretUse);
+        }
+
         $moduleTemplate = $this->moduleTemplateFactory->create($request);
         $moduleTemplate->makeDocHeaderModuleMenu();
         $this->buildDocHeaderTabMenu($moduleTemplate, 'help');
@@ -113,6 +102,76 @@ final readonly class OverviewController
         ]);
 
         return $moduleTemplate->renderResponse('Overview/Help');
+    }
+
+    /**
+     * Does the actor hold at least one vault permission?
+     *
+     * The overview is the module tree's landing page, so any single permission
+     * is enough to see it; the cards and the submodules themselves enforce the
+     * specific permission each operation needs.
+     */
+    private function hasAnyVaultPermission(): bool
+    {
+        return $this->accessGuard->isAnyGranted(...VaultPermission::cases());
+    }
+
+    /**
+     * Submodule cards, filtered to the ones the actor may actually open.
+     *
+     * The required permission per card mirrors exactly what the target
+     * controller asserts, so a rendered card can never lead to a 403.
+     *
+     * @return list<array{route: string, icon: string, title: string, description: string}>
+     */
+    private function getAccessibleSubmodules(LanguageService $lang): array
+    {
+        $llPrefix = 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:';
+
+        $candidates = [
+            [
+                'route' => 'admin_vault_secrets',
+                'icon' => 'module-vault-secrets',
+                'title' => $lang->sL($llPrefix . 'secrets.title'),
+                'description' => $lang->sL($llPrefix . 'overview.secrets.description'),
+                // SecretsController::listAction() admits any secret-handling
+                // permission.
+                'permissions' => VaultPermission::secretOperations(),
+            ],
+            [
+                'route' => 'admin_vault_analytics',
+                'icon' => 'module-vault-analytics',
+                'title' => $lang->sL($llPrefix . 'analytics.title'),
+                'description' => $lang->sL($llPrefix . 'overview.analytics.description'),
+                'permissions' => [VaultPermission::AuditView],
+            ],
+            [
+                'route' => 'admin_vault_audit',
+                'icon' => 'module-vault-audit',
+                'title' => $lang->sL($llPrefix . 'audit.title'),
+                'description' => $lang->sL($llPrefix . 'overview.audit.description'),
+                'permissions' => [VaultPermission::AuditView],
+            ],
+            [
+                'route' => 'admin_vault_migration',
+                'icon' => 'module-vault-migration',
+                'title' => $lang->sL($llPrefix . 'migration.title'),
+                'description' => $lang->sL($llPrefix . 'overview.migration.description'),
+                'permissions' => [VaultPermission::VaultConfigure],
+            ],
+        ];
+
+        $accessible = [];
+        foreach ($candidates as $card) {
+            if (!$this->accessGuard->isAnyGranted(...$card['permissions'])) {
+                continue;
+            }
+
+            unset($card['permissions']);
+            $accessible[] = $card;
+        }
+
+        return $accessible;
     }
 
     /**

--- a/Classes/Controller/SecretsController.php
+++ b/Classes/Controller/SecretsController.php
@@ -15,6 +15,7 @@ use Netresearch\NrVault\Audit\GenericContext;
 use Netresearch\NrVault\Domain\Dto\SecretMetadata;
 use Netresearch\NrVault\Exception\AccessDeniedException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -59,13 +60,22 @@ final readonly class SecretsController
         private FlashMessageService $flashMessageService,
         private ConnectionPool $connectionPool,
         private AuditLogServiceInterface $auditLogService,
+        private ModuleAccessGuard $accessGuard,
     ) {}
 
     /**
      * List all secrets (default action).
+     *
+     * Entering the module needs ANY secret-handling permission; the mutating
+     * actions below assert their own. `VaultService::list()` still filters the
+     * listing down to the secrets the actor may read per-secret.
      */
     public function listAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (!$this->accessGuard->isAnyGranted(...VaultPermission::secretOperations())) {
+            return $this->accessGuard->deniedResponse($request, VaultPermission::SecretUse);
+        }
+
         $moduleTemplate = $this->moduleTemplateFactory->create($request);
         $moduleTemplate->makeDocHeaderModuleMenu();
         /** @phpstan-ignore function.alreadyNarrowedType (v14-only method, not available in v13) */
@@ -131,9 +141,14 @@ final readonly class SecretsController
         $moduleTemplate->assignMultiple([
             'secrets' => $formattedSecrets,
             'totalCount' => \count($formattedSecrets),
-            'isAdmin' => $this->isAdmin(),
             'filters' => $filters,
             'ownerOptions' => $ownerOptions,
+            // Per-action flags so the row actions mirror what the endpoints
+            // enforce — a rendered button never leads to a 403.
+            'canReveal' => $this->accessGuard->isGranted(VaultPermission::SecretReveal),
+            'canRotate' => $this->accessGuard->isGranted(VaultPermission::SecretRotate),
+            'canDelete' => $this->accessGuard->isGranted(VaultPermission::SecretDelete),
+            'canManagePolicy' => $this->accessGuard->isGranted(VaultPermission::SecretManagePolicy),
         ]);
 
         $moduleTemplate->setTitle(
@@ -148,8 +163,12 @@ final readonly class SecretsController
     /**
      * Redirect to FormEngine for creating a new secret.
      */
-    public function createAction(): ResponseInterface
+    public function createAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (!$this->accessGuard->isGranted(VaultPermission::SecretCreate)) {
+            return $this->accessGuard->deniedResponse($request, VaultPermission::SecretCreate);
+        }
+
         // Redirect to FormEngine for native TYPO3 editing experience
         $editUrl = $this->uriBuilder->buildUriFromRoute('record_edit', [
             'edit' => [
@@ -166,9 +185,18 @@ final readonly class SecretsController
 
     /**
      * Show edit secret form.
+     *
+     * Editing hands the record to FormEngine, whose form includes the
+     * `allowed_groups` / `write_groups` tiers — i.e. the secret's access
+     * policy. That makes `secret.manage_policy` the permission this entry
+     * point needs, not a plain write permission.
      */
     public function editAction(ServerRequestInterface $request): ResponseInterface
     {
+        if (!$this->accessGuard->isGranted(VaultPermission::SecretManagePolicy)) {
+            return $this->accessGuard->deniedResponse($request, VaultPermission::SecretManagePolicy);
+        }
+
         $queryParams = $request->getQueryParams();
         $identifierVal = $queryParams['identifier'] ?? '';
         $identifier = \is_string($identifierVal) ? $identifierVal : '';
@@ -241,6 +269,18 @@ final readonly class SecretsController
         $identifier = \is_string($identifierVal) ? $identifierVal : '';
         $isAjax = $this->isAjaxRequest($request);
 
+        // Enabling/disabling a secret changes its availability to every
+        // consumer, so it belongs to policy management rather than to editing
+        // a value.
+        if (!$this->accessGuard->isGranted(VaultPermission::SecretManagePolicy)) {
+            if ($isAjax) {
+                /** @phpstan-ignore new.internalClass, method.internalClass */
+                return new JsonResponse(['success' => false, 'error' => 'Access denied'], 403);
+            }
+
+            return $this->accessGuard->deniedResponse($request, VaultPermission::SecretManagePolicy);
+        }
+
         $lang = $this->getLanguageService();
 
         if ($identifier === '') {
@@ -285,6 +325,12 @@ final readonly class SecretsController
      */
     public function deleteAction(ServerRequestInterface $request): ResponseInterface
     {
+        // Per-secret deletion rights (owner/admin/maintainer, no group tier)
+        // are still asserted by VaultService::delete() on top of this.
+        if (!$this->accessGuard->isGranted(VaultPermission::SecretDelete)) {
+            return $this->accessGuard->deniedResponse($request, VaultPermission::SecretDelete);
+        }
+
         $bodyRaw = $request->getParsedBody();
         $body = \is_array($bodyRaw) ? $bodyRaw : [];
         $identifierVal = $body['identifier'] ?? '';
@@ -442,13 +488,15 @@ final readonly class SecretsController
         $buttonBar = $moduleTemplate->getDocHeaderComponent()->getButtonBar();
         $lang = $this->getLanguageService();
 
-        // Create Secret button
-        $createButton = $buttonBar->makeLinkButton()
-            ->setHref((string) $this->uriBuilder->buildUriFromRoute(self::MODULE_NAME . '.create'))
-            ->setTitle($lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.create'))
-            ->setShowLabelText(true)
-            ->setIcon($this->iconFactory->getIcon('actions-add', IconSize::SMALL));
-        $buttonBar->addButton($createButton, ButtonBar::BUTTON_POSITION_LEFT, 1);
+        // Create Secret button — only for actors createAction() would admit.
+        if ($this->accessGuard->isGranted(VaultPermission::SecretCreate)) {
+            $createButton = $buttonBar->makeLinkButton()
+                ->setHref((string) $this->uriBuilder->buildUriFromRoute(self::MODULE_NAME . '.create'))
+                ->setTitle($lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.create'))
+                ->setShowLabelText(true)
+                ->setIcon($this->iconFactory->getIcon('actions-add', IconSize::SMALL));
+            $buttonBar->addButton($createButton, ButtonBar::BUTTON_POSITION_LEFT, 1);
+        }
 
         // Note: Reload button is automatically added by TYPO3's DocHeaderComponent
     }
@@ -457,16 +505,6 @@ final readonly class SecretsController
     {
         $flashMessage = new FlashMessage($message, '', $severity, true);
         $this->flashMessageService->getMessageQueueByIdentifier()->addMessage($flashMessage);
-    }
-
-    private function isAdmin(): bool
-    {
-        $backendUser = $GLOBALS['BE_USER'] ?? null;
-        if (!\is_object($backendUser) || !method_exists($backendUser, 'isAdmin')) {
-            return false;
-        }
-
-        return (bool) $backendUser->isAdmin();
     }
 
     private function getLanguageService(): LanguageService

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -601,7 +601,11 @@ final class AccessControlService implements AccessControlServiceInterface
      */
     private function adminOverrideGrants(BackendUserAuthentication $backendUser): bool
     {
-        return $backendUser->isAdmin() || $backendUser->isSystemMaintainer();
+        if ($backendUser->isAdmin()) {
+            return true;
+        }
+
+        return $backendUser->isSystemMaintainer();
     }
 
     private function getTechnicalActor(): ?TechnicalActor

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -40,6 +40,13 @@ final class AccessControlService implements AccessControlServiceInterface
     private const PERMISSION_DELETE = 'delete';
 
     /**
+     * Namespace of the TYPO3 custom permission options that carry the
+     * operation permissions. Must match the `customPermOptions` key
+     * registered in `ext_localconf.php`.
+     */
+    private const PERM_OPTION_GROUP = 'tx_nrvault';
+
+    /**
      * Per-request cache of group UIDs that actually exist in the be_groups table.
      * Reset only for the lifetime of the service instance.
      *
@@ -100,6 +107,64 @@ final class AccessControlService implements AccessControlServiceInterface
         }
 
         // No backend user and not CLI
+        return false;
+    }
+
+    public function isGranted(VaultPermission $permission): bool
+    {
+        // An active TechnicalActorContext::runAs() scope supersedes every
+        // ambient branch below — same precedence as hasAccess().
+        $technicalActor = $this->getTechnicalActor();
+        if ($technicalActor instanceof TechnicalActor) {
+            return $this->hasTechnicalActorGrant($technicalActor, $permission);
+        }
+
+        // A FRONTEND request never carries operation permissions, no matter
+        // what $GLOBALS['BE_USER'] holds: TYPO3 populates that global for any
+        // visitor with a valid backend session, and frontend output is shared
+        // (page cache) with anonymous visitors. Frontend reads stay governed
+        // exclusively by the secret's own `frontend_accessible` flag.
+        if ($this->isFrontendRequest()) {
+            return false;
+        }
+
+        $backendUser = $this->getBackendUser();
+
+        // The trusted CLI operator: the TYPO3 CLI bootstrap places an
+        // UNAUTHENTICATED CommandLineUserAuthentication in $GLOBALS['BE_USER']
+        // (CommandApplication::run() never logs the `_cli_` user in), so there
+        // is no user record and no group that could carry a custom permission
+        // option. The vault's own CLI trust switch decides instead — the same
+        // authority hasCliAccess() uses for the per-secret tiers, and off by
+        // default (ExtensionConfiguration::DEFAULT_ALLOW_CLI_ACCESS).
+        if ($this->isUnauthenticatedCommandLineUser($backendUser)) {
+            return $this->configuration->isCliAccessAllowed();
+        }
+
+        if ($backendUser instanceof BackendUserAuthentication) {
+            // Defence-in-depth: a disabled user must not hold any operation
+            // permission, even if a stale session reaches this layer.
+            if ($this->isBackendUserDisabled($backendUser)) {
+                return false;
+            }
+
+            if ($this->adminOverrideGrants($backendUser)) {
+                return true;
+            }
+
+            return $backendUser->check(
+                'custom_options',
+                self::PERM_OPTION_GROUP . ':' . $permission->value,
+            );
+        }
+
+        // No backend user at all but a real CLI context (no BE_USER global
+        // was ever created): same trusted-operator rule as above.
+        if ($this->isRealCliContext()) {
+            return $this->configuration->isCliAccessAllowed();
+        }
+
+        // No actor we can attribute an operation to: fail closed.
         return false;
     }
 
@@ -494,6 +559,49 @@ final class AccessControlService implements AccessControlServiceInterface
         }
 
         return false;
+    }
+
+    /**
+     * Operation permissions for a validated technical actor.
+     *
+     * A technical actor is a snapshot of a real backend user, but it has no
+     * live session and `runAs()` is explicitly NOT an authentication boundary
+     * (any code with DI access can open a scope). So a NON-admin technical
+     * actor gets no operation permissions at all — its power stays bounded by
+     * the per-secret `canRead`/`canWrite` tiers, which is what its group
+     * membership was actually provisioned for.
+     *
+     * The one exception is `SecretUse`: headless consumption is the entire
+     * purpose of a technical actor, and gating it on a group-level custom
+     * permission option would break every existing `runAs()` caller while
+     * adding nothing — the per-secret tier already decides which secrets the
+     * actor may read.
+     */
+    private function hasTechnicalActorGrant(TechnicalActor $actor, VaultPermission $permission): bool
+    {
+        if ($actor->admin) {
+            return true;
+        }
+
+        return $permission === VaultPermission::SecretUse;
+    }
+
+    /**
+     * The unconditional admin / system-maintainer override for operation
+     * permissions.
+     *
+     * Isolated in one seam on purpose: the hardened security profile will make
+     * this override disableable in a follow-up (break-glass mode), so that a
+     * TYPO3 admin no longer automatically holds every vault permission. Every
+     * "admins may do anything" decision for operation permissions must flow
+     * through here — never inline `isAdmin()` in a caller.
+     *
+     * `isSystemMaintainer()` is checked explicitly even though it implies the
+     * admin flag in core, mirroring `hasBackendUserAccess()`.
+     */
+    private function adminOverrideGrants(BackendUserAuthentication $backendUser): bool
+    {
+        return $backendUser->isAdmin() || $backendUser->isSystemMaintainer();
     }
 
     private function getTechnicalActor(): ?TechnicalActor

--- a/Classes/Security/AccessControlServiceInterface.php
+++ b/Classes/Security/AccessControlServiceInterface.php
@@ -50,6 +50,32 @@ interface AccessControlServiceInterface
     public function canCreate(): bool;
 
     /**
+     * Is the current actor granted an OPERATION permission?
+     *
+     * Orthogonal to the per-secret tiers above: `canRead()` answers "may this
+     * actor touch THIS secret?", `isGranted()` answers "may this actor perform
+     * this KIND of operation at all?". Both gates apply — e.g. revealing a
+     * secret needs `VaultPermission::SecretReveal` *and* `canRead()` for that
+     * identifier.
+     *
+     * Resolution (fail-closed at every step, mirroring the actor resolution of
+     * the per-secret tiers):
+     *
+     * - active `TechnicalActorContext::runAs()` scope → the actor's admin flag
+     *   decides, with `VaultPermission::SecretUse` granted unconditionally so
+     *   headless consumers keep working under their per-secret ACL;
+     * - frontend request → `false`, always (no operation permissions in a
+     *   context whose output is shared with anonymous visitors);
+     * - trusted CLI operator without an authenticated backend user → the
+     *   vault's `allowCliAccess` switch decides (off by default);
+     * - authenticated backend user → admin / system maintainer are granted
+     *   everything, anyone else needs the matching custom permission option
+     *   (`tx_nrvault:<permission>`) on one of their groups;
+     * - disabled user, no user at all → `false`.
+     */
+    public function isGranted(VaultPermission $permission): bool;
+
+    /**
      * Is the current actor a TYPO3 backend admin?
      *
      * Returns `true` for BE users where `BackendUserAuthentication::isAdmin()`

--- a/Classes/Security/VaultPermission.php
+++ b/Classes/Security/VaultPermission.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Security;
+
+/**
+ * Operation-level vault permissions.
+ *
+ * These are *operation* permissions ("may this actor rotate secrets at all?"),
+ * orthogonal to the *per-secret* ACL tiers of
+ * {@see AccessControlServiceInterface::canRead()} / `canWrite()` / `canDelete()`
+ * (owner / group / admin, ADR-005). Both gates apply: an actor needs the
+ * operation permission AND per-secret access for the concrete secret.
+ *
+ * The carrier is a TYPO3 custom permission option registered in
+ * `ext_localconf.php` under
+ * `$GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']['tx_nrvault']`, so
+ * every case is grantable per backend user group in the Backend Users module
+ * and checked via `$backendUser->check('custom_options', 'tx_nrvault:<value>')`.
+ * Case values are therefore part of the stored configuration — renaming one
+ * silently revokes the grant and needs an upgrade wizard.
+ */
+enum VaultPermission: string
+{
+    /**
+     * Consume a secret's plaintext programmatically.
+     *
+     * The permission every *non-display* read needs: FormEngine vault field
+     * widgets, FlexForm / TCA placeholder resolution, site-configuration
+     * processing, HTTP clients injecting a token. The plaintext flows into
+     * machinery, never onto the operator's screen.
+     *
+     * Deliberately separate from {@see self::SecretReveal}: an integration
+     * account (or an editor whose forms consume vault-backed credentials)
+     * needs `secret.use` and must NOT thereby gain the right to read the
+     * plaintext with their own eyes.
+     */
+    case SecretUse = 'secret.use';
+
+    /**
+     * Display a secret's plaintext to a human.
+     *
+     * Gates the interactive reveal surfaces (the `vault_reveal` AJAX endpoint
+     * behind the secrets list / FormEngine widget, and `vault:retrieve` which
+     * prints plaintext to a terminal). This is the permission that turns a
+     * stored secret into something an operator can copy, screenshot, or leak.
+     *
+     * Does not imply {@see self::SecretUse}, and is not implied by it: a
+     * non-admin needs BOTH granted for an end-to-end reveal, because the
+     * reveal endpoint displays plaintext (`secret.reveal`) that it obtained
+     * through the shared read path (`secret.use`).
+     */
+    case SecretReveal = 'secret.reveal';
+
+    /**
+     * Create new secrets in the vault.
+     *
+     * Covers the secrets module's create entry point and the underlying
+     * `store()` of a not-yet-existing identifier. Creating a secret makes the
+     * creator its owner, which grants full per-secret access — so this is a
+     * privilege-widening operation, not a harmless write.
+     */
+    case SecretCreate = 'secret.create';
+
+    /**
+     * Replace the value of an existing secret (rotation).
+     *
+     * Rotation is destructive to the previous value while leaving the
+     * identifier — and therefore every consumer referencing it — in place. A
+     * bad rotation is an outage; a malicious one substitutes a credential the
+     * operator's own systems then use.
+     */
+    case SecretRotate = 'secret.rotate';
+
+    /**
+     * Delete secrets from the vault.
+     *
+     * The per-secret tier for deletion is already the most restrictive
+     * (owner / admin / system maintainer, no group tier). This operation
+     * permission gates whether the actor may invoke deletion at all.
+     */
+    case SecretDelete = 'secret.delete';
+
+    /**
+     * Change a secret's access policy or availability.
+     *
+     * Enabling / disabling a secret and editing its `allowed_groups` /
+     * `write_groups` tiers. Holding this permission means being able to widen
+     * who can read or write a secret — the permission that governs the
+     * permissions, so it belongs to vault administration rather than to
+     * day-to-day secret handling.
+     */
+    case SecretManagePolicy = 'secret.manage_policy';
+
+    /**
+     * Read the tamper-evident audit log and verify its hash chain.
+     *
+     * Audit entries name who touched which secret when. That is a sensitive
+     * derivative of the secrets themselves (it maps out the credential
+     * topology), so reading it is a permission of its own rather than a
+     * side effect of holding any secret permission.
+     */
+    case AuditView = 'audit.view';
+
+    /**
+     * Export the audit log to a file (JSON / CSV).
+     *
+     * Separate from {@see self::AuditView} because export removes the data
+     * from the vault's own tamper-evident storage: the downloaded copy has no
+     * hash chain, no retention policy, and no further access control. Viewing
+     * in the module and walking off with the full history are different acts.
+     */
+    case AuditExport = 'audit.export';
+
+    /**
+     * Rotate the master key (re-encrypt every envelope).
+     *
+     * The single most powerful vault operation: it rewrites every stored
+     * secret's key envelope in one transaction and rekeys the audit chain. A
+     * failed or hostile rotation can render the entire vault unreadable.
+     */
+    case MasterKeyRotate = 'master_key.rotate';
+
+    /**
+     * Change vault configuration and run migration tooling.
+     *
+     * Gates the migration wizard (which scans the database for plaintext
+     * secrets — a map of exactly where credentials sit unencrypted — and
+     * moves values into the vault). Configuration changes decide where the
+     * master key comes from and which contexts may read secrets, so this is
+     * an administrative permission.
+     */
+    case VaultConfigure = 'vault.configure';
+
+    /**
+     * Every permission that governs handling of secrets themselves.
+     *
+     * Used as the "may this actor enter the secrets module at all?" set:
+     * holding any one of them implies a legitimate reason to see the list.
+     *
+     * @return list<self>
+     */
+    public static function secretOperations(): array
+    {
+        return [
+            self::SecretUse,
+            self::SecretReveal,
+            self::SecretCreate,
+            self::SecretRotate,
+            self::SecretDelete,
+            self::SecretManagePolicy,
+        ];
+    }
+}

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -37,6 +37,7 @@ use Netresearch\NrVault\Exception\ValidationException;
 use Netresearch\NrVault\Http\VaultHttpClientFactoryInterface;
 use Netresearch\NrVault\Http\VaultHttpClientInterface;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Utility\IdentifierValidator;
 use Psr\EventDispatcher\EventDispatcherInterface;
 use Psr\Log\LoggerInterface;
@@ -137,71 +138,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
 
     public function retrieve(string $identifier): ?string
     {
-        // Check request-scoped cache
-        if ($this->configuration->isCacheEnabled() && isset($this->cache[$identifier])) {
-            return $this->cache[$identifier];
-        }
-
-        $secret = $this->adapter->retrieve($identifier);
-        if (!$secret instanceof Secret) {
-            return null;
-        }
-
-        // Check access
-        if (!$this->accessControlService->canRead($secret)) {
-            $this->auditLogService->log($identifier, AuditAction::AccessDenied->value, false, 'Read access denied');
-
-            throw AccessDeniedException::forIdentifier($identifier, 'insufficient permissions');
-        }
-
-        // Check expiration
-        if ($secret->isExpired()) {
-            $this->auditLogService->log($identifier, AuditAction::Read->value, false, 'Secret has expired');
-
-            throw SecretExpiredException::forIdentifier($identifier, $secret->getExpiresAt());
-        }
-
-        // Decrypt
-        try {
-            $plaintext = $this->encryptionService->decrypt(
-                $secret->getEncryptedValue() ?? '',
-                $secret->getEncryptedDek(),
-                $secret->getDekNonce(),
-                $secret->getValueNonce(),
-                $identifier,
-                $secret->getEncryptionVersion(),
-                $secret->getEncryptionAlgorithm(),
-            );
-        } catch (EncryptionException $e) {
-            $this->auditLogService->log($identifier, AuditAction::Read->value, false, 'Decryption failed: ' . $e->getMessage());
-
-            throw $e;
-        }
-
-        // Update read statistics atomically (avoids full entity save + MM table churn)
-        $uid = $secret->getUid();
-        if ($uid !== null) {
-            $this->adapter->incrementReadCount($uid);
-        }
-
-        // Log success (can be disabled for high-throughput scenarios)
-        if ($this->configuration->isAuditReadsEnabled()) {
-            $this->auditLogService->log($identifier, AuditAction::Read->value, true);
-        }
-
-        // Dispatch PSR-14 event
-        $this->eventDispatcher?->dispatch(new SecretAccessedEvent(
-            $identifier,
-            $this->accessControlService->getCurrentActorUid(),
-            $secret->getContext(),
-        ));
-
-        // Cache for this request
-        if ($this->configuration->isCacheEnabled()) {
-            $this->cache[$identifier] = $plaintext;
-        }
-
-        return $plaintext;
+        return $this->doRetrieve($identifier, enforceSecretUse: true);
     }
 
     public function retrieveForFrontend(string $identifier): ?string
@@ -230,8 +167,9 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
         }
 
         // The remaining checks (read permission, expiry), the audit trail and
-        // the decryption stay with the single read path.
-        return $this->retrieve($identifier);
+        // the decryption stay with the single read path — minus the
+        // interactive `secret.use` gate, see doRetrieve().
+        return $this->doRetrieve($identifier, enforceSecretUse: false);
     }
 
     public function exists(string $identifier): bool
@@ -429,6 +367,133 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
         }
         unset($value);
         $this->cache = [];
+    }
+
+    /**
+     * The single read path shared by `retrieve()` and `retrieveForFrontend()`.
+     *
+     * `$enforceSecretUse` toggles ONLY the interactive-backend-user operation
+     * gate: the frontend path must not be subjected to it, because a frontend
+     * request's visibility is a property of the secret (`frontend_accessible`),
+     * never of whichever backend user happens to hold a session while
+     * rendering a page whose output is shared via the page cache. Every other
+     * check (per-secret ACL, expiry, audit trail, decryption) is identical for
+     * both entry points.
+     */
+    private function doRetrieve(string $identifier, bool $enforceSecretUse): ?string
+    {
+        // Check request-scoped cache
+        if ($this->configuration->isCacheEnabled() && isset($this->cache[$identifier])) {
+            return $this->cache[$identifier];
+        }
+
+        $secret = $this->adapter->retrieve($identifier);
+        if (!$secret instanceof Secret) {
+            return null;
+        }
+
+        // Check access
+        if (!$this->accessControlService->canRead($secret)) {
+            $this->auditLogService->log($identifier, AuditAction::AccessDenied->value, false, 'Read access denied');
+
+            throw AccessDeniedException::forIdentifier($identifier, 'insufficient permissions');
+        }
+
+        if ($enforceSecretUse) {
+            $this->assertInteractiveUseGranted($identifier);
+        }
+
+        // Check expiration
+        if ($secret->isExpired()) {
+            $this->auditLogService->log($identifier, AuditAction::Read->value, false, 'Secret has expired');
+
+            throw SecretExpiredException::forIdentifier($identifier, $secret->getExpiresAt());
+        }
+
+        // Decrypt
+        try {
+            $plaintext = $this->encryptionService->decrypt(
+                $secret->getEncryptedValue() ?? '',
+                $secret->getEncryptedDek(),
+                $secret->getDekNonce(),
+                $secret->getValueNonce(),
+                $identifier,
+                $secret->getEncryptionVersion(),
+                $secret->getEncryptionAlgorithm(),
+            );
+        } catch (EncryptionException $e) {
+            $this->auditLogService->log($identifier, AuditAction::Read->value, false, 'Decryption failed: ' . $e->getMessage());
+
+            throw $e;
+        }
+
+        // Update read statistics atomically (avoids full entity save + MM table churn)
+        $uid = $secret->getUid();
+        if ($uid !== null) {
+            $this->adapter->incrementReadCount($uid);
+        }
+
+        // Log success (can be disabled for high-throughput scenarios)
+        if ($this->configuration->isAuditReadsEnabled()) {
+            $this->auditLogService->log($identifier, AuditAction::Read->value, true);
+        }
+
+        // Dispatch PSR-14 event
+        $this->eventDispatcher?->dispatch(new SecretAccessedEvent(
+            $identifier,
+            $this->accessControlService->getCurrentActorUid(),
+            $secret->getContext(),
+        ));
+
+        // Cache for this request
+        if ($this->configuration->isCacheEnabled()) {
+            $this->cache[$identifier] = $plaintext;
+        }
+
+        return $plaintext;
+    }
+
+    /**
+     * Assert the `secret.use` operation permission for an interactively
+     * authenticated NON-ADMIN backend user.
+     *
+     * Applies on top of the per-secret `canRead()` tiers and only to actor type
+     * `backend`: CLI, technical actors, the frontend and admins keep exactly
+     * the behaviour they had. Non-admin backend users therefore need
+     * `secret.use` for every plaintext read — the FormEngine vault widget,
+     * FlexForm/TCA placeholder resolution and the reveal endpoint alike.
+     *
+     * The admin exemption is deliberately expressed through
+     * `isCurrentActorAdmin()` (mirroring `resolveOwnerUid()` /
+     * `resolveFrontendAccessible()`) rather than by relying on `isGranted()`
+     * returning true for admins, so this stays readable as "admins are not
+     * gated here".
+     */
+    private function assertInteractiveUseGranted(string $identifier): void
+    {
+        if ($this->accessControlService->getCurrentActorType() !== 'backend') {
+            return;
+        }
+
+        if ($this->accessControlService->isCurrentActorAdmin()) {
+            return;
+        }
+
+        if ($this->accessControlService->isGranted(VaultPermission::SecretUse)) {
+            return;
+        }
+
+        $this->auditLogService->log(
+            $identifier,
+            AuditAction::AccessDenied->value,
+            false,
+            'Read access denied: missing ' . VaultPermission::SecretUse->value . ' permission',
+        );
+
+        throw AccessDeniedException::forIdentifier(
+            $identifier,
+            'missing ' . VaultPermission::SecretUse->value . ' permission',
+        );
     }
 
     /**

--- a/Configuration/AGENTS.md
+++ b/Configuration/AGENTS.md
@@ -50,7 +50,7 @@ No separate setup — configuration is loaded by TYPO3 at bootstrap. After editi
 
 ## Security
 - **No secrets in YAML/PHP config** — master-key material comes from providers (env/file/TYPO3 encryptionKey).
-- **AJAX routes** require backend user context (`'access' => 'admin'` on modules).
+- **Modules + AJAX routes are `'access' => 'user'` on purpose** — authorization is asserted per action in the controller via `AccessControlServiceInterface::isGranted(VaultPermission)` (`ModuleAccessGuard` for modules, a 403 envelope for AJAX). Do NOT "harden" these back to `'admin'`: that silently makes the granular per-group permissions unusable for non-admins. Any new module route or AJAX endpoint MUST add its own `isGranted()` check.
 - **TCA**: every column exposing vault data must set `'displayCond'` or guard access via hooks — secrets must not render unredacted in list views.
 - **DI boundary**: avoid making internal classes `public: true`; only controllers, CLI commands, event listeners, and interfaces consumed via DI need it.
 
@@ -85,7 +85,8 @@ return [
     'admin_vault_secrets' => [
         // 'tools' works on v13 natively and is an alias for 'admin' on v14.
         'parent' => 'tools',
-        'access' => 'admin',
+        // 'user': the controller asserts the operation permission per action.
+        'access' => 'user',
         'workspaces' => 'live',
         'path' => '/module/admin/vault/secrets',
         'labels' => 'LLL:EXT:nr_vault/Resources/Private/Language/Modules/secrets.xlf',

--- a/Configuration/Backend/AjaxRoutes.php
+++ b/Configuration/Backend/AjaxRoutes.php
@@ -14,13 +14,19 @@ use Netresearch\NrVault\Controller\AjaxController;
  *
  * These routes are accessible via TYPO3.settings.ajaxUrls['route_name']
  * in JavaScript.
+ *
+ * `access => 'user'` only means "any authenticated backend user may reach the
+ * endpoint". Authorization is the controller's job: both actions re-check their
+ * operation permission (`secret.reveal` / `secret.rotate`) via
+ * `AccessControlServiceInterface::isGranted()` and answer with the uniform 403
+ * envelope otherwise — see SEC-ACCESS-6 in AjaxController.
  */
 return [
     // Reveal a secret value (for FormEngine and list view)
     'vault_reveal' => [
         'path' => '/vault/reveal',
         'methods' => ['POST'],
-        'access' => 'admin',
+        'access' => 'user',
         'target' => AjaxController::class . '::revealAction',
     ],
 
@@ -28,7 +34,7 @@ return [
     'vault_rotate' => [
         'path' => '/vault/rotate',
         'methods' => ['POST'],
-        'access' => 'admin',
+        'access' => 'user',
         'target' => AjaxController::class . '::rotateAction',
     ],
 ];

--- a/Configuration/Backend/Modules.php
+++ b/Configuration/Backend/Modules.php
@@ -29,6 +29,14 @@ use Netresearch\NrVault\Controller\SecretsController;
  * v13 compatibility: 'admin_vault_overview' is registered as first submodule so that
  * v13 (which redirects to the first submodule) shows the overview page.
  * v14 uses 'showSubmoduleOverview' on the parent module for the same effect.
+ *
+ * Access: every module is `'access' => 'user'` — the modules are reachable by
+ * any authenticated backend user, and each controller action then asserts the
+ * operation permission it actually needs (`Netresearch\NrVault\Security\
+ * VaultPermission`) via `ModuleAccessGuard`, answering 403 otherwise. The
+ * module registration is a routing convenience; the controller is the
+ * authority. Do NOT re-tighten this to 'admin' — that would silently make the
+ * granular permissions unusable for non-admins.
  */
 $indexAction = '::indexAction';
 $helpAction = '::helpAction';
@@ -40,7 +48,7 @@ return [
     'admin_vault' => [
         'parent' => 'tools',
         'position' => ['after' => 'admin_sites'],
-        'access' => 'admin',
+        'access' => 'user',
         'workspaces' => 'live',
         'path' => '/module/admin/vault',
         'labels' => 'LLL:EXT:nr_vault/Resources/Private/Language/Modules/overview.xlf',
@@ -67,7 +75,7 @@ return [
     'admin_vault_overview' => [
         'parent' => 'admin_vault',
         'position' => ['before' => '*'],
-        'access' => 'admin',
+        'access' => 'user',
         'workspaces' => 'live',
         'path' => '/module/admin/vault/overview',
         'labels' => 'LLL:EXT:nr_vault/Resources/Private/Language/Modules/overview_submodule.xlf',
@@ -85,7 +93,7 @@ return [
     // Secrets submodule
     'admin_vault_secrets' => [
         'parent' => 'admin_vault',
-        'access' => 'admin',
+        'access' => 'user',
         'workspaces' => 'live',
         'path' => '/module/admin/vault/secrets',
         'labels' => 'LLL:EXT:nr_vault/Resources/Private/Language/Modules/secrets.xlf',
@@ -114,7 +122,7 @@ return [
     // Analytics submodule
     'admin_vault_analytics' => [
         'parent' => 'admin_vault',
-        'access' => 'admin',
+        'access' => 'user',
         'workspaces' => 'live',
         'path' => '/module/admin/vault/analytics',
         'labels' => 'LLL:EXT:nr_vault/Resources/Private/Language/Modules/analytics.xlf',
@@ -129,7 +137,7 @@ return [
     // Audit submodule
     'admin_vault_audit' => [
         'parent' => 'admin_vault',
-        'access' => 'admin',
+        'access' => 'user',
         'workspaces' => 'live',
         'path' => '/module/admin/vault/audit',
         'labels' => 'LLL:EXT:nr_vault/Resources/Private/Language/Modules/audit.xlf',
@@ -151,7 +159,7 @@ return [
     // Uses handleRequest pattern like TYPO3 core - dispatches based on ?action= query param
     'admin_vault_migration' => [
         'parent' => 'admin_vault',
-        'access' => 'admin',
+        'access' => 'user',
         'workspaces' => 'live',
         'path' => '/module/admin/vault/migration',
         'labels' => 'LLL:EXT:nr_vault/Resources/Private/Language/Modules/migration.xlf',

--- a/Documentation/Security/Index.rst
+++ b/Documentation/Security/Index.rst
@@ -184,17 +184,102 @@ entries to HMAC-SHA256. See :ref:`command-audit-migrate-hmac` for details.
 Access control
 ==============
 
-Secret access is controlled at multiple levels:
+Access is decided by two independent gates. **Both** must pass.
+
+*Per-secret access* answers "may this actor touch *this* secret?":
 
 1. **Authentication**: Backend user must be logged in.
 2. **Ownership**: Creator has full access.
 3. **Group membership**: Shared access via backend groups.
 4. **Admin override**: Administrators can access all secrets.
 
+*Operation permissions* answer "may this actor perform this *kind* of
+operation at all?" — see the next section.
+
 .. note::
 
    CLI access requires explicit configuration and can be restricted
    to specific groups.
+
+.. _security-operation-permissions:
+
+Operation permissions
+---------------------
+
+Each vault operation has its own permission, granted **per backend user
+group** in the Backend Users module (field *Custom module options*,
+group *Vault: operation permissions*). They are registered as TYPO3
+custom permission options under
+``$GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']['tx_nrvault']``
+and checked server-side via
+``AccessControlServiceInterface::isGranted()``.
+
+=================================== ==============================================================
+Permission                          Governs
+=================================== ==============================================================
+``tx_nrvault:secret.use``           Programmatic consumption of a plaintext value (FormEngine
+                                    vault widgets, FlexForm/TCA placeholders, site config, HTTP
+                                    clients).
+``tx_nrvault:secret.reveal``        Displaying a plaintext to a human (the ``vault_reveal``
+                                    endpoint, ``vault:retrieve``).
+``tx_nrvault:secret.create``        Creating new secrets.
+``tx_nrvault:secret.rotate``        Replacing the value of an existing secret.
+``tx_nrvault:secret.delete``        Deleting secrets.
+``tx_nrvault:secret.manage_policy`` Enabling/disabling secrets and editing their
+                                    ``allowed_groups`` / ``write_groups`` tiers.
+``tx_nrvault:audit.view``           Reading the audit log, its usage analytics, and verifying the
+                                    hash chain.
+``tx_nrvault:audit.export``         Downloading the audit log (JSON / CSV).
+``tx_nrvault:master_key.rotate``    Rotating the master key.
+``tx_nrvault:vault.configure``      Running the migration wizard.
+=================================== ==============================================================
+``tx_nrvault:secret.use``       Programmatic consumption of a plaintext value
+                                (FormEngine vault widgets, FlexForm/TCA
+                                placeholders, site config, HTTP clients).
+``tx_nrvault:secret.reveal``    Displaying a plaintext to a human (the
+                                ``vault_reveal`` endpoint, ``vault:retrieve``).
+``tx_nrvault:secret.create``    Creating new secrets.
+``tx_nrvault:secret.rotate``    Replacing the value of an existing secret.
+``tx_nrvault:secret.delete``    Deleting secrets.
+``tx_nrvault:secret.manage_policy`` Enabling/disabling secrets and editing
+                                their ``allowed_groups`` / ``write_groups``.
+``tx_nrvault:audit.view``       Reading the audit log, its usage analytics,
+                                and verifying the hash chain.
+``tx_nrvault:audit.export``     Downloading the audit log (JSON / CSV).
+``tx_nrvault:master_key.rotate`` Rotating the master key.
+``tx_nrvault:vault.configure``  Running the migration wizard.
+=============================== ==============================================
+
+Notes on the model:
+
+-  **``secret.use`` does not imply ``secret.reveal``**, and neither
+   implies the other. A non-admin needs **both** for an end-to-end
+   reveal: the endpoint asserts ``secret.reveal`` (displaying plaintext),
+   and the shared read path asserts ``secret.use`` (obtaining it at all).
+   An integration account gets ``secret.use`` only.
+-  **Non-admin backend users need ``secret.use`` for every plaintext
+   read**, including FormEngine vault field widgets and FlexForm /
+   TypoScript placeholder resolution. Grant it to the groups whose
+   editors work with vault-backed fields.
+-  **Admins and system maintainers hold every permission**
+   unconditionally. That override lives in a single seam
+   (``AccessControlService::adminOverrideGrants()``) so a future hardened
+   profile can disable it.
+-  **The backend modules are registered ``access => 'user'``.** That is
+   deliberate: authorization is asserted by each controller action, not
+   by the module registration, so granular grants are usable by
+   non-admins. The same holds for the ``vault_reveal`` / ``vault_rotate``
+   AJAX routes.
+-  **CLI**: a trusted CLI operator has no backend user record and thus no
+   group grants, so operation permissions follow the vault's
+   :ref:`allowCliAccess <configuration>` switch (**off by default**).
+   Enabling CLI access is therefore required for
+   ``vault:rotate-master-key`` and ``vault:retrieve``.
+-  **Frontend requests never hold operation permissions**, regardless of
+   any backend session the visitor carries — frontend visibility remains
+   a property of the secret (``frontend_accessible``) alone.
+-  **Non-admin technical actors** (``runAs()`` scopes) hold only
+   ``secret.use``; their reach stays bounded by the per-secret tiers.
 
 Technical actors
 ----------------

--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -1070,6 +1070,85 @@
       <trans-unit id="analytics.note">
         <source>Core signals use durable secret metadata; the automated/manual split is derived from the audit log (actor_type is a proxy). "Automation-stale" means revealed manually but not read by automation — review, do not auto-delete.</source>
       </trans-unit>
+
+      <!-- Operation permissions (BE custom permission options, granted per backend user group) -->
+      <trans-unit id="permissions.header">
+        <source>Vault: operation permissions</source>
+      </trans-unit>
+      <trans-unit id="permissions.secret.use">
+        <source>Use secrets (programmatic)</source>
+      </trans-unit>
+      <trans-unit id="permissions.secret.use.description">
+        <source>Let forms, TypoScript and integrations resolve secret values for this user. Does not allow displaying a value on screen — grant "Reveal secrets" for that.</source>
+      </trans-unit>
+      <trans-unit id="permissions.secret.reveal">
+        <source>Reveal secrets (show plaintext)</source>
+      </trans-unit>
+      <trans-unit id="permissions.secret.reveal.description">
+        <source>Display a secret's plaintext in the backend. Grant only to people who legitimately need to read credentials; requires "Use secrets" as well.</source>
+      </trans-unit>
+      <trans-unit id="permissions.secret.create">
+        <source>Create secrets</source>
+      </trans-unit>
+      <trans-unit id="permissions.secret.create.description">
+        <source>Add new secrets to the vault. The creator becomes the owner and therefore gains full access to the secrets they create.</source>
+      </trans-unit>
+      <trans-unit id="permissions.secret.rotate">
+        <source>Rotate secrets</source>
+      </trans-unit>
+      <trans-unit id="permissions.secret.rotate.description">
+        <source>Replace the value of an existing secret. The identifier and all its consumers stay in place, so a wrong value takes systems down.</source>
+      </trans-unit>
+      <trans-unit id="permissions.secret.delete">
+        <source>Delete secrets</source>
+      </trans-unit>
+      <trans-unit id="permissions.secret.delete.description">
+        <source>Delete secrets from the vault. Per-secret deletion additionally requires ownership or admin rights.</source>
+      </trans-unit>
+      <trans-unit id="permissions.secret.manage_policy">
+        <source>Manage secret policy</source>
+      </trans-unit>
+      <trans-unit id="permissions.secret.manage_policy.description">
+        <source>Enable/disable secrets and edit their allowed/write group tiers — the permission that decides other people's access.</source>
+      </trans-unit>
+      <trans-unit id="permissions.audit.view">
+        <source>View audit log</source>
+      </trans-unit>
+      <trans-unit id="permissions.audit.view.description">
+        <source>Read the audit log, its usage analytics and verify the hash chain. The log maps out which credentials exist and who uses them.</source>
+      </trans-unit>
+      <trans-unit id="permissions.audit.export">
+        <source>Export audit log</source>
+      </trans-unit>
+      <trans-unit id="permissions.audit.export.description">
+        <source>Download the audit log as JSON or CSV. The exported copy leaves the tamper-evident storage behind — no hash chain, no retention, no access control.</source>
+      </trans-unit>
+      <trans-unit id="permissions.master_key.rotate">
+        <source>Rotate the master key</source>
+      </trans-unit>
+      <trans-unit id="permissions.master_key.rotate.description">
+        <source>Re-encrypt every secret with a new master key. The most powerful vault operation — a failed rotation can make the whole vault unreadable.</source>
+      </trans-unit>
+      <trans-unit id="permissions.vault.configure">
+        <source>Configure the vault</source>
+      </trans-unit>
+      <trans-unit id="permissions.vault.configure.description">
+        <source>Run the migration wizard, which scans the database for plaintext secrets and moves them into the vault.</source>
+      </trans-unit>
+
+      <!-- Access denied (module-level operation permission missing) -->
+      <trans-unit id="accessDenied.title">
+        <source>Access denied</source>
+      </trans-unit>
+      <trans-unit id="accessDenied.message">
+        <source>You do not have the vault permission required for this action.</source>
+      </trans-unit>
+      <trans-unit id="accessDenied.required">
+        <source>Required permission: %s</source>
+      </trans-unit>
+      <trans-unit id="accessDenied.hint">
+        <source>Ask an administrator to grant this permission to one of your backend user groups (Backend Users module, "Vault: operation permissions").</source>
+      </trans-unit>
     </body>
   </file>
 </xliff>

--- a/Resources/Private/Templates/AccessDenied.html
+++ b/Resources/Private/Templates/AccessDenied.html
@@ -1,0 +1,20 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<f:layout name="Module" />
+
+<f:section name="Content">
+    <h1><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:accessDenied.title" /></h1>
+
+    <f:be.infobox title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:accessDenied.message')}" state="2">
+        <p>
+            <f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:accessDenied.required"
+                         arguments="{0: requiredPermission}" />
+        </p>
+        <p>
+            <f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:accessDenied.hint" />
+        </p>
+    </f:be.infobox>
+</f:section>
+
+</html>

--- a/Resources/Private/Templates/Secrets/List.html
+++ b/Resources/Private/Templates/Secrets/List.html
@@ -117,62 +117,72 @@
                                     <td class="col-datetime nowrap" aria-label="Last read: {secret.last_read}">{secret.last_read}</td>
                                     <td class="col-control nowrap">
                                         <div class="btn-group" role="group" aria-label="Actions for {secret.identifier}">
-                                            <button type="button"
-                                                    class="btn btn-default btn-sm"
-                                                    data-vault-reveal="{secret.identifier}"
-                                                    data-testid="vault-reveal-btn"
-                                                    title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.reveal')}"
-                                                    aria-label="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.reveal')} {secret.identifier}">
-                                                <core:icon identifier="actions-eye" size="small" />
-                                            </button>
-                                            <f:be.link route="admin_vault_secrets.edit" parameters="{identifier: secret.identifier}"
-                                               class="btn btn-default btn-sm"
-                                               data-testid="vault-edit-btn"
-                                               title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.edit')}"
-                                               aria-label="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.edit')} {secret.identifier}">
-                                                <core:icon identifier="actions-open" size="small" />
-                                            </f:be.link>
-                                            <form method="post" action="{f:be.uri(route: 'admin_vault_secrets.toggle')}" class="d-inline" autocomplete="off">
-                                                <input type="hidden" name="identifier" value="{secret.identifier}" />
-                                                <f:if condition="{secret.hidden}">
-                                                    <f:then>
-                                                        <f:variable name="toggleTitle"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.enable" /></f:variable>
-                                                    </f:then>
-                                                    <f:else>
-                                                        <f:variable name="toggleTitle"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.disable" /></f:variable>
-                                                    </f:else>
-                                                </f:if>
-                                                <button type="submit"
+                                            <f:if condition="{canReveal}">
+                                                <button type="button"
                                                         class="btn btn-default btn-sm"
-                                                        data-vault-toggle
-                                                        data-testid="vault-toggle-btn"
-                                                        title="{toggleTitle}"
-                                                        aria-label="{toggleTitle} {secret.identifier}">
+                                                        data-vault-reveal="{secret.identifier}"
+                                                        data-testid="vault-reveal-btn"
+                                                        title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.reveal')}"
+                                                        aria-label="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.reveal')} {secret.identifier}">
+                                                    <core:icon identifier="actions-eye" size="small" />
+                                                </button>
+                                            </f:if>
+                                            <f:if condition="{canManagePolicy}">
+                                                <f:be.link route="admin_vault_secrets.edit" parameters="{identifier: secret.identifier}"
+                                                   class="btn btn-default btn-sm"
+                                                   data-testid="vault-edit-btn"
+                                                   title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.edit')}"
+                                                   aria-label="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.edit')} {secret.identifier}">
+                                                    <core:icon identifier="actions-open" size="small" />
+                                                </f:be.link>
+                                            </f:if>
+                                            <f:if condition="{canManagePolicy}">
+                                                <form method="post" action="{f:be.uri(route: 'admin_vault_secrets.toggle')}" class="d-inline" autocomplete="off">
+                                                    <input type="hidden" name="identifier" value="{secret.identifier}" />
                                                     <f:if condition="{secret.hidden}">
-                                                        <f:then><core:icon identifier="actions-toggle-off" size="small" /></f:then>
-                                                        <f:else><core:icon identifier="actions-toggle-on" size="small" /></f:else>
+                                                        <f:then>
+                                                            <f:variable name="toggleTitle"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.enable" /></f:variable>
+                                                        </f:then>
+                                                        <f:else>
+                                                            <f:variable name="toggleTitle"><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.disable" /></f:variable>
+                                                        </f:else>
                                                     </f:if>
+                                                    <button type="submit"
+                                                            class="btn btn-default btn-sm"
+                                                            data-vault-toggle
+                                                            data-testid="vault-toggle-btn"
+                                                            title="{toggleTitle}"
+                                                            aria-label="{toggleTitle} {secret.identifier}">
+                                                        <f:if condition="{secret.hidden}">
+                                                            <f:then><core:icon identifier="actions-toggle-off" size="small" /></f:then>
+                                                            <f:else><core:icon identifier="actions-toggle-on" size="small" /></f:else>
+                                                        </f:if>
+                                                    </button>
+                                                </form>
+                                            </f:if>
+                                            <f:if condition="{canRotate}">
+                                                <button type="button"
+                                                        class="btn btn-warning btn-sm"
+                                                        data-vault-rotate="{secret.identifier}"
+                                                        data-testid="vault-rotate-btn"
+                                                        title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.rotate')}"
+                                                        aria-label="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.rotate')} {secret.identifier}">
+                                                    <core:icon identifier="actions-refresh" size="small" />
                                                 </button>
-                                            </form>
-                                            <button type="button"
-                                                    class="btn btn-warning btn-sm"
-                                                    data-vault-rotate="{secret.identifier}"
-                                                    data-testid="vault-rotate-btn"
-                                                    title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.rotate')}"
-                                                    aria-label="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.rotate')} {secret.identifier}">
-                                                <core:icon identifier="actions-refresh" size="small" />
-                                            </button>
-                                            <form method="post" action="{f:be.uri(route: 'admin_vault_secrets.delete')}" class="d-inline" autocomplete="off">
-                                                <input type="hidden" name="identifier" value="{secret.identifier}" />
-                                                <button type="submit"
-                                                        class="btn btn-danger btn-sm"
-                                                        data-vault-delete="{secret.identifier}"
-                                                        data-testid="vault-delete-btn"
-                                                        title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.delete')}"
-                                                        aria-label="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.delete')} {secret.identifier}">
-                                                    <core:icon identifier="actions-delete" size="small" />
-                                                </button>
-                                            </form>
+                                            </f:if>
+                                            <f:if condition="{canDelete}">
+                                                <form method="post" action="{f:be.uri(route: 'admin_vault_secrets.delete')}" class="d-inline" autocomplete="off">
+                                                    <input type="hidden" name="identifier" value="{secret.identifier}" />
+                                                    <button type="submit"
+                                                            class="btn btn-danger btn-sm"
+                                                            data-vault-delete="{secret.identifier}"
+                                                            data-testid="vault-delete-btn"
+                                                            title="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.delete')}"
+                                                            aria-label="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.action.delete')} {secret.identifier}">
+                                                        <core:icon identifier="actions-delete" size="small" />
+                                                    </button>
+                                                </form>
+                                            </f:if>
                                         </div>
                                     </td>
                                 </tr>

--- a/Tests/Functional/Controller/AjaxControllerTest.php
+++ b/Tests/Functional/Controller/AjaxControllerTest.php
@@ -78,6 +78,101 @@ final class AjaxControllerTest extends AbstractVaultFunctionalTestCase
         self::assertSame('No identifier provided', $body['error']);
     }
 
+    /**
+     * A NON-admin holding `secret.use` + `secret.reveal` through a backend group
+     * (be_groups.custom_options) can reveal a secret whose read tier admits
+     * their group — end-to-end, through the real `check('custom_options', …)`
+     * path rather than a mocked seam.
+     *
+     * Both permissions are required: the endpoint asserts `secret.reveal`, and
+     * the shared read path in `VaultService::retrieve()` asserts `secret.use`.
+     */
+    #[Test]
+    public function revealActionSucceedsForNonAdminGrantedUseAndReveal(): void
+    {
+        // Store as admin, admitting the revealer's group to the read tier.
+        $this->setUpBackendUser(1);
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $identifier = $this->generateUuidV7();
+        $secretValue = 'group-readable-value';
+        $vaultService->store($identifier, $secretValue, ['groups' => [10]]);
+
+        $this->setUpBackendUser(3);
+
+        $controller = $this->get(AjaxController::class);
+        $response = $controller->revealAction($this->createJsonPostRequest(['identifier' => $identifier]));
+
+        self::assertSame(200, $response->getStatusCode(), (string) $response->getBody());
+        $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($body);
+        self::assertTrue($body['success']);
+        self::assertSame($secretValue, $body['secret']);
+
+        // Cleanup as admin
+        $this->setUpBackendUser(1);
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
+    }
+
+    /**
+     * `audit.view` is not a secret permission: holding it must not open the
+     * reveal endpoint. The secret's read tier admits nobody but the owner here,
+     * but the 403 is produced by the operation gate before any secret lookup.
+     */
+    #[Test]
+    public function revealActionReturns403ForNonAdminWithOnlyAuditViewPermission(): void
+    {
+        $this->setUpBackendUser(1);
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $identifier = $this->generateUuidV7();
+        $vaultService->store($identifier, 'not-for-auditors', ['groups' => [11]]);
+
+        $this->setUpBackendUser(4);
+
+        $controller = $this->get(AjaxController::class);
+        $response = $controller->revealAction($this->createJsonPostRequest(['identifier' => $identifier]));
+
+        self::assertSame(403, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($body);
+        self::assertFalse($body['success']);
+        self::assertSame('Access denied', $body['error']);
+
+        // Cleanup as admin
+        $this->setUpBackendUser(1);
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
+    }
+
+    /**
+     * The revealer group deliberately does NOT carry `secret.rotate`: reading a
+     * secret and replacing its value are separate grants.
+     */
+    #[Test]
+    public function rotateActionReturns403ForNonAdminWithoutRotatePermission(): void
+    {
+        $this->setUpBackendUser(1);
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $identifier = $this->generateUuidV7();
+        $vaultService->store($identifier, 'original-secret', ['groups' => [10]]);
+
+        $this->setUpBackendUser(3);
+
+        $controller = $this->get(AjaxController::class);
+        $response = $controller->rotateAction($this->createJsonPostRequest([
+            'identifier' => $identifier,
+            'secret' => 'rotated-by-revealer',
+        ]));
+
+        self::assertSame(403, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($body);
+        self::assertFalse($body['success']);
+
+        // The value is untouched.
+        $this->setUpBackendUser(1);
+        self::assertSame('original-secret', $vaultService->retrieve($identifier));
+        $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
+    }
+
     #[Test]
     public function revealActionAsNonAdminReturns403(): void
     {

--- a/Tests/Functional/Controller/Fixtures/be_users.csv
+++ b/Tests/Functional/Controller/Fixtures/be_users.csv
@@ -1,4 +1,10 @@
-"be_users"
-,"uid","username","password","admin","disable","starttime","endtime"
-,1,"admin","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",1,0,0,0
-,2,"editor","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0
+"be_users",,,,,,,
+,"uid","username","password","admin","disable","starttime","endtime","usergroup"
+,1,"admin","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",1,0,0,0,""
+,2,"editor","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0,""
+,3,"revealer","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0,"10"
+,4,"auditor","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0,"11"
+"be_groups",,,,
+,"uid","pid","title","custom_options"
+,10,0,"vault-revealer","tx_nrvault:secret.use,tx_nrvault:secret.reveal"
+,11,0,"vault-auditor","tx_nrvault:audit.view"

--- a/Tests/Functional/Hook/Fixtures/be_users_field_permissions.csv
+++ b/Tests/Functional/Hook/Fixtures/be_users_field_permissions.csv
@@ -1,4 +1,7 @@
-"be_users"
-,"uid","username","admin","disable","starttime","endtime","TSconfig"
+"be_users",,,,,,,
+,"uid","username","admin","disable","starttime","endtime","TSconfig","usergroup"
 ,2,"vault_field_permission_editor",0,0,0,0,"page.vault.permissions.tx_test.secret_edit_denied.edit = 0
-page.vault.permissions.tx_test.secret_read_only.readOnly = 1"
+page.vault.permissions.tx_test.secret_read_only.readOnly = 1","20"
+"be_groups",,,,
+,"uid","pid","title","custom_options"
+,20,0,"vault-field-editors","tx_nrvault:secret.use"

--- a/Tests/Unit/Command/VaultRetrieveCommandTest.php
+++ b/Tests/Unit/Command/VaultRetrieveCommandTest.php
@@ -12,6 +12,8 @@ namespace Netresearch\NrVault\Tests\Unit\Command;
 use Netresearch\NrVault\Command\VaultRetrieveCommand;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Exception\VaultException;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use org\bovigo\vfs\vfsStream;
@@ -29,6 +31,8 @@ final class VaultRetrieveCommandTest extends TestCase
 {
     private VaultServiceInterface&MockObject $vaultService;
 
+    private AccessControlServiceInterface&MockObject $accessControlService;
+
     private CommandTester $commandTester;
 
     /** @var list<string> */
@@ -39,8 +43,15 @@ final class VaultRetrieveCommandTest extends TestCase
         parent::setUp();
 
         $this->vaultService = $this->createMock(VaultServiceInterface::class);
+        // The command prints plaintext, so it asserts `secret.reveal`. Grant it
+        // by default; `deniesRetrievalWithoutRevealPermission()` builds its own
+        // command with the grant withheld.
+        $this->accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        $this->accessControlService
+            ->method('isGranted')
+            ->willReturn(true);
 
-        $command = new VaultRetrieveCommand($this->vaultService);
+        $command = new VaultRetrieveCommand($this->vaultService, $this->accessControlService);
 
         $application = new Application();
         $application->addCommand($command);
@@ -61,7 +72,7 @@ final class VaultRetrieveCommandTest extends TestCase
     #[Test]
     public function hasCorrectName(): void
     {
-        $command = new VaultRetrieveCommand($this->vaultService);
+        $command = new VaultRetrieveCommand($this->vaultService, $this->accessControlService);
 
         self::assertSame('vault:retrieve', $command->getName());
     }
@@ -263,6 +274,35 @@ final class VaultRetrieveCommandTest extends TestCase
         self::assertSame(0, $exitCode);
         self::assertSame('new-content', file_get_contents($outputFile));
         self::assertSame(0o600, fileperms($outputFile) & 0o777);
+    }
+
+    /**
+     * `vault:retrieve` prints plaintext to a terminal, so it is a reveal
+     * surface: without `secret.reveal` it must fail before ever asking the
+     * vault for the value.
+     */
+    #[Test]
+    public function deniesRetrievalWithoutRevealPermission(): void
+    {
+        $accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        $accessControlService
+            ->method('isGranted')
+            ->willReturnCallback(
+                // Everything except the reveal permission.
+                static fn (VaultPermission $permission): bool => $permission !== VaultPermission::SecretReveal,
+            );
+
+        $this->vaultService
+            ->expects(self::never())
+            ->method('retrieve');
+
+        $command = new VaultRetrieveCommand($this->vaultService, $accessControlService);
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute(['identifier' => 'some-secret']);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('secret.reveal', $tester->getDisplay());
     }
 
     private function createTempDir(): string

--- a/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
+++ b/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
@@ -26,6 +26,7 @@ use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
 use Netresearch\NrVault\Event\MasterKeyRotatedEvent;
 use Netresearch\NrVault\Exception\EncryptionException;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -93,6 +94,12 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
         $this->auditChainRekeyService = $this->createMock(AuditChainRekeyServiceInterface::class);
         $this->envelopeCodec = $this->createMock(EnvelopeCodecInterface::class);
         $this->accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        // The command asserts `master_key.rotate` before doing anything. Grant
+        // it by default so the rotation-mechanics tests reach their subject;
+        // `refusesRotationWithoutMasterKeyRotatePermission()` withholds it.
+        $this->accessControlService
+            ->method('isGranted')
+            ->willReturn(true);
         $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
 
         $command = $this->createCommand();
@@ -877,6 +884,45 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
         $display = $tester->getDisplay();
         self::assertStringContainsString('Successfully rotated', $display);
         self::assertStringContainsString('Update your configuration', $display);
+    }
+
+    /**
+     * Rotating the master key rewrites every envelope in the store, so the
+     * command refuses to start without `master_key.rotate` — before it reads
+     * any key material or touches the repository.
+     */
+    #[Test]
+    public function refusesRotationWithoutMasterKeyRotatePermission(): void
+    {
+        $accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        $accessControlService
+            ->method('isGranted')
+            ->willReturnCallback(
+                // Every other vault permission granted — only the master-key one missing.
+                static fn (VaultPermission $permission): bool => $permission !== VaultPermission::MasterKeyRotate,
+            );
+
+        $this->secretRepository
+            ->expects(self::never())
+            ->method('findIdentifiers');
+
+        $command = new VaultRotateMasterKeyCommand(
+            $this->secretRepository,
+            $this->encryptionService,
+            $this->masterKeyProviderFactory,
+            $this->connectionPool,
+            $this->auditLogService,
+            $this->auditChainRekeyService,
+            $this->envelopeCodec,
+            $accessControlService,
+            $this->eventDispatcher,
+        );
+        $tester = new CommandTester($command);
+
+        $exitCode = $tester->execute(['--confirm' => true]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('master_key.rotate', $tester->getDisplay());
     }
 
     /**

--- a/Tests/Unit/Controller/AjaxControllerTest.php
+++ b/Tests/Unit/Controller/AjaxControllerTest.php
@@ -19,6 +19,7 @@ use Netresearch\NrVault\Exception\SecretExpiredException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Exception\ValidationException;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -49,9 +50,12 @@ final class AjaxControllerTest extends TestCase
         parent::setUp();
 
         $this->vaultService = $this->createMock(VaultServiceInterface::class);
+        // Default seam: every operation permission granted, so the tests that
+        // exercise the non-authorization behaviour of the endpoints get past
+        // the gate. The permission-specific tests build their own controller.
         $this->accessControlService = $this->createMock(AccessControlServiceInterface::class);
         $this->accessControlService
-            ->method('isCurrentActorAdmin')
+            ->method('isGranted')
             ->willReturn(true);
         $this->configuration = $this->createMock(ExtensionConfigurationInterface::class);
         $this->configuration
@@ -282,11 +286,11 @@ final class AjaxControllerTest extends TestCase
     }
 
     #[Test]
-    public function revealActionReturns403WhenNotAdmin(): void
+    public function revealActionReturns403WithoutRevealPermission(): void
     {
         $request = $this->createRequestWithJsonBody(['identifier' => 'restricted-id']);
 
-        $controller = $this->createControllerForNonAdmin();
+        $controller = $this->createControllerGranting();
 
         $response = $controller->revealAction($request);
 
@@ -294,6 +298,48 @@ final class AjaxControllerTest extends TestCase
         $body = json_decode((string) $response->getBody(), true);
         self::assertFalse($body['success']);
         self::assertSame(self::MSG_ACCESS_DENIED, $body['error']);
+    }
+
+    /**
+     * "Use does not imply reveal": a holder of `secret.use` may let machinery
+     * consume secret values, but must not be able to put a plaintext on screen.
+     */
+    #[Test]
+    public function revealActionReturns403ForHolderOfSecretUseOnly(): void
+    {
+        $request = $this->createRequestWithJsonBody(['identifier' => 'restricted-id']);
+
+        $controller = $this->createControllerGranting(VaultPermission::SecretUse);
+
+        $this->vaultService
+            ->expects(self::never())
+            ->method('retrieve');
+
+        $response = $controller->revealAction($request);
+
+        self::assertSame(403, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertFalse($body['success']);
+        self::assertSame(self::MSG_ACCESS_DENIED, $body['error']);
+    }
+
+    #[Test]
+    public function revealActionSucceedsWithRevealPermissionOnly(): void
+    {
+        $request = $this->createRequestWithJsonBody(['identifier' => 'revealable-id']);
+
+        $controller = $this->createControllerGranting(VaultPermission::SecretReveal);
+
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturn('plaintext-value');
+
+        $response = $controller->revealAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true);
+        self::assertTrue($body['success']);
+        self::assertSame('plaintext-value', $body['secret']);
     }
 
     #[Test]
@@ -311,14 +357,25 @@ final class AjaxControllerTest extends TestCase
     }
 
     #[Test]
-    public function rotateActionReturns403WhenNotAdmin(): void
+    public function rotateActionReturns403WithoutRotatePermission(): void
     {
         $request = $this->createPostRequestWithBody([
             'identifier' => 'restricted-id',
             'secret' => 'new-value',
         ]);
 
-        $controller = $this->createControllerForNonAdmin();
+        // Every OTHER secret permission granted — only `secret.rotate` missing.
+        $controller = $this->createControllerGranting(
+            VaultPermission::SecretUse,
+            VaultPermission::SecretReveal,
+            VaultPermission::SecretCreate,
+            VaultPermission::SecretDelete,
+            VaultPermission::SecretManagePolicy,
+        );
+
+        $this->vaultService
+            ->expects(self::never())
+            ->method('rotate');
 
         $response = $controller->rotateAction($request);
 
@@ -552,18 +609,21 @@ final class AjaxControllerTest extends TestCase
     }
 
     /**
-     * Build a controller whose access-control seam denies admin status.
+     * Build a controller whose access-control seam grants exactly the given
+     * operation permissions and nothing else.
      *
-     * `createMock()` allows a method to be configured only once, so the
-     * non-admin variant needs a dedicated controller rather than re-stubbing
-     * the admin mock created in setUp().
+     * `createMock()` allows a method to be configured only once, so a variant
+     * with different grants needs a dedicated controller rather than
+     * re-stubbing the permissive mock created in setUp().
      */
-    private function createControllerForNonAdmin(): AjaxController
+    private function createControllerGranting(VaultPermission ...$granted): AjaxController
     {
         $accessControlService = $this->createMock(AccessControlServiceInterface::class);
         $accessControlService
-            ->method('isCurrentActorAdmin')
-            ->willReturn(false);
+            ->method('isGranted')
+            ->willReturnCallback(
+                static fn (VaultPermission $permission): bool => \in_array($permission, $granted, true),
+            );
 
         return new AjaxController($this->vaultService, $accessControlService, $this->configuration);
     }

--- a/Tests/Unit/Controller/AuditControllerTest.php
+++ b/Tests/Unit/Controller/AuditControllerTest.php
@@ -10,11 +10,18 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Controller;
 
 use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Controller\AuditController;
+use Netresearch\NrVault\Controller\ModuleAccessGuard;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 use ReflectionClass;
+use TYPO3\CMS\Backend\Template\ModuleTemplateFactory;
 
 /**
  * Unit tests for the CSV audit export writer of AuditController.
@@ -27,6 +34,7 @@ use ReflectionClass;
  * audit field could terminate its own quoted cell and inject a spreadsheet
  * formula into a cell that CsvFormulaSanitizer never inspected (CWE-1236).
  */
+#[AllowMockObjectsWithoutExpectations]
 final class AuditControllerTest extends TestCase
 {
     /**
@@ -80,6 +88,86 @@ final class AuditControllerTest extends TestCase
         $columnIndex = array_search('userAgent', $header, true);
         self::assertIsInt($columnIndex);
         self::assertSame('\'=cmd|\' /C calc\'!A0', $row[$columnIndex]);
+    }
+
+    /**
+     * `audit.view` deliberately does not cover `audit.export`: the downloaded
+     * copy leaves the tamper-evident storage behind, so reading the log in the
+     * module and walking off with the full history are separate grants.
+     */
+    #[Test]
+    public function exportActionReturns403ForHolderOfAuditViewOnly(): void
+    {
+        $auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $auditLogService
+            ->expects(self::never())
+            ->method('export');
+
+        $subject = $this->createControllerGranting($auditLogService, VaultPermission::AuditView);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn(['format' => 'json']);
+
+        $response = $subject->exportAction($request);
+
+        self::assertSame(403, $response->getStatusCode());
+        $body = json_decode((string) $response->getBody(), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($body);
+        self::assertFalse($body['success']);
+        self::assertSame('Access denied', $body['error']);
+    }
+
+    #[Test]
+    public function exportActionSucceedsWithAuditExportPermission(): void
+    {
+        $auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $auditLogService
+            ->expects(self::once())
+            ->method('export')
+            ->willReturn([]);
+
+        $subject = $this->createControllerGranting($auditLogService, VaultPermission::AuditExport);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getQueryParams')->willReturn(['format' => 'json']);
+
+        $response = $subject->exportAction($request);
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame('application/json', $response->getHeaderLine('Content-Type'));
+    }
+
+    /**
+     * Build a controller wired with only the seams `exportAction()` consults:
+     * the audit log service and the permission guard.
+     *
+     * The constructor pulls in `final readonly` TYPO3 services this test does
+     * not need, hence `newInstanceWithoutConstructor()` + property injection
+     * (same approach as the sibling OverviewControllerTest).
+     */
+    private function createControllerGranting(
+        AuditLogServiceInterface $auditLogService,
+        VaultPermission ...$granted,
+    ): AuditController {
+        $accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        $accessControlService
+            ->method('isGranted')
+            ->willReturnCallback(
+                static fn (VaultPermission $permission): bool => \in_array($permission, $granted, true),
+            );
+
+        $moduleTemplateFactory = (new ReflectionClass(ModuleTemplateFactory::class))
+            ->newInstanceWithoutConstructor();
+
+        $reflection = new ReflectionClass(AuditController::class);
+        $subject = $reflection->newInstanceWithoutConstructor();
+        $reflection->getProperty('auditLogService')->setValue($subject, $auditLogService);
+        $reflection->getProperty('accessGuard')->setValue(
+            $subject,
+            new ModuleAccessGuard($accessControlService, $moduleTemplateFactory),
+        );
+
+        return $subject;
     }
 
     /**

--- a/Tests/Unit/Security/AccessControlServiceIsGrantedTest.php
+++ b/Tests/Unit/Security/AccessControlServiceIsGrantedTest.php
@@ -1,0 +1,283 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Security;
+
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Security\AccessControlService;
+use Netresearch\NrVault\Security\TechnicalActor;
+use Netresearch\NrVault\Security\TechnicalActorContextInterface;
+use Netresearch\NrVault\Security\VaultPermission;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
+use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Http\ServerRequest;
+
+/**
+ * Operation-permission matrix for {@see AccessControlService::isGranted()}.
+ *
+ * Kept separate from the per-secret tier tests in
+ * {@see AccessControlServiceTest} because this is the orthogonal gate: which
+ * KINDS of operation an actor may perform, independent of any single secret.
+ */
+#[CoversClass(AccessControlService::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class AccessControlServiceIsGrantedTest extends TestCase
+{
+    private const OPTION_PREFIX = 'tx_nrvault:';
+
+    private AccessControlService $subject;
+
+    private ExtensionConfigurationInterface&MockObject $configuration;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->configuration = $this->createMock(ExtensionConfigurationInterface::class);
+        $this->subject = new AccessControlService($this->configuration);
+
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function adminIsGrantedEveryPermission(VaultPermission $permission): void
+    {
+        $this->setBackendUser(isAdmin: true);
+
+        self::assertTrue($this->subject->isGranted($permission));
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function systemMaintainerIsGrantedEveryPermission(VaultPermission $permission): void
+    {
+        $this->setBackendUser(isAdmin: false, isSystemMaintainer: true);
+
+        self::assertTrue($this->subject->isGranted($permission));
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function nonAdminWithoutAnyCustomOptionIsGrantedNothing(VaultPermission $permission): void
+    {
+        $this->setBackendUser(isAdmin: false, grantedOptions: []);
+
+        self::assertFalse($this->subject->isGranted($permission));
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function nonAdminWithMatchingCustomOptionIsGranted(VaultPermission $permission): void
+    {
+        $this->setBackendUser(isAdmin: false, grantedOptions: [$permission]);
+
+        self::assertTrue($this->subject->isGranted($permission));
+    }
+
+    #[Test]
+    public function nonAdminGrantIsScopedToTheGrantedPermission(): void
+    {
+        $this->setBackendUser(isAdmin: false, grantedOptions: [VaultPermission::SecretUse]);
+
+        self::assertTrue($this->subject->isGranted(VaultPermission::SecretUse));
+        self::assertFalse(
+            $this->subject->isGranted(VaultPermission::SecretReveal),
+            'secret.use must not imply secret.reveal',
+        );
+        self::assertFalse($this->subject->isGranted(VaultPermission::SecretDelete));
+        self::assertFalse($this->subject->isGranted(VaultPermission::MasterKeyRotate));
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function noBackendUserIsGrantedNothing(VaultPermission $permission): void
+    {
+        self::assertFalse($this->subject->isGranted($permission));
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function disabledBackendUserIsGrantedNothing(VaultPermission $permission): void
+    {
+        // Disabled AND admin AND holding the option: every possible grant path
+        // must still lose to the disable flag.
+        $this->setBackendUser(
+            isAdmin: true,
+            grantedOptions: VaultPermission::cases(),
+            disable: 1,
+        );
+
+        self::assertFalse($this->subject->isGranted($permission));
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function adminTechnicalActorIsGrantedEveryPermission(VaultPermission $permission): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(admin: true);
+
+        self::assertTrue($subject->isGranted($permission));
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function nonAdminTechnicalActorIsGrantedOnlySecretUse(VaultPermission $permission): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(admin: false);
+
+        self::assertSame(
+            $permission === VaultPermission::SecretUse,
+            $subject->isGranted($permission),
+            'A non-admin technical actor may only consume secrets programmatically.',
+        );
+    }
+
+    #[Test]
+    public function nonAdminTechnicalActorSupersedesAnAmbientAdminBackendUser(): void
+    {
+        // An ambient admin session must not widen a runAs() scope: the scope
+        // asked to be evaluated as the named (non-admin) technical actor.
+        $this->setBackendUser(isAdmin: true);
+        $subject = $this->createSubjectWithTechnicalActor(admin: false);
+
+        self::assertFalse($subject->isGranted(VaultPermission::SecretReveal));
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function frontendRequestIsGrantedNothingEvenWithAnAdminSession(VaultPermission $permission): void
+    {
+        $this->setBackendUser(isAdmin: true);
+        $this->setFrontendRequest();
+
+        self::assertFalse($this->subject->isGranted($permission));
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function unauthenticatedCliOperatorIsDeniedWhenCliAccessIsOff(VaultPermission $permission): void
+    {
+        $this->configuration->method('isCliAccessAllowed')->willReturn(false);
+        $this->setUnauthenticatedCommandLineUser();
+
+        self::assertFalse($this->subject->isGranted($permission));
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function unauthenticatedCliOperatorIsGrantedWhenCliAccessIsOn(VaultPermission $permission): void
+    {
+        $this->configuration->method('isCliAccessAllowed')->willReturn(true);
+        $this->setUnauthenticatedCommandLineUser();
+
+        self::assertTrue($this->subject->isGranted($permission));
+    }
+
+    /**
+     * @return iterable<string, array{VaultPermission}>
+     */
+    public static function allPermissionsProvider(): iterable
+    {
+        foreach (VaultPermission::cases() as $permission) {
+            yield $permission->value => [$permission];
+        }
+    }
+
+    /**
+     * Install a backend user whose `check('custom_options', ...)` answers for
+     * exactly the given permissions.
+     *
+     * Mirrors TYPO3 core semantics: `check()` consults the merged group data,
+     * so a grant is present or it is not — there is no per-user override.
+     *
+     * @param list<VaultPermission> $grantedOptions
+     */
+    private function setBackendUser(
+        bool $isAdmin,
+        array $grantedOptions = [],
+        bool $isSystemMaintainer = false,
+        int $disable = 0,
+    ): void {
+        $granted = array_map(
+            static fn (VaultPermission $permission): string => self::OPTION_PREFIX . $permission->value,
+            $grantedOptions,
+        );
+
+        // The shared trait owns the `user` record / `userGroupsUID` / role
+        // wiring; only the group-data lookup that carries the custom permission
+        // options is specific to this test.
+        $backendUser = $this->createMockBackendUser(
+            uid: 5,
+            isAdmin: $isAdmin,
+            disabled: $disable !== 0,
+            isSystemMaintainer: $isSystemMaintainer,
+        );
+        $backendUser
+            ->method('check')
+            ->willReturnCallback(
+                static fn (string $type, string $value): bool => $type === 'custom_options'
+                    && \in_array($value, $granted, true),
+            );
+
+        $GLOBALS['BE_USER'] = $backendUser;
+    }
+
+    /**
+     * Install the unauthenticated CommandLineUserAuthentication placeholder the
+     * TYPO3 CLI bootstrap puts into $GLOBALS['BE_USER'] (no user record).
+     */
+    private function setUnauthenticatedCommandLineUser(): void
+    {
+        $cliUser = $this->createMock(CommandLineUserAuthentication::class);
+        /** @phpstan-ignore property.internal */
+        $cliUser->user = ['uid' => 0];
+
+        $GLOBALS['BE_USER'] = $cliUser;
+    }
+
+    private function setFrontendRequest(): void
+    {
+        /** @phpstan-ignore classConstant.internal */
+        $frontendType = SystemEnvironmentBuilder::REQUESTTYPE_FE;
+
+        /** @phpstan-ignore new.internalClass, method.internalClass */
+        $request = new ServerRequest('https://example.com/');
+
+        /** @phpstan-ignore method.internalClass */
+        $GLOBALS['TYPO3_REQUEST'] = $request->withAttribute('applicationType', $frontendType);
+    }
+
+    private function createSubjectWithTechnicalActor(bool $admin): AccessControlService
+    {
+        $context = $this->createMock(TechnicalActorContextInterface::class);
+        $context
+            ->method('getCurrentActor')
+            ->willReturn(new TechnicalActor(
+                uid: 10,
+                username: 'tech_indexer',
+                admin: $admin,
+                groupIds: [5],
+            ));
+
+        return new AccessControlService($this->configuration, null, $context);
+    }
+}

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -26,6 +26,7 @@ use Netresearch\NrVault\Exception\ValidationException;
 use Netresearch\NrVault\Http\VaultHttpClientFactoryInterface;
 use Netresearch\NrVault\Http\VaultHttpClientInterface;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\VaultService;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -383,6 +384,113 @@ final class VaultServiceTest extends TestCase
         $this->expectException(AccessDeniedException::class);
 
         $this->subject->retrieve('restricted');
+    }
+
+    /**
+     * On top of the per-secret `canRead()` tier, an interactively authenticated
+     * NON-admin backend user needs the `secret.use` operation permission for
+     * every plaintext read — the FormEngine widget, FlexForm resolution and the
+     * reveal endpoint alike.
+     */
+    #[Test]
+    public function retrieveDeniesNonAdminBackendUserWithoutSecretUsePermission(): void
+    {
+        $secret = $this->createSecretEntity('usable');
+
+        $access = $this->createMock(AccessControlServiceInterface::class);
+        $access->method('getCurrentActorUid')->willReturn(7);
+        $access->method('getCurrentActorType')->willReturn('backend');
+        $access->method('isCurrentActorAdmin')->willReturn(false);
+        // Per-secret read access granted; the operation permission is not.
+        $access->method('canRead')->willReturn(true);
+        $access->method('isGranted')->willReturn(false);
+
+        $subject = $this->createSubjectWith($access);
+
+        $this->adapter->method('retrieve')->willReturn($secret);
+        $this->encryptionService->expects(self::never())->method('decrypt');
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('usable', 'access_denied', false, self::stringContains('secret.use'));
+
+        $this->expectException(AccessDeniedException::class);
+
+        $subject->retrieve('usable');
+    }
+
+    #[Test]
+    public function retrieveAllowsNonAdminBackendUserHoldingSecretUsePermission(): void
+    {
+        $secret = $this->createSecretEntity('usable');
+
+        $access = $this->createMock(AccessControlServiceInterface::class);
+        $access->method('getCurrentActorUid')->willReturn(7);
+        $access->method('getCurrentActorType')->willReturn('backend');
+        $access->method('isCurrentActorAdmin')->willReturn(false);
+        $access->method('canRead')->willReturn(true);
+        $access
+            ->method('isGranted')
+            ->willReturnCallback(
+                static fn (VaultPermission $permission): bool => $permission === VaultPermission::SecretUse,
+            );
+
+        $subject = $this->createSubjectWith($access);
+
+        $this->adapter->method('retrieve')->willReturn($secret);
+        $this->encryptionService->method('decrypt')->willReturn('plaintext');
+
+        self::assertSame('plaintext', $subject->retrieve('usable'));
+    }
+
+    /**
+     * Admins are exempt from the operation gate — the branch is expressed via
+     * `isCurrentActorAdmin()`, so `isGranted()` is never consulted for them.
+     */
+    #[Test]
+    public function retrieveDoesNotGateAdminBackendUsersOnSecretUse(): void
+    {
+        $secret = $this->createSecretEntity('usable');
+
+        $access = $this->createMock(AccessControlServiceInterface::class);
+        $access->method('getCurrentActorUid')->willReturn(1);
+        $access->method('getCurrentActorType')->willReturn('backend');
+        $access->method('isCurrentActorAdmin')->willReturn(true);
+        $access->method('canRead')->willReturn(true);
+        $access->expects(self::never())->method('isGranted');
+
+        $subject = $this->createSubjectWith($access);
+
+        $this->adapter->method('retrieve')->willReturn($secret);
+        $this->encryptionService->method('decrypt')->willReturn('plaintext');
+
+        self::assertSame('plaintext', $subject->retrieve('usable'));
+    }
+
+    /**
+     * The frontend path must keep its exact previous behaviour: a page render's
+     * output is shared via the page cache, so it may not depend on whichever
+     * backend user happens to hold a session. `frontend_accessible` decides.
+     */
+    #[Test]
+    public function retrieveForFrontendIsNotGatedOnSecretUse(): void
+    {
+        $secret = $this->createSecretEntity('publicKey', frontendAccessible: true);
+
+        $access = $this->createMock(AccessControlServiceInterface::class);
+        $access->method('getCurrentActorUid')->willReturn(7);
+        $access->method('getCurrentActorType')->willReturn('backend');
+        $access->method('isCurrentActorAdmin')->willReturn(false);
+        $access->method('canRead')->willReturn(true);
+        $access->method('isGranted')->willReturn(false);
+
+        $subject = $this->createSubjectWith($access);
+
+        $this->adapter->method('retrieve')->willReturn($secret);
+        $this->encryptionService->method('decrypt')->willReturn('plaintext');
+
+        self::assertSame('plaintext', $subject->retrieveForFrontend('publicKey'));
     }
 
     #[Test]
@@ -1169,6 +1277,26 @@ final class VaultServiceTest extends TestCase
             // The compensating store must be the original pre-rotation secret.
             self::assertSame($secret, $storeArgs[1] ?? null);
         }
+    }
+
+    /**
+     * Build a subject wired to a different access-control seam, reusing the
+     * remaining collaborators from setUp().
+     *
+     * `createMock()` allows a method to be configured only once, so tests that
+     * need other actor semantics than the CLI default must bring their own
+     * access-control mock rather than re-stubbing the shared one.
+     */
+    private function createSubjectWith(AccessControlServiceInterface $accessControlService): VaultService
+    {
+        return new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $accessControlService,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
     }
 
     /**

--- a/Tests/Unit/Traits/BackendUserMockTrait.php
+++ b/Tests/Unit/Traits/BackendUserMockTrait.php
@@ -34,17 +34,22 @@ trait BackendUserMockTrait
      * TYPO3 `be_users.disable` field).
      *
      * @param list<int> $groupIds backend user group UIDs (populates `userGroupsUID`)
+     * @param bool $isSystemMaintainer answer for `isSystemMaintainer()` — core
+     *                                 treats the role as strictly stronger than
+     *                                 `admin`, and the vault's permission gates
+     *                                 must honour it independently
      */
     protected function createMockBackendUser(
         int $uid = 1,
         bool $isAdmin = false,
         array $groupIds = [],
         bool $disabled = false,
+        bool $isSystemMaintainer = false,
     ): BackendUserAuthentication&MockObject {
         /** @var BackendUserAuthentication&MockObject $backendUser */
         $backendUser = $this->createMock(BackendUserAuthentication::class);
         $backendUser->method('isAdmin')->willReturn($isAdmin);
-        $backendUser->method('isSystemMaintainer')->willReturn(false);
+        $backendUser->method('isSystemMaintainer')->willReturn($isSystemMaintainer);
 
         $backendUser->user = [
             'uid' => $uid,

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -12,10 +12,34 @@ use Netresearch\NrVault\Form\Element\VaultSecretInputElement;
 use Netresearch\NrVault\Hook\DataHandlerHook;
 use Netresearch\NrVault\Hook\FlexFormVaultHook;
 use Netresearch\NrVault\Hook\SecretTcaHook;
+use Netresearch\NrVault\Security\VaultPermission;
 
 defined('TYPO3') || die();
 
 (static function (): void {
+    // Operation permissions as TYPO3 custom permission options, so
+    // each one is grantable per backend user group in the Backend Users module
+    // and checked via check('custom_options', 'tx_nrvault:<permission>').
+    // Enum-driven: a new VaultPermission case is grantable without touching
+    // this list. Labels/descriptions live in locallang_mod.xlf under
+    // `permissions.<case value>` / `.description`.
+    $permissionLabels = 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:permissions.';
+    $permissionItems = [];
+    foreach (VaultPermission::cases() as $permission) {
+        $permissionItems[$permission->value] = [
+            $permissionLabels . $permission->value,
+            // No icon: the Backend Users module falls back to a neutral one.
+            '',
+            $permissionLabels . $permission->value . '.description',
+        ];
+    }
+
+    $GLOBALS['TYPO3_CONF_VARS']['BE']['customPermOptions']['tx_nrvault'] = [
+        'header' => $permissionLabels . 'header',
+        'items' => $permissionItems,
+    ];
+
+
     // Register vaultSecret form element type (for OTHER tables to reference vault secrets)
     $GLOBALS['TYPO3_CONF_VARS']['SYS']['formEngine']['nodeRegistry'][1735400000] = [
         'nodeName' => 'vaultSecret',


### PR DESCRIPTION
## Summary

P0 item 3 of the hardened-profile roadmap: the coarse admin-only model becomes ten grantable operations, technically enforced server-side. Stacked on #237.

**Permissions:** `secret.use`, `secret.reveal`, `secret.create`, `secret.rotate`, `secret.delete`, `secret.manage_policy`, `audit.view`, `audit.export`, `master_key.rotate`, `vault.configure` — carried by TYPO3 custom permission options (`be_groups.custom_options`, namespace `tx_nrvault`), grantable per group in the Backend Users module.

**Enforcement:**
- `AccessControlServiceInterface::isGranted(VaultPermission)` — resolution order: technical actor (admin = all; non-admin = `secret.use` only), frontend requests never, disabled users never, unauthenticated CLI = existing `allowCliAccess` switch, BE users via the admin override seam or `check('custom_options', …)`. Fail-closed.
- Backend modules + AJAX routes move `admin` → `user`; every controller action asserts its operation; the overview filters submodule cards by permission; templates render only permitted actions.
- **use ≠ reveal:** `secret.use` gates every interactive non-admin plaintext read in `VaultService::retrieve()` (on top of the per-secret ACL tiers); the reveal endpoint additionally requires `secret.reveal`. An application/technical actor can consume a secret no human may display.
- Audit viewing is split from secret access (`audit.view` / `audit.export`); `master_key.rotate` guards `vault:rotate-master-key`; `vault:retrieve` (prints plaintext) requires `secret.reveal`.
- The admin/system-maintainer override lives in **one seam** (`adminOverrideGrants()`) — the hardened profile makes it disableable in PR 4.

**Two deliberate deviations** (details in commit/docs):
1. Unauthenticated-CLI branch routes to the existing `allowCliAccess` trust switch (the `_cli_` user is never logged in, so group grants can't apply). Behavior change: `vault:rotate-master-key` now needs `allowCliAccess=1` like every other secret command.
2. Operational note: non-admin editors using vault-backed FormEngine/FlexForm fields now need `secret.use` — documented in `Documentation/Security/Index.rst`.

## Test plan
- `composer ci` exit 0 (unit + fuzz, PHPStan 10, CGL, arch, doc-cli), Rector clean, full functional suite green locally (185 tests, sqlite).
- New: 112-case `isGranted` matrix; functional tests through the **real** `check('custom_options', …)` path (revealer uid 3: reveal 200; auditor uid 4: reveal 403; revealer rotate 403 with value unchanged).

Roadmap: PR 3 of 10 — follows #237.
