### PR TITLE
Add HashiCorp Vault Transit master key provider

### DIFF
--- a/Classes/Configuration/Dto/TransitConfig.php
+++ b/Classes/Configuration/Dto/TransitConfig.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Configuration\Dto;
+
+use SensitiveParameter;
+
+/**
+ * Data Transfer Object for the HashiCorp Vault Transit master-key provider.
+ *
+ * Separate from {@see VaultServerConfig} (which describes the *storage adapter*
+ * connection) because the Transit provider is a key-custody concern: it wraps
+ * and unwraps the vault master key through Vault's transit secrets engine and
+ * never stores secret payloads there.
+ *
+ * Both read their values from the same `hashicorp.*` extension-configuration
+ * group, so a deployment that already points at a Vault server does not have to
+ * repeat the address.
+ */
+readonly class TransitConfig
+{
+    public const DEFAULT_MOUNT = 'transit';
+
+    public const DEFAULT_KEY_NAME = 'nr-vault-master';
+
+    public const DEFAULT_TOKEN_ENV_VAR = 'VAULT_TOKEN';
+
+    /**
+     * @param string $address Vault base address, e.g. https://vault.example.com:8200
+     * @param string $mount transit engine mount path (without /v1/)
+     * @param string $keyName transit key that wraps the master key
+     * @param string $wrappedKeyPath absolute path of the locally stored wrapped
+     *                               (Vault-encrypted) master key
+     * @param string $authMethod configured auth method; only `token` is
+     *                           implemented (see TransitMasterKeyProvider)
+     * @param string $tokenEnvVar environment variable read for the Vault
+     *                            token; preferred over $token
+     * @param string $token token from extension configuration —
+     *                      fallback for development only
+     */
+    public function __construct(
+        public string $address = '',
+        public string $mount = self::DEFAULT_MOUNT,
+        public string $keyName = self::DEFAULT_KEY_NAME,
+        public string $wrappedKeyPath = '',
+        public string $authMethod = 'token',
+        public string $tokenEnvVar = self::DEFAULT_TOKEN_ENV_VAR,
+        #[SensitiveParameter]
+        public string $token = '',
+    ) {}
+
+    /**
+     * Create from the `hashicorp` extension-configuration sub-array.
+     *
+     * @param array{address?: string, authMethod?: string, token?: string, transitMount?: string, transitKeyName?: string, transitWrappedKeyPath?: string, tokenEnvVar?: string} $config
+     * @param string $fallbackWrappedKeyPath used when `transitWrappedKeyPath` is
+     *                                       empty; callers resolve it from the TYPO3 var
+     *                                       path so this DTO stays free of environment
+     *                                       lookups
+     */
+    public static function fromArray(array $config, string $fallbackWrappedKeyPath = ''): self
+    {
+        $wrappedKeyPath = trim($config['transitWrappedKeyPath'] ?? '');
+        $mount = trim($config['transitMount'] ?? '', " \t\n\r\0\x0B/");
+        $configuredKeyName = trim($config['transitKeyName'] ?? '');
+        $authMethod = trim($config['authMethod'] ?? '');
+        $configuredTokenEnvVar = trim($config['tokenEnvVar'] ?? '');
+
+        return new self(
+            address: rtrim(trim($config['address'] ?? ''), '/'),
+            mount: $mount !== '' ? $mount : self::DEFAULT_MOUNT,
+            keyName: $configuredKeyName !== '' ? $configuredKeyName : self::DEFAULT_KEY_NAME,
+            wrappedKeyPath: $wrappedKeyPath !== '' ? $wrappedKeyPath : $fallbackWrappedKeyPath,
+            authMethod: $authMethod !== '' ? $authMethod : 'token',
+            tokenEnvVar: $configuredTokenEnvVar !== '' ? $configuredTokenEnvVar : self::DEFAULT_TOKEN_ENV_VAR,
+            token: $config['token'] ?? '',
+        );
+    }
+
+    /**
+     * Everything the provider needs to build a Transit request is present.
+     *
+     * Deliberately does NOT cover the token: token presence is checked
+     * separately so a missing credential can be reported differently from an
+     * incomplete server configuration.
+     */
+    public function isComplete(): bool
+    {
+        return $this->address !== ''
+            && $this->mount !== ''
+            && $this->keyName !== ''
+            && $this->wrappedKeyPath !== '';
+    }
+
+    /**
+     * Only token auth is implemented; `kubernetes` and `approle` are rejected
+     * by the provider rather than silently treated as token auth.
+     */
+    public function usesTokenAuth(): bool
+    {
+        return $this->authMethod === 'token';
+    }
+
+    /**
+     * Absolute Vault API URL for a transit operation (`encrypt` / `decrypt`).
+     */
+    public function endpointFor(string $operation): string
+    {
+        return \sprintf('%s/v1/%s/%s/%s', $this->address, $this->mount, $operation, $this->keyName);
+    }
+
+    /**
+     * Convert to array for serialization. The token is deliberately omitted —
+     * this DTO is dumped into diagnostics output (vault:init, health checks).
+     *
+     * @return array{address: string, mount: string, keyName: string, wrappedKeyPath: string, authMethod: string, tokenEnvVar: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'address' => $this->address,
+            'mount' => $this->mount,
+            'keyName' => $this->keyName,
+            'wrappedKeyPath' => $this->wrappedKeyPath,
+            'authMethod' => $this->authMethod,
+            'tokenEnvVar' => $this->tokenEnvVar,
+        ];
+    }
+}

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -368,7 +368,6 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
         return Environment::getVarPath() . '/secrets/vault-master.key';
     }
 
-
     /**
      * Read a boolean setting pinned in
      * `$TYPO3_CONF_VARS[SYS][nrVault][<key>]` — typically set in

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Configuration;
 
 use Netresearch\NrVault\Configuration\Dto\AwsSecretsConfig;
+use Netresearch\NrVault\Configuration\Dto\TransitConfig;
 use Netresearch\NrVault\Configuration\Dto\VaultServerConfig;
 use Netresearch\NrVault\Exception\ConfigurationException;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration as Typo3ExtensionConfiguration;
@@ -120,7 +121,7 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
     }
 
     /**
-     * Get master key provider identifier (typo3, file, env, derived).
+     * Get master key provider identifier (typo3, file, env, transit).
      */
     public function getMasterKeyProvider(): string
     {
@@ -316,6 +317,35 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
     }
 
     /**
+     * Get the HashiCorp Vault Transit master-key provider configuration.
+     *
+     * Shares the `hashicorp.*` group with the (planned) storage adapter so an
+     * installation configures the Vault address once. The wrapped-key path
+     * falls back to the var path when unset, mirroring
+     * {@see self::getAutoKeyPath()} for the file provider.
+     */
+    public function getTransitConfig(): TransitConfig
+    {
+        $config = $this->configuration['hashicorp'] ?? [];
+
+        if (!\is_array($config)) {
+            $config = [];
+        }
+
+        /** @var array{address?: string, authMethod?: string, token?: string, transitMount?: string, transitKeyName?: string, transitWrappedKeyPath?: string, tokenEnvVar?: string} $config */
+        $configuredPath = \is_string($config['transitWrappedKeyPath'] ?? null)
+            ? trim($config['transitWrappedKeyPath'])
+            : '';
+
+        // Resolve the var-path default lazily: it touches Environment, which an
+        // explicitly configured path makes unnecessary.
+        return TransitConfig::fromArray(
+            $config,
+            $configuredPath === '' ? $this->getTransitWrappedKeyPathDefault() : '',
+        );
+    }
+
+    /**
      * Get AWS Secrets Manager configuration.
      */
     public function getAwsConfig(): AwsSecretsConfig
@@ -338,6 +368,7 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
         return Environment::getVarPath() . '/secrets/vault-master.key';
     }
 
+
     /**
      * Read a boolean setting pinned in
      * `$TYPO3_CONF_VARS[SYS][nrVault][<key>]` — typically set in
@@ -357,5 +388,16 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
         $nrVault = \is_array($sys['nrVault'] ?? null) ? $sys['nrVault'] : [];
 
         return \array_key_exists($key, $nrVault) ? (bool) $nrVault[$key] : null;
+    }
+
+    /**
+     * Default location of the Vault-wrapped master key.
+     *
+     * The stored blob is Transit ciphertext (`vault:v1:…`), never key material,
+     * so it lives next to the auto key path rather than in a separate store.
+     */
+    private function getTransitWrappedKeyPathDefault(): string
+    {
+        return $this->getAutoKeyPath() . '.transit';
     }
 }

--- a/Classes/Configuration/ExtensionConfigurationInterface.php
+++ b/Classes/Configuration/ExtensionConfigurationInterface.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Configuration;
 
 use Netresearch\NrVault\Configuration\Dto\AwsSecretsConfig;
+use Netresearch\NrVault\Configuration\Dto\TransitConfig;
 use Netresearch\NrVault\Configuration\Dto\VaultServerConfig;
 use Netresearch\NrVault\Exception\ConfigurationException;
 
@@ -33,7 +34,7 @@ interface ExtensionConfigurationInterface
     public function getStorageAdapter(): string;
 
     /**
-     * Get master key provider identifier (typo3, file, env, derived).
+     * Get master key provider identifier (typo3, file, env, transit).
      */
     public function getMasterKeyProvider(): string;
 
@@ -104,6 +105,11 @@ interface ExtensionConfigurationInterface
      * Get HashiCorp Vault configuration.
      */
     public function getHashiCorpConfig(): VaultServerConfig;
+
+    /**
+     * Get the HashiCorp Vault Transit master-key provider configuration.
+     */
+    public function getTransitConfig(): TransitConfig;
 
     /**
      * Get AWS Secrets Manager configuration.

--- a/Classes/Crypto/MasterKeyProviderFactory.php
+++ b/Classes/Crypto/MasterKeyProviderFactory.php
@@ -9,17 +9,50 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Crypto;
 
+use GuzzleHttp\Client;
+use GuzzleHttp\Psr7\HttpFactory;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Exception\ConfigurationException;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
 
 /**
  * Factory for creating master key providers.
  */
 final readonly class MasterKeyProviderFactory implements MasterKeyProviderFactoryInterface
 {
+    private ClientInterface $httpClient;
+
+    private RequestFactoryInterface $requestFactory;
+
+    private StreamFactoryInterface $streamFactory;
+
+    /**
+     * The HTTP dependencies are only consumed by the `transit` provider; they are
+     * optional so unit tests (and any caller that never selects `transit`) can
+     * construct the factory with configuration alone.
+     *
+     * The PSR-18 client is the platform one (TYPO3 aliases
+     * `Psr\Http\Client\ClientInterface` to its Guzzle client, so proxy, TLS and
+     * timeout settings from `$TYPO3_CONF_VARS['HTTP']` apply). The Vault address
+     * is operator-supplied extension configuration, not request input, so the
+     * SSRF/private-IP gating of `SecureHttpClientFactory` is deliberately NOT
+     * applied here: it would block the on-prem RFC1918 Vault addresses this
+     * provider primarily targets, and the master-key path must not depend on an
+     * `allowed_hosts` entry to work.
+     */
     public function __construct(
         private ExtensionConfigurationInterface $configuration,
-    ) {}
+        ?ClientInterface $httpClient = null,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
+    ) {
+        $httpFactory = new HttpFactory();
+        $this->httpClient = $httpClient ?? new Client(['http_errors' => false, 'allow_redirects' => false]);
+        $this->requestFactory = $requestFactory ?? $httpFactory;
+        $this->streamFactory = $streamFactory ?? $httpFactory;
+    }
 
     public function create(): MasterKeyProviderInterface
     {
@@ -33,6 +66,14 @@ final readonly class MasterKeyProviderFactory implements MasterKeyProviderFactor
             'typo3' => new Typo3MasterKeyProvider(),
             'file' => new FileMasterKeyProvider($this->configuration),
             'env' => new EnvironmentMasterKeyProvider($this->configuration),
+            // Allowed in the hardened profile: external KMS custody is exactly
+            // what that profile asks for.
+            'transit' => new TransitMasterKeyProvider(
+                $this->configuration,
+                $this->httpClient,
+                $this->requestFactory,
+                $this->streamFactory,
+            ),
             default => throw ConfigurationException::invalidProvider($provider),
         };
     }

--- a/Classes/Crypto/TransitMasterKeyProvider.php
+++ b/Classes/Crypto/TransitMasterKeyProvider.php
@@ -442,6 +442,7 @@ final class TransitMasterKeyProvider extends AbstractMasterKeyProvider
             }
         } catch (MasterKeyException $e) {
             if (file_exists($temporaryPath)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use - $temporaryPath is a code-generated temp path for the atomic wrapped-key write, never user input; this only cleans up our own leftover on failure.
                 unlink($temporaryPath);
             }
 

--- a/Classes/Crypto/TransitMasterKeyProvider.php
+++ b/Classes/Crypto/TransitMasterKeyProvider.php
@@ -1,0 +1,479 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Crypto;
+
+use JsonException;
+use Netresearch\NrVault\Configuration\Dto\TransitConfig;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Exception\MasterKeyException;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use SensitiveParameter;
+
+/**
+ * HashiCorp Vault Transit master-key provider.
+ *
+ * Key custody model — the master key is generated once, wrapped by Vault's
+ * transit secrets engine, and only the WRAPPED ciphertext (`vault:v1:…`) is
+ * stored on the local filesystem. Unwrapping requires a live Vault call, so the
+ * key material never sits at rest next to the database:
+ *
+ *   generateMasterKey() → random_bytes(32)
+ *   storeMasterKey()    → POST /v1/{mount}/encrypt/{key}  → local wrapped blob
+ *   getMasterKey()      → local wrapped blob → POST /v1/{mount}/decrypt/{key}
+ *
+ * What this buys, honestly:
+ *  - key custody and rotation move into Vault (`vault write -f
+ *    transit/keys/{key}/rotate` re-wraps future ciphertexts without touching
+ *    any secret in the TYPO3 database);
+ *  - every unwrap is centrally audited and revocable — pulling the token or the
+ *    policy locks the vault out immediately, with no key file to recover;
+ *  - a stolen database plus a stolen webroot is useless without Vault access.
+ *
+ * What it does NOT buy: a fully compromised PHP process can still call
+ * `decrypt` with the token it legitimately holds and obtain the master key.
+ * Transit protects custody, rotation and auditability — not a live attacker
+ * already inside the request.
+ *
+ * Auth: token only (`hashicorp.authMethod = token`), read from the configured
+ * environment variable in preference to the stored setting. `approle` and
+ * `kubernetes` are rejected rather than silently downgraded; see the class-level
+ * note in Documentation/Configuration/Index.rst for the follow-up.
+ *
+ * Allowed in the hardened security profile: it is exactly the kind of external
+ * KMS custody that profile asks for.
+ *
+ * Request-lifetime caching (one decrypt per request) is inherited from
+ * {@see AbstractMasterKeyProvider}; see ADR-020.
+ */
+final class TransitMasterKeyProvider extends AbstractMasterKeyProvider
+{
+    private const KEY_LENGTH = 32; // 256 bits
+
+    private const OPERATION_ENCRYPT = 'encrypt';
+
+    private const OPERATION_DECRYPT = 'decrypt';
+
+    /**
+     * Characters permitted in a transit mount segment or key name before they
+     * are interpolated into a Vault API path. Validated by explode + preg over
+     * single segments (no nested quantifiers) so a mount like
+     * `platform/transit` stays usable while `../` and control characters cannot
+     * reach the URL.
+     */
+    private const PATH_SEGMENT_PATTERN = '/^[A-Za-z0-9._-]+$/';
+
+    public function __construct(
+        private readonly ExtensionConfigurationInterface $configuration,
+        private readonly ClientInterface $httpClient,
+        private readonly RequestFactoryInterface $requestFactory,
+        private readonly StreamFactoryInterface $streamFactory,
+    ) {}
+
+    public function __destruct()
+    {
+        // Wipe this provider's request-lifetime cache slot; the inherited cache
+        // is keyed by class so no other provider is affected. See ADR-020.
+        self::clearCachedKey();
+    }
+
+    public function getIdentifier(): string
+    {
+        return 'transit';
+    }
+
+    /**
+     * Configuration completeness + local wrapped blob presence.
+     *
+     * Deliberately performs NO network call: availability is consulted on hot
+     * paths, and a Vault outage must not turn into a per-request HTTP timeout.
+     * A live probe is `getMasterKey()` itself (that is what
+     * VaultHealthService does).
+     */
+    public function isAvailable(): bool
+    {
+        $config = $this->configuration->getTransitConfig();
+
+        if (!$config->isComplete() || !$config->usesTokenAuth()) {
+            return false;
+        }
+
+        try {
+            $this->assertKeyReferencesAreSafe($config);
+        } catch (MasterKeyException) {
+            return false;
+        }
+
+        $vaultToken = $this->findToken($config);
+        if ($vaultToken === null) {
+            return false;
+        }
+        $this->wipeTokenCopy($vaultToken, $config);
+
+        return file_exists($config->wrappedKeyPath) && is_readable($config->wrappedKeyPath);
+    }
+
+    /**
+     * Wrap the key with Vault Transit and persist ONLY the ciphertext.
+     *
+     * Used by `vault:init` and `vault:rotate-master-key`. The plaintext never
+     * touches the filesystem: it is base64-encoded for the API call, sent, and
+     * both copies are zeroed before this method returns.
+     */
+    public function storeMasterKey(#[SensitiveParameter] string $key): void
+    {
+        if (\strlen($key) !== self::KEY_LENGTH) {
+            throw MasterKeyException::invalidLength(self::KEY_LENGTH, \strlen($key));
+        }
+
+        $config = $this->requireUsableConfig();
+
+        $encoded = base64_encode($key);
+
+        try {
+            $data = $this->callTransit($config, self::OPERATION_ENCRYPT, ['plaintext' => $encoded]);
+        } finally {
+            sodium_memzero($encoded);
+        }
+
+        $ciphertext = $data['ciphertext'] ?? null;
+        if (!\is_string($ciphertext) || !str_starts_with($ciphertext, 'vault:')) {
+            throw MasterKeyException::transitMalformedResponse(
+                self::OPERATION_ENCRYPT,
+                'missing or malformed data.ciphertext',
+            );
+        }
+
+        $this->writeWrappedKey($config->wrappedKeyPath, $ciphertext);
+    }
+
+    public function generateMasterKey(): string
+    {
+        return random_bytes(self::KEY_LENGTH);
+    }
+
+    protected function loadRawKey(): string
+    {
+        $config = $this->requireUsableConfig();
+        $wrapped = $this->readWrappedKey($config->wrappedKeyPath);
+
+        $data = $this->callTransit($config, self::OPERATION_DECRYPT, ['ciphertext' => $wrapped]);
+
+        $encoded = $data['plaintext'] ?? null;
+        if (!\is_string($encoded) || $encoded === '') {
+            throw MasterKeyException::transitMalformedResponse(
+                self::OPERATION_DECRYPT,
+                'missing or empty data.plaintext',
+            );
+        }
+
+        $rawKey = base64_decode($encoded, true);
+        sodium_memzero($encoded);
+
+        if ($rawKey === false) {
+            throw MasterKeyException::transitMalformedResponse(
+                self::OPERATION_DECRYPT,
+                'data.plaintext is not valid base64',
+            );
+        }
+
+        if (\strlen($rawKey) !== self::KEY_LENGTH) {
+            $length = \strlen($rawKey);
+            sodium_memzero($rawKey);
+
+            throw MasterKeyException::invalidLength(self::KEY_LENGTH, $length);
+        }
+
+        return $rawKey;
+    }
+
+    /**
+     * Resolve the configuration and refuse to proceed on anything that would
+     * make the request ambiguous or unauthenticated (fail closed).
+     *
+     * @throws MasterKeyException
+     */
+    private function requireUsableConfig(): TransitConfig
+    {
+        $config = $this->configuration->getTransitConfig();
+
+        if ($config->address === '') {
+            throw MasterKeyException::transitNotConfigured('hashicorp.address is empty');
+        }
+        if ($config->wrappedKeyPath === '') {
+            throw MasterKeyException::transitNotConfigured('hashicorp.transitWrappedKeyPath is empty');
+        }
+        if (!$config->usesTokenAuth()) {
+            throw MasterKeyException::transitUnsupportedAuthMethod($config->authMethod);
+        }
+
+        $this->assertKeyReferencesAreSafe($config);
+
+        return $config;
+    }
+
+    /**
+     * @throws MasterKeyException
+     */
+    private function assertKeyReferencesAreSafe(TransitConfig $config): void
+    {
+        foreach (explode('/', $config->mount) as $segment) {
+            if (!$this->isSafePathSegment($segment)) {
+                throw MasterKeyException::transitInvalidKeyReference('mount path');
+            }
+        }
+
+        if (!$this->isSafePathSegment($config->keyName)) {
+            throw MasterKeyException::transitInvalidKeyReference('key name');
+        }
+    }
+
+    /**
+     * A segment must consist of the allowed characters AND carry at least one
+     * character that is not a dot: the dot itself is legal inside a Vault mount
+     * or key name, but `.` and `..` are traversal segments and must never reach
+     * the API path.
+     */
+    private function isSafePathSegment(string $segment): bool
+    {
+        return preg_match(self::PATH_SEGMENT_PATTERN, $segment) === 1
+            && trim($segment, '.') !== '';
+    }
+
+    /**
+     * Perform a transit operation and return the response `data` array.
+     *
+     * @param array<string, string> $payload
+     *
+     * @throws MasterKeyException
+     *
+     * @return array<array-key, mixed>
+     */
+    private function callTransit(TransitConfig $config, string $operation, array $payload): array
+    {
+        $vaultToken = $this->findToken($config);
+        if ($vaultToken === null) {
+            throw MasterKeyException::transitTokenMissing($config->tokenEnvVar);
+        }
+
+        try {
+            $body = json_encode($payload, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            $this->wipeTokenCopy($vaultToken, $config);
+
+            throw MasterKeyException::transitMalformedResponse($operation, 'request payload not encodable: ' . $e->getMessage());
+        }
+
+        $request = $this->requestFactory
+            ->createRequest('POST', $config->endpointFor($operation))
+            ->withHeader('X-Vault-Token', $vaultToken)
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Accept', 'application/json')
+            ->withBody($this->streamFactory->createStream($body));
+
+        // Best effort: our copy is zeroed immediately. The PSR-7 request keeps
+        // its own immutable copy of the header value until it is collected —
+        // there is no PSR-7 API to scrub that.
+        $this->wipeTokenCopy($vaultToken, $config);
+
+        try {
+            $response = $this->httpClient->sendRequest($request);
+        } catch (ClientExceptionInterface $e) {
+            throw MasterKeyException::transitTransportFailure(
+                $operation,
+                $this->redactTokens($e->getMessage()) . \sprintf(' (caused by %s)', $e::class),
+            );
+        }
+
+        return $this->decodeTransitData($response, $operation);
+    }
+
+    /**
+     * @throws MasterKeyException
+     *
+     * @return array<array-key, mixed> the Vault response `data` object; callers
+     *                                 read individual fields and type-check them
+     */
+    private function decodeTransitData(ResponseInterface $response, string $operation): array
+    {
+        $status = $response->getStatusCode();
+        if ($status < 200 || $status >= 300) {
+            // The body is NOT surfaced: Vault echoes the submitted ciphertext on
+            // some error paths, and error text may carry cluster internals.
+            throw MasterKeyException::transitRequestRejected($operation, $status);
+        }
+
+        try {
+            /** @var mixed $decoded */
+            $decoded = json_decode((string) $response->getBody(), true, 32, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw MasterKeyException::transitMalformedResponse($operation, 'response body is not valid JSON');
+        }
+
+        if (!\is_array($decoded)) {
+            throw MasterKeyException::transitMalformedResponse($operation, 'response body is not a JSON object');
+        }
+
+        $data = $decoded['data'] ?? null;
+        if (!\is_array($data)) {
+            throw MasterKeyException::transitMalformedResponse($operation, 'response has no "data" object');
+        }
+
+        return $data;
+    }
+
+    /**
+     * Vault token, environment variable first.
+     *
+     * The env var is preferred over `hashicorp.token` so production deployments
+     * keep the credential out of the extension configuration (which is readable
+     * in the Install Tool and dumped into configuration exports).
+     *
+     * Returns null instead of throwing so `isAvailable()` can probe without
+     * producing an exception. Callers own the returned copy and should
+     * `sodium_memzero()` it.
+     */
+    private function findToken(TransitConfig $config): ?string
+    {
+        $fromEnv = getenv($config->tokenEnvVar);
+        if (\is_string($fromEnv) && $fromEnv !== '') {
+            return $fromEnv;
+        }
+
+        return $config->token !== '' ? $config->token : null;
+    }
+
+    /**
+     * Zero a token copy — but only one we actually own.
+     *
+     * A token that came from `hashicorp.token` shares its string buffer with the
+     * ExtensionConfiguration singleton (PHP copy-on-write), and
+     * `sodium_memzero()` wipes the buffer in place: zeroing it would NUL out the
+     * stored configuration, so every later lookup in the same request would send
+     * a token of NUL bytes and Vault would answer 403. Env-derived tokens are
+     * freshly allocated by `getenv()` and are safe to wipe.
+     *
+     * hash_equals() keeps the comparison constant-time, per the repo-wide rule
+     * for touching secret values.
+     *
+     * The parameter is nullable because `sodium_memzero()` nulls the variable it
+     * wipes; callers must not read $vaultToken afterwards.
+     */
+    private function wipeTokenCopy(?string &$vaultToken, TransitConfig $config): void
+    {
+        if ($vaultToken === null) {
+            return;
+        }
+
+        if (!hash_equals($config->token, $vaultToken)) {
+            sodium_memzero($vaultToken);
+        }
+    }
+
+    /**
+     * @throws MasterKeyException
+     */
+    private function readWrappedKey(string $path): string
+    {
+        if (!file_exists($path)) {
+            throw MasterKeyException::notFound($path);
+        }
+        if (!is_readable($path)) {
+            throw MasterKeyException::notFound($path . ' (not readable)');
+        }
+
+        $raw = file_get_contents($path);
+        if ($raw === false) {
+            throw MasterKeyException::notFound($path);
+        }
+
+        $wrapped = trim($raw);
+        if (!str_starts_with($wrapped, 'vault:')) {
+            throw MasterKeyException::transitNotConfigured(\sprintf(
+                'the file at %s does not contain a Vault Transit ciphertext (expected a "vault:v…" prefix)',
+                $path,
+            ));
+        }
+
+        return $wrapped;
+    }
+
+    /**
+     * Persist the wrapped key atomically with 0600 permissions.
+     *
+     * Same umask-race defence as FileMasterKeyProvider::storeMasterKey (tighten
+     * umask so the file is never briefly world-readable), plus a
+     * write-to-temp + rename so a crash mid-write cannot leave a truncated
+     * blob — a truncated wrapped key is an unrecoverable vault, not just a
+     * failed write. 0600 rather than 0400 because rotation must be able to
+     * overwrite it.
+     *
+     * @throws MasterKeyException
+     */
+    private function writeWrappedKey(string $path, string $ciphertext): void
+    {
+        $dir = \dirname($path);
+        if (!is_dir($dir) && (!mkdir($dir, 0o700, true) && !is_dir($dir))) {
+            throw MasterKeyException::cannotStore("Cannot create directory: {$dir}");
+        }
+
+        $temporaryPath = $path . '.' . bin2hex(random_bytes(6)) . '.tmp';
+        $previousUmask = umask(0o077);
+
+        try {
+            if (file_put_contents($temporaryPath, $ciphertext) === false) {
+                throw MasterKeyException::cannotStore("Cannot write to: {$temporaryPath}");
+            }
+
+            chmod($temporaryPath, 0o600);
+
+            if (!rename($temporaryPath, $path)) {
+                throw MasterKeyException::cannotStore("Cannot move wrapped key into place: {$path}");
+            }
+        } catch (MasterKeyException $e) {
+            if (file_exists($temporaryPath)) {
+                unlink($temporaryPath);
+            }
+
+            throw $e;
+        } finally {
+            umask($previousUmask);
+        }
+
+        chmod($path, 0o600);
+    }
+
+    /**
+     * Strip anything token-shaped from a transport error message before it
+     * reaches an exception or log line.
+     *
+     * Guzzle's `RequestException::getMessage()` normally carries method, URL and
+     * response excerpt — not request headers — but verbose formatting and
+     * middleware can surface the `X-Vault-Token` header, so redact defensively.
+     * All patterns are delimiter-anchored character classes (no `.*?`, no
+     * nested quantifiers) and therefore linear.
+     */
+    private function redactTokens(string $message): string
+    {
+        return (string) preg_replace(
+            [
+                '/(X-Vault-Token:\s*)\S+/i',
+                // Vault service/batch/recovery tokens and the legacy `s.` form.
+                '/\bhv[sbr]\.[A-Za-z0-9._-]+/',
+                '/\bs\.[A-Za-z0-9]{20,}/',
+            ],
+            ['$1[REDACTED]', '[REDACTED]', '[REDACTED]'],
+            $message,
+        );
+    }
+}

--- a/Classes/Exception/MasterKeyException.php
+++ b/Classes/Exception/MasterKeyException.php
@@ -45,4 +45,108 @@ final class MasterKeyException extends VaultException
             1703800011,
         );
     }
+
+    /**
+     * Transit provider: server configuration is incomplete.
+     */
+    public static function transitNotConfigured(string $detail): self
+    {
+        return new self(
+            \sprintf('HashiCorp Vault Transit provider is not configured: %s', $detail),
+            1754100001,
+        );
+    }
+
+    /**
+     * Transit provider: no Vault token available.
+     *
+     * Reports only WHERE the token was looked for, never any value.
+     */
+    public static function transitTokenMissing(string $envVarName): self
+    {
+        return new self(
+            \sprintf(
+                'No Vault token available for the Transit provider. Set the "%s" environment '
+                . 'variable (preferred) or the hashicorp.token extension setting. Token value: [REDACTED]',
+                $envVarName,
+            ),
+            1754100002,
+        );
+    }
+
+    /**
+     * Transit provider: an auth method other than `token` was configured.
+     */
+    public static function transitUnsupportedAuthMethod(string $authMethod): self
+    {
+        return new self(
+            \sprintf(
+                'Vault auth method "%s" is not supported by the Transit master-key provider. '
+                . 'Only "token" is implemented; use hashicorp.authMethod = token and provide the '
+                . 'token via environment variable.',
+                $authMethod,
+            ),
+            1754100003,
+        );
+    }
+
+    /**
+     * Transit provider: Vault answered with a non-2xx status.
+     *
+     * The response body is deliberately NOT included — it echoes the submitted
+     * ciphertext on some error paths and may carry Vault internals.
+     */
+    public static function transitRequestRejected(string $operation, int $statusCode): self
+    {
+        return new self(
+            \sprintf(
+                'Vault Transit %s failed with HTTP %d (response body suppressed). '
+                . 'Check the token policy grants %s on the configured transit key.',
+                $operation,
+                $statusCode,
+                $operation,
+            ),
+            1754100004,
+        );
+    }
+
+    /**
+     * Transit provider: transport-level failure (DNS, TLS, timeout).
+     *
+     * Callers must pass an already-redacted reason.
+     */
+    public static function transitTransportFailure(string $operation, string $redactedReason): self
+    {
+        return new self(
+            \sprintf('Vault Transit %s request could not be sent: %s', $operation, $redactedReason),
+            1754100005,
+        );
+    }
+
+    /**
+     * Transit provider: response was 2xx but not the expected shape.
+     */
+    public static function transitMalformedResponse(string $operation, string $detail): self
+    {
+        return new self(
+            \sprintf('Vault Transit %s returned an unusable response: %s', $operation, $detail),
+            1754100006,
+        );
+    }
+
+    /**
+     * Transit provider: mount path or key name contains characters that must
+     * never reach a Vault API URL.
+     */
+    public static function transitInvalidKeyReference(string $field): self
+    {
+        return new self(
+            \sprintf(
+                'HashiCorp Vault Transit %s contains characters that are not allowed in a Vault '
+                . 'API path. Allowed: letters, digits, dot, dash, underscore (and "/" for the mount).',
+                $field,
+            ),
+            1754100007,
+        );
+    }
 }

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -61,7 +61,7 @@ Configure nr-vault in :guilabel:`Admin Tools > Settings > Extension Configuratio
    :name: ext-nrvault-masterKeyProvider
    :type: string
    :Default: typo3
-   :Options: typo3, file, env
+   :Options: typo3, file, env, transit
 
    How to retrieve the master encryption key.
 
@@ -75,6 +75,11 @@ Configure nr-vault in :guilabel:`Admin Tools > Settings > Extension Configuratio
    env
       Read from an environment variable.
 
+   transit
+      Unwrap through HashiCorp Vault's transit secrets engine. Only the
+      Vault-encrypted ciphertext is stored locally — see
+      :ref:`configuration-master-key-transit`.
+
 .. confval:: masterKeySource
    :name: ext-nrvault-masterKeySource
    :type: string
@@ -85,6 +90,66 @@ Configure nr-vault in :guilabel:`Admin Tools > Settings > Extension Configuratio
    -  **file**: Path to the key file (e.g., :file:`/secure/path/vault.key`).
    -  **env**: Environment variable name (e.g., :samp:`NR_VAULT_MASTER_KEY`).
    -  **typo3**: Not used (key derived from TYPO3's encryption key).
+   -  **transit**: Not used (configured via the ``hashicorp.*`` settings below).
+
+.. confval:: hashicorp.address
+   :name: ext-nrvault-hashicorp-address
+   :type: string
+   :Default: (empty)
+
+   Vault server base address, e.g. :samp:`https://vault.example.com:8200`.
+   Required by the ``transit`` master key provider.
+
+.. confval:: hashicorp.authMethod
+   :name: ext-nrvault-hashicorp-authMethod
+   :type: string
+   :Default: token
+   :Options: token, kubernetes, approle
+
+   Vault authentication method. The ``transit`` master key provider implements
+   ``token`` only and refuses to start on the other values rather than silently
+   downgrading. See :ref:`configuration-master-key-transit`.
+
+.. confval:: hashicorp.tokenEnvVar
+   :name: ext-nrvault-hashicorp-tokenEnvVar
+   :type: string
+   :Default: VAULT_TOKEN
+
+   Name of the environment variable holding the Vault token. Read in preference
+   to :confval:`hashicorp.token <ext-nrvault-hashicorp-token>`.
+
+.. confval:: hashicorp.token
+   :name: ext-nrvault-hashicorp-token
+   :type: string
+   :Default: (empty)
+
+   Vault token stored in the extension configuration. Development fallback only
+   — a token stored here is readable in the Install Tool and ends up in
+   configuration exports. Prefer the environment variable.
+
+.. confval:: hashicorp.transitMount
+   :name: ext-nrvault-hashicorp-transitMount
+   :type: string
+   :Default: transit
+
+   Mount path of the transit secrets engine, without the ``/v1/`` prefix.
+   Nested mounts such as :samp:`platform/transit` are supported.
+
+.. confval:: hashicorp.transitKeyName
+   :name: ext-nrvault-hashicorp-transitKeyName
+   :type: string
+   :Default: nr-vault-master
+
+   Name of the transit key that wraps the vault master key.
+
+.. confval:: hashicorp.transitWrappedKeyPath
+   :name: ext-nrvault-hashicorp-transitWrappedKeyPath
+   :type: string
+   :Default: (empty)
+
+   File holding the Vault-wrapped master key. Empty resolves to
+   :file:`<var-path>/secrets/vault-master.key.transit`. The file contains
+   ciphertext only, never key material.
 
 .. confval:: allowCliAccess
    :name: ext-nrvault-allowCliAccess
@@ -295,6 +360,109 @@ Configure in extension settings:
 
 This is ideal for containerized deployments where secrets are injected
 via environment variables.
+
+.. _configuration-master-key-transit:
+
+HashiCorp Vault Transit provider
+--------------------------------
+
+The master key is generated once, wrapped by Vault's transit secrets engine,
+and only the resulting ciphertext (:samp:`vault:v1:…`) is stored on the local
+filesystem. Every start-up unwraps it through a Vault API call, so no key
+material sits at rest next to the database.
+
+Set up the transit engine and a key:
+
+.. code-block:: bash
+   :caption: Enable transit and create the wrapping key
+
+   vault secrets enable transit
+   vault write -f transit/keys/nr-vault-master
+
+Grant the TYPO3 instance encrypt and decrypt on that one key — nothing else:
+
+.. code-block:: text
+   :caption: Vault policy nr-vault-transit.hcl (HCL)
+
+   path "transit/encrypt/nr-vault-master" {
+     capabilities = ["update"]
+   }
+
+   path "transit/decrypt/nr-vault-master" {
+     capabilities = ["update"]
+   }
+
+.. code-block:: bash
+   :caption: Apply the policy and issue a token
+
+   vault policy write nr-vault-transit nr-vault-transit.hcl
+   vault token create -policy=nr-vault-transit -period=768h
+
+Provide the token through the environment, never in the extension
+configuration:
+
+.. code-block:: bash
+   :caption: Vault token via environment
+
+   export VAULT_TOKEN="hvs...."
+
+Configure in extension settings:
+
+-  :confval:`masterKeyProvider <ext-nrvault-masterKeyProvider>`: transit
+-  :confval:`hashicorp.address <ext-nrvault-hashicorp-address>`: https://vault.example.com:8200
+-  :confval:`hashicorp.authMethod <ext-nrvault-hashicorp-authMethod>`: token
+-  :confval:`hashicorp.tokenEnvVar <ext-nrvault-hashicorp-tokenEnvVar>`: VAULT_TOKEN
+-  :confval:`hashicorp.transitMount <ext-nrvault-hashicorp-transitMount>`: transit
+-  :confval:`hashicorp.transitKeyName <ext-nrvault-hashicorp-transitKeyName>`: nr-vault-master
+
+Then create and wrap the master key:
+
+.. code-block:: bash
+   :caption: Initialize the vault with a Vault-wrapped master key
+
+   vendor/bin/typo3 vault:init
+
+The wrapped key is written to
+:confval:`hashicorp.transitWrappedKeyPath <ext-nrvault-hashicorp-transitWrappedKeyPath>`
+with ``0600`` permissions. Back that file up together with the Vault key: the
+blob is worthless without Vault, and Vault is worthless without the blob.
+
+Rotating the transit key (:samp:`vault write -f transit/keys/nr-vault-master/rotate`)
+re-wraps future ciphertexts without touching any secret in the TYPO3 database.
+Rotating the vault master key itself is unchanged — the new key is wrapped
+through Vault and the local blob replaced:
+
+.. code-block:: bash
+   :caption: Rotate the vault master key
+
+   vendor/bin/typo3 vault:rotate-master-key
+
+.. note::
+
+   Only ``token`` authentication is implemented. ``approle`` and ``kubernetes``
+   are rejected with a clear error instead of being treated as token auth;
+   AppRole login support is a planned follow-up.
+
+.. warning::
+
+   What Transit does and does not protect.
+
+   It protects **key custody**: the master key can be rotated, centrally
+   audited and revoked in Vault, a stolen database plus a stolen webroot is
+   useless without Vault access, and there is no key file on disk to
+   exfiltrate.
+
+   It does **not** protect against a fully compromised PHP process. Such a
+   process holds the same Vault token the extension holds and can simply call
+   ``decrypt`` itself. Transit raises the cost of offline attacks and makes
+   access observable — it is not a sandbox around a live intruder.
+
+.. note::
+
+   The provider talks to Vault through TYPO3's HTTP client, so
+   :php:`$GLOBALS['TYPO3_CONF_VARS']['HTTP']` settings (proxy, TLS verification,
+   timeouts) apply. Use an ``https`` address: the Vault token travels in the
+   ``X-Vault-Token`` request header.
 
 .. _configuration-access-control:
 

--- a/Documentation/Installation/Index.rst
+++ b/Documentation/Installation/Index.rst
@@ -144,6 +144,16 @@ Configure the extension:
    For file and environment providers: never commit master keys to version
    control. Store them securely outside the web root.
 
+.. _installation-master-key-transit:
+
+Option 4: HashiCorp Vault Transit
+---------------------------------
+
+Where a Vault deployment already exists, the master key can be kept wrapped by
+Vault's transit engine so only ciphertext is stored locally, and custody,
+rotation and audit move into Vault. Setup (transit engine, policy, token) is
+described in :ref:`configuration-master-key-transit`.
+
 See :ref:`configuration-master-key-providers` for detailed information on each provider.
 
 .. _installation-verify:

--- a/Tests/Functional/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Functional/Configuration/ExtensionConfigurationTest.php
@@ -28,16 +28,52 @@ final class ExtensionConfigurationTest extends FunctionalTestCase
     #[Test]
     public function getAutoKeyPathReturnsPathBasedOnVarPath(): void
     {
-        $typo3Config = $this->createMock(Typo3ExtensionConfiguration::class);
-        $typo3Config->method('get')
-            ->with('nr_vault')
-            ->willReturn([]);
-
-        $config = new ExtensionConfiguration($typo3Config);
+        $config = new ExtensionConfiguration($this->createConfigurationReturning([]));
 
         $path = $config->getAutoKeyPath();
 
         self::assertStringContainsString('secrets/vault-master.key', $path);
         self::assertStringStartsWith(Environment::getVarPath(), $path);
+    }
+
+    #[Test]
+    public function getTransitConfigDefaultsTheWrappedKeyPathToTheVarPath(): void
+    {
+        // The default resolves through Environment, which is only initialized in
+        // the functional suite; the unit test asserts it stays lazy.
+        $config = new ExtensionConfiguration(
+            $this->createConfigurationReturning(['hashicorp' => ['address' => 'https://vault.example.com:8200']]),
+        );
+
+        $transitConfig = $config->getTransitConfig();
+
+        self::assertSame($config->getAutoKeyPath() . '.transit', $transitConfig->wrappedKeyPath);
+        self::assertStringContainsString(Environment::getVarPath(), $transitConfig->wrappedKeyPath);
+        self::assertTrue($transitConfig->isComplete());
+    }
+
+    #[Test]
+    public function getTransitConfigToleratesANonArrayHashicorpSetting(): void
+    {
+        $config = new ExtensionConfiguration($this->createConfigurationReturning(['hashicorp' => 'not-an-array']));
+
+        $transitConfig = $config->getTransitConfig();
+
+        self::assertSame('', $transitConfig->address);
+        self::assertSame('transit', $transitConfig->mount);
+        self::assertFalse($transitConfig->isComplete());
+    }
+
+    /**
+     * @param array<string, mixed> $configuration
+     */
+    private function createConfigurationReturning(array $configuration): Typo3ExtensionConfiguration
+    {
+        $typo3Config = $this->createMock(Typo3ExtensionConfiguration::class);
+        $typo3Config->method('get')
+            ->with('nr_vault')
+            ->willReturn($configuration);
+
+        return $typo3Config;
     }
 }

--- a/Tests/Functional/Crypto/MasterKeyProviderFactoryWiringTest.php
+++ b/Tests/Functional/Crypto/MasterKeyProviderFactoryWiringTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Crypto;
+
+use Netresearch\NrVault\Crypto\MasterKeyProviderFactory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use ReflectionProperty;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * The transit provider's HTTP stack must come from the DI container, not from
+ * the constructor fallbacks: only the platform client honours the
+ * `$TYPO3_CONF_VARS['HTTP']` proxy / TLS / timeout settings the documentation
+ * promises. The fallbacks exist for TYPO3 versions that do not alias the PSR-17
+ * factories, so a silent fallback here would go unnoticed without this test.
+ */
+#[CoversClass(MasterKeyProviderFactory::class)]
+final class MasterKeyProviderFactoryWiringTest extends FunctionalTestCase
+{
+    protected array $testExtensionsToLoad = [
+        'netresearch/nr-vault',
+    ];
+
+    #[Test]
+    public function factoryReceivesThePlatformHttpClientFromTheContainer(): void
+    {
+        $factory = $this->get(MasterKeyProviderFactory::class);
+        self::assertInstanceOf(MasterKeyProviderFactory::class, $factory);
+
+        self::assertSame(
+            $this->get(ClientInterface::class),
+            (new ReflectionProperty($factory, 'httpClient'))->getValue($factory),
+        );
+    }
+
+    #[Test]
+    public function factoryReceivesThePsr17FactoriesFromTheContainer(): void
+    {
+        $factory = $this->get(MasterKeyProviderFactory::class);
+        self::assertInstanceOf(MasterKeyProviderFactory::class, $factory);
+
+        self::assertSame(
+            $this->get(RequestFactoryInterface::class),
+            (new ReflectionProperty($factory, 'requestFactory'))->getValue($factory),
+        );
+        self::assertSame(
+            $this->get(StreamFactoryInterface::class),
+            (new ReflectionProperty($factory, 'streamFactory'))->getValue($factory),
+        );
+    }
+}

--- a/Tests/Unit/Configuration/Dto/TransitConfigTest.php
+++ b/Tests/Unit/Configuration/Dto/TransitConfigTest.php
@@ -1,0 +1,165 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Configuration\Dto;
+
+use Netresearch\NrVault\Configuration\Dto\TransitConfig;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(TransitConfig::class)]
+final class TransitConfigTest extends TestCase
+{
+    private const ADDRESS = 'https://vault.example.com:8200';
+
+    private const FALLBACK_PATH = '/var/www/var/secrets/vault-master.key.transit';
+
+    #[Test]
+    public function constructorAppliesTransitDefaults(): void
+    {
+        $subject = new TransitConfig();
+
+        self::assertSame('', $subject->address);
+        self::assertSame('transit', $subject->mount);
+        self::assertSame('nr-vault-master', $subject->keyName);
+        self::assertSame('', $subject->wrappedKeyPath);
+        self::assertSame('token', $subject->authMethod);
+        self::assertSame('VAULT_TOKEN', $subject->tokenEnvVar);
+        self::assertSame('', $subject->token);
+    }
+
+    #[Test]
+    public function fromArrayReadsTheHashicorpGroup(): void
+    {
+        $subject = TransitConfig::fromArray([
+            'address' => self::ADDRESS,
+            'authMethod' => 'token',
+            'token' => 'unit-test-dev-token',
+            'transitMount' => 'platform/transit',
+            'transitKeyName' => 'master-key',
+            'transitWrappedKeyPath' => '/secure/wrapped.key',
+            'tokenEnvVar' => 'MY_VAULT_TOKEN',
+        ]);
+
+        self::assertSame(self::ADDRESS, $subject->address);
+        self::assertSame('platform/transit', $subject->mount);
+        self::assertSame('master-key', $subject->keyName);
+        self::assertSame('/secure/wrapped.key', $subject->wrappedKeyPath);
+        self::assertSame('MY_VAULT_TOKEN', $subject->tokenEnvVar);
+        self::assertSame('unit-test-dev-token', $subject->token);
+    }
+
+    #[Test]
+    public function fromArrayFallsBackToDefaultsForEmptyValues(): void
+    {
+        $subject = TransitConfig::fromArray([
+            'address' => self::ADDRESS,
+            'transitMount' => '',
+            'transitKeyName' => '',
+            'transitWrappedKeyPath' => '',
+            'tokenEnvVar' => '',
+            'authMethod' => '',
+        ], self::FALLBACK_PATH);
+
+        self::assertSame('transit', $subject->mount);
+        self::assertSame('nr-vault-master', $subject->keyName);
+        self::assertSame(self::FALLBACK_PATH, $subject->wrappedKeyPath);
+        self::assertSame('VAULT_TOKEN', $subject->tokenEnvVar);
+        self::assertSame('token', $subject->authMethod);
+    }
+
+    #[Test]
+    public function fromArrayNormalisesAddressAndMountSeparators(): void
+    {
+        $subject = TransitConfig::fromArray([
+            'address' => ' https://vault.example.com:8200/ ',
+            'transitMount' => '/transit/',
+        ]);
+
+        self::assertSame(self::ADDRESS, $subject->address);
+        self::assertSame('transit', $subject->mount);
+    }
+
+    #[Test]
+    public function fromArrayOnEmptyConfigurationYieldsIncompleteConfig(): void
+    {
+        self::assertFalse(TransitConfig::fromArray([])->isComplete());
+    }
+
+    #[Test]
+    public function isCompleteRequiresAddressAndWrappedKeyPath(): void
+    {
+        self::assertTrue($this->config(address: self::ADDRESS, wrappedKeyPath: '/tmp/w.key')->isComplete());
+        self::assertFalse($this->config(address: '', wrappedKeyPath: '/tmp/w.key')->isComplete());
+        self::assertFalse($this->config(address: self::ADDRESS, wrappedKeyPath: '')->isComplete());
+    }
+
+    #[Test]
+    #[DataProvider('authMethodProvider')]
+    public function usesTokenAuthOnlyAcceptsToken(string $authMethod, bool $expected): void
+    {
+        self::assertSame($expected, $this->config(authMethod: $authMethod)->usesTokenAuth());
+    }
+
+    /**
+     * @return iterable<string, array{0: string, 1: bool}>
+     */
+    public static function authMethodProvider(): iterable
+    {
+        yield 'token' => ['token', true];
+        yield 'approle' => ['approle', false];
+        yield 'kubernetes' => ['kubernetes', false];
+        yield 'empty' => ['', false];
+    }
+
+    #[Test]
+    public function endpointForBuildsTheVaultApiUrl(): void
+    {
+        $subject = $this->config(address: self::ADDRESS);
+
+        self::assertSame(
+            self::ADDRESS . '/v1/transit/encrypt/nr-vault-master',
+            $subject->endpointFor('encrypt'),
+        );
+        self::assertSame(
+            self::ADDRESS . '/v1/transit/decrypt/nr-vault-master',
+            $subject->endpointFor('decrypt'),
+        );
+    }
+
+    #[Test]
+    public function toArrayOmitsTheToken(): void
+    {
+        $subject = $this->config(address: self::ADDRESS, token: 'unit-test-hidden-token');
+
+        $array = $subject->toArray();
+
+        self::assertArrayNotHasKey('token', $array);
+        self::assertStringNotContainsString(
+            'unit-test-hidden-token',
+            json_encode($array, JSON_THROW_ON_ERROR),
+        );
+    }
+
+    private function config(
+        string $address = self::ADDRESS,
+        string $wrappedKeyPath = '/tmp/wrapped.key',
+        string $authMethod = 'token',
+        string $token = '',
+    ): TransitConfig {
+        return new TransitConfig(
+            address: $address,
+            wrappedKeyPath: $wrappedKeyPath,
+            authMethod: $authMethod,
+            token: $token,
+        );
+    }
+}

--- a/Tests/Unit/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/Configuration/ExtensionConfigurationTest.php
@@ -388,6 +388,57 @@ final class ExtensionConfigurationTest extends TestCase
     }
 
     #[Test]
+    public function getTransitConfigReadsTheTransitSettingsFromTheHashicorpGroup(): void
+    {
+        $this->typo3Config->method('get')
+            ->willReturn(['hashicorp' => [
+                'address' => 'https://vault.example.com:8200',
+                'authMethod' => 'token',
+                'transitMount' => 'platform/transit',
+                'transitKeyName' => 'master-key',
+                'transitWrappedKeyPath' => '/secure/wrapped.key',
+                'tokenEnvVar' => 'MY_VAULT_TOKEN',
+            ]]);
+
+        $result = (new ExtensionConfiguration($this->typo3Config))->getTransitConfig();
+
+        self::assertSame('https://vault.example.com:8200', $result->address);
+        self::assertSame('platform/transit', $result->mount);
+        self::assertSame('master-key', $result->keyName);
+        self::assertSame('/secure/wrapped.key', $result->wrappedKeyPath);
+        self::assertSame('MY_VAULT_TOKEN', $result->tokenEnvVar);
+        self::assertTrue($result->isComplete());
+    }
+
+    #[Test]
+    public function getTransitConfigReadsTheTransitSettingsAndKeepsTheVarPathLazy(): void
+    {
+        // Environment is not initialized in the unit suite, so a configured path
+        // must be enough — this also proves the var-path fallback stays lazy. The
+        // fallback itself is covered by the functional counterpart of this test.
+        $this->typo3Config->method('get')->willReturn(['hashicorp' => [
+            'transitWrappedKeyPath' => '/secure/wrapped.key',
+        ]]);
+
+        $result = (new ExtensionConfiguration($this->typo3Config))->getTransitConfig();
+
+        self::assertSame('/secure/wrapped.key', $result->wrappedKeyPath);
+    }
+
+    #[Test]
+    public function getTransitConfigIsIncompleteWithoutAnAddress(): void
+    {
+        $this->typo3Config->method('get')->willReturn(['hashicorp' => [
+            'transitWrappedKeyPath' => '/secure/wrapped.key',
+        ]]);
+
+        $result = (new ExtensionConfiguration($this->typo3Config))->getTransitConfig();
+
+        self::assertSame('', $result->address);
+        self::assertFalse($result->isComplete());
+    }
+
+    #[Test]
     public function getAwsConfigReturnsEmptyConfigByDefault(): void
     {
         $this->typo3Config->method('get')

--- a/Tests/Unit/Crypto/MasterKeyProviderFactoryTest.php
+++ b/Tests/Unit/Crypto/MasterKeyProviderFactoryTest.php
@@ -9,12 +9,15 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Crypto;
 
+use GuzzleHttp\Psr7\HttpFactory;
+use Netresearch\NrVault\Configuration\Dto\TransitConfig;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Configuration\SecurityProfile;
 use Netresearch\NrVault\Crypto\EnvironmentMasterKeyProvider;
 use Netresearch\NrVault\Crypto\FileMasterKeyProvider;
 use Netresearch\NrVault\Crypto\MasterKeyProviderFactory;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
+use Netresearch\NrVault\Crypto\TransitMasterKeyProvider;
 use Netresearch\NrVault\Crypto\Typo3MasterKeyProvider;
 use Netresearch\NrVault\Exception\ConfigurationException;
 use Netresearch\NrVault\Tests\Unit\TestCase;
@@ -22,6 +25,7 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Client\ClientInterface;
 
 #[CoversClass(MasterKeyProviderFactory::class)]
 #[AllowMockObjectsWithoutExpectations]
@@ -76,6 +80,50 @@ final class MasterKeyProviderFactoryTest extends TestCase
         $result = $this->subject->create();
 
         self::assertInstanceOf(Typo3MasterKeyProvider::class, $result);
+    }
+
+    #[Test]
+    public function createReturnsTransitMasterKeyProviderForTransitType(): void
+    {
+        $this->configuration
+            ->method('getMasterKeyProvider')
+            ->willReturn('transit');
+
+        $result = $this->subject->create();
+
+        self::assertInstanceOf(TransitMasterKeyProvider::class, $result);
+    }
+
+    #[Test]
+    public function createAllowsTransitProviderInHardenedProfile(): void
+    {
+        // Transit is external-KMS key custody — exactly what the hardened
+        // profile asks for, so it must NOT be rejected like the typo3 provider.
+        $factory = $this->createHardenedFactory('transit');
+
+        self::assertInstanceOf(TransitMasterKeyProvider::class, $factory->create());
+    }
+
+    #[Test]
+    public function createPassesTheInjectedHttpStackToTheTransitProvider(): void
+    {
+        $this->configuration
+            ->method('getMasterKeyProvider')
+            ->willReturn('transit');
+        $this->configuration
+            ->method('getTransitConfig')
+            ->willReturn(new TransitConfig(address: 'https://vault.example.com', wrappedKeyPath: '/nonexistent/wrapped.key'));
+
+        $httpFactory = new HttpFactory();
+        // Never dispatched: provider construction alone must not touch the network.
+        $client = $this->createMock(ClientInterface::class);
+        $client->expects(self::never())->method('sendRequest');
+
+        $factory = new MasterKeyProviderFactory($this->configuration, $client, $httpFactory, $httpFactory);
+        $provider = $factory->create();
+
+        self::assertInstanceOf(TransitMasterKeyProvider::class, $provider);
+        self::assertFalse($provider->isAvailable());
     }
 
     #[Test]

--- a/Tests/Unit/Crypto/TransitMasterKeyProviderTest.php
+++ b/Tests/Unit/Crypto/TransitMasterKeyProviderTest.php
@@ -1,0 +1,537 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Crypto;
+
+use GuzzleHttp\Psr7\HttpFactory;
+use GuzzleHttp\Psr7\Response;
+use Netresearch\NrVault\Configuration\Dto\TransitConfig;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Crypto\TransitMasterKeyProvider;
+use Netresearch\NrVault\Exception\MasterKeyException;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamContent;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+
+#[CoversClass(TransitMasterKeyProvider::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class TransitMasterKeyProviderTest extends TestCase
+{
+    private const ADDRESS = 'https://vault.example.com:8200';
+
+    private const TOKEN_ENV_VAR = 'NR_VAULT_TEST_TRANSIT_TOKEN';
+
+    private const WRAPPED_CIPHERTEXT = 'vault:v1:dGVzdC1jaXBoZXJ0ZXh0LXBheWxvYWQ=';
+
+    private const TOKEN = 'unit-test-vault-token';
+
+    private vfsStreamDirectory $root;
+
+    private ?RequestInterface $lastRequest = null;
+
+    private int $requestCount = 0;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        TransitMasterKeyProvider::clearCachedKey();
+        $this->root = vfsStream::setup('transit');
+        $this->lastRequest = null;
+        $this->requestCount = 0;
+        putenv(self::TOKEN_ENV_VAR . '=' . self::TOKEN);
+    }
+
+    protected function tearDown(): void
+    {
+        TransitMasterKeyProvider::clearCachedKey();
+        putenv(self::TOKEN_ENV_VAR);
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function getIdentifierReturnsTransit(): void
+    {
+        $provider = $this->createProvider($this->createMock(ClientInterface::class));
+
+        self::assertSame('transit', $provider->getIdentifier());
+    }
+
+    #[Test]
+    public function getMasterKeyUnwrapsCiphertextIntoRawKey(): void
+    {
+        $key = random_bytes(32);
+        $this->writeWrappedKeyFile();
+
+        $client = $this->clientReturning($this->transitResponse(['plaintext' => base64_encode($key)]));
+
+        $provider = $this->createProvider($client);
+
+        self::assertSame($key, $provider->getMasterKey());
+
+        $request = $this->assertSingleRequest();
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame(
+            self::ADDRESS . '/v1/transit/decrypt/nr-vault-master',
+            (string) $request->getUri(),
+        );
+        self::assertSame(self::TOKEN, $request->getHeaderLine('X-Vault-Token'));
+        self::assertSame(
+            ['ciphertext' => self::WRAPPED_CIPHERTEXT],
+            json_decode((string) $request->getBody(), true, 8, JSON_THROW_ON_ERROR),
+        );
+    }
+
+    #[Test]
+    public function getMasterKeyThrowsWhenPlaintextHasWrongLength(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        $provider = $this->createProvider(
+            $this->clientReturning($this->transitResponse(['plaintext' => base64_encode('too-short')])),
+        );
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionCode(1703800009);
+        $this->expectExceptionMessage('Invalid master key length');
+
+        $provider->getMasterKey();
+    }
+
+    #[Test]
+    public function getMasterKeyThrowsWhenPlaintextIsNotBase64(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        $provider = $this->createProvider(
+            $this->clientReturning($this->transitResponse(['plaintext' => 'not!valid!base64!'])),
+        );
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionCode(1754100006);
+
+        $provider->getMasterKey();
+    }
+
+    #[Test]
+    public function getMasterKeyThrowsWhenResponseHasNoDataObject(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        $provider = $this->createProvider(
+            $this->clientReturning(new Response(200, [], '{"errors":[]}')),
+        );
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionCode(1754100006);
+
+        $provider->getMasterKey();
+    }
+
+    #[Test]
+    public function getMasterKeyOnForbiddenReportsStatusWithoutLeakingTokenOrCiphertext(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        // Vault echoes the submitted ciphertext on some error paths — the body
+        // must never reach the exception message.
+        $body = json_encode([
+            'errors' => ['permission denied for ' . self::WRAPPED_CIPHERTEXT . ' with token ' . self::TOKEN],
+        ], JSON_THROW_ON_ERROR);
+
+        $provider = $this->createProvider($this->clientReturning(new Response(403, [], $body)));
+
+        try {
+            $provider->getMasterKey();
+            self::fail('Expected MasterKeyException was not thrown.');
+        } catch (MasterKeyException $e) {
+            self::assertSame(1754100004, $e->getCode());
+            self::assertStringContainsString('HTTP 403', $e->getMessage());
+            self::assertStringNotContainsString(self::TOKEN, $e->getMessage());
+            self::assertStringNotContainsString(self::WRAPPED_CIPHERTEXT, $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function getMasterKeyRedactsTokensFromTransportErrors(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        $client = $this->createMock(ClientInterface::class);
+        $client
+            ->method('sendRequest')
+            ->willThrowException(new class ('cURL error 7 with X-Vault-Token: ' . self::TOKEN) extends RuntimeException implements ClientExceptionInterface {});
+
+        $provider = $this->createProvider($client);
+
+        try {
+            $provider->getMasterKey();
+            self::fail('Expected MasterKeyException was not thrown.');
+        } catch (MasterKeyException $e) {
+            self::assertSame(1754100005, $e->getCode());
+            self::assertStringNotContainsString(self::TOKEN, $e->getMessage());
+            self::assertStringContainsString('[REDACTED]', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function isAvailableReturnsFalseWhenWrappedKeyFileIsMissing(): void
+    {
+        $provider = $this->createProvider($this->createMock(ClientInterface::class));
+
+        self::assertFalse($provider->isAvailable());
+    }
+
+    #[Test]
+    public function getMasterKeyThrowsWhenWrappedKeyFileIsMissing(): void
+    {
+        $provider = $this->createProvider($this->createMock(ClientInterface::class));
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionMessage('Master key not found');
+
+        $provider->getMasterKey();
+    }
+
+    #[Test]
+    public function isAvailableReturnsTrueWhenConfigurationAndWrappedKeyArePresent(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        $provider = $this->createProvider($this->createMock(ClientInterface::class));
+
+        self::assertTrue($provider->isAvailable());
+    }
+
+    #[Test]
+    public function isAvailableReturnsFalseWithoutToken(): void
+    {
+        $this->writeWrappedKeyFile();
+        putenv(self::TOKEN_ENV_VAR);
+
+        $provider = $this->createProvider($this->createMock(ClientInterface::class));
+
+        self::assertFalse($provider->isAvailable());
+    }
+
+    #[Test]
+    public function isAvailableReturnsFalseForUnsupportedAuthMethod(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        $provider = $this->createProvider(
+            $this->createMock(ClientInterface::class),
+            $this->transitConfig(authMethod: 'approle'),
+        );
+
+        self::assertFalse($provider->isAvailable());
+    }
+
+    #[Test]
+    public function getMasterKeyThrowsForUnsupportedAuthMethod(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        $provider = $this->createProvider(
+            $this->createMock(ClientInterface::class),
+            $this->transitConfig(authMethod: 'kubernetes'),
+        );
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionCode(1754100003);
+
+        $provider->getMasterKey();
+    }
+
+    #[Test]
+    public function getMasterKeyThrowsWhenTokenIsMissing(): void
+    {
+        $this->writeWrappedKeyFile();
+        putenv(self::TOKEN_ENV_VAR);
+
+        $provider = $this->createProvider($this->createMock(ClientInterface::class));
+
+        try {
+            $provider->getMasterKey();
+            self::fail('Expected MasterKeyException was not thrown.');
+        } catch (MasterKeyException $e) {
+            self::assertSame(1754100002, $e->getCode());
+            self::assertStringContainsString(self::TOKEN_ENV_VAR, $e->getMessage());
+            self::assertStringContainsString('[REDACTED]', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function getMasterKeyThrowsWhenMountPathIsUnsafe(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        $provider = $this->createProvider(
+            $this->createMock(ClientInterface::class),
+            $this->transitConfig(mount: '../../sys'),
+        );
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionCode(1754100007);
+
+        $provider->getMasterKey();
+    }
+
+    #[Test]
+    public function getMasterKeyThrowsWhenKeyNameIsATraversalSegment(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        // A dot is legal inside a key name, but "." / ".." are traversal
+        // segments and must never be interpolated into the Vault API path.
+        $provider = $this->createProvider(
+            $this->createMock(ClientInterface::class),
+            $this->transitConfig(keyName: '..'),
+        );
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionCode(1754100007);
+
+        $provider->getMasterKey();
+    }
+
+    #[Test]
+    public function getMasterKeyThrowsWhenLocalFileHoldsNoTransitCiphertext(): void
+    {
+        // A raw key file (file-provider format) must not be mistaken for a
+        // wrapped blob and shipped to Vault.
+        file_put_contents($this->wrappedKeyPath(), base64_encode(random_bytes(32)));
+
+        $provider = $this->createProvider($this->createMock(ClientInterface::class));
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionCode(1754100001);
+
+        $provider->getMasterKey();
+    }
+
+    #[Test]
+    public function storeMasterKeyPersistsOnlyTheCiphertext(): void
+    {
+        $key = random_bytes(32);
+
+        $client = $this->clientReturning($this->transitResponse(['ciphertext' => self::WRAPPED_CIPHERTEXT]));
+
+        $this->createProvider($client)->storeMasterKey($key);
+
+        $request = $this->assertSingleRequest();
+        self::assertSame(
+            self::ADDRESS . '/v1/transit/encrypt/nr-vault-master',
+            (string) $request->getUri(),
+        );
+        self::assertSame(
+            ['plaintext' => base64_encode($key)],
+            json_decode((string) $request->getBody(), true, 8, JSON_THROW_ON_ERROR),
+        );
+
+        $stored = (string) file_get_contents($this->wrappedKeyPath());
+        self::assertSame(self::WRAPPED_CIPHERTEXT, $stored);
+        self::assertStringNotContainsString($key, $stored);
+        self::assertStringNotContainsString(base64_encode($key), $stored);
+    }
+
+    #[Test]
+    public function storeMasterKeyWritesTheWrappedKeyWithOwnerOnlyPermissions(): void
+    {
+        $client = $this->clientReturning($this->transitResponse(['ciphertext' => self::WRAPPED_CIPHERTEXT]));
+
+        $this->createProvider($client)->storeMasterKey(random_bytes(32));
+
+        $file = $this->root->getChild('vault-master.key.transit');
+        self::assertNotNull($file);
+        self::assertSame(0o600, $file->getPermissions());
+    }
+
+    #[Test]
+    public function storeMasterKeyLeavesNoTemporaryFileBehind(): void
+    {
+        $client = $this->clientReturning($this->transitResponse(['ciphertext' => self::WRAPPED_CIPHERTEXT]));
+
+        $this->createProvider($client)->storeMasterKey(random_bytes(32));
+
+        // glob() cannot traverse stream wrappers — inspect the vfs tree directly.
+        $names = array_map(
+            static fn (vfsStreamContent $child): string => $child->getName(),
+            $this->root->getChildren(),
+        );
+
+        self::assertSame(['vault-master.key.transit'], $names);
+    }
+
+    #[Test]
+    public function storeMasterKeyThrowsWhenVaultReturnsNoCiphertext(): void
+    {
+        $client = $this->clientReturning($this->transitResponse(['plaintext' => 'unexpected']));
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionCode(1754100006);
+
+        $this->createProvider($client)->storeMasterKey(random_bytes(32));
+    }
+
+    #[Test]
+    public function storeMasterKeyRejectsKeyOfWrongLength(): void
+    {
+        $provider = $this->createProvider($this->createMock(ClientInterface::class));
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionCode(1703800009);
+
+        $provider->storeMasterKey('too-short');
+    }
+
+    #[Test]
+    public function generateMasterKeyReturns32Bytes(): void
+    {
+        $provider = $this->createProvider($this->createMock(ClientInterface::class));
+
+        self::assertSame(32, \strlen($provider->generateMasterKey()));
+    }
+
+    #[Test]
+    public function nestedMountPathIsInterpolatedIntoTheEndpoint(): void
+    {
+        $key = random_bytes(32);
+        $this->writeWrappedKeyFile();
+
+        $client = $this->clientReturning($this->transitResponse(['plaintext' => base64_encode($key)]));
+
+        $provider = $this->createProvider(
+            $client,
+            $this->transitConfig(mount: 'platform/transit', keyName: 'master_key-1'),
+        );
+
+        self::assertSame($key, $provider->getMasterKey());
+        self::assertSame(
+            self::ADDRESS . '/v1/platform/transit/decrypt/master_key-1',
+            (string) $this->assertSingleRequest()->getUri(),
+        );
+    }
+
+    #[Test]
+    public function configuredTokenIsUsedWhenNoEnvironmentVariableIsSetAndSurvivesRepeatedLookups(): void
+    {
+        $this->writeWrappedKeyFile();
+        putenv(self::TOKEN_ENV_VAR);
+
+        $config = $this->transitConfig(token: self::TOKEN);
+        $key = random_bytes(32);
+
+        $client = $this->clientReturning($this->transitResponse(['plaintext' => base64_encode($key)]));
+        $provider = $this->createProvider($client, $config);
+
+        // isAvailable() also resolves the token; the configuration DTO shares its
+        // string buffer with the ExtensionConfiguration singleton, so a
+        // sodium_memzero() on that copy would corrupt the token for this call.
+        self::assertTrue($provider->isAvailable());
+        self::assertSame($key, $provider->getMasterKey());
+
+        self::assertSame(self::TOKEN, $this->assertSingleRequest()->getHeaderLine('X-Vault-Token'));
+        self::assertSame(self::TOKEN, $config->token);
+    }
+
+    private function createProvider(
+        ClientInterface $client,
+        ?TransitConfig $config = null,
+    ): TransitMasterKeyProvider {
+        $configuration = $this->createMock(ExtensionConfigurationInterface::class);
+        $configuration
+            ->method('getTransitConfig')
+            ->willReturn($config ?? $this->transitConfig());
+
+        $httpFactory = new HttpFactory();
+
+        return new TransitMasterKeyProvider($configuration, $client, $httpFactory, $httpFactory);
+    }
+
+    private function transitConfig(
+        string $mount = 'transit',
+        string $keyName = 'nr-vault-master',
+        string $authMethod = 'token',
+        string $token = '',
+    ): TransitConfig {
+        return new TransitConfig(
+            address: self::ADDRESS,
+            mount: $mount,
+            keyName: $keyName,
+            wrappedKeyPath: $this->wrappedKeyPath(),
+            authMethod: $authMethod,
+            tokenEnvVar: self::TOKEN_ENV_VAR,
+            token: $token,
+        );
+    }
+
+    private function wrappedKeyPath(): string
+    {
+        return vfsStream::url('transit/vault-master.key.transit');
+    }
+
+    private function writeWrappedKeyFile(): void
+    {
+        file_put_contents($this->wrappedKeyPath(), self::WRAPPED_CIPHERTEXT);
+    }
+
+    /**
+     * @param array<string, string> $data
+     */
+    private function transitResponse(array $data): ResponseInterface
+    {
+        return new Response(
+            200,
+            ['Content-Type' => 'application/json'],
+            json_encode(['data' => $data], JSON_THROW_ON_ERROR),
+        );
+    }
+
+    /**
+     * PSR-18 client that records every dispatched request and always answers
+     * with $response.
+     */
+    private function clientReturning(ResponseInterface $response): ClientInterface
+    {
+        $client = $this->createMock(ClientInterface::class);
+        $client
+            ->method('sendRequest')
+            ->willReturnCallback(function (RequestInterface $request) use ($response): ResponseInterface {
+                $this->lastRequest = $request;
+                ++$this->requestCount;
+
+                return $response;
+            });
+
+        return $client;
+    }
+
+    /**
+     * Assert exactly one request was dispatched and return it.
+     */
+    private function assertSingleRequest(): RequestInterface
+    {
+        self::assertSame(1, $this->requestCount);
+        $request = $this->lastRequest;
+        self::assertNotNull($request);
+
+        return $request;
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -10,7 +10,7 @@ storageAdapter = local
 ### MASTER KEY ###
 #################
 
-# cat=Master Key; type=options[typo3=TYPO3 Encryption Key,file=External File,env=Environment Variable]; label=Master Key Provider: Source of the master encryption key
+# cat=Master Key; type=options[typo3=TYPO3 Encryption Key,file=External File,env=Environment Variable,transit=HashiCorp Vault Transit]; label=Master Key Provider: Source of the master encryption key. "transit" keeps the master key wrapped by HashiCorp Vault's transit engine and stores only the ciphertext locally (see the hashicorp.transit* settings).
 masterKeyProvider = typo3
 
 # cat=Master Key; type=string; label=Master Key Source: File path (for 'file' provider) or environment variable name (for 'env' provider). Ignored when using 'typo3' provider.
@@ -61,19 +61,32 @@ cacheEnabled = 1
 ########################
 ### HASHICORP VAULT ###
 ########################
-# NOTE: HashiCorp Vault adapter is planned but not yet implemented. These settings are reserved for future use.
+# NOTE: The HashiCorp Vault STORAGE adapter (hashicorp.path) is planned but not yet implemented.
+# The settings below are live for the "transit" master key provider (masterKeyProvider = transit).
 
-# cat=HashiCorp Vault; type=string; label=Vault Address: HashiCorp Vault server address (e.g., https://vault.example.com:8200)
+# cat=HashiCorp Vault; type=string; label=Vault Address: HashiCorp Vault server address (e.g., https://vault.example.com:8200). Used by the transit master key provider.
 hashicorp.address =
 
-# cat=HashiCorp Vault; type=string; label=Secret Path: Path prefix for secrets in Vault (e.g., secret/data/typo3)
+# cat=HashiCorp Vault; type=string; label=Secret Path: Path prefix for secrets in Vault (e.g., secret/data/typo3). Reserved for the not-yet-implemented storage adapter.
 hashicorp.path = secret/data/typo3
 
-# cat=HashiCorp Vault; type=options[token,kubernetes,approle]; label=Auth Method: Authentication method for Vault
+# cat=HashiCorp Vault; type=options[token,kubernetes,approle]; label=Auth Method: Authentication method for Vault. The transit master key provider implements "token" only and refuses to start on the others.
 hashicorp.authMethod = token
 
-# cat=HashiCorp Vault; type=string; label=Token: Vault token (only for token auth method). Use environment variable VAULT_TOKEN in production.
+# cat=HashiCorp Vault; type=string; label=Token: Vault token (only for token auth method). Prefer the environment variable named in hashicorp.tokenEnvVar — a token stored here is readable in the Install Tool and lands in configuration exports.
 hashicorp.token =
+
+# cat=HashiCorp Vault; type=string; label=Token Environment Variable: Name of the environment variable holding the Vault token. Read in preference to hashicorp.token.
+hashicorp.tokenEnvVar = VAULT_TOKEN
+
+# cat=HashiCorp Vault; type=string; label=Transit Mount: Mount path of the transit secrets engine (without /v1/). Nested mounts like "platform/transit" are supported.
+hashicorp.transitMount = transit
+
+# cat=HashiCorp Vault; type=string; label=Transit Key Name: Name of the transit key that wraps the vault master key. The Vault token's policy needs encrypt + decrypt on this key only.
+hashicorp.transitKeyName = nr-vault-master
+
+# cat=HashiCorp Vault; type=string; label=Wrapped Master Key Path: File holding the Vault-wrapped (encrypted) master key. Empty = <var-path>/secrets/vault-master.key.transit. The file contains ciphertext only — never key material.
+hashicorp.transitWrappedKeyPath =
 
 ################################
 ### AWS SECRETS MANAGER ###


### PR DESCRIPTION
## Summary

P1 item 7 of the hardened-profile roadmap: first external KMS integration — a `transit` master key provider backed by HashiCorp Vault's Transit secrets engine. Stacked on #236 (needs `SecurityProfile`; `transit` is allowed in the hardened profile, unlike `typo3`).

**Custody model:** the 32-byte master key is generated once, wrapped by Transit (`encrypt`), and only the `vault:v1:…` ciphertext is stored locally (0600, atomic write). Every unwrap is a live, centrally audited Vault call — revoking the token/policy locks the vault out immediately; a stolen database + webroot is useless without Vault access.

- Token auth (env var `VAULT_TOKEN` by default, preferred over stored config); `approle`/`kubernetes` are **rejected, not silently downgraded** (documented follow-up).
- Fail-closed handling: traversal-safe mount/key path segments, no network in `isAvailable()` (live probe = `getMasterKey()` via the health service), Vault error bodies never surfaced (they can echo ciphertexts), token redaction in transport errors, `sodium_memzero` on all owned copies.
- `vault:init` / `vault:rotate-master-key` work unchanged through `storeMasterKey()`.
- New config: `hashicorp.transitMount`, `hashicorp.transitKeyName`, `hashicorp.transitWrappedKeyPath`, `hashicorp.tokenEnvVar` (+ `TransitConfig` DTO); `masterKeyProvider` option list gains `transit`.
- Honest trust model in `Documentation/Configuration/Index.rst`: Transit protects custody, rotation, and central auditability — it does **not** stop a fully compromised PHP process from calling `decrypt` with the token it legitimately holds.

## Test plan
- `composer ci` exit 0, Rector clean, full functional suite green locally (sqlite).
- 25 new provider unit tests (mocked PSR-18): decrypt round trip, wrong plaintext length, HTTP 403 without token leakage, missing wrapped blob, `storeMasterKey` persists ciphertext only (0600 asserted via vfsStream); 12 `TransitConfig` DTO tests; factory tests for the `transit` arm incl. hardened profile.

Roadmap: PR 9 of 10 (pulled forward — independent of PRs 3-6). Follows #236.
