### PR TITLE
Anchor the audit log outside the database

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -142,7 +142,7 @@ AuditLogServiceInterface::verifyHashChain(?int $fromUid = null, ?int $toUid = nu
 ```
 
 ## CLI Commands (TYPO3 `vendor/bin/typo3`)
-> All 13 registered `vault:*` commands. Full options/examples in
+> All 15 registered `vault:*` commands. Full options/examples in
 > `Documentation/Developer/Commands.rst`.
 ```
 vault:init                 # Initialize the vault (generate master key, verify configuration)
@@ -154,6 +154,8 @@ vault:delete               # Delete a secret from the vault
 vault:scan                 # Scan database content for exposed secrets
 vault:migrate-field        # Migrate a database field value into the vault
 vault:audit                # View / verify audit log entries
+vault:audit-anchor         # Publish the audit chain tip to the external audit sinks (scheduled task wrapper)
+vault:audit-verify         # Verify the hash chain AND the external chain-tip anchor (scheduled task wrapper)
 vault:audit-migrate-hmac   # Migrate audit log hash chain from SHA-256 to HMAC-SHA256
 vault:rotate-master-key    # Re-encrypt all secrets with a new master key
 vault:cleanup-orphans      # Clean up orphaned vault entries (scheduled task wrapper)

--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -2476,6 +2476,22 @@ parameters:
 			count: 2
 			path: ../Tests/Unit/Task/OrphanCleanupTaskTest.php
 
+		# TYPO3 v13's AbstractTask::__construct() resolves the Scheduler via
+		# GeneralUtility; a unit test cannot instantiate the task without
+		# registering a Scheduler stand-in. Same framework-imposed pattern as
+		# OrphanCleanupTaskTest above; no public API exists for it.
+		-
+			rawMessage: 'Call to internal static method TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance() from outside its root namespace TYPO3.'
+			identifier: staticMethod.internal
+			count: 1
+			path: ../Tests/Unit/Task/AuditAnchorTaskTest.php
+
+		-
+			rawMessage: 'Call to internal static method TYPO3\CMS\Core\Utility\GeneralUtility::setSingletonInstance() from outside its root namespace TYPO3.'
+			identifier: staticMethod.internal
+			count: 1
+			path: ../Tests/Unit/Task/AuditVerifyTaskTest.php
+
 		-
 			rawMessage: 'Dynamic call to static method PHPUnit\Framework\Assert::isInt().'
 			identifier: staticMethod.dynamicCall

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -16,7 +16,9 @@ Strict types, final classes, readonly properties, constructor promotion. DI via 
 | `Classes/Crypto/FileMasterKeyProvider.php` | Reads master key from filesystem (config-driven) |
 | `Classes/Crypto/EnvironmentMasterKeyProvider.php` | Reads master key from env var |
 | `Classes/Crypto/Typo3MasterKeyProvider.php` | Uses TYPO3 encryptionKey as fallback |
-| `Classes/Audit/AuditLogService.php` | Tamper-evident audit log (HMAC hash chain) |
+| `Classes/Audit/AuditLogService.php` | Tamper-evident audit log (HMAC hash chain); fans out to external sinks after the chain write |
+| `Classes/Audit/Sink/AuditSinkRegistry.php` | Fan-out to external sinks; contains + counts per-sink failures |
+| `Classes/Audit/Anchor/ChainTipAnchorService.php` | Publishes + verifies external chain-tip anchors (detects a full table reset) |
 | `Classes/Controller/SecretsController.php` | Backend module: list/create/rotate UI |
 | `Classes/Controller/AjaxController.php` | AJAX reveal/copy endpoints |
 | `Classes/Hook/FlexFormVaultHook.php` | Rewrites vault placeholders in FlexForms |
@@ -45,7 +47,9 @@ Strict types, final classes, readonly properties, constructor promotion. DI via 
 ```
 Classes/
 ├── Adapter/       # Vault backend adapters (LocalEncryptionAdapter, external)
-├── Audit/         # AuditLogService, HashChainVerificationResult
+├── Audit/         # AuditLogService, HashChainVerificationResult, AuditIntegrityReport
+│   ├── Anchor/     # External chain-tip anchoring (ChainTipAnchorService, AnchorFileReader)
+│   └── Sink/       # External audit sinks (syslog, NDJSON file, webhook) + registry
 ├── Command/       # Symfony Console commands (vault:*)
 ├── Configuration/ # ExtensionConfiguration wrapper
 ├── Controller/    # Backend module + AJAX controllers

--- a/Classes/Audit/Anchor/AnchorFileReader.php
+++ b/Classes/Audit/Anchor/AnchorFileReader.php
@@ -1,0 +1,133 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Anchor;
+
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Reads chain-tip anchors from the NDJSON anchor file written by
+ * {@see \Netresearch\NrVault\Audit\Sink\JsonFileAuditSink}.
+ *
+ * ## Why the highest sequence wins, not the last line
+ *
+ * The file is append-only, so the last line is *usually* the newest anchor — but
+ * "usually" is not a security property. An attacker with write access to the file
+ * can append an anchor claiming sequence 1, and picking the last line would then
+ * silently downgrade the baseline to something a truncated chain satisfies. Taking
+ * the MAXIMUM sequence makes appending useless: to weaken the baseline an attacker
+ * must rewrite or truncate the file, which is exactly what append-only storage
+ * (or an off-host copy) is there to prevent.
+ *
+ * ## Bounded reading
+ *
+ * The file grows by one line per anchoring run, so it stays small — but it lives
+ * on a filesystem this code does not control, so it is read line-by-line rather
+ * than slurped, and unparseable lines are skipped rather than aborting the scan.
+ * A single corrupted line must not cost the verification its entire baseline.
+ */
+final readonly class AnchorFileReader implements AnchorReaderInterface
+{
+    public function __construct(
+        private ExtensionConfigurationInterface $extensionConfiguration,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function readLatestAnchor(): ?ChainTipAnchor
+    {
+        $path = $this->extensionConfiguration->getAuditSinkAnchorPath();
+        if (!is_file($path) || !is_readable($path)) {
+            return null;
+        }
+
+        // No `@` suppression (the project's PHPStan ruleset forbids it) — an
+        // unreadable file surfaces as either `false` or, under TYPO3's
+        // warning-to-exception error handler, a Throwable. Both mean the same
+        // thing here: verification has no external baseline.
+        try {
+            $handle = fopen($path, 'rb');
+        } catch (Throwable) {
+            $handle = false;
+        }
+
+        if ($handle === false) {
+            $this->logger->warning(
+                'nr-vault could not open the audit anchor file; verification has no external baseline.',
+                ['path' => $path],
+            );
+
+            return null;
+        }
+
+        $best = null;
+
+        try {
+            while (($line = fgets($handle)) !== false) {
+                $anchor = $this->parseLine($line);
+                if (!$anchor instanceof ChainTipAnchor) {
+                    continue;
+                }
+
+                if (!$best instanceof ChainTipAnchor || $anchor->sequence > $best->sequence) {
+                    $best = $anchor;
+                }
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        return $best;
+    }
+
+    public function isAvailable(): bool
+    {
+        $path = $this->extensionConfiguration->getAuditSinkAnchorPath();
+
+        return is_file($path) && is_readable($path);
+    }
+
+    /**
+     * Decode one NDJSON line into an anchor, or null when it is not an anchor
+     * record.
+     *
+     * The anchor stream also carries `alert` records (see
+     * {@see \Netresearch\NrVault\Audit\Sink\JsonFileAuditSink::publishAlert()}),
+     * so a non-anchor line is normal traffic, not corruption — it is skipped
+     * without a log entry.
+     */
+    private function parseLine(string $line): ?ChainTipAnchor
+    {
+        $line = trim($line);
+        if ($line === '') {
+            return null;
+        }
+
+        try {
+            $decoded = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+        } catch (Throwable) {
+            // A truncated final line (crash mid-write) or a hand-edit. Skipping
+            // keeps every intact earlier anchor usable.
+            return null;
+        }
+
+        if (!\is_array($decoded) || ($decoded['type'] ?? null) !== 'anchor') {
+            return null;
+        }
+
+        $payload = $decoded['anchor'] ?? null;
+        if (!\is_array($payload)) {
+            return null;
+        }
+
+        /** @var array<string, mixed> $payload */
+        return ChainTipAnchor::fromArray($payload);
+    }
+}

--- a/Classes/Audit/Anchor/AnchorReaderInterface.php
+++ b/Classes/Audit/Anchor/AnchorReaderInterface.php
@@ -1,0 +1,41 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Anchor;
+
+/**
+ * Reads back the most recently published chain-tip anchor.
+ *
+ * Separate from the sink that writes it, because verification must work even
+ * when the file sink is currently disabled: an operator who anchored for months
+ * and then turned the sink off must still be able to check the chain against the
+ * evidence already on disk. The read path therefore depends only on the
+ * configured anchor path, never on sink enablement.
+ */
+interface AnchorReaderInterface
+{
+    /**
+     * The highest-sequence anchor available, or null when none can be read.
+     *
+     * Null covers "no anchor file", "empty anchor file" and "no parseable anchor
+     * record" alike: all three mean verification has no external baseline, and
+     * the caller reports that as its own finding rather than distinguishing
+     * causes it cannot act on differently.
+     */
+    public function readLatestAnchor(): ?ChainTipAnchor;
+
+    /**
+     * Whether an anchor source exists and is readable.
+     *
+     * Lets callers tell "anchoring was never set up" apart from "the anchor
+     * store exists but holds nothing usable" — the second is a corruption signal
+     * worth reporting differently in operator output.
+     */
+    public function isAvailable(): bool;
+}

--- a/Classes/Audit/Anchor/ChainTipAnchor.php
+++ b/Classes/Audit/Anchor/ChainTipAnchor.php
@@ -1,0 +1,108 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Anchor;
+
+use JsonSerializable;
+
+/**
+ * An externally-published snapshot of the audit chain's tip.
+ *
+ * The hash chain in `tx_nrvault_audit_log` proves that no row was altered
+ * *within* the stored chain, but it cannot prove that the chain is still the
+ * same chain: an attacker with DELETE rights can TRUNCATE the table and let the
+ * service build a fresh, internally-consistent chain from uid 1. Nothing inside
+ * the database distinguishes that from a genuinely young installation.
+ *
+ * An anchor closes that gap by recording, outside the database, that sequence
+ * `$sequence` once carried entry hash `$chainTip`. Verification then has two
+ * external facts to check (see {@see ChainTipAnchorServiceInterface::verify()}):
+ *
+ *  1. the chain must not have shrunk — current max uid >= anchored sequence;
+ *  2. the row at the anchored sequence must still hash to the anchored tip.
+ *
+ * `$hmacEpoch` is carried so an anchor also witnesses the protection level in
+ * force when it was taken: a chain re-labelled down to keyless epoch-0 SHA-256
+ * is detectable even if the row count and hashes were rebuilt consistently.
+ */
+final readonly class ChainTipAnchor implements JsonSerializable
+{
+    /**
+     * @param int $sequence Highest audit uid at capture time (0 = empty chain)
+     * @param string $chainTip `entry_hash` of that row ('' = empty chain)
+     * @param int $timestamp Unix timestamp of capture
+     * @param int $hmacEpoch `hmac_key_epoch` in force at capture time
+     */
+    public function __construct(
+        public int $sequence,
+        public string $chainTip,
+        public int $timestamp,
+        public int $hmacEpoch,
+    ) {}
+
+    /**
+     * Rehydrate an anchor from its decoded JSON form.
+     *
+     * Returns null for anything that is not a structurally complete anchor, so
+     * a truncated final line or a hand-edited file degrades to "no anchor
+     * found" rather than to a bogus comparison baseline.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): ?self
+    {
+        $sequence = $data['sequence'] ?? null;
+        $chainTip = $data['chainTip'] ?? null;
+        $timestamp = $data['timestamp'] ?? null;
+        $hmacEpoch = $data['hmacEpoch'] ?? null;
+
+        if (!is_numeric($sequence) || !\is_string($chainTip) || !is_numeric($timestamp) || !is_numeric($hmacEpoch)) {
+            return null;
+        }
+
+        return new self(
+            sequence: (int) $sequence,
+            chainTip: $chainTip,
+            timestamp: (int) $timestamp,
+            hmacEpoch: (int) $hmacEpoch,
+        );
+    }
+
+    /**
+     * @return array{sequence: int, chainTip: string, timestamp: int, hmacEpoch: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'sequence' => $this->sequence,
+            'chainTip' => $this->chainTip,
+            'timestamp' => $this->timestamp,
+            'hmacEpoch' => $this->hmacEpoch,
+        ];
+    }
+
+    /**
+     * @return array{sequence: int, chainTip: string, timestamp: int, hmacEpoch: int}
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+
+    /**
+     * Whether this anchor witnesses an actual chain (rather than an empty one).
+     *
+     * An empty-chain anchor is worth publishing (it dates the installation) but
+     * carries no hash to compare against.
+     */
+    public function isEmpty(): bool
+    {
+        return $this->sequence <= 0 || $this->chainTip === '';
+    }
+}

--- a/Classes/Audit/Anchor/ChainTipAnchorService.php
+++ b/Classes/Audit/Anchor/ChainTipAnchorService.php
@@ -1,0 +1,446 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Anchor;
+
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditIntegrityReport;
+use Netresearch\NrVault\Audit\AuditLogService;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\HashChainVerificationResult;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Event\AuditIntegrityAlertEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+
+/**
+ * Publishes chain-tip anchors and verifies the chain against them.
+ *
+ * ## The two checks that need external evidence
+ *
+ * `verifyHashChain()` proves internal consistency. It cannot detect a
+ * `TRUNCATE TABLE tx_nrvault_audit_log` followed by fresh writes, because the
+ * resulting chain is perfectly self-consistent — there is nothing left to
+ * contradict it. Comparing against an anchor published earlier adds the two
+ * missing facts:
+ *
+ *  1. **Shrinkage** — the chain is append-only, so its highest uid can never go
+ *     down. `currentSequence < anchor->sequence` is a reset.
+ *  2. **Substitution** — the row at the anchored sequence must still hash to the
+ *     anchored tip. A different (or absent) hash there means the chain was
+ *     rebuilt, even if it is now longer than the anchor.
+ *
+ * The anchored `hmacEpoch` gives a third check for free: an anchor witnesses the
+ * protection level in force at capture time, so a chain relabelled downward is
+ * detectable as `EPOCH_DOWNGRADE` even when every stored hash recomputes.
+ *
+ * ## Chain-error classification
+ *
+ * `HashChainVerificationResult` reports errors as human-readable strings keyed by
+ * uid. UID gaps are read from its structured `missingUidCount`; the remaining
+ * error strings are classified by the marker substrings below, with an
+ * unrecognised error falling back to `HASH_MISMATCH`. The fallback is the safe
+ * direction: an unclassified chain error is still a chain error, so a future
+ * message added to the verifier degrades to a generic hash finding rather than
+ * disappearing from the report.
+ */
+final readonly class ChainTipAnchorService implements ChainTipAnchorServiceInterface
+{
+    /**
+     * Marker substring identifying an epoch-downgrade error emitted by
+     * {@see AuditLogService::verifyHashChain()}.
+     */
+    private const ERROR_MARKER_EPOCH_DOWNGRADE = 'epoch downgrade detected';
+
+    /**
+     * Marker substring identifying a uid-gap error emitted by
+     * {@see AuditLogService::verifyHashChain()}.
+     */
+    private const ERROR_MARKER_UID_GAP = 'uid gap detected';
+
+    public function __construct(
+        private ConnectionPool $connectionPool,
+        private AuditLogServiceInterface $auditLogService,
+        private AuditSinkRegistryInterface $sinkRegistry,
+        private AnchorReaderInterface $anchorReader,
+        private ExtensionConfigurationInterface $extensionConfiguration,
+        private EventDispatcherInterface $eventDispatcher,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function capture(): ChainTipAnchor
+    {
+        $sequence = $this->fetchMaxUid();
+
+        return new ChainTipAnchor(
+            sequence: $sequence,
+            chainTip: $sequence > 0 ? ($this->auditLogService->getLatestHash() ?? '') : '',
+            timestamp: time(),
+            hmacEpoch: $this->extensionConfiguration->getAuditHmacEpoch(),
+        );
+    }
+
+    public function publish(ChainTipAnchor $anchor): int
+    {
+        $accepted = $this->sinkRegistry->dispatchAnchor($anchor);
+
+        if ($accepted === 0) {
+            // Not an exception: the caller (command / scheduler task) decides how
+            // loudly to fail, and it has the operator context to say why. But it
+            // must never look like success, so log it at error level here too.
+            $this->logger->error(
+                'nr-vault published an audit chain anchor to zero external sinks; '
+                . 'the anchor provides no table-reset protection. Enable at least one audit sink.',
+                ['sequence' => $anchor->sequence],
+            );
+
+            return 0;
+        }
+
+        $this->logger->info('nr-vault published an audit chain anchor.', [
+            'sequence' => $anchor->sequence,
+            'sinks' => $accepted,
+        ]);
+
+        return $accepted;
+    }
+
+    public function verify(): AuditIntegrityReport
+    {
+        $chainResult = $this->auditLogService->verifyHashChain();
+        $currentSequence = $this->fetchMaxUid();
+        $anchor = $this->anchorReader->readLatestAnchor();
+
+        $findings = [
+            ...$this->classifyChainErrors($chainResult),
+            ...$this->compareWithAnchor($anchor, $currentSequence),
+            ...$this->checkExternalSinkRequirement($anchor),
+        ];
+
+        $report = new AuditIntegrityReport(
+            findings: $findings,
+            chainValid: $chainResult->isValid(),
+            currentSequence: $currentSequence,
+            anchor: $anchor,
+            warnings: $chainResult->warnings,
+        );
+
+        $this->dispatchFindings($report);
+
+        return $report;
+    }
+
+    /**
+     * Map hash-chain errors onto reason codes.
+     *
+     * One finding per reason code, not per erroring row: a broken chain commonly
+     * fails every row after the break, and 10 000 identical alerts would bury the
+     * signal in any SIEM. The affected-row count travels in the finding context.
+     *
+     * @return list<AuditIntegrityAlert>
+     */
+    private function classifyChainErrors(HashChainVerificationResult $result): array
+    {
+        $findings = [];
+
+        if ($result->hasMissingUids()) {
+            $findings[] = AuditIntegrityAlert::create(
+                AuditIntegrityReason::UidGap,
+                \sprintf(
+                    'Audit chain has %d missing uid(s); rows were deleted from the chain.',
+                    $result->missingUidCount,
+                ),
+                [
+                    'missingUidCount' => $result->missingUidCount,
+                    // Bounded sample: the full list can be up to 1000 entries and
+                    // this value ends up in a syslog line and a webhook payload.
+                    'missingUidSample' => implode(',', \array_slice($result->missingUids, 0, 20)),
+                ],
+            );
+        }
+
+        $epochDowngradeUids = [];
+        $hashMismatchUids = [];
+
+        foreach ($result->errors as $uid => $message) {
+            $lower = strtolower($message);
+
+            if (str_contains($lower, self::ERROR_MARKER_UID_GAP)) {
+                // Already reported above from the structured missing-uid data.
+                continue;
+            }
+
+            if (str_contains($lower, self::ERROR_MARKER_EPOCH_DOWNGRADE)) {
+                $epochDowngradeUids[] = $uid;
+
+                continue;
+            }
+
+            $hashMismatchUids[] = $uid;
+        }
+
+        if ($epochDowngradeUids !== []) {
+            $findings[] = AuditIntegrityAlert::create(
+                AuditIntegrityReason::EpochDowngrade,
+                \sprintf(
+                    'Audit chain HMAC epoch was downgraded on %d row(s); a weaker or keyless '
+                    . 'verification algorithm was selected.',
+                    \count($epochDowngradeUids),
+                ),
+                [
+                    'affectedRows' => \count($epochDowngradeUids),
+                    'firstUid' => $epochDowngradeUids[0],
+                ],
+            );
+        }
+
+        if ($hashMismatchUids !== []) {
+            $findings[] = AuditIntegrityAlert::create(
+                AuditIntegrityReason::HashMismatch,
+                \sprintf('Audit chain hash verification failed on %d row(s).', \count($hashMismatchUids)),
+                [
+                    'affectedRows' => \count($hashMismatchUids),
+                    'firstUid' => $hashMismatchUids[0],
+                ],
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Compare the live chain against the anchored snapshot.
+     *
+     * @return list<AuditIntegrityAlert>
+     */
+    private function compareWithAnchor(?ChainTipAnchor $anchor, int $currentSequence): array
+    {
+        if (!$anchor instanceof ChainTipAnchor || $anchor->isEmpty()) {
+            // No baseline (or a baseline taken when the chain was still empty).
+            // Absence of evidence is handled by checkExternalSinkRequirement();
+            // there is nothing to compare here.
+            return [];
+        }
+
+        // Check 1 — shrinkage. An append-only chain's highest uid cannot decrease.
+        if ($currentSequence < $anchor->sequence) {
+            return [
+                AuditIntegrityAlert::create(
+                    AuditIntegrityReason::TableReset,
+                    \sprintf(
+                        'Audit chain shrank: highest uid is %d but sequence %d was anchored on %s. '
+                        . 'The audit table was truncated or rows were deleted wholesale.',
+                        $currentSequence,
+                        $anchor->sequence,
+                        gmdate('Y-m-d H:i:s', $anchor->timestamp) . ' UTC',
+                    ),
+                    [
+                        'currentSequence' => $currentSequence,
+                        'anchoredSequence' => $anchor->sequence,
+                        'anchoredAt' => $anchor->timestamp,
+                    ],
+                ),
+            ];
+        }
+
+        $row = $this->fetchRowAt($anchor->sequence);
+
+        // Check 2 — substitution. The anchored row must still be there, and must
+        // still hash to the anchored tip.
+        if ($row === null) {
+            return [
+                AuditIntegrityAlert::create(
+                    AuditIntegrityReason::TableReset,
+                    \sprintf(
+                        'Anchored audit row %d no longer exists although the chain reaches uid %d; '
+                        . 'the chain was rebuilt.',
+                        $anchor->sequence,
+                        $currentSequence,
+                    ),
+                    ['anchoredSequence' => $anchor->sequence, 'currentSequence' => $currentSequence],
+                ),
+            ];
+        }
+
+        $findings = [];
+
+        // hash_equals() rather than !==: this compares an integrity tag, and the
+        // project mandates constant-time comparison for those (AGENTS.md
+        // Security Requirement #2).
+        if (!hash_equals($anchor->chainTip, $row['entryHash'])) {
+            $findings[] = AuditIntegrityAlert::create(
+                AuditIntegrityReason::TableReset,
+                \sprintf(
+                    'Audit row %d hashes differently than anchored: the chain at that sequence is '
+                    . 'not the chain that was anchored on %s.',
+                    $anchor->sequence,
+                    gmdate('Y-m-d H:i:s', $anchor->timestamp) . ' UTC',
+                ),
+                ['anchoredSequence' => $anchor->sequence, 'anchoredAt' => $anchor->timestamp],
+            );
+        }
+
+        // Check 3 — epoch regression against external evidence. The in-chain
+        // check only sees relabelling relative to other rows; the anchor sees it
+        // relative to the level that was actually in force.
+        if ($row['epoch'] < $anchor->hmacEpoch) {
+            $findings[] = AuditIntegrityAlert::create(
+                AuditIntegrityReason::EpochDowngrade,
+                \sprintf(
+                    'Audit row %d now reports HMAC epoch %d but epoch %d was anchored; the '
+                    . 'verification algorithm was downgraded.',
+                    $anchor->sequence,
+                    $row['epoch'],
+                    $anchor->hmacEpoch,
+                ),
+                [
+                    'anchoredSequence' => $anchor->sequence,
+                    'currentEpoch' => $row['epoch'],
+                    'anchoredEpoch' => $anchor->hmacEpoch,
+                ],
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Under the hardened profile, missing external evidence is itself a finding.
+     *
+     * The standard profile treats sinks as opt-in, so it reports nothing here —
+     * flagging a default installation for not having configured a SIEM would make
+     * the check noise rather than signal.
+     *
+     * @return list<AuditIntegrityAlert>
+     */
+    private function checkExternalSinkRequirement(?ChainTipAnchor $anchor): array
+    {
+        try {
+            $profile = $this->extensionConfiguration->getSecurityProfile();
+        } catch (Throwable $e) {
+            // An invalid profile value is a configuration fault the verifier must
+            // not swallow into a "valid chain" verdict, but it is also not an
+            // integrity finding. Log and skip this check.
+            $this->logger->error(
+                'nr-vault could not resolve the security profile while verifying audit integrity.',
+                ['error' => $e->getMessage()],
+            );
+
+            return [];
+        }
+
+        if ($profile !== SecurityProfile::Hardened) {
+            return [];
+        }
+
+        if (!$this->sinkRegistry->hasExternalAuditSink()) {
+            return [
+                AuditIntegrityAlert::create(
+                    AuditIntegrityReason::NoExternalSink,
+                    'Hardened profile requires at least one external audit sink, but none is enabled '
+                    . 'and usable. The audit trail exists only in the database it is meant to protect, '
+                    . 'and no chain-tip anchor can be published.',
+                    ['profile' => $profile->value],
+                ),
+            ];
+        }
+
+        if (!$anchor instanceof ChainTipAnchor) {
+            return [
+                AuditIntegrityAlert::create(
+                    AuditIntegrityReason::NoExternalSink,
+                    'Hardened profile requires an external chain-tip anchor, but none could be read. '
+                    . 'A full audit-table reset would be undetectable. Run vault:audit-anchor '
+                    . '(or schedule the anchor task).',
+                    ['anchorAvailable' => $this->anchorReader->isAvailable()],
+                ),
+            ];
+        }
+
+        return [];
+    }
+
+    /**
+     * Dispatch every finding as a PSR-14 event so SIEM/notification listeners
+     * fire even when nobody reads the CLI output.
+     */
+    private function dispatchFindings(AuditIntegrityReport $report): void
+    {
+        foreach ($report->findings as $finding) {
+            try {
+                $this->eventDispatcher->dispatch(new AuditIntegrityAlertEvent($finding));
+            } catch (Throwable $e) {
+                // A throwing listener must not cost us the remaining findings or
+                // the report itself.
+                $this->logger->error('nr-vault could not dispatch an audit integrity alert.', [
+                    'reason' => $finding->reason->value,
+                    'error' => $e->getMessage(),
+                ]);
+            }
+        }
+    }
+
+    /**
+     * Highest uid in the audit table (0 = empty chain).
+     */
+    private function fetchMaxUid(): int
+    {
+        $result = $this->getQueryBuilder()
+            ->select('uid')
+            ->from(AuditLogService::TABLE_NAME)
+            ->orderBy('uid', 'DESC')
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($result) ? (int) $result : 0;
+    }
+
+    /**
+     * Read the entry hash and epoch of one audit row.
+     *
+     * @return array{entryHash: string, epoch: int}|null Null when the row is absent
+     */
+    private function fetchRowAt(int $uid): ?array
+    {
+        $queryBuilder = $this->getQueryBuilder();
+        $row = $queryBuilder
+            ->select('entry_hash', 'hmac_key_epoch')
+            ->from(AuditLogService::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)),
+            )
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if ($row === false) {
+            return null;
+        }
+
+        return [
+            'entryHash' => \is_string($row['entry_hash'] ?? null) ? $row['entry_hash'] : '',
+            'epoch' => is_numeric($row['hmac_key_epoch'] ?? null) ? (int) $row['hmac_key_epoch'] : 0,
+        ];
+    }
+
+    private function getQueryBuilder(): QueryBuilder
+    {
+        return $this->connectionPool
+            ->getConnectionForTable(AuditLogService::TABLE_NAME)
+            ->createQueryBuilder();
+    }
+}

--- a/Classes/Audit/Anchor/ChainTipAnchorServiceInterface.php
+++ b/Classes/Audit/Anchor/ChainTipAnchorServiceInterface.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Anchor;
+
+use Netresearch\NrVault\Audit\AuditIntegrityReport;
+
+/**
+ * Publishes and verifies external chain-tip anchors.
+ *
+ * Answers the one question the in-database hash chain structurally cannot: is
+ * this still the same chain? See {@see ChainTipAnchor} for why that gap exists.
+ */
+interface ChainTipAnchorServiceInterface
+{
+    /**
+     * Snapshot the current chain tip without publishing it.
+     *
+     * Read-only, so it is safe to call from a status/health surface.
+     */
+    public function capture(): ChainTipAnchor;
+
+    /**
+     * Publish an anchor to every enabled external sink.
+     *
+     * @return int Number of sinks that accepted it. **Zero means the anchor was
+     *             not persisted anywhere outside the database and provides no
+     *             reset protection** — callers must treat zero as a failed
+     *             anchoring run, not as a no-op
+     */
+    public function publish(ChainTipAnchor $anchor): int;
+
+    /**
+     * Verify the chain against itself AND against the latest external anchor.
+     *
+     * Combines the full-range hash-chain pass with the anchor comparison and the
+     * hardened-profile external-sink requirement, classifying every finding into
+     * a machine-readable {@see \Netresearch\NrVault\Audit\AuditIntegrityReason}.
+     * Findings are dispatched as
+     * {@see \Netresearch\NrVault\Event\AuditIntegrityAlertEvent} so SIEM
+     * listeners are notified even when nobody reads the command output.
+     */
+    public function verify(): AuditIntegrityReport;
+}

--- a/Classes/Audit/AuditIntegrityAlert.php
+++ b/Classes/Audit/AuditIntegrityAlert.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit;
+
+use JsonSerializable;
+
+/**
+ * A single audit-integrity finding, ready to be shipped to a SIEM.
+ *
+ * Carried by {@see \Netresearch\NrVault\Event\AuditIntegrityAlertEvent} and
+ * published through the external sinks. Deliberately free of secret material:
+ * `$detail` is written by the verifier / dispatcher, never by a caller holding
+ * plaintext, and the sink layer never adds the secret identifier's value.
+ */
+final readonly class AuditIntegrityAlert implements JsonSerializable
+{
+    /**
+     * @param AuditIntegrityReason $reason Machine-readable reason code
+     * @param string $detail Human-readable, secret-free description
+     * @param int $timestamp Unix timestamp the finding was raised
+     * @param array<string, bool|int|string> $context Scalar-only extra facts
+     *                                                (uid, sink identifier, anchored sequence, …).
+     *                                                Scalars only so the payload can never smuggle a
+     *                                                nested object graph into an external system.
+     */
+    public function __construct(
+        public AuditIntegrityReason $reason,
+        public string $detail,
+        public int $timestamp,
+        public array $context = [],
+    ) {}
+
+    /**
+     * @param array<string, bool|int|string> $context
+     */
+    public static function create(AuditIntegrityReason $reason, string $detail, array $context = []): self
+    {
+        return new self($reason, $detail, time(), $context);
+    }
+
+    /**
+     * @return array{reason: string, tamperEvidence: bool, detail: string, timestamp: int, context: array<string, bool|int|string>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'reason' => $this->reason->value,
+            'tamperEvidence' => $this->reason->isTamperEvidence(),
+            'detail' => $this->detail,
+            'timestamp' => $this->timestamp,
+            'context' => $this->context,
+        ];
+    }
+
+    /**
+     * @return array{reason: string, tamperEvidence: bool, detail: string, timestamp: int, context: array<string, bool|int|string>}
+     */
+    public function jsonSerialize(): array
+    {
+        return $this->toArray();
+    }
+}

--- a/Classes/Audit/AuditIntegrityReason.php
+++ b/Classes/Audit/AuditIntegrityReason.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit;
+
+/**
+ * Machine-readable reason codes for audit-integrity findings.
+ *
+ * These are the codes a SIEM / notification listener switches on, and the codes
+ * `vault:audit-verify` prints and exits on. The backing strings are part of the
+ * external contract (they appear in webhook payloads, syslog structured data and
+ * the NDJSON anchor stream) — treat them as stable API, not as labels.
+ */
+enum AuditIntegrityReason: string
+{
+    /**
+     * A stored `entry_hash` or `previous_hash` does not match the recomputed value.
+     */
+    case HashMismatch = 'HASH_MISMATCH';
+
+    /**
+     * The uid sequence is not contiguous — rows were deleted from the chain.
+     */
+    case UidGap = 'UID_GAP';
+
+    /**
+     * The chain no longer contains the externally anchored tip: either it is
+     * shorter than the anchored sequence, or the row at that sequence hashes
+     * differently. The signature of a truncate-and-rebuild.
+     */
+    case TableReset = 'TABLE_RESET';
+
+    /**
+     * The chain's `hmac_key_epoch` was relabelled downward — an attempt to move
+     * rows onto a weaker (or keyless) verification algorithm.
+     */
+    case EpochDowngrade = 'EPOCH_DOWNGRADE';
+
+    /**
+     * An external sink could not be delivered to. Availability, not integrity.
+     */
+    case SinkFailure = 'SINK_FAILURE';
+
+    /**
+     * No external audit sink is enabled, so the audit trail exists only in the
+     * database it is meant to protect and no anchor can be published. A finding
+     * only under the hardened security profile; the standard profile treats
+     * external sinks as opt-in.
+     */
+    case NoExternalSink = 'NO_EXTERNAL_SINK';
+
+    /**
+     * Reserved for the break-glass emergency-access flow, which raises an alert
+     * of its own severity class. Declared here so listeners can be written
+     * against the complete code set before that flow lands.
+     */
+    case BreakGlass = 'BREAK_GLASS';
+
+    /**
+     * Whether the code indicates evidence of tampering (as opposed to a
+     * delivery/availability problem).
+     *
+     * Listeners use this to decide between "page someone now" and "log it".
+     */
+    public function isTamperEvidence(): bool
+    {
+        return match ($this) {
+            self::HashMismatch, self::UidGap, self::TableReset, self::EpochDowngrade => true,
+            self::SinkFailure, self::NoExternalSink, self::BreakGlass => false,
+        };
+    }
+
+    /**
+     * Human-readable label for CLI output and backend display.
+     */
+    public function label(): string
+    {
+        return ucwords(strtolower(str_replace('_', ' ', $this->value)));
+    }
+}

--- a/Classes/Audit/AuditIntegrityReport.php
+++ b/Classes/Audit/AuditIntegrityReport.php
@@ -1,0 +1,131 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+
+/**
+ * Combined result of an audit-integrity verification run.
+ *
+ * Wider than {@see HashChainVerificationResult}, which only answers "does the
+ * stored chain verify against itself". This report adds the external evidence
+ * that the stored chain cannot supply:
+ *
+ *  - is it still the SAME chain the last published anchor witnessed
+ *    (`TABLE_RESET`), and
+ *  - is external evidence being produced at all (`NO_EXTERNAL_SINK`).
+ *
+ * Findings are {@see AuditIntegrityAlert} objects rather than plain strings so the
+ * same value that `vault:audit-verify` prints is the value dispatched to SIEM
+ * listeners — one representation, no drift between what an operator sees and what
+ * a collector receives.
+ */
+final readonly class AuditIntegrityReport
+{
+    /**
+     * @param list<AuditIntegrityAlert> $findings Empty = fully verified
+     * @param bool $chainValid Result of the internal hash-chain pass alone
+     * @param int $currentSequence Highest audit uid at verification time
+     * @param ChainTipAnchor|null $anchor Anchor compared against (null = none available)
+     * @param array<int, string> $warnings Non-fatal chain notes, keyed by uid
+     */
+    public function __construct(
+        public array $findings,
+        public bool $chainValid,
+        public int $currentSequence,
+        public ?ChainTipAnchor $anchor = null,
+        public array $warnings = [],
+    ) {}
+
+    /**
+     * Whether the run produced no findings at all.
+     */
+    public function isValid(): bool
+    {
+        return $this->findings === [];
+    }
+
+    /**
+     * Whether any finding is evidence of tampering (as opposed to a
+     * configuration or delivery problem).
+     *
+     * The discriminator between "the audit trail may have been altered" and
+     * "the audit pipeline needs attention" — a distinction worth keeping in
+     * alerting rules, because only the former is an incident.
+     */
+    public function hasTamperEvidence(): bool
+    {
+        foreach ($this->findings as $finding) {
+            if ($finding->reason->isTamperEvidence()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function hasReason(AuditIntegrityReason $reason): bool
+    {
+        foreach ($this->findings as $finding) {
+            if ($finding->reason === $reason) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Distinct reason codes, in first-seen order, for machine-readable output.
+     *
+     * @return list<string>
+     */
+    public function getReasonCodes(): array
+    {
+        $codes = [];
+        foreach ($this->findings as $finding) {
+            $code = $finding->reason->value;
+            if (!\in_array($code, $codes, true)) {
+                $codes[] = $code;
+            }
+        }
+
+        return $codes;
+    }
+
+    /**
+     * @return array{
+     *     valid: bool,
+     *     tamperEvidence: bool,
+     *     chainValid: bool,
+     *     currentSequence: int,
+     *     anchor: array{sequence: int, chainTip: string, timestamp: int, hmacEpoch: int}|null,
+     *     reasonCodes: list<string>,
+     *     findings: list<array{reason: string, tamperEvidence: bool, detail: string, timestamp: int, context: array<string, bool|int|string>}>,
+     *     warnings: array<int, string>,
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'valid' => $this->isValid(),
+            'tamperEvidence' => $this->hasTamperEvidence(),
+            'chainValid' => $this->chainValid,
+            'currentSequence' => $this->currentSequence,
+            'anchor' => $this->anchor?->toArray(),
+            'reasonCodes' => $this->getReasonCodes(),
+            'findings' => array_map(
+                static fn (AuditIntegrityAlert $finding): array => $finding->toArray(),
+                $this->findings,
+            ),
+            'warnings' => $this->warnings,
+        ];
+    }
+}

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -16,10 +16,12 @@ use DateTimeInterface;
 use Doctrine\DBAL\Platforms\SQLitePlatform;
 use Generator;
 use InvalidArgumentException;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
 use SensitiveParameter;
 use Throwable;
 use TYPO3\CMS\Core\Database\Connection;
@@ -33,7 +35,14 @@ final readonly class AuditLogService implements AuditLogServiceInterface
 {
     use AuditChainLockTrait;
 
-    private const TABLE_NAME = 'tx_nrvault_audit_log';
+    /**
+     * Public so the anchoring subsystem
+     * ({@see Anchor\ChainTipAnchorService}) can read
+     * the chain tip and the row at an anchored sequence from the same table
+     * without a second, drift-prone copy of the name. This service remains the
+     * only WRITER.
+     */
+    public const TABLE_NAME = 'tx_nrvault_audit_log';
 
     /**
      * Column widths (in characters, as `varchar(N)` counts them) of the two
@@ -44,11 +53,23 @@ final readonly class AuditLogService implements AuditLogServiceInterface
 
     private const MAX_REQUEST_ID_LENGTH = 100;
 
+    /**
+     * @param AuditSinkRegistryInterface|null $sinkRegistry External audit sinks.
+     *                                                      Optional so the many existing callers that construct this
+     *                                                      service with four arguments (tests, migration tooling) keep
+     *                                                      working; DI autowires it in production. Null simply means no
+     *                                                      fan-out — the database chain is unaffected either way.
+     * @param LoggerInterface|null $logger Used only to report a failure of the
+     *                                     sink fan-out plumbing itself. Chain writes report failures by
+     *                                     throwing, so this service needs no logger for its primary job.
+     */
     public function __construct(
         private ConnectionPool $connectionPool,
         private AccessControlServiceInterface $accessControlService,
         private MasterKeyProviderInterface $masterKeyProvider,
         private ExtensionConfigurationInterface $extensionConfiguration,
+        private ?AuditSinkRegistryInterface $sinkRegistry = null,
+        private ?LoggerInterface $logger = null,
     ) {}
 
     public function log(
@@ -94,7 +115,7 @@ final readonly class AuditLogService implements AuditLogServiceInterface
                 ),
                 $previousHash,
             );
-            $this->insertAndUpdateHash($connection, $data, $previousHash);
+            $persistedRow = $this->insertAndUpdateHash($connection, $data, $previousHash);
             $this->commitAuditLock($connection, $isSQLite);
         } catch (Throwable $e) {
             $this->rollbackAuditLock($connection, $isSQLite);
@@ -103,6 +124,14 @@ final readonly class AuditLogService implements AuditLogServiceInterface
         } finally {
             $this->releaseAuditLock($connection, $isSQLite);
         }
+
+        // Fan out to external sinks only here: the transaction has committed and
+        // the advisory lock is released, so a slow or hanging sink cannot
+        // serialise every other vault operation behind the audit lock. The
+        // database row is already durable, so a sink failure is a delivery
+        // problem, never a reason to fail (or roll back) the audited operation —
+        // the registry contains every error and counts it.
+        $this->publishToSinks($persistedRow);
     }
 
     public function query(?AuditLogFilter $filter = null, int $limit = 100, int $offset = 0): array
@@ -915,12 +944,17 @@ final readonly class AuditLogService implements AuditLogServiceInterface
      * its own row (otherwise the hash would need a placeholder UID).
      *
      * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed> The persisted row, including the assigned
+     *                              `uid` and the computed `entry_hash`, so the
+     *                              caller can fan it out to external sinks
+     *                              without re-reading it from the database
      */
     private function insertAndUpdateHash(
         Connection $connection,
         array $data,
         string $previousHash,
-    ): void {
+    ): array {
         $connection->insert(self::TABLE_NAME, $data);
         $uid = (int) $connection->lastInsertId();
         $data['uid'] = $uid;
@@ -932,6 +966,48 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             ['entry_hash' => $entryHash],
             ['uid' => $uid],
         );
+
+        $data['entry_hash'] = $entryHash;
+
+        return $data;
+    }
+
+    /**
+     * Hand the committed row to the external audit sinks.
+     *
+     * The registry never throws (see {@see AuditSinkRegistryInterface}), so the
+     * only failure mode left is a registry that is itself broken — caught here so
+     * that even a misconfigured DI graph cannot turn audit fan-out into a failed
+     * vault operation.
+     *
+     * @param array<string, mixed> $row Persisted audit row (DB column names)
+     */
+    private function publishToSinks(array $row): void
+    {
+        if (!$this->sinkRegistry instanceof AuditSinkRegistryInterface) {
+            return;
+        }
+
+        try {
+            $entry = AuditLogEntry::fromDatabaseRow($row);
+            // The chain tip after this write IS this entry's hash — the row was
+            // inserted under the advisory lock, so nothing can have appended
+            // since.
+            $this->sinkRegistry->dispatch($entry, $entry->entryHash);
+        } catch (Throwable $e) {
+            // Reaching here means the fan-out plumbing broke, not a single sink —
+            // the registry contains per-sink failures itself. Report it and let
+            // the audited operation complete: the chain-authoritative row is
+            // already committed.
+            $this->logger?->error(
+                'nr-vault audit sink fan-out failed; the database audit entry is committed and intact.',
+                [
+                    'uid' => is_numeric($row['uid'] ?? null) ? (int) $row['uid'] : 0,
+                    'error' => $e->getMessage(),
+                    'exception' => $e::class,
+                ],
+            );
+        }
     }
 
     /**

--- a/Classes/Audit/Sink/AuditSinkInterface.php
+++ b/Classes/Audit/Sink/AuditSinkInterface.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Sink;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+
+/**
+ * An external destination for audit evidence.
+ *
+ * The database table `tx_nrvault_audit_log` is the ONE chain-authoritative sink
+ * and is deliberately NOT modelled as an implementation of this interface: it is
+ * written transactionally, its failure aborts the audited operation, and it owns
+ * the hash chain. Everything here is a *copy* whose only job is to put evidence
+ * somewhere a database-write attacker cannot reach.
+ *
+ * Contract:
+ *
+ *  - Implementations MAY throw. The caller is
+ *    {@see AuditSinkRegistryInterface}, which catches per sink, logs, counts the
+ *    failure, and moves on — a broken sink must never fail a vault operation.
+ *    Do not swallow errors internally; a silent sink is worse than a failing one
+ *    because nothing tells the operator that the evidence stopped flowing.
+ *  - Implementations MUST NOT log secret material. They receive an
+ *    {@see AuditLogEntry}, which carries the secret *identifier* and value
+ *    checksums, never a plaintext value.
+ *  - `isEnabled()` covers both "the operator turned it on" and "it is actually
+ *    usable" (path safe and writable, URL configured). A sink that is configured
+ *    but unusable MUST report false and explain why via the PSR-3 log, so it is
+ *    never mistaken for working external evidence.
+ *
+ * All three publish methods live on one interface rather than being split into a
+ * separate anchor/alert contract: every sink handles all three record kinds, the
+ * enablement and configuration are shared, and
+ * {@see AuditSinkRegistryInterface::hasExternalAuditSink()} can only be
+ * meaningful — "there is a destination that can carry an anchor" — if anchor
+ * support is structurally guaranteed rather than checked at runtime.
+ */
+interface AuditSinkInterface
+{
+    /**
+     * Publish one committed audit entry.
+     *
+     * Called after the entry hash has been written and the audit lock released,
+     * so `$chainTip` is the chain tip *including* `$entry` (identical to
+     * `$entry->entryHash` for a live write; passed separately so a replay tool
+     * can publish historical entries with the tip they belonged to).
+     */
+    public function publish(AuditLogEntry $entry, string $chainTip): void;
+
+    /**
+     * Publish a chain-tip anchor.
+     *
+     * Anchors are what make a full table reset detectable, so a sink that
+     * accepts entries but silently drops anchors would give false confidence.
+     */
+    public function publishAnchor(ChainTipAnchor $anchor): void;
+
+    /**
+     * Publish an integrity finding (hash mismatch, uid gap, table reset, …).
+     */
+    public function publishAlert(AuditIntegrityAlert $alert): void;
+
+    /**
+     * Stable, log-safe identifier for this sink ('syslog', 'file', 'webhook').
+     *
+     * Appears in failure log messages and in the `SINK_FAILURE` alert context,
+     * so it MUST NOT embed a URL, a path, or any credential.
+     */
+    public function getIdentifier(): string;
+
+    /**
+     * Whether this sink is enabled AND usable right now.
+     */
+    public function isEnabled(): bool;
+}

--- a/Classes/Audit/Sink/AuditSinkRegistry.php
+++ b/Classes/Audit/Sink/AuditSinkRegistry.php
@@ -1,0 +1,239 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Sink;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Event\AuditIntegrityAlertEvent;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Default {@see AuditSinkRegistryInterface} implementation.
+ *
+ * Sinks arrive as a tagged iterator (`nr_vault.audit_sink`, wired in
+ * `Services.yaml`), so a consuming extension can add its own destination by
+ * implementing {@see AuditSinkInterface} and tagging it — no change here.
+ *
+ * ## Failure containment
+ *
+ * Every sink call is wrapped individually. A throwing sink is logged, counted,
+ * and does NOT stop the remaining sinks: partial external evidence beats none,
+ * and one broken destination must not blind the others.
+ *
+ * ## Why this class is not readonly
+ *
+ * The failure counters are the point: the health surface needs to report "the
+ * audit pipeline stopped flowing" and the only place that observes every
+ * delivery is here. The class holds no configuration state — just counters and
+ * the reentrancy flag below.
+ *
+ * ## Alert reentrancy
+ *
+ * A failed delivery raises a `SINK_FAILURE` alert, and the alert listener sends
+ * alerts back through {@see dispatchAlert()}. Without a guard, one broken sink
+ * would recurse until the stack ran out. `$dispatchingAlert` makes alert
+ * delivery non-reentrant: failures observed while delivering an alert are logged
+ * and counted but raise no further alert.
+ */
+final class AuditSinkRegistry implements AuditSinkRegistryInterface
+{
+    /** @var array<string, int> */
+    private array $failuresBySink = [];
+
+    private int $failureCount = 0;
+
+    /** Guards against alert-delivery failures raising further alerts. */
+    private bool $dispatchingAlert = false;
+
+    /**
+     * @param iterable<AuditSinkInterface> $sinks Tagged sink collection
+     */
+    public function __construct(
+        private readonly iterable $sinks,
+        private readonly LoggerInterface $logger,
+        private readonly EventDispatcherInterface $eventDispatcher,
+    ) {}
+
+    public function dispatch(AuditLogEntry $entry, string $chainTip): int
+    {
+        return $this->fanOut(
+            static fn (AuditSinkInterface $sink): null => $sink->publish($entry, $chainTip),
+            'entry',
+            ['uid' => $entry->uid, 'action' => $entry->action],
+        );
+    }
+
+    public function dispatchAnchor(ChainTipAnchor $anchor): int
+    {
+        return $this->fanOut(
+            static fn (AuditSinkInterface $sink): null => $sink->publishAnchor($anchor),
+            'anchor',
+            ['sequence' => $anchor->sequence],
+        );
+    }
+
+    public function dispatchAlert(AuditIntegrityAlert $alert): int
+    {
+        if ($this->dispatchingAlert) {
+            // Re-entered from a SINK_FAILURE raised while delivering an alert.
+            // Drop the nested delivery rather than recurse; the failure that
+            // triggered it was already logged and counted.
+            return 0;
+        }
+
+        $this->dispatchingAlert = true;
+
+        try {
+            return $this->fanOut(
+                static fn (AuditSinkInterface $sink): null => $sink->publishAlert($alert),
+                'alert',
+                ['reason' => $alert->reason->value],
+            );
+        } finally {
+            $this->dispatchingAlert = false;
+        }
+    }
+
+    public function hasExternalAuditSink(): bool
+    {
+        foreach ($this->sinks as $sink) {
+            if ($this->isEnabledSafely($sink)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    public function getEnabledSinkIdentifiers(): array
+    {
+        $identifiers = [];
+        foreach ($this->sinks as $sink) {
+            if ($this->isEnabledSafely($sink)) {
+                $identifiers[] = $sink->getIdentifier();
+            }
+        }
+
+        return $identifiers;
+    }
+
+    public function getFailureCount(): int
+    {
+        return $this->failureCount;
+    }
+
+    public function getFailureCountsBySink(): array
+    {
+        return $this->failuresBySink;
+    }
+
+    /**
+     * Run `$publish` against every enabled sink, containing failures per sink.
+     *
+     * @param callable(AuditSinkInterface): void $publish
+     * @param array<string, bool|int|string> $logContext Record-identifying facts
+     *                                                   for the failure log and the SINK_FAILURE alert.
+     *                                                   Never carries secret material — the audit entry's
+     *                                                   uid and action, not its payload
+     *
+     * @return int Number of sinks that accepted the record
+     */
+    private function fanOut(callable $publish, string $recordKind, array $logContext): int
+    {
+        $accepted = 0;
+
+        foreach ($this->sinks as $sink) {
+            if (!$this->isEnabledSafely($sink)) {
+                continue;
+            }
+
+            try {
+                $publish($sink);
+                ++$accepted;
+            } catch (Throwable $e) {
+                $this->recordFailure($sink->getIdentifier(), $recordKind, $e, $logContext);
+            }
+        }
+
+        return $accepted;
+    }
+
+    /**
+     * A sink whose own `isEnabled()` throws is treated as disabled.
+     *
+     * Without this, a misconfigured sink could throw during the enablement probe
+     * — outside the per-call try/catch — and take the audited operation down,
+     * which is exactly the outcome this registry exists to prevent.
+     */
+    private function isEnabledSafely(AuditSinkInterface $sink): bool
+    {
+        try {
+            return $sink->isEnabled();
+        } catch (Throwable $e) {
+            $this->recordFailure($sink->getIdentifier(), 'enablement-probe', $e, []);
+
+            return false;
+        }
+    }
+
+    /**
+     * Log, count, and (unless already delivering an alert) raise a
+     * `SINK_FAILURE` integrity alert.
+     *
+     * @param array<string, bool|int|string> $logContext
+     */
+    private function recordFailure(string $sinkIdentifier, string $recordKind, Throwable $e, array $logContext): void
+    {
+        ++$this->failureCount;
+        $this->failuresBySink[$sinkIdentifier] = ($this->failuresBySink[$sinkIdentifier] ?? 0) + 1;
+
+        $this->logger->error(
+            'nr-vault audit sink delivery failed; the database chain entry is unaffected.',
+            [
+                'sink' => $sinkIdentifier,
+                'record' => $recordKind,
+                'error' => $e->getMessage(),
+                'exception' => $e::class,
+            ] + $logContext,
+        );
+
+        if ($this->dispatchingAlert) {
+            return;
+        }
+
+        $this->raiseSinkFailureAlert($sinkIdentifier, $recordKind, $logContext);
+    }
+
+    /**
+     * @param array<string, bool|int|string> $logContext
+     */
+    private function raiseSinkFailureAlert(string $sinkIdentifier, string $recordKind, array $logContext): void
+    {
+        $alert = AuditIntegrityAlert::create(
+            AuditIntegrityReason::SinkFailure,
+            \sprintf('External audit sink "%s" failed to accept a %s record.', $sinkIdentifier, $recordKind),
+            ['sink' => $sinkIdentifier, 'record' => $recordKind] + $logContext,
+        );
+
+        try {
+            $this->eventDispatcher->dispatch(new AuditIntegrityAlertEvent($alert));
+        } catch (Throwable $dispatchError) {
+            // A throwing listener must not escalate into the audited operation.
+            $this->logger->error(
+                'nr-vault could not dispatch the audit sink failure alert.',
+                ['sink' => $sinkIdentifier, 'error' => $dispatchError->getMessage()],
+            );
+        }
+    }
+}

--- a/Classes/Audit/Sink/AuditSinkRegistryInterface.php
+++ b/Classes/Audit/Sink/AuditSinkRegistryInterface.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Sink;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+
+/**
+ * Fans audit evidence out to every enabled external sink.
+ *
+ * The single guarantee every method makes: **it never throws**. Callers are the
+ * audit write path and the verification command; neither may be taken down by a
+ * full disk or an unreachable collector. Failures are logged, counted
+ * ({@see getFailureCount()}) and raised as `SINK_FAILURE` integrity alerts, so
+ * "never throws" does not mean "fails silently".
+ */
+interface AuditSinkRegistryInterface
+{
+    /**
+     * Publish a committed audit entry to every enabled sink.
+     *
+     * @return int Number of sinks that accepted the entry
+     */
+    public function dispatch(AuditLogEntry $entry, string $chainTip): int;
+
+    /**
+     * Publish a chain-tip anchor to every enabled sink.
+     *
+     * @return int Number of sinks that accepted the anchor. Zero means the
+     *             anchor exists nowhere outside the database and provides no
+     *             reset protection — callers should treat that as a failure of
+     *             the anchoring operation
+     */
+    public function dispatchAnchor(ChainTipAnchor $anchor): int;
+
+    /**
+     * Publish an integrity alert to every enabled sink.
+     *
+     * @return int Number of sinks that accepted the alert
+     */
+    public function dispatchAlert(AuditIntegrityAlert $alert): int;
+
+    /**
+     * Whether at least one external sink is enabled and usable.
+     *
+     * The hardened security profile treats a false here as a finding: a vault
+     * whose only audit copy lives in the database it is meant to protect has no
+     * external tamper evidence at all.
+     */
+    public function hasExternalAuditSink(): bool;
+
+    /**
+     * Identifiers of the currently enabled sinks, for status output.
+     *
+     * @return list<string>
+     */
+    public function getEnabledSinkIdentifiers(): array;
+
+    /**
+     * Number of sink delivery failures observed in this process.
+     *
+     * Read by the health/status surface. Per-process rather than persisted: a
+     * sink failure is an availability signal for the current runtime, and
+     * persisting it would mean writing to the very storage a sink failure may
+     * indicate is broken.
+     */
+    public function getFailureCount(): int;
+
+    /**
+     * Per-sink failure counts, keyed by sink identifier.
+     *
+     * @return array<string, int>
+     */
+    public function getFailureCountsBySink(): array;
+}

--- a/Classes/Audit/Sink/JsonFileAuditSink.php
+++ b/Classes/Audit/Sink/JsonFileAuditSink.php
@@ -1,0 +1,344 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Sink;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Exception\AuditSinkException;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Core\Environment;
+
+/**
+ * Appends audit evidence to newline-delimited JSON files.
+ *
+ * Two separate streams, because they have different retention and access needs:
+ *  - the **entry stream** (`auditSinkFilePath`) — one JSON object per audit
+ *    entry, carrying its `uid` and the `chainTip` it produced;
+ *  - the **anchor stream** (`auditSinkAnchorPath`) — one JSON object per
+ *    published chain-tip anchor. This is the file `vault:audit-verify` reads back
+ *    to detect a full audit-table reset, so it is the one worth putting on
+ *    append-only or off-host storage.
+ *
+ * Both are append-only by construction (`fopen($path, 'ab')`) and every write
+ * takes an exclusive advisory lock, so concurrent PHP workers cannot interleave
+ * half-written lines. Files are created with mode 0600: an audit stream names
+ * every secret identifier and every actor, which is reconnaissance material even
+ * without the secret values.
+ *
+ * ## Why the public-web-root check disables the sink
+ *
+ * A path under the public document root would publish the audit trail — secret
+ * identifiers, usernames, IP addresses, chain hashes — to anyone who guesses the
+ * URL. That is a worse outcome than having no external sink, so a path inside the
+ * public root makes {@see isEnabled()} report false rather than writing anyway.
+ * The refusal is logged with the resolved path and the setting to change, and
+ * `vault:audit-verify` surfaces it, so it fails loudly rather than silently.
+ *
+ * The default (`<var>/log/…`) is outside the public root in every Composer-based
+ * TYPO3 installation. A legacy (non-Composer) layout, where `getVarPath()` lives
+ * under `typo3temp/`, must configure an explicit path.
+ */
+final class JsonFileAuditSink implements AuditSinkInterface
+{
+    public const IDENTIFIER = 'file';
+
+    /** Mode for freshly created stream files — owner read/write only. */
+    private const FILE_MODE = 0o600;
+
+    /** Mode for a stream directory we have to create — owner only. */
+    private const DIRECTORY_MODE = 0o700;
+
+    /**
+     * Memoised result of the path-safety check, keyed by path.
+     *
+     * `isEnabled()` is called for every audit write; resolving `realpath()` each
+     * time would add filesystem syscalls to the hot path of every vault
+     * operation. The check depends only on configuration and the filesystem
+     * layout, neither of which changes within a request.
+     *
+     * @var array<string, bool>
+     */
+    private array $pathSafetyCache = [];
+
+    public function __construct(
+        private readonly ExtensionConfigurationInterface $extensionConfiguration,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function publish(AuditLogEntry $entry, string $chainTip): void
+    {
+        $this->appendLine($this->extensionConfiguration->getAuditSinkFilePath(), [
+            'type' => 'entry',
+            'uid' => $entry->uid,
+            'chainTip' => $chainTip,
+            'entry' => $entry->jsonSerialize(),
+        ]);
+    }
+
+    public function publishAnchor(ChainTipAnchor $anchor): void
+    {
+        $this->appendLine($this->extensionConfiguration->getAuditSinkAnchorPath(), [
+            'type' => 'anchor',
+            'anchor' => $anchor->toArray(),
+        ]);
+    }
+
+    public function publishAlert(AuditIntegrityAlert $alert): void
+    {
+        // Alerts go to the anchor stream, not the entry stream: both are the
+        // "chain health" record an auditor reads, and keeping them together means
+        // a single off-host file tells the whole integrity story.
+        $this->appendLine($this->extensionConfiguration->getAuditSinkAnchorPath(), [
+            'type' => 'alert',
+            'alert' => $alert->toArray(),
+        ]);
+    }
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    public function isEnabled(): bool
+    {
+        if (!$this->extensionConfiguration->isAuditSinkFileEnabled()) {
+            return false;
+        }
+
+        // BOTH streams must be safe. Enabling the sink with a safe entry path but
+        // a web-exposed anchor path would publish the integrity record, and the
+        // anchor stream is the more sensitive of the two (it is the file an
+        // auditor trusts).
+        return $this->isPathSafe($this->extensionConfiguration->getAuditSinkFilePath())
+            && $this->isPathSafe($this->extensionConfiguration->getAuditSinkAnchorPath());
+    }
+
+    /**
+     * Append one JSON object as a single line.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @throws AuditSinkException On any filesystem or encoding failure — the
+     *                            registry catches, logs and counts it
+     */
+    private function appendLine(string $path, array $payload): void
+    {
+        $json = json_encode(
+            $payload,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE,
+        );
+
+        if ($json === false) {
+            throw AuditSinkException::encodingFailed(self::IDENTIFIER, json_last_error_msg());
+        }
+
+        $this->ensureDirectory($path);
+        $this->assertAppendable($path);
+
+        $isNew = !file_exists($path);
+
+        // `fopen()` reports failure by returning false AND emitting a warning; under
+        // TYPO3's warning-to-exception error handler the warning arrives as a
+        // Throwable instead. Normalise both into AuditSinkException so the registry
+        // sees one failure type either way.
+        try {
+            $handle = fopen($path, 'ab');
+        } catch (Throwable $e) {
+            throw AuditSinkException::writeFailed(self::IDENTIFIER, 'cannot open stream for appending: ' . $e->getMessage());
+        }
+
+        if ($handle === false) {
+            throw AuditSinkException::writeFailed(self::IDENTIFIER, 'cannot open stream for appending');
+        }
+
+        try {
+            if (!flock($handle, LOCK_EX)) {
+                throw AuditSinkException::writeFailed(self::IDENTIFIER, 'cannot acquire exclusive lock');
+            }
+
+            try {
+                // A short write (disk full, quota) would leave a truncated line
+                // that breaks the NDJSON contract for every later reader, so it
+                // is an error, not a partial success.
+                $line = $json . "\n";
+                $written = fwrite($handle, $line);
+                if ($written === false || $written !== \strlen($line)) {
+                    throw AuditSinkException::writeFailed(self::IDENTIFIER, 'incomplete write (disk full or quota exceeded?)');
+                }
+                fflush($handle);
+            } finally {
+                flock($handle, LOCK_UN);
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        if ($isNew) {
+            // `fopen()` honours the process umask, which commonly yields 0644.
+            // Tighten immediately after creation. The window is bounded by the
+            // directory mode (0700 for directories we create ourselves).
+            chmod($path, self::FILE_MODE);
+        }
+    }
+
+    /**
+     * Reject an unusable target before `fopen()` sees it.
+     *
+     * Two reasons to check up front rather than letting `fopen()` fail: the
+     * exception says WHAT is wrong ("path is a directory") instead of the generic
+     * "cannot open stream", and `fopen()` emits a PHP warning on failure which —
+     * depending on the host's error handler — either pollutes the log or is
+     * converted into an unrelated exception type.
+     *
+     * @throws AuditSinkException
+     */
+    private function assertAppendable(string $path): void
+    {
+        if (file_exists($path)) {
+            if (!is_file($path)) {
+                throw AuditSinkException::writeFailed(self::IDENTIFIER, 'path exists but is not a regular file');
+            }
+
+            if (!is_writable($path)) {
+                throw AuditSinkException::writeFailed(self::IDENTIFIER, 'stream file is not writable');
+            }
+
+            return;
+        }
+
+        if (!is_writable(\dirname($path))) {
+            throw AuditSinkException::writeFailed(self::IDENTIFIER, 'stream directory is not writable');
+        }
+    }
+
+    /**
+     * Create the stream's parent directory when missing.
+     *
+     * @throws AuditSinkException If the directory cannot be created
+     */
+    private function ensureDirectory(string $path): void
+    {
+        $directory = \dirname($path);
+        if (is_dir($directory)) {
+            return;
+        }
+
+        if (!mkdir($directory, self::DIRECTORY_MODE, true) && !is_dir($directory)) {
+            throw AuditSinkException::writeFailed(self::IDENTIFIER, 'cannot create stream directory');
+        }
+    }
+
+    /**
+     * Whether the path is outside the public web root.
+     *
+     * Resolution walks up to the nearest EXISTING ancestor before comparing:
+     * the stream file (and possibly its directory) does not exist on the first
+     * write, and `realpath()` returns false for a missing path — which would
+     * otherwise make an unwritten path look safe by accident. Resolving an
+     * existing ancestor also collapses `..` segments and symlinks, so a path
+     * like `<var>/log/../../public/audit.ndjson` cannot slip past the check.
+     */
+    private function isPathSafe(string $path): bool
+    {
+        if (isset($this->pathSafetyCache[$path])) {
+            return $this->pathSafetyCache[$path];
+        }
+
+        return $this->pathSafetyCache[$path] = $this->evaluatePathSafety($path);
+    }
+
+    private function evaluatePathSafety(string $path): bool
+    {
+        if ($path === '' || !$this->isAbsolute($path)) {
+            $this->logger->error(
+                'nr-vault audit file sink disabled: path must be absolute.',
+                ['sink' => self::IDENTIFIER, 'path' => $path],
+            );
+
+            return false;
+        }
+
+        $publicPath = realpath(Environment::getPublicPath());
+        if ($publicPath === false) {
+            // Cannot establish the boundary → cannot prove the path is outside
+            // it. Fail closed.
+            $this->logger->error(
+                'nr-vault audit file sink disabled: public web root could not be resolved.',
+                ['sink' => self::IDENTIFIER],
+            );
+
+            return false;
+        }
+
+        $resolved = $this->resolveAgainstNearestExistingAncestor($path);
+        if ($resolved === null) {
+            $this->logger->error(
+                'nr-vault audit file sink disabled: no existing ancestor directory for the configured path.',
+                ['sink' => self::IDENTIFIER, 'path' => $path],
+            );
+
+            return false;
+        }
+
+        if ($resolved === $publicPath || str_starts_with($resolved, $publicPath . \DIRECTORY_SEPARATOR)) {
+            $this->logger->error(
+                'nr-vault audit file sink disabled: the configured path is inside the public web root, '
+                . 'which would expose the audit trail over HTTP. Point auditSinkFilePath / '
+                . 'auditSinkAnchorPath at a location outside the document root.',
+                ['sink' => self::IDENTIFIER, 'path' => $path, 'resolved' => $resolved],
+            );
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Resolve `$path` to an absolute, symlink- and `..`-free form by resolving
+     * its nearest existing ancestor and re-appending the missing tail.
+     *
+     * Returns null when not even the filesystem root of the path exists.
+     */
+    private function resolveAgainstNearestExistingAncestor(string $path): ?string
+    {
+        $tail = [];
+        $current = $path;
+
+        while (true) {
+            $real = realpath($current);
+            if ($real !== false) {
+                return $tail === [] ? $real : $real . \DIRECTORY_SEPARATOR . implode(\DIRECTORY_SEPARATOR, array_reverse($tail));
+            }
+
+            $parent = \dirname($current);
+            if ($parent === $current) {
+                return null;
+            }
+
+            $tail[] = basename($current);
+            $current = $parent;
+        }
+    }
+
+    /**
+     * Absolute-path test that also accepts Windows drive/UNC forms, so the
+     * sink is not silently unusable off Linux.
+     */
+    private function isAbsolute(string $path): bool
+    {
+        return str_starts_with($path, '/')
+            || str_starts_with($path, '\\\\')
+            || preg_match('/^[A-Za-z]:[\\\\\/]/', $path) === 1;
+    }
+}

--- a/Classes/Audit/Sink/Rfc5424Formatter.php
+++ b/Classes/Audit/Sink/Rfc5424Formatter.php
@@ -1,0 +1,234 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Sink;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+
+/**
+ * Builds RFC 5424 §6.3 STRUCTURED-DATA elements for the syslog sink.
+ *
+ * Split out from {@see SyslogAuditSink} for one reason: `syslog()` writes to a
+ * process-global handle and its output is not observable from a unit test. The
+ * formatting — which is where the bugs live (escaping, field order, truncation)
+ * — is pure and fully testable here.
+ *
+ * ## What we emit, and what syslog adds
+ *
+ * A complete RFC 5424 frame is
+ * `HEADER SP STRUCTURED-DATA [SP MSG]`. PHP's `syslog()` only lets us supply the
+ * MSG portion; the PRI, VERSION, TIMESTAMP, HOSTNAME, APP-NAME and PROCID of the
+ * HEADER are produced by the local syslog implementation (APP-NAME from the
+ * `openlog()` ident). We therefore emit
+ * `STRUCTURED-DATA SP <human-readable summary>` and let the daemon prepend the
+ * header. Collectors that parse RFC 5424 see a well-formed SD element; a plain
+ * `tail -f` still shows a readable line.
+ *
+ * ## SD-ID
+ *
+ * RFC 5424 §6.3.2 requires an SD-ID to be either IANA-registered or of the form
+ * `name@<private-enterprise-number>`. Netresearch has no registered PEN, so the
+ * elements use IANA's documentation/example PEN 32473 (RFC 5612 §5) — a
+ * syntactically valid, deliberately non-colliding choice. Collector rules should
+ * match on the full SD-ID string.
+ *
+ * ## Escaping
+ *
+ * Inside a PARAM-VALUE, RFC 5424 §6.3.3 requires `"`, `\` and `]` to be escaped
+ * with a backslash. Control characters are additionally stripped: audit fields
+ * such as `user_agent` originate from attacker-controlled request headers, and an
+ * embedded newline would let a caller forge an extra syslog record
+ * (CWE-117 log injection).
+ */
+final readonly class Rfc5424Formatter
+{
+    /** Structured-data element for a single audit entry. */
+    public const SD_ID_ENTRY = 'nrVaultAudit@32473';
+
+    /** Structured-data element for a chain-tip anchor. */
+    public const SD_ID_ANCHOR = 'nrVaultAnchor@32473';
+
+    /** Structured-data element for an integrity alert. */
+    public const SD_ID_ALERT = 'nrVaultAlert@32473';
+
+    /**
+     * Cap on a single PARAM-VALUE. Keeps one oversized field (a 500-char
+     * user-agent, a long error message) from pushing the record past the
+     * 1024-byte minimum a receiver is required to accept.
+     */
+    private const MAX_PARAM_LENGTH = 200;
+
+    /**
+     * Cap on the free-text summary that follows the structured-data element.
+     *
+     * Bounded for the same reason as a PARAM-VALUE: the summary interpolates
+     * caller-influenced fields (secret identifier, actor username, alert detail),
+     * so leaving it unbounded would let one oversized value inflate the record
+     * regardless of how carefully the SD params are trimmed.
+     */
+    private const MAX_SUMMARY_LENGTH = 300;
+
+    /**
+     * Format one audit entry.
+     *
+     * Field set per the sink contract: secret identifier, action, actor,
+     * success, uid, chain tip. `actor` is the human-readable username plus its
+     * uid so a SIEM can correlate without a second lookup.
+     */
+    public function formatEntry(AuditLogEntry $entry, string $chainTip): string
+    {
+        $sd = $this->buildStructuredData(self::SD_ID_ENTRY, [
+            'uid' => (string) $entry->uid,
+            'secret' => $entry->secretIdentifier,
+            'action' => $entry->action,
+            'actor' => $entry->actorUsername,
+            'actorUid' => (string) $entry->actorUid,
+            'actorType' => $entry->actorType,
+            'success' => $entry->success ? 'true' : 'false',
+            'chainTip' => $chainTip,
+        ]);
+
+        return $sd . ' ' . $this->summary(\sprintf(
+            'vault audit %s %s on %s by %s',
+            $entry->action,
+            $entry->success ? 'succeeded' : 'FAILED',
+            $entry->secretIdentifier,
+            $entry->actorUsername !== '' ? $entry->actorUsername : ('uid:' . $entry->actorUid),
+        ));
+    }
+
+    /**
+     * Format a chain-tip anchor.
+     */
+    public function formatAnchor(ChainTipAnchor $anchor): string
+    {
+        $sd = $this->buildStructuredData(self::SD_ID_ANCHOR, [
+            'sequence' => (string) $anchor->sequence,
+            'chainTip' => $anchor->chainTip,
+            'hmacEpoch' => (string) $anchor->hmacEpoch,
+            'anchoredAt' => (string) $anchor->timestamp,
+        ]);
+
+        return $sd . ' ' . $this->summary(\sprintf(
+            'vault audit chain anchored at sequence %d (epoch %d)',
+            $anchor->sequence,
+            $anchor->hmacEpoch,
+        ));
+    }
+
+    /**
+     * Format an integrity alert.
+     */
+    public function formatAlert(AuditIntegrityAlert $alert): string
+    {
+        $params = [
+            'reason' => $alert->reason->value,
+            'tamperEvidence' => $alert->reason->isTamperEvidence() ? 'true' : 'false',
+            'raisedAt' => (string) $alert->timestamp,
+        ];
+
+        foreach ($alert->context as $key => $value) {
+            // Prefix so a context key can never collide with (or override) one
+            // of the fixed params above.
+            $params['ctx_' . $key] = \is_bool($value) ? ($value ? 'true' : 'false') : (string) $value;
+        }
+
+        $sd = $this->buildStructuredData(self::SD_ID_ALERT, $params);
+
+        return $sd . ' ' . $this->summary(\sprintf(
+            'vault audit integrity alert %s: %s',
+            $alert->reason->value,
+            $alert->detail,
+        ));
+    }
+
+    /**
+     * Assemble `[SD-ID name="value" ...]` from an ordered param map.
+     *
+     * Empty values are kept rather than dropped: a collector rule matching on
+     * `chainTip=""` should be able to see that the field was present and blank,
+     * not have to guess whether the sink omitted it.
+     *
+     * @param array<string, string> $params
+     */
+    private function buildStructuredData(string $sdId, array $params): string
+    {
+        $parts = [$sdId];
+        foreach ($params as $name => $value) {
+            $parts[] = \sprintf('%s="%s"', $this->sanitizeParamName($name), $this->escapeParamValue($value));
+        }
+
+        return '[' . implode(' ', $parts) . ']';
+    }
+
+    /**
+     * RFC 5424 PARAM-NAME is restricted to printable US-ASCII without `=`,
+     * space, `]` or `"`. Every name we emit is a literal from this class, but
+     * alert context keys come from callers — filter rather than trust.
+     */
+    private function sanitizeParamName(string $name): string
+    {
+        $clean = (string) preg_replace('/[^A-Za-z0-9_.-]/', '_', $name);
+
+        return $clean === '' ? 'param' : $clean;
+    }
+
+    /**
+     * Escape a PARAM-VALUE per RFC 5424 §6.3.3, after stripping control
+     * characters and bounding the length.
+     */
+    private function escapeParamValue(string $value): string
+    {
+        $clean = $this->sanitize($value);
+
+        if (mb_strlen($clean, 'UTF-8') > self::MAX_PARAM_LENGTH) {
+            $clean = mb_substr($clean, 0, self::MAX_PARAM_LENGTH - 3, 'UTF-8') . '...';
+        }
+
+        // Order matters: the backslash must be doubled before the escapes that
+        // introduce new backslashes, otherwise those get double-escaped.
+        return str_replace(['\\', '"', ']'], ['\\\\', '\\"', '\\]'], $clean);
+    }
+
+    /**
+     * Sanitise and bound the free-text summary.
+     */
+    private function summary(string $text): string
+    {
+        $clean = $this->sanitize($text);
+
+        if (mb_strlen($clean, 'UTF-8') > self::MAX_SUMMARY_LENGTH) {
+            return mb_substr($clean, 0, self::MAX_SUMMARY_LENGTH - 3, 'UTF-8') . '...';
+        }
+
+        return $clean;
+    }
+
+    /**
+     * Drop control characters (including CR/LF) and repair invalid UTF-8.
+     *
+     * A newline in a syslog MSG terminates the record, so an unfiltered
+     * attacker-controlled field could append a second, forged record.
+     */
+    private function sanitize(string $value): string
+    {
+        if ($value === '') {
+            return '';
+        }
+
+        if (!mb_check_encoding($value, 'UTF-8')) {
+            $scrubbed = mb_convert_encoding($value, 'UTF-8', 'UTF-8');
+            $value = \is_string($scrubbed) ? $scrubbed : '';
+        }
+
+        return trim((string) preg_replace('/[\x00-\x1F\x7F]+/', ' ', $value));
+    }
+}

--- a/Classes/Audit/Sink/SyslogAuditSink.php
+++ b/Classes/Audit/Sink/SyslogAuditSink.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Sink;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+
+/**
+ * Mirrors audit evidence to the local syslog as RFC 5424 structured data.
+ *
+ * The cheapest useful external sink: on any host with a log shipper (rsyslog,
+ * syslog-ng, journald + vector, a container runtime's log driver) the audit
+ * chain leaves the TYPO3 database with zero additional infrastructure, and a
+ * database-write attacker can no longer erase the evidence without also owning
+ * the log pipeline.
+ *
+ * Facility is fixed at `LOG_LOCAL0` — the conventional slot for
+ * application-defined audit streams, and the one a collector rule can rely on
+ * without a per-installation lookup. Only the `openlog()` ident is configurable
+ * (it becomes RFC 5424's APP-NAME), which is the field operators actually need
+ * to vary when several TYPO3 instances share a host.
+ *
+ * Severity mapping:
+ *  - `LOG_INFO` — successful audit entry
+ *  - `LOG_WARNING` — failed audit entry (denied access, failed rotation, …)
+ *  - `LOG_NOTICE` — chain-tip anchor
+ *  - `LOG_CRIT` — integrity alert that is tamper evidence
+ *  - `LOG_ERR` — integrity alert that is a delivery failure
+ *
+ * Message construction lives in {@see Rfc5424Formatter} (see its docblock for
+ * the SD-ID choice and the escaping rules).
+ */
+final readonly class SyslogAuditSink implements AuditSinkInterface
+{
+    public const IDENTIFIER = 'syslog';
+
+    public function __construct(
+        private ExtensionConfigurationInterface $extensionConfiguration,
+        private Rfc5424Formatter $formatter,
+    ) {}
+
+    public function publish(AuditLogEntry $entry, string $chainTip): void
+    {
+        $this->emit(
+            $entry->success ? LOG_INFO : LOG_WARNING,
+            $this->formatter->formatEntry($entry, $chainTip),
+        );
+    }
+
+    public function publishAnchor(ChainTipAnchor $anchor): void
+    {
+        $this->emit(LOG_NOTICE, $this->formatter->formatAnchor($anchor));
+    }
+
+    public function publishAlert(AuditIntegrityAlert $alert): void
+    {
+        $this->emit(
+            $alert->reason->isTamperEvidence() ? LOG_CRIT : LOG_ERR,
+            $this->formatter->formatAlert($alert),
+        );
+    }
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    public function isEnabled(): bool
+    {
+        // No usability probe beyond the toggle: `openlog()` against a missing
+        // socket does not fail here but at `syslog()` time, which the registry
+        // already reports as a sink failure. Claiming "enabled but unusable"
+        // would need a test write on every isEnabled() call.
+        return $this->extensionConfiguration->isAuditSinkSyslogEnabled();
+    }
+
+    /**
+     * Open the log with our ident, write, and close again.
+     *
+     * `closelog()` is deliberate rather than wasteful: `openlog()` mutates
+     * process-global state, so leaving our ident installed would relabel
+     * unrelated `syslog()` calls made later in the same request (TYPO3 core,
+     * other extensions) as nr-vault audit records — silently corrupting the
+     * audit stream a collector trusts.
+     */
+    private function emit(int $priority, string $message): void
+    {
+        openlog($this->extensionConfiguration->getAuditSinkSyslogIdent(), LOG_PID | LOG_ODELAY, LOG_LOCAL0);
+
+        try {
+            syslog($priority, $message);
+        } finally {
+            closelog();
+        }
+    }
+}

--- a/Classes/Audit/Sink/WebhookAuditSink.php
+++ b/Classes/Audit/Sink/WebhookAuditSink.php
@@ -1,0 +1,209 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Sink;
+
+use GuzzleHttp\Psr7\HttpFactory;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Exception\AuditSinkException;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\StreamFactoryInterface;
+use Throwable;
+
+/**
+ * POSTs audit evidence as JSON to an HTTP endpoint (typically a SIEM collector).
+ *
+ * ## Payload
+ *
+ * One JSON object per request, always with a `type` discriminator
+ * (`entry` | `anchor` | `alert`) plus a `source` marker, so a single collector
+ * endpoint can route all three record kinds without a per-kind URL.
+ *
+ * ## Transport hardening
+ *
+ * The client is built by
+ * {@see \Netresearch\NrVault\Http\SecureHttpClientFactory} (wired in
+ * `Services.yaml`), so this sink inherits the extension-wide SSRF and
+ * DNS-rebinding defences, the no-redirect default, and TYPO3's proxy/TLS
+ * configuration. That has one operational consequence worth stating plainly: a
+ * collector on a private/RFC1918/loopback address is REFUSED unless the operator
+ * allow-lists the host literally in
+ * `$GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts']`.
+ *
+ * That is the intended trade-off. The webhook URL is settable from the backend
+ * Settings module, so a compromised admin could otherwise repoint it at a cloud
+ * metadata service and use the vault as an SSRF pivot. `allowed_hosts` is
+ * filesystem-bound and out of the backend's reach, which keeps the pivot closed
+ * while leaving the legitimate on-premise path available. The refusal is not
+ * silent: it surfaces as a sink failure (logged, counted, and reported by
+ * `vault:audit-verify`).
+ *
+ * ## Timeouts
+ *
+ * The injected client is created with a short total timeout (see `Services.yaml`).
+ * Audit fan-out happens after the chain write and outside the advisory lock, so a
+ * slow endpoint cannot serialise vault operations — but it can still hold a web
+ * request open, so the bound is deliberately tight rather than generous.
+ */
+final readonly class WebhookAuditSink implements AuditSinkInterface
+{
+    public const IDENTIFIER = 'webhook';
+
+    /** Marks the payload's origin so a shared collector can filter on it. */
+    private const PAYLOAD_SOURCE = 'nr-vault';
+
+    // No explicit `readonly` modifier: the class is readonly, so its properties
+    // are implicitly readonly and PHP rejects the redundant keyword.
+    private RequestFactoryInterface $requestFactory;
+
+    private StreamFactoryInterface $streamFactory;
+
+    /**
+     * @param ClientInterface $httpClient MUST be a hardened client — `Services.yaml`
+     *                                    injects one built by `SecureHttpClientFactory::create(3)`
+     * @param RequestFactoryInterface|null $requestFactory PSR-17 factories are not
+     *                                                     registered in the TYPO3 core DI container, so they default to
+     *                                                     Guzzle's `HttpFactory` (the same approach as
+     *                                                     {@see \Netresearch\NrVault\Http\OAuth\OAuthTokenManager}) and stay
+     *                                                     injectable for tests
+     */
+    public function __construct(
+        private ExtensionConfigurationInterface $extensionConfiguration,
+        private ClientInterface $httpClient,
+        ?RequestFactoryInterface $requestFactory = null,
+        ?StreamFactoryInterface $streamFactory = null,
+    ) {
+        $httpFactory = new HttpFactory();
+        $this->requestFactory = $requestFactory ?? $httpFactory;
+        $this->streamFactory = $streamFactory ?? $httpFactory;
+    }
+
+    public function publish(AuditLogEntry $entry, string $chainTip): void
+    {
+        $this->post([
+            'type' => 'entry',
+            'source' => self::PAYLOAD_SOURCE,
+            'uid' => $entry->uid,
+            'chainTip' => $chainTip,
+            'entry' => $entry->jsonSerialize(),
+        ]);
+    }
+
+    public function publishAnchor(ChainTipAnchor $anchor): void
+    {
+        $this->post([
+            'type' => 'anchor',
+            'source' => self::PAYLOAD_SOURCE,
+            'anchor' => $anchor->toArray(),
+        ]);
+    }
+
+    public function publishAlert(AuditIntegrityAlert $alert): void
+    {
+        $this->post([
+            'type' => 'alert',
+            'source' => self::PAYLOAD_SOURCE,
+            'alert' => $alert->toArray(),
+        ]);
+    }
+
+    public function getIdentifier(): string
+    {
+        return self::IDENTIFIER;
+    }
+
+    public function isEnabled(): bool
+    {
+        if (!$this->extensionConfiguration->isAuditSinkWebhookEnabled()) {
+            return false;
+        }
+
+        // An enabled-but-unconfigured webhook would report itself as external
+        // evidence while delivering nothing, which is precisely the false
+        // confidence the hardened-profile check exists to catch.
+        return $this->isUsableUrl($this->extensionConfiguration->getAuditSinkWebhookUrl());
+    }
+
+    /**
+     * Send one JSON payload.
+     *
+     * @param array<string, mixed> $payload
+     *
+     * @throws AuditSinkException On encoding, transport, or non-2xx response
+     */
+    private function post(array $payload): void
+    {
+        $url = $this->extensionConfiguration->getAuditSinkWebhookUrl();
+        if (!$this->isUsableUrl($url)) {
+            throw AuditSinkException::writeFailed(self::IDENTIFIER, 'no usable http(s) endpoint configured');
+        }
+
+        $json = json_encode(
+            $payload,
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE | JSON_INVALID_UTF8_SUBSTITUTE,
+        );
+        if ($json === false) {
+            throw AuditSinkException::encodingFailed(self::IDENTIFIER, json_last_error_msg());
+        }
+
+        $request = $this->requestFactory->createRequest('POST', $url)
+            ->withHeader('Content-Type', 'application/json')
+            ->withHeader('Accept', 'application/json')
+            ->withBody($this->streamFactory->createStream($json));
+
+        try {
+            $response = $this->httpClient->sendRequest($request);
+        } catch (ClientExceptionInterface $e) {
+            // PSR-18 transport failure: DNS, TLS, timeout, refused connection —
+            // and the SSRF guard's own rejection, which arrives as a
+            // RequestException. The endpoint URL is omitted from the message so
+            // a URL carrying a collector token cannot reach the log.
+            throw AuditSinkException::transportFailed(self::IDENTIFIER, $e->getMessage());
+        } catch (Throwable $e) {
+            // A PSR-17/18 implementation may also throw InvalidArgumentException
+            // for a malformed URI before any request is attempted. Normalise it
+            // so the registry's per-sink handling stays uniform.
+            throw AuditSinkException::transportFailed(self::IDENTIFIER, $e->getMessage());
+        }
+
+        $status = $response->getStatusCode();
+        if ($status < 200 || $status >= 300) {
+            throw AuditSinkException::rejectedByEndpoint(self::IDENTIFIER, $status);
+        }
+    }
+
+    /**
+     * Whether the configured value is a syntactically usable http(s) URL.
+     *
+     * Scheme is restricted to http/https so a `file://` or `php://` value cannot
+     * turn an audit fan-out into a local-file write. Reachability is NOT probed
+     * here — that is the request's job, and probing on every `isEnabled()` call
+     * would put a network round-trip in the path of every vault operation.
+     */
+    private function isUsableUrl(string $url): bool
+    {
+        if ($url === '') {
+            return false;
+        }
+
+        $scheme = parse_url($url, PHP_URL_SCHEME);
+        if (!\is_string($scheme) || !\in_array(strtolower($scheme), ['http', 'https'], true)) {
+            return false;
+        }
+
+        $host = parse_url($url, PHP_URL_HOST);
+
+        return \is_string($host) && $host !== '';
+    }
+}

--- a/Classes/Command/VaultAuditAnchorCommand.php
+++ b/Classes/Command/VaultAuditAnchorCommand.php
@@ -1,0 +1,166 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Command;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+/**
+ * Publishes the current audit chain tip to the external sinks.
+ *
+ * Run this on a schedule (see
+ * {@see \Netresearch\NrVault\Task\AuditAnchorTask}). Each run records, outside
+ * the database, that the chain had reached a given sequence with a given tip
+ * hash — which is what makes a later full table reset detectable by
+ * `vault:audit-verify`. The anchoring interval is the blind window: an attacker
+ * who resets the table can only hide entries written since the last anchor.
+ *
+ * Usage:
+ *   vendor/bin/typo3 vault:audit-anchor
+ *   vendor/bin/typo3 vault:audit-anchor --dry-run
+ *   vendor/bin/typo3 vault:audit-anchor --format=json
+ */
+#[AsCommand(
+    name: 'vault:audit-anchor',
+    description: 'Publish the audit log chain tip to the external audit sinks',
+)]
+final class VaultAuditAnchorCommand extends Command
+{
+    public function __construct(
+        private readonly ChainTipAnchorServiceInterface $anchorService,
+        private readonly AuditSinkRegistryInterface $sinkRegistry,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'dry-run',
+                null,
+                InputOption::VALUE_NONE,
+                'Show the anchor that would be published without writing it to any sink',
+            )
+            ->addOption(
+                'format',
+                'f',
+                InputOption::VALUE_REQUIRED,
+                'Output format: text (default) or json',
+                'text',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $formatOption = $input->getOption('format');
+        $json = \is_string($formatOption) && strtolower($formatOption) === 'json';
+        $dryRun = (bool) $input->getOption('dry-run');
+
+        try {
+            $anchor = $this->anchorService->capture();
+        } catch (Throwable $e) {
+            $this->fail($io, $output, $json, 'Could not read the audit chain tip: ' . $e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $enabledSinks = $this->sinkRegistry->getEnabledSinkIdentifiers();
+
+        if ($dryRun) {
+            $this->render($io, $output, $json, $anchor, $enabledSinks, 0, true);
+            if (!$json) {
+                $io->note('Dry run — nothing was published.');
+            }
+
+            return Command::SUCCESS;
+        }
+
+        $published = $this->anchorService->publish($anchor);
+
+        $this->render($io, $output, $json, $anchor, $enabledSinks, $published, false);
+
+        if ($published === 0) {
+            // Exit non-zero: an anchoring run that reached no external sink gives
+            // no reset protection, and a green scheduler task would misreport
+            // that as working tamper evidence.
+            if (!$json) {
+                $io->error(
+                    'The anchor was not accepted by any external sink, so it provides no '
+                    . 'table-reset protection. Enable and configure at least one audit sink '
+                    . '(auditSinkFileEnabled / auditSinkSyslogEnabled / auditSinkWebhookEnabled).',
+                );
+            }
+
+            return Command::FAILURE;
+        }
+
+        if (!$json) {
+            $io->success(\sprintf(
+                'Anchored audit chain at sequence %d across %d sink(s).',
+                $anchor->sequence,
+                $published,
+            ));
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param list<string> $enabledSinks
+     */
+    private function render(
+        SymfonyStyle $io,
+        OutputInterface $output,
+        bool $json,
+        ChainTipAnchor $anchor,
+        array $enabledSinks,
+        int $published,
+        bool $dryRun,
+    ): void {
+        if ($json) {
+            $output->writeln(json_encode([
+                'dryRun' => $dryRun,
+                'anchor' => $anchor->toArray(),
+                'enabledSinks' => $enabledSinks,
+                'published' => $published,
+            ], JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+
+            return;
+        }
+
+        $io->definitionList(
+            ['Sequence (max uid)' => (string) $anchor->sequence],
+            ['Chain tip' => $anchor->chainTip !== '' ? $anchor->chainTip : '(empty chain)'],
+            ['HMAC epoch' => (string) $anchor->hmacEpoch],
+            ['Enabled sinks' => $enabledSinks === [] ? '(none)' : implode(', ', $enabledSinks)],
+        );
+    }
+
+    private function fail(SymfonyStyle $io, OutputInterface $output, bool $json, string $message): void
+    {
+        if ($json) {
+            $output->writeln(json_encode(['error' => $message], JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+
+            return;
+        }
+
+        $io->error($message);
+    }
+}

--- a/Classes/Command/VaultAuditVerifyCommand.php
+++ b/Classes/Command/VaultAuditVerifyCommand.php
@@ -1,0 +1,210 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Command;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReport;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+/**
+ * Full audit-integrity verification: internal hash chain plus external anchor.
+ *
+ * Complements `vault:audit --verify`, which only runs the in-database hash-chain
+ * pass. That pass cannot detect a truncate-and-rebuild, because the rebuilt chain
+ * is internally consistent. This command additionally compares the chain against
+ * the last published chain-tip anchor and reports every finding under a
+ * machine-readable reason code:
+ *
+ *   HASH_MISMATCH      a stored hash does not recompute
+ *   UID_GAP            rows were deleted from the middle of the chain
+ *   TABLE_RESET        the chain is not the chain that was anchored
+ *   EPOCH_DOWNGRADE    the verification algorithm was relabelled downward
+ *   NO_EXTERNAL_SINK   hardened profile without usable external evidence
+ *   SINK_FAILURE       a sink could not be delivered to during this process
+ *
+ * Exits non-zero on ANY finding, so it can be wired straight into monitoring.
+ * Every finding is also dispatched as
+ * {@see \Netresearch\NrVault\Event\AuditIntegrityAlertEvent}, so SIEM listeners
+ * fire whether or not anyone reads this output.
+ *
+ * Usage:
+ *   vendor/bin/typo3 vault:audit-verify
+ *   vendor/bin/typo3 vault:audit-verify --format=json
+ *   vendor/bin/typo3 vault:audit-verify --tamper-only
+ */
+#[AsCommand(
+    name: 'vault:audit-verify',
+    description: 'Verify audit log integrity against the hash chain and the external chain-tip anchor',
+)]
+final class VaultAuditVerifyCommand extends Command
+{
+    public function __construct(
+        private readonly ChainTipAnchorServiceInterface $anchorService,
+        private readonly AuditSinkRegistryInterface $sinkRegistry,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'format',
+                'f',
+                InputOption::VALUE_REQUIRED,
+                'Output format: text (default) or json',
+                'text',
+            )
+            ->addOption(
+                'tamper-only',
+                null,
+                InputOption::VALUE_NONE,
+                'Only fail on tamper evidence; treat configuration and delivery findings '
+                . '(NO_EXTERNAL_SINK, SINK_FAILURE) as warnings',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $formatOption = $input->getOption('format');
+        $json = \is_string($formatOption) && strtolower($formatOption) === 'json';
+        $tamperOnly = (bool) $input->getOption('tamper-only');
+
+        try {
+            $report = $this->anchorService->verify();
+        } catch (Throwable $e) {
+            // A verifier that cannot run must never look like a verifier that
+            // found nothing.
+            if ($json) {
+                $output->writeln(json_encode(
+                    ['valid' => false, 'error' => $e->getMessage()],
+                    JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR,
+                ));
+            } else {
+                $io->error('Audit integrity verification could not run: ' . $e->getMessage());
+            }
+
+            return Command::FAILURE;
+        }
+
+        $failed = $tamperOnly ? $report->hasTamperEvidence() : !$report->isValid();
+
+        if ($json) {
+            $output->writeln(json_encode(
+                $report->toArray() + [
+                    'tamperOnly' => $tamperOnly,
+                    'exitFailure' => $failed,
+                    'sinkFailures' => $this->sinkRegistry->getFailureCountsBySink(),
+                    'enabledSinks' => $this->sinkRegistry->getEnabledSinkIdentifiers(),
+                ],
+                JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR,
+            ));
+
+            return $failed ? Command::FAILURE : Command::SUCCESS;
+        }
+
+        $this->renderText($io, $report, $failed);
+
+        return $failed ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    private function renderText(SymfonyStyle $io, AuditIntegrityReport $report, bool $failed): void
+    {
+        $io->title('Vault Audit Integrity Verification');
+
+        $anchor = $report->anchor;
+        $io->definitionList(
+            ['Chain length (max uid)' => (string) $report->currentSequence],
+            ['Hash chain' => $report->chainValid ? 'valid' : 'INVALID'],
+            ['Anchor' => $anchor instanceof ChainTipAnchor
+                ? \sprintf(
+                    'sequence %d, epoch %d, taken %s UTC',
+                    $anchor->sequence,
+                    $anchor->hmacEpoch,
+                    gmdate('Y-m-d H:i:s', $anchor->timestamp),
+                )
+                : 'none available'],
+            ['Enabled sinks' => $this->formatSinkList()],
+        );
+
+        if ($report->warnings !== []) {
+            $io->warning(\sprintf('%d chain warning(s):', \count($report->warnings)));
+            $io->table(
+                ['Entry UID', 'Warning'],
+                array_map(
+                    static fn (int|string $uid, string $warning): array => [(string) $uid, $warning],
+                    array_keys($report->warnings),
+                    array_values($report->warnings),
+                ),
+            );
+        }
+
+        if ($report->isValid()) {
+            $io->success('Audit log integrity verified — hash chain intact and consistent with the external anchor.');
+
+            return;
+        }
+
+        $io->section('Findings');
+        $io->table(
+            ['Code', 'Tamper evidence', 'Detail'],
+            array_map(
+                static fn (AuditIntegrityAlert $finding): array => [
+                    $finding->reason->value,
+                    $finding->reason->isTamperEvidence() ? 'YES' : 'no',
+                    $finding->detail,
+                ],
+                $report->findings,
+            ),
+        );
+
+        $codes = implode(', ', $report->getReasonCodes());
+
+        if ($failed) {
+            $io->error(\sprintf('Audit integrity verification FAILED: %s', $codes));
+
+            return;
+        }
+
+        // Reached only with --tamper-only and non-tamper findings present.
+        $io->warning(\sprintf(
+            'Audit integrity findings present but no tamper evidence (%s); '
+            . 'exiting successfully because --tamper-only was given.',
+            $codes,
+        ));
+    }
+
+    private function formatSinkList(): string
+    {
+        $sinks = $this->sinkRegistry->getEnabledSinkIdentifiers();
+        if ($sinks === []) {
+            return '(none)';
+        }
+
+        $failures = $this->sinkRegistry->getFailureCountsBySink();
+
+        return implode(', ', array_map(
+            static fn (string $id): string => isset($failures[$id])
+                ? \sprintf('%s (%d failure(s))', $id, $failures[$id])
+                : $id,
+            $sinks,
+        ));
+    }
+}

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -436,7 +436,6 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
         return Environment::getVarPath() . '/secrets/vault-master.key';
     }
 
-
     /**
      * Resolve a configured audit-sink file path, falling back to
      * `<var>/log/<basename>` when unset or empty.

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -67,6 +67,22 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
      */
     public const DEFAULT_AUDIT_HMAC_EPOCH = 3;
 
+    public const DEFAULT_AUDIT_SINK_SYSLOG_ENABLED = false;
+
+    public const DEFAULT_AUDIT_SINK_SYSLOG_IDENT = 'nr-vault';
+
+    public const DEFAULT_AUDIT_SINK_FILE_ENABLED = false;
+
+    /** Basename appended to `Environment::getVarPath() . '/log'` when no path is configured. */
+    public const DEFAULT_AUDIT_SINK_FILE_BASENAME = 'nr-vault-audit.ndjson';
+
+    /** Basename appended to `Environment::getVarPath() . '/log'` when no anchor path is configured. */
+    public const DEFAULT_AUDIT_SINK_ANCHOR_BASENAME = 'nr-vault-audit-anchor.ndjson';
+
+    public const DEFAULT_AUDIT_SINK_WEBHOOK_ENABLED = false;
+
+    public const DEFAULT_AUDIT_SINK_WEBHOOK_URL = '';
+
     public const DEFAULT_STALE_NEVER_READ_DAYS = 30;
 
     public const DEFAULT_STALE_NOT_READ_DAYS = 90;
@@ -253,6 +269,88 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
     }
 
     /**
+     * Whether the syslog audit sink is enabled.
+     */
+    public function isAuditSinkSyslogEnabled(): bool
+    {
+        return (bool) ($this->configuration['auditSinkSyslogEnabled'] ?? self::DEFAULT_AUDIT_SINK_SYSLOG_ENABLED);
+    }
+
+    /**
+     * `openlog()` ident for the syslog audit sink.
+     *
+     * Falls back to the default for an empty or non-string value: an empty
+     * ident makes syslog lines unattributable, which defeats the point of the
+     * sink.
+     */
+    public function getAuditSinkSyslogIdent(): string
+    {
+        $val = $this->configuration['auditSinkSyslogIdent'] ?? null;
+        if (!\is_string($val) || trim($val) === '') {
+            return self::DEFAULT_AUDIT_SINK_SYSLOG_IDENT;
+        }
+
+        return trim($val);
+    }
+
+    /**
+     * Whether the append-only NDJSON file audit sink is enabled.
+     */
+    public function isAuditSinkFileEnabled(): bool
+    {
+        return (bool) ($this->configuration['auditSinkFileEnabled'] ?? self::DEFAULT_AUDIT_SINK_FILE_ENABLED);
+    }
+
+    /**
+     * Absolute path of the append-only NDJSON audit file.
+     *
+     * An unset/empty value resolves to `<var>/log/nr-vault-audit.ndjson`, which
+     * is outside the public web root on every standard TYPO3 layout.
+     */
+    public function getAuditSinkFilePath(): string
+    {
+        return $this->resolveLogPath(
+            $this->configuration['auditSinkFilePath'] ?? null,
+            self::DEFAULT_AUDIT_SINK_FILE_BASENAME,
+        );
+    }
+
+    /**
+     * Absolute path of the append-only chain-tip anchor file.
+     *
+     * Deliberately a separate setting rather than a name derived from the
+     * NDJSON path: the anchor file is the external evidence that survives a
+     * full audit-table reset, so operators must be able to point it at a
+     * different (ideally append-only or off-host) location than the bulk
+     * entry stream.
+     */
+    public function getAuditSinkAnchorPath(): string
+    {
+        return $this->resolveLogPath(
+            $this->configuration['auditSinkAnchorPath'] ?? null,
+            self::DEFAULT_AUDIT_SINK_ANCHOR_BASENAME,
+        );
+    }
+
+    /**
+     * Whether the webhook audit sink is enabled.
+     */
+    public function isAuditSinkWebhookEnabled(): bool
+    {
+        return (bool) ($this->configuration['auditSinkWebhookEnabled'] ?? self::DEFAULT_AUDIT_SINK_WEBHOOK_ENABLED);
+    }
+
+    /**
+     * Endpoint the webhook audit sink POSTs to ('' = unconfigured).
+     */
+    public function getAuditSinkWebhookUrl(): string
+    {
+        $val = $this->configuration['auditSinkWebhookUrl'] ?? self::DEFAULT_AUDIT_SINK_WEBHOOK_URL;
+
+        return \is_string($val) ? trim($val) : self::DEFAULT_AUDIT_SINK_WEBHOOK_URL;
+    }
+
+    /**
      * Days after creation with zero reads before a secret is "dead".
      */
     public function getStaleNeverReadDays(): int
@@ -318,5 +416,22 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
     public function getAutoKeyPath(): string
     {
         return Environment::getVarPath() . '/secrets/vault-master.key';
+    }
+
+    /**
+     * Resolve a configured audit-sink file path, falling back to
+     * `<var>/log/<basename>` when unset or empty.
+     *
+     * Only whitespace is trimmed here; whether the resulting path is *safe*
+     * (outside the public web root, writable) is decided by the sink, which is
+     * the layer that can disable itself and report the reason.
+     */
+    private function resolveLogPath(mixed $configured, string $defaultBasename): string
+    {
+        if (\is_string($configured) && trim($configured) !== '') {
+            return trim($configured);
+        }
+
+        return Environment::getVarPath() . '/log/' . $defaultBasename;
     }
 }

--- a/Classes/Configuration/ExtensionConfigurationInterface.php
+++ b/Classes/Configuration/ExtensionConfigurationInterface.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrVault\Configuration;
 
 use Netresearch\NrVault\Configuration\Dto\AwsSecretsConfig;
 use Netresearch\NrVault\Configuration\Dto\VaultServerConfig;
+use Netresearch\NrVault\Exception\ConfigurationException;
 
 /**
  * Interface for extension configuration access.
@@ -20,9 +21,9 @@ interface ExtensionConfigurationInterface
     /**
      * Get the configured security profile.
      *
-     * @throws \Netresearch\NrVault\Exception\ConfigurationException if the
-     *                                                               configured value is not a valid profile (fail-closed: an
-     *                                                               unknown profile must never silently degrade to Standard)
+     * @throws ConfigurationException if the
+     *                                configured value is not a valid profile (fail-closed: an
+     *                                unknown profile must never silently degrade to Standard)
      */
     public function getSecurityProfile(): SecurityProfile;
 
@@ -98,6 +99,45 @@ interface ExtensionConfigurationInterface
      * Get the audit HMAC epoch (0 = legacy SHA-256, 1+ = HMAC-SHA256).
      */
     public function getAuditHmacEpoch(): int;
+
+    /**
+     * Whether the syslog audit sink is enabled.
+     */
+    public function isAuditSinkSyslogEnabled(): bool;
+
+    /**
+     * `openlog()` ident for the syslog audit sink (never empty).
+     */
+    public function getAuditSinkSyslogIdent(): string;
+
+    /**
+     * Whether the append-only NDJSON file audit sink is enabled.
+     */
+    public function isAuditSinkFileEnabled(): bool;
+
+    /**
+     * Absolute path of the append-only NDJSON audit file.
+     *
+     * Never empty — an unconfigured value resolves to `<var>/log/`.
+     */
+    public function getAuditSinkFilePath(): string;
+
+    /**
+     * Absolute path of the append-only chain-tip anchor file.
+     *
+     * Never empty — an unconfigured value resolves to `<var>/log/`.
+     */
+    public function getAuditSinkAnchorPath(): string;
+
+    /**
+     * Whether the webhook audit sink is enabled.
+     */
+    public function isAuditSinkWebhookEnabled(): bool;
+
+    /**
+     * Endpoint the webhook audit sink POSTs to ('' = unconfigured).
+     */
+    public function getAuditSinkWebhookUrl(): string;
 
     /**
      * Days after creation with zero reads before a secret is "dead".

--- a/Classes/Event/AuditIntegrityAlertEvent.php
+++ b/Classes/Event/AuditIntegrityAlertEvent.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+namespace Netresearch\NrVault\Event;
+
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+
+/**
+ * Dispatched whenever an audit-integrity finding is raised.
+ *
+ * The subscription point for SIEM forwarding, paging, and e-mail notification.
+ * Reason codes are {@see AuditIntegrityReason}: `HASH_MISMATCH`, `UID_GAP`,
+ * `TABLE_RESET`, `EPOCH_DOWNGRADE`, `SINK_FAILURE`, and the reserved
+ * `BREAK_GLASS`.
+ *
+ * Dispatch sites:
+ *  - {@see \Netresearch\NrVault\Audit\Sink\AuditSinkRegistry} — `SINK_FAILURE`,
+ *    when an external sink refuses a record.
+ *  - {@see \Netresearch\NrVault\Audit\Anchor\ChainTipAnchorService} — the four
+ *    tamper-evidence codes, when verification fails.
+ *
+ * ## Listener contract
+ *
+ * The event is informational, not vetoable: there is nothing to cancel, the
+ * finding has already happened. Listeners SHOULD be fast and MUST tolerate being
+ * called from a CLI verification run as well as from a web request — the
+ * `SINK_FAILURE` path fires inside the audit write path of a live vault
+ * operation. A listener that throws is caught by the dispatch site and logged; it
+ * never propagates into the audited operation.
+ *
+ * The built-in {@see \Netresearch\NrVault\EventListener\AuditIntegrityAlertSinkListener}
+ * forwards every alert to the enabled external sinks.
+ */
+final readonly class AuditIntegrityAlertEvent
+{
+    public function __construct(
+        private AuditIntegrityAlert $alert,
+    ) {}
+
+    public function getAlert(): AuditIntegrityAlert
+    {
+        return $this->alert;
+    }
+
+    public function getReason(): AuditIntegrityReason
+    {
+        return $this->alert->reason;
+    }
+
+    /**
+     * Whether the finding is evidence of tampering rather than a delivery
+     * problem — the usual discriminator between "page someone" and "log it".
+     */
+    public function isTamperEvidence(): bool
+    {
+        return $this->alert->reason->isTamperEvidence();
+    }
+}

--- a/Classes/EventListener/AuditIntegrityAlertSinkListener.php
+++ b/Classes/EventListener/AuditIntegrityAlertSinkListener.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\EventListener;
+
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Event\AuditIntegrityAlertEvent;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+
+/**
+ * Forwards every audit-integrity alert to the enabled external sinks.
+ *
+ * Registered by default so an installation that enables the webhook sink gets
+ * SIEM alerting without extra wiring: the same collector that receives audit
+ * entries also receives `HASH_MISMATCH`, `UID_GAP`, `TABLE_RESET` and
+ * `EPOCH_DOWNGRADE` findings. Sinks that are disabled are skipped by the
+ * registry, so the listener is a no-op on a default installation.
+ *
+ * Delivery failures are contained by
+ * {@see AuditSinkRegistryInterface::dispatchAlert()}, which never throws and
+ * suppresses the nested `SINK_FAILURE` alert that would otherwise recurse.
+ */
+#[AsEventListener(identifier: 'nr-vault/audit-integrity-alert-sinks')]
+final readonly class AuditIntegrityAlertSinkListener
+{
+    public function __construct(
+        private AuditSinkRegistryInterface $sinkRegistry,
+    ) {}
+
+    public function __invoke(AuditIntegrityAlertEvent $event): void
+    {
+        $this->sinkRegistry->dispatchAlert($event->getAlert());
+    }
+}

--- a/Classes/Exception/AuditSinkException.php
+++ b/Classes/Exception/AuditSinkException.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Exception;
+
+/**
+ * Thrown when an external audit sink cannot deliver a record.
+ *
+ * Unlike {@see AuditWriteException}, this NEVER fails the audited vault
+ * operation: the database table is the chain-authoritative sink and has already
+ * committed by the time a sink runs. Every instance is caught by
+ * {@see \Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface}, which logs
+ * it, counts it, and raises a `SINK_FAILURE` integrity alert.
+ *
+ * Sinks throw rather than swallow deliberately. A sink that quietly returns on
+ * failure looks identical to a working one, and an audit pipeline that stopped
+ * flowing without anyone noticing is the failure mode this whole subsystem
+ * exists to prevent.
+ *
+ * Messages must stay free of secret material and of credentials embedded in
+ * configuration (webhook URLs, file paths are acceptable; tokens are not).
+ */
+final class AuditSinkException extends VaultException
+{
+    /**
+     * The record could not be written to its destination.
+     */
+    public static function writeFailed(string $sinkIdentifier, string $detail): self
+    {
+        return new self(
+            \sprintf('Audit sink "%s" write failed: %s.', $sinkIdentifier, $detail),
+            1753900001,
+        );
+    }
+
+    /**
+     * The record could not be serialised for transport.
+     */
+    public static function encodingFailed(string $sinkIdentifier, string $detail): self
+    {
+        return new self(
+            \sprintf('Audit sink "%s" could not encode the record: %s.', $sinkIdentifier, $detail),
+            1753900002,
+        );
+    }
+
+    /**
+     * The remote endpoint rejected the record (non-2xx response).
+     */
+    public static function rejectedByEndpoint(string $sinkIdentifier, int $statusCode): self
+    {
+        return new self(
+            \sprintf(
+                'Audit sink "%s" endpoint returned HTTP %d; the record was not accepted.',
+                $sinkIdentifier,
+                $statusCode,
+            ),
+            1753900003,
+        );
+    }
+
+    /**
+     * The transport itself failed (DNS, TLS, timeout, refused connection).
+     */
+    public static function transportFailed(string $sinkIdentifier, string $detail): self
+    {
+        return new self(
+            \sprintf('Audit sink "%s" transport failed: %s.', $sinkIdentifier, $detail),
+            1753900004,
+        );
+    }
+}

--- a/Classes/Task/AuditAnchorTask.php
+++ b/Classes/Task/AuditAnchorTask.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Task;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Throwable;
+use TYPO3\CMS\Core\Log\LogManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Task\AbstractTask;
+
+/**
+ * Scheduler counterpart of `vault:audit-anchor`.
+ *
+ * Publishes the current audit chain tip to the external sinks on a schedule. The
+ * interval IS the security parameter: entries written since the last anchor are
+ * the window an attacker who truncates the audit table can still hide. Hourly is
+ * a reasonable starting point; daily is the loosest defensible setting for a
+ * vault under audit.
+ *
+ * The task FAILS (returns false) when no sink accepted the anchor — an anchoring
+ * run that reached nothing outside the database provides no reset protection, and
+ * a green scheduler entry would misreport that as working tamper evidence.
+ *
+ * Constructor arguments are nullable and lazily resolved via
+ * `GeneralUtility::makeInstance()` because the scheduler unserializes task
+ * objects without going through the DI container — the same pattern as
+ * {@see OrphanCleanupTask}.
+ */
+final class AuditAnchorTask extends AbstractTask
+{
+    public function __construct(
+        private readonly ?ChainTipAnchorServiceInterface $anchorService = null,
+        private readonly ?LogManager $logManager = null,
+    ) {
+        parent::__construct();
+    }
+
+    public function execute(): bool
+    {
+        $logger = $this->getLogger();
+
+        try {
+            $anchorService = $this->getAnchorService();
+            $anchor = $anchorService->capture();
+            $published = $anchorService->publish($anchor);
+        } catch (Throwable $e) {
+            $logger->error('Vault audit anchoring failed', ['error' => $e->getMessage()]);
+
+            return false;
+        }
+
+        if ($published === 0) {
+            $logger->error('Vault audit anchoring reached no external sink', [
+                'sequence' => $anchor->sequence,
+            ]);
+
+            return false;
+        }
+
+        $logger->info('Vault audit chain anchored', [
+            'sequence' => $anchor->sequence,
+            'sinks' => $published,
+        ]);
+
+        return true;
+    }
+
+    /**
+     * Additional information shown in the scheduler module.
+     */
+    public function getAdditionalInformation(): string
+    {
+        try {
+            $anchor = $this->getAnchorService()->capture();
+        } catch (Throwable) {
+            // The scheduler list view must render even when the vault is
+            // misconfigured (missing master key, unavailable database).
+            return 'Publishes the audit chain tip to the external audit sinks';
+        }
+
+        return \sprintf(
+            'Publishes the audit chain tip to the external audit sinks (current sequence: %d)',
+            $anchor->sequence,
+        );
+    }
+
+    private function getAnchorService(): ChainTipAnchorServiceInterface
+    {
+        return $this->anchorService ?? GeneralUtility::makeInstance(ChainTipAnchorServiceInterface::class);
+    }
+
+    private function getLogger(): LoggerInterface
+    {
+        if (!$this->logManager instanceof LogManager) {
+            return new NullLogger();
+        }
+
+        return $this->logManager->getLogger(self::class);
+    }
+}

--- a/Classes/Task/AuditVerifyTask.php
+++ b/Classes/Task/AuditVerifyTask.php
@@ -1,0 +1,135 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Task;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use Throwable;
+use TYPO3\CMS\Core\Log\LogManager;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Task\AbstractTask;
+
+/**
+ * Scheduler counterpart of `vault:audit-verify`.
+ *
+ * Verifies the audit hash chain and compares it against the last published
+ * chain-tip anchor. Findings are dispatched as
+ * {@see \Netresearch\NrVault\Event\AuditIntegrityAlertEvent} by the anchor
+ * service itself, so SIEM and notification listeners fire from a scheduled run
+ * exactly as they do from the CLI — nobody has to be watching the scheduler log.
+ *
+ * Configuration (TCA field on `tx_scheduler_task`):
+ * - `nr_vault_tamper_only`: when set, the task only fails on tamper evidence
+ *   (`HASH_MISMATCH`, `UID_GAP`, `TABLE_RESET`, `EPOCH_DOWNGRADE`) and treats
+ *   configuration/delivery findings (`NO_EXTERNAL_SINK`, `SINK_FAILURE`) as
+ *   warnings. Useful while external sinks are still being rolled out, so a
+ *   pending SIEM integration does not mask a real tamper alarm behind a
+ *   permanently red task.
+ */
+final class AuditVerifyTask extends AbstractTask
+{
+    /** Only fail the task on tamper evidence, not on configuration findings. */
+    protected bool $tamperOnly = false;
+
+    public function __construct(
+        private readonly ?ChainTipAnchorServiceInterface $anchorService = null,
+        private readonly ?LogManager $logManager = null,
+    ) {
+        parent::__construct();
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getTaskParameters(): array
+    {
+        return [
+            'nr_vault_tamper_only' => $this->tamperOnly ? 1 : 0,
+        ];
+    }
+
+    /**
+     * The scheduler hands over whatever the TCA record holds, so the parameter
+     * stays as wide as the parent's untyped `array` rather than narrowing to
+     * `array<string, mixed>` (which would break contravariance).
+     *
+     * @param array<array-key, mixed> $parameters
+     */
+    public function setTaskParameters(array $parameters): void
+    {
+        $this->tamperOnly = (bool) ($parameters['nr_vault_tamper_only'] ?? false);
+    }
+
+    public function execute(): bool
+    {
+        $logger = $this->getLogger();
+
+        try {
+            $report = $this->getAnchorService()->verify();
+        } catch (Throwable $e) {
+            // A verification that could not run must never report success.
+            $logger->error('Vault audit integrity verification could not run', ['error' => $e->getMessage()]);
+
+            return false;
+        }
+
+        if ($report->isValid()) {
+            $logger->info('Vault audit integrity verified', [
+                'sequence' => $report->currentSequence,
+                'anchoredSequence' => $report->anchor?->sequence,
+            ]);
+
+            return true;
+        }
+
+        $codes = implode(',', $report->getReasonCodes());
+        $context = [
+            'reasonCodes' => $codes,
+            'sequence' => $report->currentSequence,
+            'tamperEvidence' => $report->hasTamperEvidence(),
+        ];
+
+        if ($report->hasTamperEvidence()) {
+            $logger->critical('Vault audit integrity FAILED — possible tampering', $context);
+
+            return false;
+        }
+
+        $logger->warning('Vault audit integrity findings without tamper evidence', $context);
+
+        // tamperOnly => configuration/delivery findings are warnings, task passes.
+        return $this->tamperOnly;
+    }
+
+    /**
+     * Additional information shown in the scheduler module.
+     */
+    public function getAdditionalInformation(): string
+    {
+        return $this->tamperOnly
+            ? 'Verifies the audit hash chain and external anchor (fails on tamper evidence only)'
+            : 'Verifies the audit hash chain and external anchor (fails on any finding)';
+    }
+
+    private function getAnchorService(): ChainTipAnchorServiceInterface
+    {
+        return $this->anchorService ?? GeneralUtility::makeInstance(ChainTipAnchorServiceInterface::class);
+    }
+
+    private function getLogger(): LoggerInterface
+    {
+        if (!$this->logManager instanceof LogManager) {
+            return new NullLogger();
+        }
+
+        return $this->logManager->getLogger(self::class);
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -4,6 +4,14 @@ services:
     autoconfigure: true
     public: false
 
+  # Every AuditSinkInterface implementation discovered by the resource glob below
+  # is tagged automatically, so the registry receives new sinks without another
+  # edit here. A consuming extension adds its own destination by implementing the
+  # interface and applying the same tag in ITS Services.yaml.
+  _instanceof:
+    Netresearch\NrVault\Audit\Sink\AuditSinkInterface:
+      tags: ['nr_vault.audit_sink']
+
   Netresearch\NrVault\:
     resource: '../Classes/*'
     exclude:
@@ -73,6 +81,19 @@ services:
   Netresearch\NrVault\Audit\AuditChainRekeyServiceInterface:
     alias: Netresearch\NrVault\Audit\AuditChainRekeyService
 
+  Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface:
+    alias: Netresearch\NrVault\Audit\Sink\AuditSinkRegistry
+
+  Netresearch\NrVault\Audit\Anchor\AnchorReaderInterface:
+    alias: Netresearch\NrVault\Audit\Anchor\AnchorFileReader
+
+  Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface:
+    alias: Netresearch\NrVault\Audit\Anchor\ChainTipAnchorService
+    # public: AuditAnchorTask / AuditVerifyTask run in the scheduler context,
+    # which unserializes task objects outside the DI container and resolves the
+    # service via GeneralUtility::makeInstance(<Interface>::class).
+    public: true
+
   Netresearch\NrVault\Adapter\VaultAdapterInterface:
     alias: Netresearch\NrVault\Adapter\LocalEncryptionAdapter
 
@@ -101,6 +122,27 @@ services:
 
   Netresearch\NrVault\Crypto\MasterKeyProviderInterface:
     factory: ['@Netresearch\NrVault\Crypto\MasterKeyProviderFactory', 'create']
+
+  # ----- External audit sinks ---------------------------------------------
+
+  Netresearch\NrVault\Audit\Sink\AuditSinkRegistry:
+    arguments:
+      $sinks: !tagged_iterator nr_vault.audit_sink
+
+  # The webhook sink deliberately uses a SHORT-timeout client built by
+  # SecureHttpClientFactory rather than the ambient PSR-18 client: audit fan-out
+  # must inherit the extension-wide SSRF / DNS-rebinding / no-redirect defences
+  # (Tests/Architecture enforces that no other class stands up its own Guzzle
+  # client), and a slow collector must not hold a web request open. 3s total
+  # bounds the whole transfer; connect_timeout stays platform-managed.
+  nr_vault.audit_sink.webhook_client:
+    class: Psr\Http\Client\ClientInterface
+    factory: ['@Netresearch\NrVault\Http\SecureHttpClientFactory', 'create']
+    arguments: [3]
+
+  Netresearch\NrVault\Audit\Sink\WebhookAuditSink:
+    arguments:
+      $httpClient: '@nr_vault.audit_sink.webhook_client'
 
   # ----- Classes that need public visibility ------------------------------
   # TYPO3 DataHandler resolves $TYPO3_CONF_VARS hook references via

--- a/Configuration/TCA/Overrides/tx_scheduler_task.php
+++ b/Configuration/TCA/Overrides/tx_scheduler_task.php
@@ -7,6 +7,8 @@
 
 declare(strict_types=1);
 
+use Netresearch\NrVault\Task\AuditAnchorTask;
+use Netresearch\NrVault\Task\AuditVerifyTask;
 use Netresearch\NrVault\Task\OrphanCleanupTask;
 use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 
@@ -40,6 +42,15 @@ if (is_array($GLOBALS['TCA'] ?? null) && isset($GLOBALS['TCA']['tx_scheduler_tas
                     'placeholder' => 'e.g., tx_myext_settings',
                 ],
             ],
+            'nr_vault_tamper_only' => [
+                'label' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang.xlf:task.auditVerify.tamperOnly',
+                'description' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang.xlf:task.auditVerify.tamperOnly.description',
+                'config' => [
+                    'type' => 'check',
+                    'renderType' => 'checkboxToggle',
+                    'default' => 0,
+                ],
+            ],
         ],
     );
 
@@ -59,6 +70,64 @@ if (is_array($GLOBALS['TCA'] ?? null) && isset($GLOBALS['TCA']['tx_scheduler_tas
                 description,
                 nr_vault_retention_days,
                 nr_vault_table_filter,
+            --div--;LLL:EXT:scheduler/Resources/Private/Language/locallang.xlf:scheduler.form.palettes.timing,
+                execution_details,
+                nextexecution,
+                --palette--;;lastexecution,
+            --div--;LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.accessTab,
+                disable,
+            --div--;LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.extended,
+        ',
+        [],
+        '',
+        'tx_scheduler_task',
+    );
+
+    // Register the AuditAnchorTask — publishes the audit chain tip to the
+    // external sinks. No task-specific fields: what it does is fully determined
+    // by which audit sinks are enabled in the extension configuration.
+    ExtensionManagementUtility::addRecordType(
+        [
+            'label' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang.xlf:task.auditAnchor.title',
+            'description' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang.xlf:task.auditAnchor.description',
+            'value' => AuditAnchorTask::class,
+            'icon' => 'actions-lock',
+            'group' => 'nr_vault',
+        ],
+        '
+            --div--;LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.generalTab,
+                tasktype,
+                task_group,
+                description,
+            --div--;LLL:EXT:scheduler/Resources/Private/Language/locallang.xlf:scheduler.form.palettes.timing,
+                execution_details,
+                nextexecution,
+                --palette--;;lastexecution,
+            --div--;LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.accessTab,
+                disable,
+            --div--;LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.extended,
+        ',
+        [],
+        '',
+        'tx_scheduler_task',
+    );
+
+    // Register the AuditVerifyTask — verifies the hash chain against the
+    // external anchor and dispatches integrity alerts.
+    ExtensionManagementUtility::addRecordType(
+        [
+            'label' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang.xlf:task.auditVerify.title',
+            'description' => 'LLL:EXT:nr_vault/Resources/Private/Language/locallang.xlf:task.auditVerify.description',
+            'value' => AuditVerifyTask::class,
+            'icon' => 'actions-check',
+            'group' => 'nr_vault',
+        ],
+        '
+            --div--;LLL:EXT:core/Resources/Private/Language/locallang_core.xlf:labels.generalTab,
+                tasktype,
+                task_group,
+                description,
+                nr_vault_tamper_only,
             --div--;LLL:EXT:scheduler/Resources/Private/Language/locallang.xlf:scheduler.form.palettes.timing,
                 execution_details,
                 nextexecution,

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -148,6 +148,152 @@ Configure nr-vault in :guilabel:`Admin Tools > Settings > Extension Configuratio
    repeated retrievals of the same secret within a single request
    return the cached value instead of decrypting again.
 
+.. _configuration-audit-sinks:
+
+External audit sinks
+====================
+
+The database table ``tx_nrvault_audit_log`` is the chain-authoritative audit
+sink. External sinks are additional, best-effort *copies* whose purpose is to
+put audit evidence somewhere a database-write attacker cannot reach.
+
+Two properties are worth stating up front:
+
+*  A sink failure **never** fails the audited vault operation. Fan-out happens
+   after the chain row has committed and after the audit lock has been released,
+   so a slow or broken destination cannot roll back a secret operation or
+   serialise every other vault call behind itself. Failures are logged, counted,
+   and reported by :ref:`vault:audit-verify <command-audit-verify>`.
+*  Only an external sink makes a **full audit table reset** detectable. See
+   :ref:`vault:audit-anchor <command-audit-anchor>` for why the in-database hash
+   chain structurally cannot catch a truncate-and-rebuild.
+
+Under the hardened security profile (``securityProfile = hardened``), having no
+usable external sink is reported as a ``NO_EXTERNAL_SINK`` finding.
+
+.. confval:: auditSinkSyslogEnabled
+   :name: ext-nrvault-auditSinkSyslogEnabled
+   :type: boolean
+   :Default: false
+
+   Mirror every audit entry, chain-tip anchor and integrity alert to the local
+   syslog as an RFC 5424 structured-data message on facility ``local0``. The
+   cheapest useful sink: on any host with a log shipper the audit trail leaves
+   the TYPO3 database with no extra infrastructure.
+
+.. confval:: auditSinkSyslogIdent
+   :name: ext-nrvault-auditSinkSyslogIdent
+   :type: string
+   :Default: 'nr-vault'
+
+   ``openlog()`` ident, which becomes RFC 5424's APP-NAME. Vary it when several
+   TYPO3 instances share a host. An empty value falls back to the default — an
+   unattributable syslog line would defeat the purpose of the sink.
+
+.. confval:: auditSinkFileEnabled
+   :name: ext-nrvault-auditSinkFileEnabled
+   :type: boolean
+   :Default: false
+
+   Append audit evidence to newline-delimited JSON files (one JSON object per
+   line). This is also the sink that writes the chain-tip anchors
+   :ref:`vault:audit-verify <command-audit-verify>` reads back, so enabling it is
+   the minimum for table-reset detection.
+
+   Files are created with mode ``0600`` and only ever appended to.
+
+.. confval:: auditSinkFilePath
+   :name: ext-nrvault-auditSinkFilePath
+   :type: string
+   :Default: '' (resolves to :file:`var/log/nr-vault-audit.ndjson`)
+
+   Absolute path of the append-only audit entry stream.
+
+   .. warning::
+
+      A path inside the public web root **disables** the sink rather than
+      writing there: the stream names every secret identifier, actor, IP address
+      and chain hash, so publishing it over HTTP would be worse than having no
+      external sink at all. The refusal is logged with the resolved path.
+
+      The default is outside the document root on every Composer-based
+      installation. A legacy (non-Composer) layout, where ``var/`` lives under
+      :file:`typo3temp/`, must configure an explicit path.
+
+.. confval:: auditSinkAnchorPath
+   :name: ext-nrvault-auditSinkAnchorPath
+   :type: string
+   :Default: '' (resolves to :file:`var/log/nr-vault-audit-anchor.ndjson`)
+
+   Absolute path of the append-only chain-tip anchor stream, written by
+   :ref:`vault:audit-anchor <command-audit-anchor>` and read back by
+   :ref:`vault:audit-verify <command-audit-verify>`. Integrity alerts are
+   appended here too, so this one file tells the whole chain-health story.
+
+   Deliberately separate from ``auditSinkFilePath``: this is the evidence that
+   survives a table reset, so point it at append-only or off-host storage.
+   Verification always takes the anchor with the **highest sequence**, never the
+   last line — appending a low-sequence anchor therefore cannot weaken the
+   baseline.
+
+   The public-web-root refusal described above applies to this path as well.
+
+.. confval:: auditSinkWebhookEnabled
+   :name: ext-nrvault-auditSinkWebhookEnabled
+   :type: boolean
+   :Default: false
+
+   POST every audit entry, anchor and integrity alert as JSON to an HTTP
+   endpoint — typically a SIEM collector. Each payload carries a ``type``
+   discriminator (``entry``, ``anchor``, ``alert``) so one endpoint can route all
+   three.
+
+   When enabled, the webhook also receives integrity alerts by default through
+   the built-in ``nr-vault/audit-integrity-alert-sinks`` event listener.
+
+.. confval:: auditSinkWebhookUrl
+   :name: ext-nrvault-auditSinkWebhookUrl
+   :type: string
+   :Default: ''
+
+   ``https://`` (or ``http://``) endpoint receiving the payloads. Only
+   ``http``/``https`` are accepted, so a ``file://`` or ``php://`` value cannot
+   turn audit fan-out into a local write.
+
+   .. note::
+
+      Outbound calls go through the hardened HTTP client, inheriting the
+      extension-wide SSRF and DNS-rebinding defences. A collector on a
+      private/RFC1918 address is therefore **refused** unless the host is
+      allow-listed literally in
+      :php:`$GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts']`.
+
+      That is intentional. This URL is settable from the backend Settings
+      module, so without the guard a compromised administrator could repoint it
+      at a cloud metadata service and use the vault as an SSRF pivot.
+      ``allowed_hosts`` is filesystem-bound and out of the backend's reach,
+      which keeps that pivot closed while leaving the legitimate on-premise path
+      available. A refusal is not silent — it is logged, counted, and reported
+      as a ``SINK_FAILURE`` finding.
+
+.. _configuration-audit-sink-scheduling:
+
+Scheduling
+----------
+
+Two scheduler tasks accompany the CLI commands:
+
+Vault Audit Chain Anchoring
+   Publishes the current chain tip (``vault:audit-anchor``). The interval is the
+   blind window — entries written since the last anchor are what an attacker who
+   resets the table can still hide. Hourly is a reasonable starting point.
+
+Vault Audit Integrity Verification
+   Verifies the chain against the anchor (``vault:audit-verify``) and dispatches
+   an integrity alert event per finding. Set *Fail on tamper evidence only*
+   while sinks are still being rolled out, so a pending integration does not keep
+   the task permanently red and train operators to ignore it.
+
 .. _configuration-master-key-providers:
 
 Master key providers

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -321,6 +321,183 @@ Example
    # Export to JSON
    vendor/bin/typo3 vault:audit --format=json > audit.json
 
+.. _command-audit-anchor:
+
+vault:audit-anchor
+==================
+
+Publish the current audit log chain tip to the enabled external audit sinks.
+
+The in-database hash chain proves that no stored row was altered, but it cannot
+prove that the chain is still the *same* chain: an attacker with ``DELETE``
+rights can truncate ``tx_nrvault_audit_log`` and let the service build a fresh,
+internally consistent chain from uid 1. Nothing inside the database
+distinguishes that from a young installation.
+
+Each anchoring run records — outside the database — that the chain had reached a
+given sequence with a given tip hash. :ref:`command-audit-verify` compares the
+live chain against the newest anchor and reports ``TABLE_RESET`` when they
+disagree.
+
+.. important::
+
+   The anchoring interval is the blind window: an attacker who resets the table
+   can only hide entries written since the last anchor. Schedule it hourly for a
+   vault under audit; daily is the loosest defensible setting. Use the
+   *Vault Audit Chain Anchoring* scheduler task for this.
+
+.. code-block:: bash
+   :caption: Command syntax
+
+   vendor/bin/typo3 vault:audit-anchor [options]
+
+.. _command-audit-anchor-options:
+
+Options
+-------
+
+--dry-run
+   Show the anchor that would be published without writing it to any sink.
+
+--format, -f =FORMAT
+   Output format: ``text`` (default) or ``json``.
+
+.. _command-audit-anchor-exit-codes:
+
+Exit codes
+----------
+
+0
+   The anchor was accepted by at least one external sink.
+
+1
+   The chain tip could not be read, or **no sink accepted the anchor**. An
+   anchor that reached nothing outside the database provides no table-reset
+   protection, so this is a failure rather than a no-op — enable at least one of
+   ``auditSinkFileEnabled``, ``auditSinkSyslogEnabled`` or
+   ``auditSinkWebhookEnabled``.
+
+.. _command-audit-anchor-example:
+
+Example
+-------
+
+.. code-block:: bash
+   :caption: vault:audit-anchor examples
+
+   # Publish the current chain tip
+   vendor/bin/typo3 vault:audit-anchor
+
+   # Preview without writing
+   vendor/bin/typo3 vault:audit-anchor --dry-run
+
+   # Machine-readable output for a monitoring wrapper
+   vendor/bin/typo3 vault:audit-anchor --format=json
+
+.. _command-audit-verify:
+
+vault:audit-verify
+==================
+
+Verify audit log integrity against both the hash chain and the external
+chain-tip anchor.
+
+This complements ``vault:audit --verify``, which runs the in-database hash-chain
+pass only. In addition to that pass, this command compares the chain against the
+newest anchor published by :ref:`command-audit-anchor` and classifies every
+finding under a machine-readable reason code.
+
+.. code-block:: bash
+   :caption: Command syntax
+
+   vendor/bin/typo3 vault:audit-verify [options]
+
+.. _command-audit-verify-options:
+
+Options
+-------
+
+--format, -f =FORMAT
+   Output format: ``text`` (default) or ``json``. The JSON form carries the full
+   finding list, the compared anchor, the enabled sinks and their failure counts.
+
+--tamper-only
+   Only fail on tamper evidence; treat configuration and delivery findings
+   (``NO_EXTERNAL_SINK``, ``SINK_FAILURE``) as warnings. Useful while external
+   sinks are still being rolled out, so a pending integration does not keep the
+   check permanently red and train operators to ignore a real alarm.
+
+.. _command-audit-verify-reason-codes:
+
+Reason codes
+------------
+
+HASH_MISMATCH
+   A stored ``entry_hash`` or ``previous_hash`` does not match the recomputed
+   value. Tamper evidence.
+
+UID_GAP
+   The uid sequence is not contiguous — rows were deleted from the chain. Tamper
+   evidence (may also be a retention purge; confirm against your purge log).
+
+TABLE_RESET
+   The chain no longer contains the anchored tip: it is shorter than the anchored
+   sequence, or the row at that sequence hashes differently. The signature of a
+   truncate-and-rebuild. Tamper evidence.
+
+EPOCH_DOWNGRADE
+   The ``hmac_key_epoch`` was relabelled downward, moving rows onto a weaker or
+   keyless verification algorithm. Tamper evidence.
+
+NO_EXTERNAL_SINK
+   The hardened security profile is active but no external audit sink is enabled
+   and usable, or no anchor could be read. Configuration finding, not tamper
+   evidence.
+
+SINK_FAILURE
+   An external sink could not be delivered to during this process. Availability
+   finding, not tamper evidence.
+
+.. _command-audit-verify-alerting:
+
+Alerting
+--------
+
+Every finding is dispatched as
+``\Netresearch\NrVault\Event\AuditIntegrityAlertEvent`` before the command
+returns, so SIEM and notification listeners fire whether or not anyone reads this
+output. When the webhook sink is enabled it receives the alerts by default via
+the built-in ``nr-vault/audit-integrity-alert-sinks`` listener.
+
+.. _command-audit-verify-exit-codes:
+
+Exit codes
+----------
+
+0
+   No findings — or, with ``--tamper-only``, no tamper evidence.
+
+1
+   At least one finding (see ``--tamper-only``), or verification could not run at
+   all. A verifier that cannot run never reports success.
+
+.. _command-audit-verify-example:
+
+Example
+-------
+
+.. code-block:: bash
+   :caption: vault:audit-verify examples
+
+   # Full verification
+   vendor/bin/typo3 vault:audit-verify
+
+   # Machine-readable output for monitoring
+   vendor/bin/typo3 vault:audit-verify --format=json
+
+   # Only alarm on tamper evidence while sinks are being rolled out
+   vendor/bin/typo3 vault:audit-verify --tamper-only
+
 .. _command-rotate-master-key:
 
 vault:rotate-master-key

--- a/Resources/Private/Language/locallang.xlf
+++ b/Resources/Private/Language/locallang.xlf
@@ -31,6 +31,28 @@
             <trans-unit id="task.orphanCleanup.tableFilter.description">
                 <source>Optional: Only check secrets from this specific table. Leave empty to check all tables.</source>
             </trans-unit>
+
+            <!-- Scheduler Task: Audit Chain Anchoring -->
+            <trans-unit id="task.auditAnchor.title">
+                <source>Vault Audit Chain Anchoring</source>
+            </trans-unit>
+            <trans-unit id="task.auditAnchor.description">
+                <source>Publishes the current audit log chain tip to the enabled external audit sinks. Each run records outside the database that the chain had reached a given sequence, which is what makes a later full audit table reset detectable. The scheduling interval is the window an attacker could still hide.</source>
+            </trans-unit>
+
+            <!-- Scheduler Task: Audit Integrity Verification -->
+            <trans-unit id="task.auditVerify.title">
+                <source>Vault Audit Integrity Verification</source>
+            </trans-unit>
+            <trans-unit id="task.auditVerify.description">
+                <source>Verifies the audit log hash chain and compares it against the last published chain-tip anchor. Reports hash mismatches, uid gaps, table resets and epoch downgrades, and dispatches an integrity alert event for SIEM or notification listeners.</source>
+            </trans-unit>
+            <trans-unit id="task.auditVerify.tamperOnly">
+                <source>Fail on tamper evidence only</source>
+            </trans-unit>
+            <trans-unit id="task.auditVerify.tamperOnly.description">
+                <source>When enabled, the task only fails on tamper evidence (hash mismatch, uid gap, table reset, epoch downgrade) and treats configuration or delivery findings (no external sink, sink failure) as warnings. Useful while external sinks are still being rolled out, so a pending integration does not keep the task permanently red and mask a real alarm.</source>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -140,7 +140,10 @@ final class AuditLogServiceTest extends AbstractVaultFunctionalTestCase
 | `Tests/Unit/Traits/TcaSchemaMockTrait.php` | `mockTcaSchemaForTable()` (was duplicated 4x) |
 | `Tests/Unit/Traits/BackendUserMockTrait.php` | `createMockBackendUser()` (was duplicated 3x) |
 | `Tests/Unit/Traits/EnvironmentSandboxTrait.php` | Throwaway project layout + initialised `Environment` for tests that resolve paths via `getVarPath()` / check the `getPublicPath()` boundary (audit file sink, extension-config path defaults) |
+| `Tests/Unit/Traits/ErrorSuppressionTrait.php` | `withoutPhpDiagnostics()` — run one call with PHP diagnostics silenced, for code that handles a native failure by checking the return value (`fopen`/`mkdir` returning false) instead of using `@`, where the genuine warning would otherwise trip `failOnWarning` |
 | `Tests/Unit/Fixtures/SecretFixtureBuilder.php` | Fluent builder for `SecretDetails` / `SecretMetadata` / `Secret` DTOs (replaces ~6 hand-rolled factory methods) |
+| `Tests/Unit/Fixtures/FailingStreamWrapper.php` | Stream wrapper that stats as a healthy writable file but fails at a chosen point (`fopen` refused/throwing, `flock` refused, short write) — the audit-sink write layers a real filesystem cannot reach |
+| `Tests/Unit/Fixtures/AuditChainLockHost.php` | Host exposing `AuditChainLockTrait`'s private lock primitives so the raw-vs-savepoint lock protocol can be tested without a consumer's write path |
 | `Tests/scripts/check-test-base-class.php` | Architecture check enforcing the project base on new unit tests |
 
 ## When Stuck

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -139,6 +139,7 @@ final class AuditLogServiceTest extends AbstractVaultFunctionalTestCase
 | `Tests/Unit/TestCase.php` | Project base composing the two mock traits below |
 | `Tests/Unit/Traits/TcaSchemaMockTrait.php` | `mockTcaSchemaForTable()` (was duplicated 4x) |
 | `Tests/Unit/Traits/BackendUserMockTrait.php` | `createMockBackendUser()` (was duplicated 3x) |
+| `Tests/Unit/Traits/EnvironmentSandboxTrait.php` | Throwaway project layout + initialised `Environment` for tests that resolve paths via `getVarPath()` / check the `getPublicPath()` boundary (audit file sink, extension-config path defaults) |
 | `Tests/Unit/Fixtures/SecretFixtureBuilder.php` | Fluent builder for `SecretDetails` / `SecretMetadata` / `Secret` DTOs (replaces ~6 hand-rolled factory methods) |
 | `Tests/scripts/check-test-base-class.php` | Architecture check enforcing the project base on new unit tests |
 

--- a/Tests/Functional/Audit/ChainTipAnchorServiceTest.php
+++ b/Tests/Functional/Audit/ChainTipAnchorServiceTest.php
@@ -1,0 +1,440 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Audit;
+
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorService;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditLogService;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use Netresearch\NrVault\Tests\Functional\Traits\AuditSinkSandboxTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Functional tests for external chain-tip anchoring.
+ *
+ * The scenario that matters, and that no in-database check can catch: an attacker
+ * with DELETE rights truncates `tx_nrvault_audit_log` and lets the service build a
+ * fresh chain from uid 1. That chain verifies perfectly against itself — there is
+ * nothing left inside the database to contradict it. Only an anchor published
+ * earlier, outside the database, can reveal it.
+ *
+ * These tests run the real sink stack (the NDJSON file sink writing to a real
+ * temp path), so the anchor is genuinely round-tripped through the filesystem
+ * rather than through a stub.
+ */
+#[CoversClass(ChainTipAnchorService::class)]
+final class ChainTipAnchorServiceTest extends AbstractVaultFunctionalTestCase
+{
+    use AuditSinkSandboxTrait;
+
+    protected ?string $backendUserFixture = __DIR__ . '/../../Functional/Service/Fixtures/be_users.csv';
+
+    /** @var array<string, mixed> */
+    protected array $extensionConfiguration = [
+        'masterKeyProvider' => 'file',
+        'auditHmacEpoch' => 3,
+    ];
+
+    protected function setUp(): void
+    {
+        $this->extensionConfiguration = $this->prepareAuditSinkSandbox($this->extensionConfiguration);
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpAuditSinkSandbox();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function captureReadsTheCurrentChainTip(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $auditService->log('anchor_test_secret', 'create', true);
+        $auditService->log('anchor_test_secret', 'read', true);
+
+        $anchor = $this->getAnchorService()->capture();
+
+        self::assertSame(2, $anchor->sequence);
+        self::assertSame($auditService->getLatestHash(), $anchor->chainTip);
+        self::assertSame(3, $anchor->hmacEpoch);
+        self::assertFalse($anchor->isEmpty());
+    }
+
+    #[Test]
+    public function captureOnAnEmptyChainYieldsAnEmptyAnchor(): void
+    {
+        $anchor = $this->getAnchorService()->capture();
+
+        self::assertSame(0, $anchor->sequence);
+        self::assertSame('', $anchor->chainTip);
+        self::assertTrue($anchor->isEmpty());
+    }
+
+    #[Test]
+    public function publishWritesTheAnchorToTheFileSink(): void
+    {
+        $this->get(AuditLogServiceInterface::class)->log('anchor_test_secret', 'create', true);
+
+        $service = $this->getAnchorService();
+        $accepted = $service->publish($service->capture());
+
+        self::assertSame(1, $accepted);
+        self::assertFileExists($this->auditSinkAnchorPath);
+    }
+
+    #[Test]
+    public function anIntactChainVerifiesAgainstItsAnchor(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $auditService->log('anchor_test_secret', 'create', true);
+        $auditService->log('anchor_test_secret', 'read', true);
+
+        $service = $this->getAnchorService();
+        $service->publish($service->capture());
+
+        // The chain keeps growing after the anchor — that is normal and must not
+        // be mistaken for tampering.
+        $auditService->log('anchor_test_secret', 'read', true);
+
+        $report = $service->verify();
+
+        self::assertTrue($report->isValid(), 'findings: ' . implode(',', $report->getReasonCodes()));
+        self::assertTrue($report->chainValid);
+        self::assertInstanceOf(ChainTipAnchor::class, $report->anchor);
+        self::assertSame(2, $report->anchor->sequence);
+        self::assertSame(3, $report->currentSequence);
+    }
+
+    /**
+     * THE case this whole subsystem exists for: truncate the table, re-seed a
+     * shorter chain. The new chain is internally valid, so `verifyHashChain()`
+     * alone reports success — the anchor is what catches it.
+     */
+    #[Test]
+    public function fullTableResetIsDetectedAsTableReset(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $service = $this->getAnchorService();
+
+        // Build a chain of five entries and anchor it.
+        for ($i = 0; $i < 5; $i++) {
+            $auditService->log('anchor_test_secret', 'read', true);
+        }
+        $anchor = $service->capture();
+        $service->publish($anchor);
+        self::assertSame(5, $anchor->sequence);
+
+        // Wipe the table and re-seed a SHORTER chain from uid 1.
+        $this->truncateAuditTable();
+        $auditService->log('attacker_seeded', 'create', true);
+        $auditService->log('attacker_seeded', 'read', true);
+
+        // The rebuilt chain is internally consistent — this is exactly why the
+        // in-database check cannot see the reset.
+        self::assertTrue(
+            $auditService->verifyHashChain()->isValid(),
+            'the rebuilt chain verifies against itself, which is the premise of this test',
+        );
+
+        $report = $service->verify();
+
+        self::assertFalse($report->isValid());
+        self::assertTrue($report->hasReason(AuditIntegrityReason::TableReset));
+        self::assertTrue($report->hasTamperEvidence());
+        self::assertContains('TABLE_RESET', $report->getReasonCodes());
+        self::assertSame(2, $report->currentSequence);
+    }
+
+    /**
+     * A reset that re-seeds MORE rows than were anchored cannot be caught by the
+     * length check, so the hash at the anchored sequence has to be compared too.
+     */
+    #[Test]
+    public function tableResetIsDetectedEvenWhenTheRebuiltChainIsLonger(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $service = $this->getAnchorService();
+
+        for ($i = 0; $i < 3; $i++) {
+            $auditService->log('anchor_test_secret', 'read', true);
+        }
+        $anchor = $service->capture();
+        $service->publish($anchor);
+
+        $this->truncateAuditTable();
+        for ($i = 0; $i < 6; $i++) {
+            $auditService->log('attacker_seeded', 'read', true);
+        }
+
+        $report = $service->verify();
+
+        self::assertGreaterThan($anchor->sequence, $report->currentSequence, 'the new chain is longer');
+        self::assertTrue($report->hasReason(AuditIntegrityReason::TableReset));
+    }
+
+    /**
+     * Deleting the anchored row while leaving later rows in place shows up as a
+     * missing row at the anchored sequence, not just as a uid gap.
+     */
+    #[Test]
+    public function deletingTheAnchoredRowIsDetected(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $service = $this->getAnchorService();
+
+        for ($i = 0; $i < 4; $i++) {
+            $auditService->log('anchor_test_secret', 'read', true);
+        }
+        $anchor = $service->capture();
+        $service->publish($anchor);
+
+        // Remove the anchored row but keep the chain longer than the anchor by
+        // appending a new entry.
+        $connection = $this->getAuditConnection();
+        $connection->delete(AuditLogService::TABLE_NAME, ['uid' => $anchor->sequence]);
+        $auditService->log('anchor_test_secret', 'read', true);
+
+        $report = $service->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::TableReset));
+    }
+
+    /**
+     * A row deleted from the middle leaves a uid gap the chain check itself
+     * detects. The report must classify it as UID_GAP rather than folding it into
+     * a generic hash error, so an operator can tell deletion from forgery.
+     */
+    #[Test]
+    public function deletedMiddleRowIsClassifiedAsUidGap(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+
+        for ($i = 0; $i < 4; $i++) {
+            $auditService->log('anchor_test_secret', 'read', true);
+        }
+
+        $this->getAuditConnection()->delete(AuditLogService::TABLE_NAME, ['uid' => 2]);
+
+        $report = $this->getAnchorService()->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::UidGap));
+        self::assertFalse($report->chainValid);
+    }
+
+    /**
+     * A rewritten payload breaks the row's own hash. That must surface as
+     * HASH_MISMATCH — distinct from a reset, because the remedy differs.
+     */
+    #[Test]
+    public function tamperedRowIsClassifiedAsHashMismatch(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $auditService->log('anchor_test_secret', 'create', true);
+        $auditService->log('anchor_test_secret', 'read', true);
+
+        $this->getAuditConnection()->update(
+            AuditLogService::TABLE_NAME,
+            ['secret_identifier' => 'rewritten_by_attacker'],
+            ['uid' => 1],
+        );
+
+        $report = $this->getAnchorService()->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::HashMismatch));
+        self::assertTrue($report->hasTamperEvidence());
+    }
+
+    /**
+     * Relabelling every row down to keyless epoch-0 lets an attacker re-sign the
+     * chain without the HMAC key. The anchor witnesses the epoch that was really
+     * in force, so the downgrade is detectable even after a full re-sign.
+     */
+    #[Test]
+    public function epochDowngradeBelowTheAnchoredEpochIsDetected(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $auditService->log('anchor_test_secret', 'create', true);
+        $auditService->log('anchor_test_secret', 'read', true);
+
+        $service = $this->getAnchorService();
+        $anchor = $service->capture();
+        $service->publish($anchor);
+        self::assertSame(3, $anchor->hmacEpoch);
+
+        $connection = $this->getAuditConnection();
+        $connection->update(AuditLogService::TABLE_NAME, ['hmac_key_epoch' => 0], ['uid' => $anchor->sequence]);
+
+        $report = $service->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::EpochDowngrade));
+    }
+
+    /**
+     * Without a baseline there is nothing to compare against. Under the standard
+     * profile that is not an error (sinks are opt-in), but the report must say so
+     * rather than implying the chain was checked against external evidence.
+     */
+    #[Test]
+    public function verificationWithoutAnyAnchorReportsNoAnchor(): void
+    {
+        $this->get(AuditLogServiceInterface::class)->log('anchor_test_secret', 'create', true);
+
+        $report = $this->getAnchorService()->verify();
+
+        self::assertNull($report->anchor);
+        self::assertTrue($report->isValid(), 'standard profile treats a missing anchor as acceptable');
+    }
+
+    /**
+     * The hardened profile requires external evidence, so a missing anchor is a
+     * finding there — a vault under audit must not silently lose reset detection.
+     */
+    #[Test]
+    public function hardenedProfileWithoutAnAnchorReportsNoExternalSink(): void
+    {
+        $this->switchToHardenedProfile();
+
+        $this->get(AuditLogServiceInterface::class)->log('anchor_test_secret', 'create', true);
+
+        $report = $this->getAnchorService()->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::NoExternalSink));
+        self::assertFalse($report->hasTamperEvidence(), 'a configuration gap is not tamper evidence');
+    }
+
+    #[Test]
+    public function hardenedProfileWithAnAnchorHasNoSinkFinding(): void
+    {
+        $this->switchToHardenedProfile();
+
+        $this->get(AuditLogServiceInterface::class)->log('anchor_test_secret', 'create', true);
+
+        $service = $this->getAnchorService();
+        $service->publish($service->capture());
+
+        $report = $service->verify();
+
+        self::assertFalse($report->hasReason(AuditIntegrityReason::NoExternalSink));
+        self::assertTrue($report->isValid(), 'findings: ' . implode(',', $report->getReasonCodes()));
+    }
+
+    #[Test]
+    public function theFileSinkIsReportedAsAnExternalAuditSink(): void
+    {
+        $registry = $this->get(AuditSinkRegistryInterface::class);
+
+        self::assertTrue($registry->hasExternalAuditSink());
+        self::assertContains('file', $registry->getEnabledSinkIdentifiers());
+    }
+
+    /**
+     * The audit write path must fan out to the sinks. Without this, anchoring
+     * works but the entry stream stays empty and nobody notices.
+     */
+    #[Test]
+    public function auditWritesReachTheExternalSink(): void
+    {
+        $this->get(AuditLogServiceInterface::class)->log('anchor_test_secret', 'create', true);
+
+        self::assertFileExists($this->auditSinkEntryPath);
+
+        $contents = file_get_contents($this->auditSinkEntryPath);
+        self::assertIsString($contents);
+        self::assertStringContainsString('anchor_test_secret', $contents);
+    }
+
+    /**
+     * A later anchor with a HIGHER sequence must become the baseline, so the blind
+     * window shrinks with every run.
+     */
+    #[Test]
+    public function theHighestPublishedAnchorBecomesTheBaseline(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $service = $this->getAnchorService();
+
+        $auditService->log('anchor_test_secret', 'create', true);
+        $service->publish($service->capture());
+
+        for ($i = 0; $i < 3; $i++) {
+            $auditService->log('anchor_test_secret', 'read', true);
+        }
+        $service->publish($service->capture());
+
+        $report = $service->verify();
+
+        self::assertInstanceOf(ChainTipAnchor::class, $report->anchor);
+        self::assertSame(4, $report->anchor->sequence);
+    }
+
+    /**
+     * Flip the running instance to the hardened profile.
+     *
+     * Written through a typed local because `$GLOBALS` is `mixed` to static
+     * analysis, so chained offset writes on it cannot be verified.
+     */
+    private function switchToHardenedProfile(): void
+    {
+        $confVars = \is_array($GLOBALS['TYPO3_CONF_VARS'] ?? null) ? $GLOBALS['TYPO3_CONF_VARS'] : [];
+        $extensions = \is_array($confVars['EXTENSIONS'] ?? null) ? $confVars['EXTENSIONS'] : [];
+        $nrVault = \is_array($extensions['nr_vault'] ?? null) ? $extensions['nr_vault'] : [];
+
+        $nrVault['securityProfile'] = 'hardened';
+        $extensions['nr_vault'] = $nrVault;
+        $confVars['EXTENSIONS'] = $extensions;
+        $GLOBALS['TYPO3_CONF_VARS'] = $confVars;
+    }
+
+    private function getAnchorService(): ChainTipAnchorServiceInterface
+    {
+        return $this->get(ChainTipAnchorServiceInterface::class);
+    }
+
+    private function getAuditConnection(): Connection
+    {
+        return $this->get(ConnectionPool::class)->getConnectionForTable(AuditLogService::TABLE_NAME);
+    }
+
+    /**
+     * Emulate the attack: remove every row so the next write starts a fresh
+     * chain. `DELETE` plus an explicit sqlite sequence reset rather than
+     * `TRUNCATE`, because the testing framework runs on SQLite here and the
+     * auto-increment counter must also go back to 1 for the rebuilt chain to
+     * reuse the anchored uid.
+     */
+    private function truncateAuditTable(): void
+    {
+        $connection = $this->getAuditConnection();
+        $connection->executeStatement('DELETE FROM ' . AuditLogService::TABLE_NAME);
+
+        $platform = $connection->getDatabasePlatform();
+        if ($platform instanceof SQLitePlatform) {
+            $connection->executeStatement(
+                "DELETE FROM sqlite_sequence WHERE name = '" . AuditLogService::TABLE_NAME . "'",
+            );
+
+            return;
+        }
+
+        $connection->executeStatement('ALTER TABLE ' . AuditLogService::TABLE_NAME . ' AUTO_INCREMENT = 1');
+    }
+}

--- a/Tests/Functional/Command/VaultAuditAnchorCommandTest.php
+++ b/Tests/Functional/Command/VaultAuditAnchorCommandTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Command;
+
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Command\VaultAuditAnchorCommand;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use Netresearch\NrVault\Tests\Functional\Traits\AuditSinkSandboxTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * End-to-end tests for `vault:audit-anchor` through CommandTester.
+ *
+ * Resolving the command from the container also proves its DI registration —
+ * an unregistered command would be unreachable from the CLI even though the
+ * class exists.
+ */
+#[CoversClass(VaultAuditAnchorCommand::class)]
+final class VaultAuditAnchorCommandTest extends AbstractVaultFunctionalTestCase
+{
+    use AuditSinkSandboxTrait;
+
+    protected ?string $backendUserFixture = __DIR__ . '/../Fixtures/Users/be_users.csv';
+
+    /** @var array<string, mixed> */
+    protected array $extensionConfiguration = [
+        'auditHmacEpoch' => 3,
+    ];
+
+    protected function setUp(): void
+    {
+        $this->extensionConfiguration = $this->prepareAuditSinkSandbox($this->extensionConfiguration);
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpAuditSinkSandbox();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function anchoringSucceedsAndWritesTheAnchorFile(): void
+    {
+        $this->get(AuditLogServiceInterface::class)->log('anchor_cmd_secret', 'create', true);
+
+        $tester = new CommandTester($this->get(VaultAuditAnchorCommand::class));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
+        self::assertFileExists($this->auditSinkAnchorPath);
+    }
+
+    #[Test]
+    public function outputReportsTheSequenceAndTheEnabledSink(): void
+    {
+        $this->get(AuditLogServiceInterface::class)->log('anchor_cmd_secret', 'create', true);
+
+        $tester = new CommandTester($this->get(VaultAuditAnchorCommand::class));
+        $tester->execute([]);
+
+        $output = $tester->getDisplay();
+        self::assertStringContainsString('file', $output);
+        self::assertStringContainsString('1', $output);
+    }
+
+    #[Test]
+    public function jsonOutputCarriesTheAnchorAndTheSinkCount(): void
+    {
+        $this->get(AuditLogServiceInterface::class)->log('anchor_cmd_secret', 'create', true);
+
+        $tester = new CommandTester($this->get(VaultAuditAnchorCommand::class));
+        $tester->execute(['--format' => 'json']);
+
+        $payload = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+        self::assertIsArray($payload['anchor']);
+        self::assertSame(1, $payload['anchor']['sequence']);
+        self::assertSame(3, $payload['anchor']['hmacEpoch']);
+        self::assertSame(1, $payload['published']);
+        self::assertFalse($payload['dryRun']);
+    }
+
+    #[Test]
+    public function dryRunWritesNothing(): void
+    {
+        $this->get(AuditLogServiceInterface::class)->log('anchor_cmd_secret', 'create', true);
+
+        $tester = new CommandTester($this->get(VaultAuditAnchorCommand::class));
+        $exitCode = $tester->execute(['--dry-run' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
+        self::assertFileDoesNotExist($this->auditSinkAnchorPath);
+    }
+
+    /**
+     * The contract monitoring depends on: an anchor that reached no external sink
+     * provides no table-reset protection, so it must exit non-zero rather than
+     * reporting a successful run.
+     */
+    #[Test]
+    public function anchoringWithoutAnyEnabledSinkFails(): void
+    {
+        $this->disableFileSink();
+        $this->get(AuditLogServiceInterface::class)->log('anchor_cmd_secret', 'create', true);
+
+        $tester = new CommandTester($this->get(VaultAuditAnchorCommand::class));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('no', strtolower($tester->getDisplay()));
+    }
+
+    #[Test]
+    public function anchoringAnEmptyChainStillSucceeds(): void
+    {
+        $tester = new CommandTester($this->get(VaultAuditAnchorCommand::class));
+        $exitCode = $tester->execute([]);
+
+        // An empty-chain anchor carries no hash to compare against, but it dates
+        // the installation — which is worth recording, not an error.
+        self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
+        self::assertStringContainsString('empty chain', $tester->getDisplay());
+    }
+
+    /**
+     * Turn the file sink off after the container was built, mirroring an
+     * installation that never enabled a sink.
+     */
+    private function disableFileSink(): void
+    {
+        $confVars = \is_array($GLOBALS['TYPO3_CONF_VARS'] ?? null) ? $GLOBALS['TYPO3_CONF_VARS'] : [];
+        $extensions = \is_array($confVars['EXTENSIONS'] ?? null) ? $confVars['EXTENSIONS'] : [];
+        $nrVault = \is_array($extensions['nr_vault'] ?? null) ? $extensions['nr_vault'] : [];
+
+        $nrVault['auditSinkFileEnabled'] = 0;
+        $extensions['nr_vault'] = $nrVault;
+        $confVars['EXTENSIONS'] = $extensions;
+        $GLOBALS['TYPO3_CONF_VARS'] = $confVars;
+    }
+}

--- a/Tests/Functional/Command/VaultAuditVerifyCommandTest.php
+++ b/Tests/Functional/Command/VaultAuditVerifyCommandTest.php
@@ -1,0 +1,231 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Command;
+
+use Doctrine\DBAL\Platforms\SQLitePlatform;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\AuditLogService;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Command\VaultAuditVerifyCommand;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use Netresearch\NrVault\Tests\Functional\Traits\AuditSinkSandboxTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * End-to-end tests for `vault:audit-verify` through CommandTester.
+ *
+ * The exit code is the load-bearing contract here: the command is meant to be
+ * wired straight into monitoring, so "found a problem" and "could not check" must
+ * both be non-zero, and a clean chain must be zero.
+ */
+#[CoversClass(VaultAuditVerifyCommand::class)]
+final class VaultAuditVerifyCommandTest extends AbstractVaultFunctionalTestCase
+{
+    use AuditSinkSandboxTrait;
+
+    protected ?string $backendUserFixture = __DIR__ . '/../Fixtures/Users/be_users.csv';
+
+    /** @var array<string, mixed> */
+    protected array $extensionConfiguration = [
+        'auditHmacEpoch' => 3,
+    ];
+
+    protected function setUp(): void
+    {
+        $this->extensionConfiguration = $this->prepareAuditSinkSandbox($this->extensionConfiguration);
+
+        parent::setUp();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanUpAuditSinkSandbox();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function anIntactAnchoredChainExitsZero(): void
+    {
+        $this->seedChain(3);
+        $this->publishAnchor();
+
+        $tester = new CommandTester($this->get(VaultAuditVerifyCommand::class));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
+        self::assertStringContainsString('verified', $tester->getDisplay());
+    }
+
+    /**
+     * The end-to-end version of the reset scenario: publish an anchor, wipe the
+     * table, re-seed, and confirm the CLI both exits non-zero and names the code.
+     */
+    #[Test]
+    public function aTableResetExitsNonZeroAndNamesTheReasonCode(): void
+    {
+        $this->seedChain(5);
+        $this->publishAnchor();
+
+        $this->resetAuditTable();
+        $this->seedChain(2);
+
+        $tester = new CommandTester($this->get(VaultAuditVerifyCommand::class));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('TABLE_RESET', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function jsonOutputCarriesTheReasonCodesAndTheAnchor(): void
+    {
+        $this->seedChain(4);
+        $this->publishAnchor();
+
+        $this->resetAuditTable();
+        $this->seedChain(1);
+
+        $tester = new CommandTester($this->get(VaultAuditVerifyCommand::class));
+        $exitCode = $tester->execute(['--format' => 'json']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+
+        $payload = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+        self::assertFalse($payload['valid']);
+        self::assertTrue($payload['tamperEvidence']);
+        self::assertIsArray($payload['reasonCodes']);
+        self::assertContains('TABLE_RESET', $payload['reasonCodes']);
+        self::assertIsArray($payload['anchor']);
+        self::assertSame(4, $payload['anchor']['sequence']);
+        self::assertContains('file', $payload['enabledSinks']);
+    }
+
+    #[Test]
+    public function aTamperedRowExitsNonZeroWithHashMismatch(): void
+    {
+        $this->seedChain(2);
+
+        $this->getAuditConnection()->update(
+            AuditLogService::TABLE_NAME,
+            ['secret_identifier' => 'rewritten_by_attacker'],
+            ['uid' => 1],
+        );
+
+        $tester = new CommandTester($this->get(VaultAuditVerifyCommand::class));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('HASH_MISMATCH', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function aDeletedRowExitsNonZeroWithUidGap(): void
+    {
+        $this->seedChain(4);
+
+        $this->getAuditConnection()->delete(AuditLogService::TABLE_NAME, ['uid' => 2]);
+
+        $tester = new CommandTester($this->get(VaultAuditVerifyCommand::class));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('UID_GAP', $tester->getDisplay());
+    }
+
+    /**
+     * `--tamper-only` must NOT soften a real tamper finding — that would make the
+     * flag a way to silence the alarm it exists to preserve.
+     */
+    #[Test]
+    public function tamperOnlyStillFailsOnTamperEvidence(): void
+    {
+        $this->seedChain(4);
+        $this->getAuditConnection()->delete(AuditLogService::TABLE_NAME, ['uid' => 2]);
+
+        $tester = new CommandTester($this->get(VaultAuditVerifyCommand::class));
+        $exitCode = $tester->execute(['--tamper-only' => true]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+    }
+
+    /**
+     * With no anchor and the standard profile there is nothing to compare against,
+     * which is acceptable — sinks are opt-in outside the hardened profile.
+     */
+    #[Test]
+    public function aChainWithoutAnAnchorExitsZeroUnderTheStandardProfile(): void
+    {
+        $this->seedChain(2);
+
+        $tester = new CommandTester($this->get(VaultAuditVerifyCommand::class));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
+        self::assertStringContainsString('none available', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function outputListsTheEnabledSinks(): void
+    {
+        $this->seedChain(1);
+
+        $tester = new CommandTester($this->get(VaultAuditVerifyCommand::class));
+        $tester->execute([]);
+
+        self::assertStringContainsString('file', $tester->getDisplay());
+    }
+
+    private function seedChain(int $entries): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        for ($i = 0; $i < $entries; $i++) {
+            $auditService->log('verify_cmd_secret', 'read', true);
+        }
+    }
+
+    private function publishAnchor(): void
+    {
+        $service = $this->get(ChainTipAnchorServiceInterface::class);
+        $service->publish($service->capture());
+    }
+
+    private function getAuditConnection(): Connection
+    {
+        return $this->get(ConnectionPool::class)->getConnectionForTable(AuditLogService::TABLE_NAME);
+    }
+
+    /**
+     * Wipe the table AND its auto-increment counter, so the next write starts a
+     * fresh chain at uid 1 — the state a truncate-and-rebuild leaves behind.
+     */
+    private function resetAuditTable(): void
+    {
+        $connection = $this->getAuditConnection();
+        $connection->executeStatement('DELETE FROM ' . AuditLogService::TABLE_NAME);
+
+        if ($connection->getDatabasePlatform() instanceof SQLitePlatform) {
+            $connection->executeStatement(
+                "DELETE FROM sqlite_sequence WHERE name = '" . AuditLogService::TABLE_NAME . "'",
+            );
+
+            return;
+        }
+
+        $connection->executeStatement('ALTER TABLE ' . AuditLogService::TABLE_NAME . ' AUTO_INCREMENT = 1');
+    }
+}

--- a/Tests/Functional/Traits/AuditSinkSandboxTrait.php
+++ b/Tests/Functional/Traits/AuditSinkSandboxTrait.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Traits;
+
+/**
+ * Points the NDJSON audit sink at a throwaway directory outside the test instance.
+ *
+ * Outside on purpose: the functional test instance uses the LEGACY layout, where
+ * `Environment::getVarPath()` resolves to `<publicPath>/typo3temp/var` — inside
+ * the public web root, which
+ * {@see \Netresearch\NrVault\Audit\Sink\JsonFileAuditSink} refuses because it
+ * would publish the audit trail over HTTP. A path under the system temp directory
+ * reproduces the Composer-based production layout these tests need to exercise.
+ *
+ * Usage: call `prepareAuditSinkSandbox()` BEFORE `parent::setUp()` (so the paths
+ * land in `$this->extensionConfiguration` before the singleton is built) and
+ * `cleanUpAuditSinkSandbox()` in `tearDown()`.
+ */
+trait AuditSinkSandboxTrait
+{
+    private string $auditSinkDirectory = '';
+
+    private string $auditSinkAnchorPath = '';
+
+    private string $auditSinkEntryPath = '';
+
+    /**
+     * Register the sandbox paths in the extension configuration under test.
+     *
+     * @param array<string, mixed> $extensionConfiguration Existing configuration to extend
+     *
+     * @return array<string, mixed> Configuration with the sink keys added
+     */
+    private function prepareAuditSinkSandbox(array $extensionConfiguration, bool $enableFileSink = true): array
+    {
+        $this->auditSinkDirectory = sys_get_temp_dir() . '/nr-vault-sink-' . bin2hex(random_bytes(6));
+        $this->auditSinkAnchorPath = $this->auditSinkDirectory . '/anchor.ndjson';
+        $this->auditSinkEntryPath = $this->auditSinkDirectory . '/entries.ndjson';
+
+        $extensionConfiguration['auditSinkFileEnabled'] = $enableFileSink ? 1 : 0;
+        $extensionConfiguration['auditSinkFilePath'] = $this->auditSinkEntryPath;
+        $extensionConfiguration['auditSinkAnchorPath'] = $this->auditSinkAnchorPath;
+
+        return $extensionConfiguration;
+    }
+
+    private function cleanUpAuditSinkSandbox(): void
+    {
+        if ($this->auditSinkDirectory === '' || !is_dir($this->auditSinkDirectory)) {
+            return;
+        }
+
+        $files = glob($this->auditSinkDirectory . '/*');
+        foreach ($files === false ? [] : $files as $file) {
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned temp path
+            unlink($file);
+        }
+
+        rmdir($this->auditSinkDirectory);
+        $this->auditSinkDirectory = '';
+    }
+}

--- a/Tests/Unit/Audit/Anchor/AnchorFileReaderTest.php
+++ b/Tests/Unit/Audit/Anchor/AnchorFileReaderTest.php
@@ -12,7 +12,9 @@ namespace Netresearch\NrVault\Tests\Unit\Audit\Anchor;
 use Netresearch\NrVault\Audit\Anchor\AnchorFileReader;
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Tests\Unit\Fixtures\FailingStreamWrapper;
 use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\ErrorSuppressionTrait;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -27,6 +29,8 @@ use Psr\Log\NullLogger;
 #[CoversClass(AnchorFileReader::class)]
 final class AnchorFileReaderTest extends TestCase
 {
+    use ErrorSuppressionTrait;
+
     private vfsStreamDirectory $root;
 
     protected function setUp(): void
@@ -189,6 +193,46 @@ final class AnchorFileReaderTest extends TestCase
 
         self::assertInstanceOf(ChainTipAnchor::class, $anchor);
         self::assertSame(4, $anchor->sequence);
+    }
+
+    /**
+     * A file that stats as a readable regular file but cannot actually be opened
+     * (a revoked ACL, an NFS mount that went away between the stat and the open).
+     * Verification then has no external baseline — and must say so by returning
+     * null rather than by dying inside the integrity check.
+     */
+    #[Test]
+    public function anUnopenableAnchorFileYieldsNoAnchorInsteadOfFailing(): void
+    {
+        FailingStreamWrapper::register(FailingStreamWrapper::MODE_OPEN_REFUSED);
+
+        try {
+            $subject = $this->createSubject(FailingStreamWrapper::path('anchor.ndjson'));
+
+            // `isAvailable()` still reports true: the file is there, which is
+            // exactly why the read path needs its own guard.
+            self::assertTrue($subject->isAvailable());
+            self::assertNull($this->withoutPhpDiagnostics(static fn (): ?ChainTipAnchor => $subject->readLatestAnchor()));
+        } finally {
+            FailingStreamWrapper::unregister();
+        }
+    }
+
+    /**
+     * On a host whose error handler promotes warnings to exceptions, the failed
+     * open arrives as a Throwable rather than as `false`. Both must degrade to
+     * "no baseline", never propagate out of the verifier.
+     */
+    #[Test]
+    public function aThrowingOpenAlsoYieldsNoAnchor(): void
+    {
+        FailingStreamWrapper::register(FailingStreamWrapper::MODE_OPEN_THROWS);
+
+        try {
+            self::assertNull($this->createSubject(FailingStreamWrapper::path('anchor.ndjson'))->readLatestAnchor());
+        } finally {
+            FailingStreamWrapper::unregister();
+        }
     }
 
     private function createSubject(string $path): AnchorFileReader

--- a/Tests/Unit/Audit/Anchor/AnchorFileReaderTest.php
+++ b/Tests/Unit/Audit/Anchor/AnchorFileReaderTest.php
@@ -1,0 +1,222 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit\Anchor;
+
+use Netresearch\NrVault\Audit\Anchor\AnchorFileReader;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+
+/**
+ * The reader only ever reads, so vfsStream models it faithfully (unlike the
+ * write path in {@see \Netresearch\NrVault\Tests\Unit\Audit\Sink\JsonFileAuditSinkTest},
+ * which needs real `flock`/`chmod`/`realpath` behaviour).
+ */
+#[CoversClass(AnchorFileReader::class)]
+final class AnchorFileReaderTest extends TestCase
+{
+    private vfsStreamDirectory $root;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->root = vfsStream::setup('anchors');
+    }
+
+    #[Test]
+    public function missingFileYieldsNoAnchor(): void
+    {
+        $subject = $this->createSubject($this->root->url() . '/absent.ndjson');
+
+        self::assertNull($subject->readLatestAnchor());
+        self::assertFalse($subject->isAvailable());
+    }
+
+    #[Test]
+    public function existingFileIsReportedAsAvailable(): void
+    {
+        $path = $this->writeFile('');
+
+        self::assertTrue($this->createSubject($path)->isAvailable());
+    }
+
+    #[Test]
+    public function emptyFileYieldsNoAnchor(): void
+    {
+        $subject = $this->createSubject($this->writeFile(''));
+
+        self::assertNull($subject->readLatestAnchor());
+        // Distinguishable from "never set up": the store exists but holds nothing.
+        self::assertTrue($subject->isAvailable());
+    }
+
+    #[Test]
+    public function singleAnchorIsRead(): void
+    {
+        $path = $this->writeFile($this->anchorLine(10, 'tip-10', 1_750_000_000, 3));
+
+        $anchor = $this->createSubject($path)->readLatestAnchor();
+
+        self::assertInstanceOf(ChainTipAnchor::class, $anchor);
+        self::assertSame(10, $anchor->sequence);
+        self::assertSame('tip-10', $anchor->chainTip);
+        self::assertSame(1_750_000_000, $anchor->timestamp);
+        self::assertSame(3, $anchor->hmacEpoch);
+    }
+
+    /**
+     * The security-relevant rule. Picking the LAST line would let an attacker
+     * with append-only access weaken the baseline by appending a low-sequence
+     * anchor that a truncated chain satisfies. Taking the maximum means the file
+     * must be rewritten or truncated to weaken it — which is exactly what
+     * append-only storage prevents.
+     */
+    #[Test]
+    public function highestSequenceWinsOverAppendOrder(): void
+    {
+        $path = $this->writeFile(
+            $this->anchorLine(100, 'tip-100', 1_750_000_000, 3)
+            . $this->anchorLine(1, 'tip-1', 1_750_000_900, 3),
+        );
+
+        $anchor = $this->createSubject($path)->readLatestAnchor();
+
+        self::assertInstanceOf(ChainTipAnchor::class, $anchor);
+        self::assertSame(100, $anchor->sequence);
+        self::assertSame('tip-100', $anchor->chainTip);
+    }
+
+    #[Test]
+    public function anchorsAreReadAcrossManyLines(): void
+    {
+        $lines = '';
+        foreach ([5, 25, 15] as $sequence) {
+            $lines .= $this->anchorLine($sequence, 'tip-' . $sequence, 1_750_000_000, 3);
+        }
+
+        $anchor = $this->createSubject($this->writeFile($lines))->readLatestAnchor();
+
+        self::assertInstanceOf(ChainTipAnchor::class, $anchor);
+        self::assertSame(25, $anchor->sequence);
+    }
+
+    /**
+     * A crash mid-write leaves a truncated final line. Losing every earlier
+     * anchor over it would destroy the baseline exactly when it matters.
+     */
+    #[Test]
+    public function truncatedFinalLineDoesNotDiscardEarlierAnchors(): void
+    {
+        $path = $this->writeFile(
+            $this->anchorLine(42, 'tip-42', 1_750_000_000, 3)
+            . '{"type":"anchor","anchor":{"sequence":43,"chainTi',
+        );
+
+        $anchor = $this->createSubject($path)->readLatestAnchor();
+
+        self::assertInstanceOf(ChainTipAnchor::class, $anchor);
+        self::assertSame(42, $anchor->sequence);
+    }
+
+    /**
+     * Alerts share the anchor stream, so a non-anchor record is normal traffic
+     * that must be skipped without disturbing the scan.
+     */
+    #[Test]
+    public function alertRecordsInTheSameStreamAreSkipped(): void
+    {
+        $path = $this->writeFile(
+            '{"type":"alert","alert":{"reason":"TABLE_RESET"}}' . "\n"
+            . $this->anchorLine(7, 'tip-7', 1_750_000_000, 3) . "\n"
+            . '{"type":"alert","alert":{"reason":"SINK_FAILURE"}}' . "\n",
+        );
+
+        $anchor = $this->createSubject($path)->readLatestAnchor();
+
+        self::assertInstanceOf(ChainTipAnchor::class, $anchor);
+        self::assertSame(7, $anchor->sequence);
+    }
+
+    #[Test]
+    public function blankLinesAreIgnored(): void
+    {
+        $path = $this->writeFile("\n\n" . $this->anchorLine(3, 'tip-3', 1, 3) . "\n   \n");
+
+        $anchor = $this->createSubject($path)->readLatestAnchor();
+
+        self::assertInstanceOf(ChainTipAnchor::class, $anchor);
+        self::assertSame(3, $anchor->sequence);
+    }
+
+    /**
+     * A structurally incomplete anchor must not become a comparison baseline —
+     * a missing `chainTip` would compare against '' and could read as a match.
+     */
+    #[Test]
+    public function structurallyIncompleteAnchorRecordsAreRejected(): void
+    {
+        $path = $this->writeFile(
+            '{"type":"anchor","anchor":{"sequence":9}}' . "\n"
+            . '{"type":"anchor","anchor":{"chainTip":"x"}}' . "\n"
+            . '{"type":"anchor"}' . "\n"
+            . '{"type":"anchor","anchor":"not-an-array"}' . "\n",
+        );
+
+        self::assertNull($this->createSubject($path)->readLatestAnchor());
+    }
+
+    #[Test]
+    public function nonJsonLinesAreSkipped(): void
+    {
+        $path = $this->writeFile(
+            "not json at all\n"
+            . $this->anchorLine(4, 'tip-4', 1, 3),
+        );
+
+        $anchor = $this->createSubject($path)->readLatestAnchor();
+
+        self::assertInstanceOf(ChainTipAnchor::class, $anchor);
+        self::assertSame(4, $anchor->sequence);
+    }
+
+    private function createSubject(string $path): AnchorFileReader
+    {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('getAuditSinkAnchorPath')->willReturn($path);
+
+        return new AnchorFileReader($configuration, new NullLogger());
+    }
+
+    private function writeFile(string $contents): string
+    {
+        $path = $this->root->url() . '/anchor.ndjson';
+        file_put_contents($path, $contents);
+
+        return $path;
+    }
+
+    private function anchorLine(int $sequence, string $chainTip, int $timestamp, int $epoch): string
+    {
+        return json_encode([
+            'type' => 'anchor',
+            'anchor' => [
+                'sequence' => $sequence,
+                'chainTip' => $chainTip,
+                'timestamp' => $timestamp,
+                'hmacEpoch' => $epoch,
+            ],
+        ], JSON_THROW_ON_ERROR) . "\n";
+    }
+}

--- a/Tests/Unit/Audit/Anchor/ChainTipAnchorServiceTest.php
+++ b/Tests/Unit/Audit/Anchor/ChainTipAnchorServiceTest.php
@@ -1,0 +1,667 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit\Anchor;
+
+use Doctrine\DBAL\Result;
+use Netresearch\NrVault\Audit\Anchor\AnchorReaderInterface;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorService;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\HashChainVerificationResult;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Event\AuditIntegrityAlertEvent;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use UnexpectedValueException;
+
+/**
+ * Unit tests for the branches of chain-tip anchoring that the functional suite
+ * cannot drive.
+ *
+ * {@see \Netresearch\NrVault\Tests\Functional\Audit\ChainTipAnchorServiceTest}
+ * owns the end-to-end evidence — a real chain, a real NDJSON sink, a real
+ * truncate-and-reseed attack. What it cannot reach is the behaviour of the
+ * service when its COLLABORATORS misbehave: a sink registry that accepts
+ * nothing, a configuration that cannot resolve its own security profile, an
+ * event listener that throws. Those are the paths that decide whether a failing
+ * integrity check reports honestly or silently degrades, so they are driven here
+ * with stubbed collaborators instead.
+ */
+#[CoversClass(ChainTipAnchorService::class)]
+final class ChainTipAnchorServiceTest extends TestCase
+{
+    // -------------------------------------------------------------------------
+    // publish()
+    // -------------------------------------------------------------------------
+
+    /**
+     * An anchor nobody stored provides no table-reset protection whatsoever. The
+     * service does not throw — the command/scheduler caller owns how loudly to
+     * fail — but it must never look like success, so it returns 0 AND logs at
+     * error level.
+     */
+    #[Test]
+    public function publishingToZeroSinksReturnsZeroAndLogsAnError(): void
+    {
+        $registry = self::createStub(AuditSinkRegistryInterface::class);
+        $registry->method('dispatchAnchor')->willReturn(0);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with(
+                self::stringContains('zero external sinks'),
+                ['sequence' => 12],
+            );
+        $logger->expects(self::never())->method('info');
+
+        $subject = $this->createSubject(sinkRegistry: $registry, logger: $logger);
+
+        self::assertSame(0, $subject->publish(new ChainTipAnchor(12, 'tip-12', 1_750_000_000, 3)));
+    }
+
+    /**
+     * The accepted-sink count is passed through verbatim: the caller uses it to
+     * report how much external evidence actually exists.
+     */
+    #[Test]
+    public function publishingReturnsTheNumberOfSinksThatAcceptedTheAnchor(): void
+    {
+        $registry = self::createStub(AuditSinkRegistryInterface::class);
+        $registry->method('dispatchAnchor')->willReturn(3);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('info')
+            ->with(self::stringContains('published an audit chain anchor'), ['sequence' => 5, 'sinks' => 3]);
+        $logger->expects(self::never())->method('error');
+
+        $subject = $this->createSubject(sinkRegistry: $registry, logger: $logger);
+
+        self::assertSame(3, $subject->publish(new ChainTipAnchor(5, 'tip-5', 1_750_000_000, 3)));
+    }
+
+    // -------------------------------------------------------------------------
+    // capture()
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function captureBindsTheConfiguredEpochToTheChainTip(): void
+    {
+        $auditLogService = self::createStub(AuditLogServiceInterface::class);
+        $auditLogService->method('getLatestHash')->willReturn('tip-9');
+
+        $subject = $this->createSubject(
+            auditLogService: $auditLogService,
+            maxUid: 9,
+            hmacEpoch: 4,
+        );
+
+        $anchor = $subject->capture();
+
+        self::assertSame(9, $anchor->sequence);
+        self::assertSame('tip-9', $anchor->chainTip);
+        self::assertSame(4, $anchor->hmacEpoch);
+    }
+
+    /**
+     * A chain whose tip cannot be read must not be anchored as if the tip were
+     * the empty string of an empty chain — the anchor would then match anything.
+     * The empty-anchor marker is what `compareWithAnchor()` refuses to use as a
+     * baseline.
+     */
+    #[Test]
+    public function captureOnAChainWithoutAReadableTipYieldsAnEmptyChainTip(): void
+    {
+        $auditLogService = self::createStub(AuditLogServiceInterface::class);
+        $auditLogService->method('getLatestHash')->willReturn(null);
+
+        $anchor = $this->createSubject(auditLogService: $auditLogService, maxUid: 7)->capture();
+
+        self::assertSame(7, $anchor->sequence);
+        self::assertSame('', $anchor->chainTip);
+    }
+
+    // -------------------------------------------------------------------------
+    // Chain-error classification
+    // -------------------------------------------------------------------------
+
+    /**
+     * An epoch downgrade is reported by the chain verifier as an error STRING, so
+     * the report has to recognise it by its marker substring. Misclassifying it
+     * as a generic hash mismatch would tell an operator to look for a rewritten
+     * row when the real event was an algorithm downgrade.
+     */
+    #[Test]
+    public function anEpochDowngradeErrorIsClassifiedAsEpochDowngradeNotHashMismatch(): void
+    {
+        $report = $this->createSubject(
+            chainResult: HashChainVerificationResult::invalid([
+                4 => 'HMAC key epoch downgrade detected: 3 -> 0 (possible algorithm-downgrade forgery)',
+            ]),
+        )->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::EpochDowngrade));
+        self::assertFalse($report->hasReason(AuditIntegrityReason::HashMismatch));
+    }
+
+    /**
+     * A broken chain commonly fails every row after the break. One finding per
+     * ERRORING ROW would bury the signal under thousands of identical SIEM
+     * alerts, so the rows collapse into a single finding carrying the count.
+     */
+    #[Test]
+    public function manyEpochDowngradeRowsCollapseIntoOneFindingCarryingTheCount(): void
+    {
+        $errors = [];
+        foreach ([11, 12, 13, 14] as $uid) {
+            $errors[$uid] = 'HMAC key epoch downgrade detected: 3 -> 0 (possible algorithm-downgrade forgery)';
+        }
+
+        $report = $this->createSubject(chainResult: HashChainVerificationResult::invalid($errors))->verify();
+
+        $downgrades = array_values(array_filter(
+            $report->findings,
+            static fn (AuditIntegrityAlert $finding): bool => $finding->reason === AuditIntegrityReason::EpochDowngrade,
+        ));
+
+        self::assertCount(1, $downgrades);
+        self::assertSame(4, $downgrades[0]->context['affectedRows']);
+        self::assertSame(11, $downgrades[0]->context['firstUid'], 'the earliest affected row locates the break');
+        self::assertStringContainsString('4 row(s)', $downgrades[0]->detail);
+    }
+
+    /**
+     * Both classes in one chain must both be reported — an operator needs to know
+     * that rows were rewritten AND that the algorithm was relabelled.
+     */
+    #[Test]
+    public function epochDowngradeAndHashMismatchRowsAreReportedSeparately(): void
+    {
+        $report = $this->createSubject(
+            chainResult: HashChainVerificationResult::invalid([
+                2 => 'HMAC key epoch downgrade detected: 3 -> 0 (possible algorithm-downgrade forgery)',
+                5 => 'Entry hash mismatch - possible tampering',
+            ]),
+        )->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::EpochDowngrade));
+        self::assertTrue($report->hasReason(AuditIntegrityReason::HashMismatch));
+    }
+
+    /**
+     * The uid-gap error string duplicates the structured `missingUidCount`, which
+     * is already reported as UID_GAP. Counting it twice would inflate the
+     * hash-mismatch row count and invent a finding that is not there.
+     */
+    #[Test]
+    public function theUidGapErrorStringIsNotCountedAgainAsAHashMismatch(): void
+    {
+        $report = $this->createSubject(
+            chainResult: HashChainVerificationResult::invalid(
+                [3 => 'Audit log uid gap detected: missing uids 2..2 (chain could have been tampered by deletion + previous_hash patch)'],
+                [],
+                [2],
+                1,
+            ),
+        )->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::UidGap));
+        self::assertFalse($report->hasReason(AuditIntegrityReason::HashMismatch));
+    }
+
+    /**
+     * An error message the classifier does not recognise still has to appear:
+     * degrading to a generic hash finding keeps a future verifier message
+     * visible, where dropping it would hide a real chain error.
+     */
+    #[Test]
+    public function anUnrecognisedChainErrorDegradesToAHashMismatchRatherThanDisappearing(): void
+    {
+        $report = $this->createSubject(
+            chainResult: HashChainVerificationResult::invalid([9 => 'Something the verifier learned to say later']),
+        )->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::HashMismatch));
+        self::assertFalse($report->isValid());
+    }
+
+    // -------------------------------------------------------------------------
+    // External-sink requirement
+    // -------------------------------------------------------------------------
+
+    /**
+     * Under the hardened profile the audit trail must exist somewhere other than
+     * the database it protects. No usable sink means no anchor can ever be
+     * published, so a full table reset would be undetectable.
+     */
+    #[Test]
+    public function theHardenedProfileWithoutAnyUsableSinkReportsNoExternalSink(): void
+    {
+        $registry = self::createStub(AuditSinkRegistryInterface::class);
+        $registry->method('hasExternalAuditSink')->willReturn(false);
+
+        $report = $this->createSubject(
+            sinkRegistry: $registry,
+            profile: SecurityProfile::Hardened,
+        )->verify();
+
+        $findings = array_values(array_filter(
+            $report->findings,
+            static fn (AuditIntegrityAlert $finding): bool => $finding->reason === AuditIntegrityReason::NoExternalSink,
+        ));
+
+        self::assertCount(1, $findings);
+        self::assertSame('hardened', $findings[0]->context['profile']);
+        self::assertStringContainsString('only in the database it is meant to protect', $findings[0]->detail);
+        self::assertFalse($report->hasTamperEvidence(), 'a configuration gap is not tamper evidence');
+    }
+
+    /**
+     * The standard profile treats external sinks as opt-in — flagging a default
+     * installation for not having a SIEM would make the check noise.
+     */
+    #[Test]
+    public function theStandardProfileWithoutAnyUsableSinkReportsNothing(): void
+    {
+        $registry = self::createStub(AuditSinkRegistryInterface::class);
+        $registry->method('hasExternalAuditSink')->willReturn(false);
+
+        $report = $this->createSubject(sinkRegistry: $registry)->verify();
+
+        self::assertTrue($report->isValid());
+        self::assertSame([], $report->getReasonCodes());
+    }
+
+    /**
+     * A configuration value the profile enum cannot parse is a configuration
+     * fault, not an integrity finding. It must not be swallowed into a
+     * "valid chain" verdict silently — hence the error log — but it also must not
+     * abort the rest of the verification.
+     */
+    #[Test]
+    public function anUnresolvableSecurityProfileIsLoggedAndSkipsTheSinkCheckOnly(): void
+    {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('getAuditHmacEpoch')->willReturn(3);
+        $configuration->method('getSecurityProfile')
+            ->willThrowException(new UnexpectedValueException('unknown profile "military-grade"', 1750000030));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with(
+                self::stringContains('could not resolve the security profile'),
+                ['error' => 'unknown profile "military-grade"'],
+            );
+
+        $report = $this->createSubject(
+            configuration: $configuration,
+            logger: $logger,
+            chainResult: HashChainVerificationResult::invalid([1 => 'Entry hash mismatch - possible tampering']),
+        )->verify();
+
+        // The chain findings survive the configuration fault.
+        self::assertTrue($report->hasReason(AuditIntegrityReason::HashMismatch));
+        self::assertFalse($report->hasReason(AuditIntegrityReason::NoExternalSink));
+    }
+
+    // -------------------------------------------------------------------------
+    // Finding dispatch
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function everyFindingIsDispatchedAsAnEvent(): void
+    {
+        $dispatched = [];
+        $dispatcher = self::createStub(EventDispatcherInterface::class);
+        $dispatcher->method('dispatch')->willReturnCallback(
+            static function (object $event) use (&$dispatched): object {
+                if ($event instanceof AuditIntegrityAlertEvent) {
+                    $dispatched[] = $event->getAlert()->reason;
+                }
+
+                return $event;
+            },
+        );
+
+        $registry = self::createStub(AuditSinkRegistryInterface::class);
+        $registry->method('hasExternalAuditSink')->willReturn(false);
+
+        $this->createSubject(
+            sinkRegistry: $registry,
+            eventDispatcher: $dispatcher,
+            chainResult: HashChainVerificationResult::invalid([1 => 'Entry hash mismatch - possible tampering']),
+            profile: SecurityProfile::Hardened,
+        )->verify();
+
+        self::assertSame(
+            [AuditIntegrityReason::HashMismatch, AuditIntegrityReason::NoExternalSink],
+            $dispatched,
+        );
+    }
+
+    /**
+     * A throwing listener must cost neither the remaining findings nor the report
+     * itself: the integrity verdict is the whole point of the run, and a
+     * misbehaving SIEM notifier must not be able to suppress it.
+     */
+    #[Test]
+    public function aThrowingListenerDoesNotCostTheRemainingFindingsOrTheReport(): void
+    {
+        $seen = [];
+        $dispatcher = self::createStub(EventDispatcherInterface::class);
+        $dispatcher->method('dispatch')->willReturnCallback(
+            static function (object $event) use (&$seen): object {
+                if (!$event instanceof AuditIntegrityAlertEvent) {
+                    return $event;
+                }
+
+                $seen[] = $event->getAlert()->reason;
+
+                if ($event->getAlert()->reason === AuditIntegrityReason::HashMismatch) {
+                    throw new RuntimeException('notifier exploded', 1750000031);
+                }
+
+                return $event;
+            },
+        );
+
+        $registry = self::createStub(AuditSinkRegistryInterface::class);
+        $registry->method('hasExternalAuditSink')->willReturn(false);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with(
+                self::stringContains('could not dispatch an audit integrity alert'),
+                ['reason' => 'HASH_MISMATCH', 'error' => 'notifier exploded'],
+            );
+
+        $report = $this->createSubject(
+            sinkRegistry: $registry,
+            eventDispatcher: $dispatcher,
+            logger: $logger,
+            chainResult: HashChainVerificationResult::invalid([1 => 'Entry hash mismatch - possible tampering']),
+            profile: SecurityProfile::Hardened,
+        )->verify();
+
+        self::assertSame(
+            [AuditIntegrityReason::HashMismatch, AuditIntegrityReason::NoExternalSink],
+            $seen,
+            'the finding after the throwing one must still be dispatched',
+        );
+        self::assertFalse($report->isValid(), 'the report survives the listener failure');
+    }
+
+    // -------------------------------------------------------------------------
+    // Anchor comparison against a non-shrinking chain
+    // -------------------------------------------------------------------------
+
+    /**
+     * An anchor captured while the chain was still empty matches any chain, so it
+     * is no baseline at all and must not be treated as one.
+     */
+    #[Test]
+    public function anEmptyAnchorIsNotUsedAsAComparisonBaseline(): void
+    {
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn(new ChainTipAnchor(0, '', 1_750_000_000, 3));
+
+        $report = $this->createSubject(anchorReader: $anchorReader, maxUid: 5)->verify();
+
+        self::assertTrue($report->isValid());
+        self::assertSame([], $report->getReasonCodes());
+    }
+
+    /**
+     * Growth past the anchor is normal operation. Only shrinkage, substitution or
+     * epoch regression are findings.
+     */
+    #[Test]
+    public function aChainThatGrewPastItsAnchorIsValid(): void
+    {
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn(new ChainTipAnchor(2, 'tip-2', 1_750_000_000, 3));
+
+        $report = $this->createSubject(
+            anchorReader: $anchorReader,
+            maxUid: 9,
+            rowAtAnchor: ['entry_hash' => 'tip-2', 'hmac_key_epoch' => 3],
+        )->verify();
+
+        self::assertTrue($report->isValid(), 'findings: ' . implode(',', $report->getReasonCodes()));
+        self::assertSame(9, $report->currentSequence);
+    }
+
+    /**
+     * A row whose stored hash is not a string (a NULL column after a partial
+     * write) must not compare equal to the anchored tip by collapsing to ''.
+     */
+    #[Test]
+    public function anAnchoredRowWithoutAUsableHashIsReportedAsATableReset(): void
+    {
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn(new ChainTipAnchor(2, 'tip-2', 1_750_000_000, 3));
+
+        $report = $this->createSubject(
+            anchorReader: $anchorReader,
+            maxUid: 4,
+            rowAtAnchor: ['entry_hash' => null, 'hmac_key_epoch' => 3],
+        )->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::TableReset));
+    }
+
+    /**
+     * A non-numeric epoch column degrades to 0, which is below any anchored
+     * epoch — the fail-closed direction.
+     */
+    #[Test]
+    public function anAnchoredRowWithoutAUsableEpochIsReportedAsAnEpochDowngrade(): void
+    {
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn(new ChainTipAnchor(2, 'tip-2', 1_750_000_000, 3));
+
+        $report = $this->createSubject(
+            anchorReader: $anchorReader,
+            maxUid: 4,
+            rowAtAnchor: ['entry_hash' => 'tip-2', 'hmac_key_epoch' => 'not-a-number'],
+        )->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::EpochDowngrade));
+    }
+
+    /**
+     * The shrinkage check. An append-only chain's highest uid cannot decrease, so
+     * `current < anchored` is a truncate — and the finding has to name both
+     * sequences and the capture time, because that is what an operator needs to
+     * bound the window in which the rows disappeared.
+     */
+    #[Test]
+    public function aChainShorterThanItsAnchorReportsATableResetNamingBothSequences(): void
+    {
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn(new ChainTipAnchor(9, 'tip-9', 1_750_000_000, 3));
+
+        $report = $this->createSubject(anchorReader: $anchorReader, maxUid: 2)->verify();
+
+        $findings = array_values(array_filter(
+            $report->findings,
+            static fn (AuditIntegrityAlert $finding): bool => $finding->reason === AuditIntegrityReason::TableReset,
+        ));
+
+        self::assertCount(1, $findings);
+        self::assertSame(2, $findings[0]->context['currentSequence']);
+        self::assertSame(9, $findings[0]->context['anchoredSequence']);
+        self::assertSame(1_750_000_000, $findings[0]->context['anchoredAt']);
+        self::assertStringContainsString('2025-06-15 15:06:40 UTC', $findings[0]->detail);
+        self::assertTrue($report->hasTamperEvidence());
+    }
+
+    /**
+     * A reset that re-seeds MORE rows than were anchored passes the length check,
+     * so the anchored row's absence is the only remaining evidence.
+     */
+    #[Test]
+    public function aMissingAnchoredRowInALongerChainReportsATableReset(): void
+    {
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn(new ChainTipAnchor(3, 'tip-3', 1_750_000_000, 3));
+
+        $report = $this->createSubject(
+            anchorReader: $anchorReader,
+            maxUid: 11,
+            rowAtAnchor: false,
+        )->verify();
+
+        $findings = array_values(array_filter(
+            $report->findings,
+            static fn (AuditIntegrityAlert $finding): bool => $finding->reason === AuditIntegrityReason::TableReset,
+        ));
+
+        self::assertCount(1, $findings);
+        self::assertSame(3, $findings[0]->context['anchoredSequence']);
+        self::assertSame(11, $findings[0]->context['currentSequence']);
+        self::assertStringContainsString('no longer exists', $findings[0]->detail);
+    }
+
+    /**
+     * Hardened profile, a usable sink, but no anchor yet: reset detection is not
+     * in place, and the finding must say whether the anchor store is even
+     * reachable so the operator knows whether to run `vault:audit-anchor` or to
+     * fix the sink first.
+     */
+    #[Test]
+    public function theHardenedProfileWithASinkButNoAnchorReportsNoExternalSink(): void
+    {
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn(null);
+        $anchorReader->method('isAvailable')->willReturn(false);
+
+        $report = $this->createSubject(
+            anchorReader: $anchorReader,
+            profile: SecurityProfile::Hardened,
+        )->verify();
+
+        $findings = array_values(array_filter(
+            $report->findings,
+            static fn (AuditIntegrityAlert $finding): bool => $finding->reason === AuditIntegrityReason::NoExternalSink,
+        ));
+
+        self::assertCount(1, $findings);
+        self::assertFalse($findings[0]->context['anchorAvailable']);
+        self::assertStringContainsString('vault:audit-anchor', $findings[0]->detail);
+    }
+
+    /**
+     * An empty audit table reports sequence 0 rather than failing on the absent
+     * row — `vault:audit-verify` runs on fresh installations too.
+     */
+    #[Test]
+    public function anEmptyChainReportsSequenceZero(): void
+    {
+        self::assertSame(0, $this->createSubject(maxUid: false)->verify()->currentSequence);
+    }
+
+    /**
+     * @param mixed $maxUid Whatever `fetchOne()` returns for the highest uid
+     * @param array<string, mixed>|false $rowAtAnchor Whatever `fetchAssociative()`
+     *                                                returns for the anchored row
+     */
+    private function createSubject(
+        ?AuditLogServiceInterface $auditLogService = null,
+        ?AuditSinkRegistryInterface $sinkRegistry = null,
+        ?AnchorReaderInterface $anchorReader = null,
+        ?ExtensionConfigurationInterface $configuration = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+        ?LoggerInterface $logger = null,
+        ?HashChainVerificationResult $chainResult = null,
+        mixed $maxUid = 0,
+        array|false $rowAtAnchor = false,
+        int $hmacEpoch = 3,
+        SecurityProfile $profile = SecurityProfile::Standard,
+    ): ChainTipAnchorService {
+        if (!$auditLogService instanceof AuditLogServiceInterface) {
+            $stub = self::createStub(AuditLogServiceInterface::class);
+            $stub->method('verifyHashChain')->willReturn($chainResult ?? HashChainVerificationResult::valid());
+            $stub->method('getLatestHash')->willReturn('tip');
+            $auditLogService = $stub;
+        }
+
+        if (!$configuration instanceof ExtensionConfigurationInterface) {
+            $stub = self::createStub(ExtensionConfigurationInterface::class);
+            $stub->method('getAuditHmacEpoch')->willReturn($hmacEpoch);
+            $stub->method('getSecurityProfile')->willReturn($profile);
+            $configuration = $stub;
+        }
+
+        if (!$sinkRegistry instanceof AuditSinkRegistryInterface) {
+            $stub = self::createStub(AuditSinkRegistryInterface::class);
+            $stub->method('hasExternalAuditSink')->willReturn(true);
+            $stub->method('dispatchAnchor')->willReturn(1);
+            $sinkRegistry = $stub;
+        }
+
+        return new ChainTipAnchorService(
+            $this->createConnectionPool($maxUid, $rowAtAnchor),
+            $auditLogService,
+            $sinkRegistry,
+            $anchorReader ?? self::createStub(AnchorReaderInterface::class),
+            $configuration,
+            $eventDispatcher ?? self::createStub(EventDispatcherInterface::class),
+            $logger ?? new NullLogger(),
+        );
+    }
+
+    /**
+     * The service issues exactly two queries — the highest uid (`fetchOne()`) and
+     * the anchored row (`fetchAssociative()`) — so one result double serves both.
+     *
+     * @param array<string, mixed>|false $rowAtAnchor
+     */
+    private function createConnectionPool(mixed $maxUid, array|false $rowAtAnchor): ConnectionPool
+    {
+        $result = self::createStub(Result::class);
+        $result->method('fetchOne')->willReturn($maxUid);
+        $result->method('fetchAssociative')->willReturn($rowAtAnchor);
+
+        $queryBuilder = self::createStub(QueryBuilder::class);
+        $queryBuilder->method('expr')->willReturn(self::createStub(ExpressionBuilder::class));
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('orderBy')->willReturnSelf();
+        $queryBuilder->method('setMaxResults')->willReturnSelf();
+        $queryBuilder->method('createNamedParameter')->willReturn('?');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $connection = self::createStub(Connection::class);
+        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
+
+        $connectionPool = self::createStub(ConnectionPool::class);
+        $connectionPool->method('getConnectionForTable')->willReturn($connection);
+
+        return $connectionPool;
+    }
+}

--- a/Tests/Unit/Audit/Anchor/ChainTipAnchorTest.php
+++ b/Tests/Unit/Audit/Anchor/ChainTipAnchorTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit\Anchor;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(ChainTipAnchor::class)]
+final class ChainTipAnchorTest extends TestCase
+{
+    #[Test]
+    public function toArrayExposesTheFourAnchorFields(): void
+    {
+        $anchor = new ChainTipAnchor(sequence: 42, chainTip: 'tip', timestamp: 1_750_000_000, hmacEpoch: 3);
+
+        self::assertSame(
+            ['sequence' => 42, 'chainTip' => 'tip', 'timestamp' => 1_750_000_000, 'hmacEpoch' => 3],
+            $anchor->toArray(),
+        );
+    }
+
+    #[Test]
+    public function jsonSerializationMatchesTheArrayForm(): void
+    {
+        $anchor = new ChainTipAnchor(1, 'tip', 2, 3);
+
+        self::assertSame($anchor->toArray(), $anchor->jsonSerialize());
+    }
+
+    /**
+     * The published JSON is read back by the verifier, so the round trip has to
+     * be lossless — a silent field rename would leave every anchor unusable.
+     */
+    #[Test]
+    public function anchorSurvivesAJsonRoundTrip(): void
+    {
+        $original = new ChainTipAnchor(sequence: 987, chainTip: 'deadbeef', timestamp: 1_750_000_123, hmacEpoch: 2);
+
+        $decoded = json_decode(json_encode($original, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+        /** @var array<string, mixed> $decoded */
+        $restored = ChainTipAnchor::fromArray($decoded);
+
+        self::assertInstanceOf(ChainTipAnchor::class, $restored);
+        self::assertSame($original->toArray(), $restored->toArray());
+    }
+
+    /**
+     * Numeric strings arrive from JSON produced by other tooling. Accepting them
+     * keeps a hand-written or replayed anchor usable.
+     */
+    #[Test]
+    public function numericStringsAreCoercedToIntegers(): void
+    {
+        $anchor = ChainTipAnchor::fromArray([
+            'sequence' => '42',
+            'chainTip' => 'tip',
+            'timestamp' => '1750000000',
+            'hmacEpoch' => '3',
+        ]);
+
+        self::assertInstanceOf(ChainTipAnchor::class, $anchor);
+        self::assertSame(42, $anchor->sequence);
+        self::assertSame(1_750_000_000, $anchor->timestamp);
+        self::assertSame(3, $anchor->hmacEpoch);
+    }
+
+    /**
+     * An incomplete record must not become a comparison baseline: defaulting a
+     * missing `chainTip` to '' could make a rebuilt chain compare as unchanged.
+     *
+     * @param array<string, mixed> $data
+     */
+    #[Test]
+    #[DataProvider('incompletePayloadProvider')]
+    public function structurallyIncompletePayloadYieldsNull(array $data): void
+    {
+        self::assertNull(ChainTipAnchor::fromArray($data));
+    }
+
+    /**
+     * @return iterable<string, array{array<string, mixed>}>
+     */
+    public static function incompletePayloadProvider(): iterable
+    {
+        $complete = ['sequence' => 1, 'chainTip' => 'tip', 'timestamp' => 2, 'hmacEpoch' => 3];
+
+        yield 'empty' => [[]];
+
+        foreach (array_keys($complete) as $missing) {
+            $payload = $complete;
+            unset($payload[$missing]);
+            yield 'missing ' . $missing => [$payload];
+        }
+
+        yield 'non-string chainTip' => [['sequence' => 1, 'chainTip' => 5, 'timestamp' => 2, 'hmacEpoch' => 3]];
+        yield 'non-numeric sequence' => [['sequence' => 'x', 'chainTip' => 'tip', 'timestamp' => 2, 'hmacEpoch' => 3]];
+        yield 'null sequence' => [['sequence' => null, 'chainTip' => 'tip', 'timestamp' => 2, 'hmacEpoch' => 3]];
+    }
+
+    #[Test]
+    #[DataProvider('emptyAnchorProvider')]
+    public function anchorWithoutAUsableTipIsReportedEmpty(int $sequence, string $chainTip): void
+    {
+        self::assertTrue((new ChainTipAnchor($sequence, $chainTip, 1, 3))->isEmpty());
+    }
+
+    /**
+     * @return iterable<string, array{int, string}>
+     */
+    public static function emptyAnchorProvider(): iterable
+    {
+        yield 'zero sequence' => [0, 'tip'];
+        yield 'negative sequence' => [-1, 'tip'];
+        yield 'blank tip' => [5, ''];
+        yield 'both blank' => [0, ''];
+    }
+
+    #[Test]
+    public function anchorWithSequenceAndTipIsNotEmpty(): void
+    {
+        self::assertFalse((new ChainTipAnchor(1, 'tip', 1, 3))->isEmpty());
+    }
+}

--- a/Tests/Unit/Audit/AuditActionTest.php
+++ b/Tests/Unit/Audit/AuditActionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit;
+
+use Netresearch\NrVault\Audit\AuditAction;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The backing values are bound into the HMAC hash payload of every audit row, so
+ * a changed string would break verification of all historical entries that used
+ * the old one. They are pinned here so such a change fails a test rather than a
+ * production chain verification.
+ */
+#[CoversClass(AuditAction::class)]
+final class AuditActionTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('labelProvider')]
+    public function labelHumanisesTheBackingValue(AuditAction $action, string $expected): void
+    {
+        self::assertSame($expected, $action->label());
+    }
+
+    /**
+     * @return iterable<string, array{AuditAction, string}>
+     */
+    public static function labelProvider(): iterable
+    {
+        yield 'no underscore' => [AuditAction::Create, 'Create'];
+        yield 'single underscore' => [AuditAction::MetadataUpdate, 'Metadata Update'];
+        yield 'three underscores' => [AuditAction::MasterKeyRotateStart, 'Master Key Rotate Start'];
+        yield 'longest value' => [
+            AuditAction::OAuthFallbackClientCredentials,
+            'Oauth Fallback Client Credentials',
+        ];
+    }
+
+    /**
+     * `ucwords()` capitalises but must not otherwise rewrite the value: every
+     * label has to remain recognisable as its wire form with separators swapped.
+     */
+    #[Test]
+    public function labelDiffersFromTheWireValueOnlyInSeparatorsAndCase(): void
+    {
+        foreach (AuditAction::cases() as $action) {
+            self::assertStringNotContainsString('_', $action->label());
+            self::assertSame(
+                $action->value,
+                strtolower(str_replace(' ', '_', $action->label())),
+                'label() must be losslessly reversible to the persisted action string',
+            );
+        }
+    }
+
+    #[Test]
+    public function unknownActionIsRejected(): void
+    {
+        self::assertNull(AuditAction::tryFrom('exfiltrate'));
+    }
+}

--- a/Tests/Unit/Audit/AuditChainLockTraitTest.php
+++ b/Tests/Unit/Audit/AuditChainLockTraitTest.php
@@ -1,0 +1,271 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit;
+
+use Doctrine\DBAL\Result;
+use Netresearch\NrVault\Audit\AuditChainLockTrait;
+use Netresearch\NrVault\Exception\AuditWriteException;
+use Netresearch\NrVault\Tests\Unit\Fixtures\AuditChainLockHost;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversTrait;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use TYPO3\CMS\Core\Database\Connection;
+
+/**
+ * The audit chain's write serialisation. Two distinct protocols hide behind one
+ * API, and picking the wrong one is not a cosmetic bug:
+ *
+ *  - **Raw mode** (SQLite, no outer transaction) issues `BEGIN EXCLUSIVE` /
+ *    `COMMIT` / `ROLLBACK` as statements, because that is the only way to get an
+ *    exclusive SQLite write lock.
+ *  - **Nested mode** (SQLite inside a caller-managed Doctrine transaction, as
+ *    master-key rotation does) must use Doctrine's begin/commit/rollBack so the
+ *    nesting counter maps them onto savepoints. A raw `BEGIN EXCLUSIVE` there
+ *    would fail — SQLite cannot nest transactions — and take the rotation down.
+ *
+ * `Connection::isTransactionActive()` is the discriminator, so each of the six
+ * mode/operation combinations is pinned to the exact calls it must make.
+ */
+#[CoversTrait(AuditChainLockTrait::class)]
+final class AuditChainLockTraitTest extends TestCase
+{
+    private AuditChainLockHost $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new AuditChainLockHost();
+    }
+
+    // -------------------------------------------------------------------------
+    // acquire
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function sqliteWithoutAnOuterTransactionIssuesBeginExclusive(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isTransactionActive')->willReturn(false);
+        $connection->expects(self::once())->method('executeStatement')->with('BEGIN EXCLUSIVE');
+        $connection->expects(self::never())->method('beginTransaction');
+
+        $this->subject->acquire($connection, true);
+    }
+
+    /**
+     * Inside a caller-managed transaction the raw statement would fail, so the
+     * trait must fall back to a Doctrine savepoint instead.
+     */
+    #[Test]
+    public function sqliteInsideAnOuterTransactionTakesASavepointInsteadOfBeginExclusive(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isTransactionActive')->willReturn(true);
+        $connection->expects(self::once())->method('beginTransaction');
+        $connection->expects(self::never())->method('executeStatement');
+
+        $this->subject->acquire($connection, true);
+    }
+
+    #[Test]
+    public function mysqlTakesTheNamedLockAndThenOpensATransaction(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('executeQuery')
+            ->with('SELECT GET_LOCK("nr_vault_audit", 5)')
+            ->willReturn($this->lockResult(1));
+        $connection->expects(self::once())->method('beginTransaction');
+
+        $this->subject->acquire($connection, false);
+    }
+
+    /**
+     * `GET_LOCK` returns 0 on timeout and NULL on error. Anything but 1 must
+     * abort — writing an audit entry without the lock would let two workers
+     * interleave chain links.
+     */
+    #[Test]
+    public function mysqlLockTimeoutAbortsBeforeAnyTransactionIsOpened(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('executeQuery')->willReturn($this->lockResult(0));
+        $connection->expects(self::never())->method('beginTransaction');
+
+        $this->expectException(AuditWriteException::class);
+
+        $this->subject->acquire($connection, false);
+    }
+
+    #[Test]
+    public function mysqlLockErrorAbortsWhenGetLockReturnsNull(): void
+    {
+        $connection = self::createStub(Connection::class);
+        $connection->method('executeQuery')->willReturn($this->lockResult(null));
+
+        $this->expectException(AuditWriteException::class);
+
+        $this->subject->acquire($connection, false);
+    }
+
+    /**
+     * The lock is already held when `beginTransaction()` runs, and the caller's
+     * `finally` has not started yet — so the trait itself has to release it or it
+     * leaks for the connection's lifetime.
+     */
+    #[Test]
+    public function mysqlReleasesTheNamedLockWhenOpeningTheTransactionFails(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('executeQuery')->willReturn($this->lockResult(1));
+        $connection->method('beginTransaction')->willThrowException(new RuntimeException('deadlock', 1750000010));
+        $connection->expects(self::once())
+            ->method('executeStatement')
+            ->with('SELECT RELEASE_LOCK("nr_vault_audit")');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('deadlock');
+
+        $this->subject->acquire($connection, false);
+    }
+
+    /**
+     * The release is best-effort: if it also fails, the ORIGINAL failure must
+     * still be what reaches the caller — swapping it for the release error would
+     * hide the real cause, and closing the connection releases the lock anyway.
+     */
+    #[Test]
+    public function aFailingReleaseDoesNotMaskTheOriginalTransactionFailure(): void
+    {
+        $connection = self::createStub(Connection::class);
+        $connection->method('executeQuery')->willReturn($this->lockResult(1));
+        $connection->method('beginTransaction')->willThrowException(new RuntimeException('original', 1750000011));
+        $connection->method('executeStatement')->willThrowException(new RuntimeException('gone', 1750000012));
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('original');
+
+        $this->subject->acquire($connection, false);
+    }
+
+    // -------------------------------------------------------------------------
+    // commit
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function sqliteCommitWithoutAnOuterTransactionIssuesCommitAsAStatement(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isTransactionActive')->willReturn(false);
+        $connection->expects(self::once())->method('executeStatement')->with('COMMIT');
+        $connection->expects(self::never())->method('commit');
+
+        $this->subject->commit($connection, true);
+    }
+
+    #[Test]
+    public function sqliteCommitInsideAnOuterTransactionReleasesTheSavepoint(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isTransactionActive')->willReturn(true);
+        $connection->expects(self::once())->method('commit');
+        $connection->expects(self::never())->method('executeStatement');
+
+        $this->subject->commit($connection, true);
+    }
+
+    #[Test]
+    public function mysqlCommitUsesDoctrine(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())->method('commit');
+        $connection->expects(self::never())->method('executeStatement');
+
+        $this->subject->commit($connection, false);
+    }
+
+    // -------------------------------------------------------------------------
+    // rollback
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function sqliteRollbackWithoutAnOuterTransactionIssuesRollbackAsAStatement(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isTransactionActive')->willReturn(false);
+        $connection->expects(self::once())->method('executeStatement')->with('ROLLBACK');
+        $connection->expects(self::never())->method('rollBack');
+
+        $this->subject->rollback($connection, true);
+    }
+
+    /**
+     * Rolling back to the savepoint leaves the caller's outer transaction alive —
+     * a raw `ROLLBACK` would abort the master-key rotation wrapped around it.
+     */
+    #[Test]
+    public function sqliteRollbackInsideAnOuterTransactionRollsBackToTheSavepointOnly(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->method('isTransactionActive')->willReturn(true);
+        $connection->expects(self::once())->method('rollBack');
+        $connection->expects(self::never())->method('executeStatement');
+
+        $this->subject->rollback($connection, true);
+    }
+
+    #[Test]
+    public function mysqlRollbackUsesDoctrine(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())->method('rollBack');
+        $connection->expects(self::never())->method('executeStatement');
+
+        $this->subject->rollback($connection, false);
+    }
+
+    // -------------------------------------------------------------------------
+    // release
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function mysqlReleaseDropsTheNamedLock(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::once())
+            ->method('executeStatement')
+            ->with('SELECT RELEASE_LOCK("nr_vault_audit")');
+
+        $this->subject->release($connection, false);
+    }
+
+    /**
+     * SQLite has no named lock — the transaction IS the lock, so a release would
+     * be a stray statement.
+     */
+    #[Test]
+    public function sqliteReleaseIsANoOp(): void
+    {
+        $connection = $this->createMock(Connection::class);
+        $connection->expects(self::never())->method('executeStatement');
+
+        $this->subject->release($connection, true);
+    }
+
+    private function lockResult(mixed $value): Result
+    {
+        $result = self::createStub(Result::class);
+        $result->method('fetchOne')->willReturn($value);
+
+        return $result;
+    }
+}

--- a/Tests/Unit/Audit/AuditChainRekeyServiceTest.php
+++ b/Tests/Unit/Audit/AuditChainRekeyServiceTest.php
@@ -1,0 +1,323 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit;
+
+use Doctrine\DBAL\Result;
+use Netresearch\NrVault\Audit\AuditChainRekeyService;
+use Netresearch\NrVault\Audit\AuditLogService;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+
+/**
+ * Master-key rotation re-signs the whole audit chain under the new key. Two
+ * properties make or break the tamper evidence:
+ *
+ *  1. **Each row keeps its OWN epoch.** A row written at epoch 2 must be
+ *     re-signed with the epoch-2 payload. Re-signing it with a different epoch's
+ *     payload would make every later verification report a tamper that never
+ *     happened — and rotation is exactly when nobody can tell the difference.
+ *  2. **`previous_hash` is re-linked as the walk proceeds**, including across
+ *     batch boundaries, or the chain breaks at the seam.
+ *
+ * {@see \Netresearch\NrVault\Tests\Functional\Audit\AuditChainRekeyServiceTest}
+ * proves the result verifies against a real database. These tests pin the
+ * per-epoch dispatch and the update decision, which need a row of every epoch in
+ * one chain.
+ */
+#[CoversClass(AuditChainRekeyService::class)]
+final class AuditChainRekeyServiceTest extends TestCase
+{
+    private const NEW_MASTER_KEY_MATERIAL = 'rotation-target-key-material-32b';
+
+    /**
+     * The load-bearing case: one chain holding a row of every epoch. Each row's
+     * expected hash is recomputed here with the algorithm its OWN epoch selects,
+     * so a mis-dispatched arm shows up as a mismatch rather than as a silently
+     * different-but-plausible hash.
+     */
+    #[Test]
+    public function everyEpochIsReSignedWithItsOwnAlgorithm(): void
+    {
+        $rows = [
+            $this->row(uid: 1, epoch: 0),
+            $this->row(uid: 2, epoch: 1),
+            $this->row(uid: 3, epoch: 2),
+            $this->row(uid: 4, epoch: 3),
+        ];
+
+        $updates = [];
+        $rewritten = $this->rekey($rows, $updates);
+
+        self::assertSame(4, $rewritten, 'every row carried a stale hash and had to be rewritten');
+        self::assertSame([1, 2, 3, 4], array_column($updates, 'uid'));
+        self::assertSame(
+            $this->expectedHashes($rows),
+            array_column($updates, 'entry_hash'),
+        );
+    }
+
+    /**
+     * The four arms must not agree with one another: if two epochs produced the
+     * same hash for the same row, a mis-dispatch would be invisible.
+     */
+    #[Test]
+    public function theEpochArmsProduceDistinctHashesForOtherwiseIdenticalRows(): void
+    {
+        $rows = [
+            $this->row(uid: 1, epoch: 0),
+            $this->row(uid: 1, epoch: 1),
+            $this->row(uid: 1, epoch: 2),
+            $this->row(uid: 1, epoch: 3),
+        ];
+
+        $hashes = [];
+        foreach ($rows as $row) {
+            $updates = [];
+            $this->rekey([$row], $updates);
+            $hash = $updates[0]['entry_hash'];
+            self::assertIsString($hash);
+            $hashes[] = $hash;
+        }
+
+        self::assertSame($hashes, array_unique($hashes));
+    }
+
+    /**
+     * An epoch above the highest known selector must fall through to the newest
+     * algorithm rather than to the oldest — the fail-forward direction, so a
+     * future epoch is never re-signed with a weaker payload.
+     */
+    #[Test]
+    public function anEpochAboveTheHighestSelectorUsesTheNewestAlgorithm(): void
+    {
+        $row = $this->row(uid: 1, epoch: 9);
+
+        $updates = [];
+        $this->rekey([$row], $updates);
+
+        self::assertSame(
+            AuditLogService::calculateHashV3(
+                AuditLogService::extractV3HashRow($row),
+                '',
+                $this->hmacKey(),
+            ),
+            $updates[0]['entry_hash'],
+        );
+    }
+
+    /**
+     * `previous_hash` must be re-linked to the RECOMPUTED predecessor, not to
+     * whatever the row carried before — otherwise the re-signed chain verifies
+     * row-by-row but fails at every link.
+     */
+    #[Test]
+    public function previousHashIsRelinkedToTheRecomputedPredecessor(): void
+    {
+        $rows = [$this->row(uid: 1, epoch: 3), $this->row(uid: 2, epoch: 3)];
+
+        $updates = [];
+        $this->rekey($rows, $updates);
+
+        $expected = $this->expectedHashes($rows);
+
+        self::assertSame('', $updates[0]['previous_hash'], 'the first row anchors the chain at the empty hash');
+        self::assertSame($expected[0], $updates[1]['previous_hash']);
+    }
+
+    /**
+     * A row already carrying the correct hash and link needs no UPDATE. Rewriting
+     * it anyway would make a second rotation report work it did not do, and the
+     * count is what the rotation command shows the operator.
+     */
+    #[Test]
+    public function alreadyCorrectRowsAreLeftUntouched(): void
+    {
+        $hmacKey = $this->hmacKey();
+        $first = $this->row(uid: 1, epoch: 3);
+        $first['entry_hash'] = AuditLogService::calculateHashV3(
+            AuditLogService::extractV3HashRow($first),
+            '',
+            $hmacKey,
+        );
+        $first['previous_hash'] = '';
+
+        $updates = [];
+        $rewritten = $this->rekey([$first], $updates);
+
+        self::assertSame(0, $rewritten);
+        self::assertSame([], $updates);
+    }
+
+    /**
+     * A row whose hash is right but whose link is wrong still has to be rewritten
+     * — a broken link is exactly the state a deletion-plus-patch attack leaves.
+     */
+    #[Test]
+    public function aRowWithACorrectHashButAWrongLinkIsStillRewritten(): void
+    {
+        $hmacKey = $this->hmacKey();
+        $first = $this->row(uid: 1, epoch: 3);
+        $first['entry_hash'] = AuditLogService::calculateHashV3(
+            AuditLogService::extractV3HashRow($first),
+            '',
+            $hmacKey,
+        );
+        $first['previous_hash'] = 'stale-link';
+
+        $updates = [];
+
+        self::assertSame(1, $this->rekey([$first], $updates));
+        self::assertSame('', $updates[0]['previous_hash']);
+    }
+
+    #[Test]
+    public function anEmptyChainRewritesNothing(): void
+    {
+        $updates = [];
+
+        self::assertSame(0, $this->rekey([], $updates));
+    }
+
+    /**
+     * Run the re-key over `$rows` and collect every UPDATE the service issued.
+     *
+     * @param list<array<string, mixed>> $rows
+     * @param list<array{uid: mixed, entry_hash: mixed, previous_hash: mixed}> $updates
+     */
+    private function rekey(array $rows, array &$updates): int
+    {
+        $collected = [];
+
+        $result = self::createStub(Result::class);
+        $result->method('fetchAllAssociative')->willReturn($rows);
+
+        $queryBuilder = self::createStub(QueryBuilder::class);
+        $queryBuilder->method('expr')->willReturn(self::createStub(ExpressionBuilder::class));
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('orderBy')->willReturnSelf();
+        $queryBuilder->method('setMaxResults')->willReturnSelf();
+        $queryBuilder->method('createNamedParameter')->willReturn('?');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $connection = self::createStub(Connection::class);
+        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
+        $connection->method('update')->willReturnCallback(
+            static function (string $table, array $data, array $identifier) use (&$collected): int {
+                $collected[] = [
+                    'uid' => $identifier['uid'] ?? null,
+                    'entry_hash' => $data['entry_hash'] ?? null,
+                    'previous_hash' => $data['previous_hash'] ?? null,
+                ];
+
+                return 1;
+            },
+        );
+
+        $rewritten = (new AuditChainRekeyService())->rekeyChain($connection, self::NEW_MASTER_KEY_MATERIAL);
+
+        $updates = $collected;
+
+        return $rewritten;
+    }
+
+    /**
+     * Recompute the chain's expected hashes independently of the service, using
+     * each row's own epoch and re-linking as it goes.
+     *
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return list<string>
+     */
+    private function expectedHashes(array $rows): array
+    {
+        $hmacKey = $this->hmacKey();
+        $previousHash = '';
+        $hashes = [];
+
+        foreach ($rows as $row) {
+            $entry = AuditLogService::extractHashRow($row);
+
+            $hashes[] = $previousHash = match ($entry['epoch']) {
+                0 => AuditLogService::calculateHash(
+                    $entry['uid'],
+                    $entry['secretId'],
+                    $entry['action'],
+                    $entry['actorUid'],
+                    $entry['crdate'],
+                    $previousHash,
+                ),
+                1 => AuditLogService::calculateHash(
+                    $entry['uid'],
+                    $entry['secretId'],
+                    $entry['action'],
+                    $entry['actorUid'],
+                    $entry['crdate'],
+                    $previousHash,
+                    $hmacKey,
+                ),
+                2 => AuditLogService::calculateHashV2(
+                    AuditLogService::extractV2HashRow($row),
+                    $previousHash,
+                    $hmacKey,
+                ),
+                default => AuditLogService::calculateHashV3(
+                    AuditLogService::extractV3HashRow($row),
+                    $previousHash,
+                    $hmacKey,
+                ),
+            };
+        }
+
+        return $hashes;
+    }
+
+    private function hmacKey(): string
+    {
+        return AuditLogService::deriveHmacKeyFromMasterKey(self::NEW_MASTER_KEY_MATERIAL);
+    }
+
+    /**
+     * A full audit row as the chain walk reads it, with a deliberately stale
+     * `entry_hash` so the default expectation is "must be rewritten".
+     *
+     * @return array<string, mixed>
+     */
+    private function row(int $uid, int $epoch): array
+    {
+        return [
+            'uid' => $uid,
+            'secret_identifier' => 'api/stripe',
+            'action' => 'read',
+            'success' => 1,
+            'actor_uid' => 7,
+            'crdate' => 1_750_000_000 + $uid,
+            'error_message' => '',
+            'reason' => '',
+            'ip_address' => '203.0.113.7',
+            'user_agent' => 'curl/8',
+            'hash_before' => '',
+            'hash_after' => '',
+            'context' => '{}',
+            'hmac_key_epoch' => $epoch,
+            'actor_type' => 'be_user',
+            'actor_username' => 'editor',
+            'actor_role' => 'groups:1',
+            'request_id' => 'req-' . $uid,
+            'previous_hash' => 'stale-previous',
+            'entry_hash' => 'stale-entry',
+        ];
+    }
+}

--- a/Tests/Unit/Audit/AuditIntegrityAlertTest.php
+++ b/Tests/Unit/Audit/AuditIntegrityAlertTest.php
@@ -1,0 +1,147 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit;
+
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The alert is the payload that leaves the installation — it is what a webhook
+ * collector, a syslog daemon and the NDJSON anchor stream all receive. Its array
+ * shape is therefore an external contract, and `tamperEvidence` is the field a
+ * SIEM rule routes on.
+ */
+#[CoversClass(AuditIntegrityAlert::class)]
+final class AuditIntegrityAlertTest extends TestCase
+{
+    #[Test]
+    public function constructorKeepsEveryFieldVerbatim(): void
+    {
+        $alert = new AuditIntegrityAlert(
+            AuditIntegrityReason::TableReset,
+            'chain shrank from 9 to 2',
+            1_750_000_000,
+            ['anchoredSequence' => 9],
+        );
+
+        self::assertSame(AuditIntegrityReason::TableReset, $alert->reason);
+        self::assertSame('chain shrank from 9 to 2', $alert->detail);
+        self::assertSame(1_750_000_000, $alert->timestamp);
+        self::assertSame(['anchoredSequence' => 9], $alert->context);
+    }
+
+    #[Test]
+    public function contextDefaultsToEmpty(): void
+    {
+        $alert = new AuditIntegrityAlert(AuditIntegrityReason::SinkFailure, 'webhook refused', 1);
+
+        self::assertSame([], $alert->context);
+    }
+
+    /**
+     * `create()` is the constructor used everywhere in the verifier, and the
+     * timestamp it stamps is the only record of WHEN a finding was raised.
+     */
+    #[Test]
+    public function createStampsTheCurrentTime(): void
+    {
+        $before = time();
+        $alert = AuditIntegrityAlert::create(AuditIntegrityReason::UidGap, '3 rows missing');
+        $after = time();
+
+        self::assertGreaterThanOrEqual($before, $alert->timestamp);
+        self::assertLessThanOrEqual($after, $alert->timestamp);
+    }
+
+    #[Test]
+    public function createPassesReasonDetailAndContextThrough(): void
+    {
+        $alert = AuditIntegrityAlert::create(
+            AuditIntegrityReason::EpochDowngrade,
+            'epoch 3 relabelled to 0',
+            ['firstUid' => 12, 'affectedRows' => 4],
+        );
+
+        self::assertSame(AuditIntegrityReason::EpochDowngrade, $alert->reason);
+        self::assertSame('epoch 3 relabelled to 0', $alert->detail);
+        self::assertSame(['firstUid' => 12, 'affectedRows' => 4], $alert->context);
+    }
+
+    #[Test]
+    public function createDefaultsToAnEmptyContext(): void
+    {
+        self::assertSame([], AuditIntegrityAlert::create(AuditIntegrityReason::BreakGlass, 'x')->context);
+    }
+
+    /**
+     * The wire shape: exactly these five keys, with the reason flattened to its
+     * backing string so a consumer needs no PHP enum to read it.
+     */
+    #[Test]
+    public function toArrayEmitsTheExternalWireShape(): void
+    {
+        $alert = new AuditIntegrityAlert(
+            AuditIntegrityReason::HashMismatch,
+            'row 7 hashes differently',
+            1_750_000_123,
+            ['affectedRows' => 1],
+        );
+
+        $array = $alert->toArray();
+
+        self::assertSame(
+            ['reason', 'tamperEvidence', 'detail', 'timestamp', 'context'],
+            array_keys($array),
+        );
+        self::assertSame('HASH_MISMATCH', $array['reason']);
+        self::assertSame('row 7 hashes differently', $array['detail']);
+        self::assertSame(1_750_000_123, $array['timestamp']);
+        self::assertSame(['affectedRows' => 1], $array['context']);
+    }
+
+    /**
+     * The flag is derived, not stored: a caller cannot hand a listener a
+     * TABLE_RESET marked as harmless.
+     */
+    #[Test]
+    public function tamperEvidenceIsDerivedFromTheReason(): void
+    {
+        self::assertTrue(
+            AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'reset')->toArray()['tamperEvidence'],
+        );
+        self::assertFalse(
+            AuditIntegrityAlert::create(AuditIntegrityReason::SinkFailure, 'refused')->toArray()['tamperEvidence'],
+        );
+    }
+
+    #[Test]
+    public function jsonSerializeMatchesToArray(): void
+    {
+        $alert = AuditIntegrityAlert::create(AuditIntegrityReason::NoExternalSink, 'none enabled', ['profile' => 'hardened']);
+
+        self::assertSame($alert->toArray(), $alert->jsonSerialize());
+    }
+
+    #[Test]
+    public function encodesToJsonWithoutLosingTheReasonCode(): void
+    {
+        $alert = AuditIntegrityAlert::create(AuditIntegrityReason::UidGap, '2 missing', ['missingUidSample' => '4,5']);
+
+        $decoded = json_decode(json_encode($alert, JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($decoded);
+        self::assertSame('UID_GAP', $decoded['reason']);
+        self::assertTrue($decoded['tamperEvidence']);
+        self::assertSame(['missingUidSample' => '4,5'], $decoded['context']);
+    }
+}

--- a/Tests/Unit/Audit/AuditIntegrityReasonTest.php
+++ b/Tests/Unit/Audit/AuditIntegrityReasonTest.php
@@ -1,0 +1,122 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit;
+
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The backing strings are an external contract (webhook payloads, syslog
+ * structured data, the NDJSON anchor stream) and `isTamperEvidence()` is what a
+ * listener switches on to decide between paging someone and writing a log line.
+ * Both are pinned here rather than left to be inferred from the enum body.
+ */
+#[CoversClass(AuditIntegrityReason::class)]
+final class AuditIntegrityReasonTest extends TestCase
+{
+    #[Test]
+    #[DataProvider('tamperEvidenceProvider')]
+    public function tamperEvidenceClassificationIsExplicitPerCase(
+        AuditIntegrityReason $reason,
+        bool $expected,
+    ): void {
+        self::assertSame($expected, $reason->isTamperEvidence());
+    }
+
+    /**
+     * @return iterable<string, array{AuditIntegrityReason, bool}>
+     */
+    public static function tamperEvidenceProvider(): iterable
+    {
+        yield 'hash mismatch is tamper evidence' => [AuditIntegrityReason::HashMismatch, true];
+        yield 'uid gap is tamper evidence' => [AuditIntegrityReason::UidGap, true];
+        yield 'table reset is tamper evidence' => [AuditIntegrityReason::TableReset, true];
+        yield 'epoch downgrade is tamper evidence' => [AuditIntegrityReason::EpochDowngrade, true];
+        yield 'sink failure is availability only' => [AuditIntegrityReason::SinkFailure, false];
+        yield 'missing external sink is configuration only' => [AuditIntegrityReason::NoExternalSink, false];
+        yield 'break glass is its own severity class' => [AuditIntegrityReason::BreakGlass, false];
+    }
+
+    /**
+     * A new case added without a `match` arm would raise `UnhandledMatchError`
+     * at runtime — inside the verifier, i.e. exactly where an integrity check
+     * must not blow up. Cover every declared case so that failure is a test
+     * failure instead.
+     */
+    #[Test]
+    public function everyDeclaredCaseIsClassified(): void
+    {
+        $classified = array_map(
+            static fn (array $case): AuditIntegrityReason => $case[0],
+            iterator_to_array(self::tamperEvidenceProvider()),
+        );
+
+        self::assertEqualsCanonicalizing(AuditIntegrityReason::cases(), array_values($classified));
+    }
+
+    /**
+     * These strings travel to external systems and are matched on by SIEM rules,
+     * so they are API, not labels.
+     */
+    #[Test]
+    #[DataProvider('backingValueProvider')]
+    public function backingValuesAreStable(AuditIntegrityReason $reason, string $expected): void
+    {
+        self::assertSame($expected, $reason->value);
+    }
+
+    /**
+     * @return iterable<string, array{AuditIntegrityReason, string}>
+     */
+    public static function backingValueProvider(): iterable
+    {
+        yield 'HASH_MISMATCH' => [AuditIntegrityReason::HashMismatch, 'HASH_MISMATCH'];
+        yield 'UID_GAP' => [AuditIntegrityReason::UidGap, 'UID_GAP'];
+        yield 'TABLE_RESET' => [AuditIntegrityReason::TableReset, 'TABLE_RESET'];
+        yield 'EPOCH_DOWNGRADE' => [AuditIntegrityReason::EpochDowngrade, 'EPOCH_DOWNGRADE'];
+        yield 'SINK_FAILURE' => [AuditIntegrityReason::SinkFailure, 'SINK_FAILURE'];
+        yield 'NO_EXTERNAL_SINK' => [AuditIntegrityReason::NoExternalSink, 'NO_EXTERNAL_SINK'];
+        yield 'BREAK_GLASS' => [AuditIntegrityReason::BreakGlass, 'BREAK_GLASS'];
+    }
+
+    #[Test]
+    #[DataProvider('labelProvider')]
+    public function labelHumanisesTheBackingValue(AuditIntegrityReason $reason, string $expected): void
+    {
+        self::assertSame($expected, $reason->label());
+    }
+
+    /**
+     * @return iterable<string, array{AuditIntegrityReason, string}>
+     */
+    public static function labelProvider(): iterable
+    {
+        yield 'single underscore' => [AuditIntegrityReason::HashMismatch, 'Hash Mismatch'];
+        yield 'short word' => [AuditIntegrityReason::UidGap, 'Uid Gap'];
+        yield 'two underscores' => [AuditIntegrityReason::NoExternalSink, 'No External Sink'];
+    }
+
+    #[Test]
+    public function labelNeverLeaksTheUnderscoredWireFormat(): void
+    {
+        foreach (AuditIntegrityReason::cases() as $reason) {
+            self::assertStringNotContainsString('_', $reason->label());
+        }
+    }
+
+    #[Test]
+    public function unknownCodeIsNotAReason(): void
+    {
+        self::assertNull(AuditIntegrityReason::tryFrom('CHAIN_ON_FIRE'));
+    }
+}

--- a/Tests/Unit/Audit/AuditIntegrityReportTest.php
+++ b/Tests/Unit/Audit/AuditIntegrityReportTest.php
@@ -1,0 +1,196 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditIntegrityReport;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(AuditIntegrityReport::class)]
+final class AuditIntegrityReportTest extends TestCase
+{
+    #[Test]
+    public function reportWithoutFindingsIsValid(): void
+    {
+        $report = new AuditIntegrityReport(findings: [], chainValid: true, currentSequence: 10);
+
+        self::assertTrue($report->isValid());
+        self::assertFalse($report->hasTamperEvidence());
+        self::assertSame([], $report->getReasonCodes());
+    }
+
+    #[Test]
+    public function anyFindingMakesTheReportInvalid(): void
+    {
+        $report = new AuditIntegrityReport(
+            findings: [AuditIntegrityAlert::create(AuditIntegrityReason::NoExternalSink, 'none enabled')],
+            chainValid: true,
+            currentSequence: 10,
+        );
+
+        self::assertFalse($report->isValid());
+    }
+
+    /**
+     * The distinction alerting rules act on: a configuration gap is not an
+     * incident, a hash mismatch is.
+     */
+    #[Test]
+    #[DataProvider('tamperEvidenceProvider')]
+    public function tamperEvidenceIsReportedPerReasonCode(AuditIntegrityReason $reason, bool $expected): void
+    {
+        $report = new AuditIntegrityReport(
+            findings: [AuditIntegrityAlert::create($reason, 'detail')],
+            chainValid: false,
+            currentSequence: 1,
+        );
+
+        self::assertSame($expected, $report->hasTamperEvidence());
+    }
+
+    /**
+     * @return iterable<string, array{AuditIntegrityReason, bool}>
+     */
+    public static function tamperEvidenceProvider(): iterable
+    {
+        yield 'hash mismatch' => [AuditIntegrityReason::HashMismatch, true];
+        yield 'uid gap' => [AuditIntegrityReason::UidGap, true];
+        yield 'table reset' => [AuditIntegrityReason::TableReset, true];
+        yield 'epoch downgrade' => [AuditIntegrityReason::EpochDowngrade, true];
+        yield 'sink failure' => [AuditIntegrityReason::SinkFailure, false];
+        yield 'no external sink' => [AuditIntegrityReason::NoExternalSink, false];
+        yield 'break glass' => [AuditIntegrityReason::BreakGlass, false];
+    }
+
+    #[Test]
+    public function tamperEvidenceIsDetectedAmongNonTamperFindings(): void
+    {
+        $report = new AuditIntegrityReport(
+            findings: [
+                AuditIntegrityAlert::create(AuditIntegrityReason::SinkFailure, 'webhook down'),
+                AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'chain shrank'),
+            ],
+            chainValid: true,
+            currentSequence: 1,
+        );
+
+        self::assertTrue($report->hasTamperEvidence());
+    }
+
+    #[Test]
+    public function hasReasonMatchesOnlyThePresentCodes(): void
+    {
+        $report = new AuditIntegrityReport(
+            findings: [AuditIntegrityAlert::create(AuditIntegrityReason::UidGap, '3 missing')],
+            chainValid: false,
+            currentSequence: 1,
+        );
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::UidGap));
+        self::assertFalse($report->hasReason(AuditIntegrityReason::TableReset));
+    }
+
+    /**
+     * Codes drive monitoring rules, so duplicates must collapse and order must be
+     * stable rather than depending on how many rows happened to fail.
+     */
+    #[Test]
+    public function reasonCodesAreDeduplicatedInFirstSeenOrder(): void
+    {
+        $report = new AuditIntegrityReport(
+            findings: [
+                AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'a'),
+                AuditIntegrityAlert::create(AuditIntegrityReason::UidGap, 'b'),
+                AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'c'),
+            ],
+            chainValid: false,
+            currentSequence: 1,
+        );
+
+        self::assertSame(['TABLE_RESET', 'UID_GAP'], $report->getReasonCodes());
+    }
+
+    #[Test]
+    public function arrayFormCarriesTheAnchorWhenOneWasCompared(): void
+    {
+        $anchor = new ChainTipAnchor(sequence: 50, chainTip: 'tip', timestamp: 1_750_000_000, hmacEpoch: 3);
+        $report = new AuditIntegrityReport(
+            findings: [],
+            chainValid: true,
+            currentSequence: 60,
+            anchor: $anchor,
+        );
+
+        $array = $report->toArray();
+
+        self::assertSame($anchor->toArray(), $array['anchor']);
+        self::assertSame(60, $array['currentSequence']);
+        self::assertTrue($array['valid']);
+        self::assertFalse($array['tamperEvidence']);
+    }
+
+    #[Test]
+    public function arrayFormReportsANullAnchorWhenNoneWasAvailable(): void
+    {
+        $report = new AuditIntegrityReport(findings: [], chainValid: true, currentSequence: 1);
+
+        self::assertNull($report->toArray()['anchor']);
+    }
+
+    /**
+     * The JSON output is a machine interface for monitoring, so it must stay
+     * serialisable and carry every finding.
+     */
+    #[Test]
+    public function arrayFormIsJsonSerialisableAndListsEveryFinding(): void
+    {
+        $report = new AuditIntegrityReport(
+            findings: [
+                AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'reset', ['anchoredSequence' => 9]),
+                AuditIntegrityAlert::create(AuditIntegrityReason::UidGap, 'gap', ['missingUidCount' => 2]),
+            ],
+            chainValid: false,
+            currentSequence: 3,
+            warnings: [7 => 'HMAC key epoch boundary: 2 -> 3'],
+        );
+
+        $decoded = json_decode(json_encode($report->toArray(), JSON_THROW_ON_ERROR), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($decoded);
+        self::assertIsArray($decoded['findings']);
+        self::assertCount(2, $decoded['findings']);
+        self::assertSame('TABLE_RESET', $decoded['findings'][0]['reason']);
+        self::assertSame(9, $decoded['findings'][0]['context']['anchoredSequence']);
+        self::assertSame(['TABLE_RESET', 'UID_GAP'], $decoded['reasonCodes']);
+        self::assertSame('HMAC key epoch boundary: 2 -> 3', $decoded['warnings']['7']);
+    }
+
+    /**
+     * `chainValid` reports the internal hash pass alone, so a chain that verifies
+     * against itself but fails the external anchor check must still say so.
+     */
+    #[Test]
+    public function chainValidRemainsIndependentOfAnchorFindings(): void
+    {
+        $report = new AuditIntegrityReport(
+            findings: [AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'reset')],
+            chainValid: true,
+            currentSequence: 1,
+        );
+
+        self::assertTrue($report->chainValid);
+        self::assertFalse($report->isValid());
+    }
+}

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -12,12 +12,16 @@ namespace Netresearch\NrVault\Tests\Unit\Audit;
 use ArrayIterator;
 use DateTimeImmutable;
 use Doctrine\DBAL\Result;
+use InvalidArgumentException;
 use Iterator;
+use Netresearch\NrVault\Audit\AuditAction;
 use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Audit\AuditLogFilter;
+use Netresearch\NrVault\Audit\AuditLogInputs;
 use Netresearch\NrVault\Audit\AuditLogService;
 use Netresearch\NrVault\Audit\GenericContext;
 use Netresearch\NrVault\Audit\HashChainVerificationResult;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
 use Netresearch\NrVault\Exception\AuditWriteException;
@@ -28,6 +32,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Message\ServerRequestInterface;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
@@ -36,6 +41,7 @@ use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 
 #[CoversClass(AuditLogService::class)]
 #[CoversClass(AuditLogEntry::class)]
+#[CoversClass(AuditLogInputs::class)]
 #[AllowMockObjectsWithoutExpectations]
 final class AuditLogServiceTest extends TestCase
 {
@@ -2562,6 +2568,452 @@ final class AuditLogServiceTest extends TestCase
         );
     }
 
+    // =========================================================================
+    // Guard rails and branches around the chain write.
+    // =========================================================================
+
+    /**
+     * An unknown action string would be sealed into the tamper-evident chain
+     * forever and could never be verified against a known payload again, so it is
+     * a hard programming error — not an `AuditWriteException` the VaultService
+     * atomicity path compensates for.
+     */
+    #[Test]
+    public function anUnknownActionIsRejectedBeforeAnythingIsWritten(): void
+    {
+        $this->connectionMock()->expects(self::never())->method('insert');
+
+        try {
+            $this->getSubject()->log('api_creds', 'exfiltrate', true);
+            self::fail('an unknown action must not be accepted');
+        } catch (InvalidArgumentException $e) {
+            self::assertSame(1717100000, $e->getCode());
+            self::assertStringContainsString('exfiltrate', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function everyDeclaredAuditActionIsAcceptedByLog(): void
+    {
+        $actions = AuditAction::cases();
+
+        $this->setupDatabaseMocks();
+        // The guard must reject typos, not the canonical set: every case has to
+        // reach the INSERT.
+        $this->connectionMock()->expects(self::exactly(\count($actions)))->method('insert');
+
+        foreach ($actions as $action) {
+            $this->getSubject()->log('api_creds', $action->value, true);
+        }
+    }
+
+    /**
+     * `export()` materialises what `exportIterable()` streams. Exercised over a
+     * non-empty result so the accumulation — not just the empty short-circuit —
+     * is covered.
+     */
+    #[Test]
+    public function exportMaterialisesEveryStreamedEntry(): void
+    {
+        $this->setupQueryMocks([
+            ['uid' => 1, 'secret_identifier' => 'a', 'action' => 'create', 'success' => 1, 'actor_uid' => 1, 'crdate' => 100, 'entry_hash' => 'h1', 'previous_hash' => '', 'hmac_key_epoch' => 1],
+            ['uid' => 2, 'secret_identifier' => 'b', 'action' => 'read', 'success' => 1, 'actor_uid' => 1, 'crdate' => 200, 'entry_hash' => 'h2', 'previous_hash' => 'h1', 'hmac_key_epoch' => 1],
+        ]);
+
+        $entries = $this->getSubject()->export();
+
+        self::assertCount(2, $entries);
+        self::assertContainsOnlyInstancesOf(AuditLogEntry::class, $entries);
+        self::assertSame([1, 2], array_map(static fn (AuditLogEntry $e): int => $e->uid, $entries));
+    }
+
+    #[Test]
+    public function exportIterableYieldsTheSameEntriesItStreams(): void
+    {
+        $this->setupQueryMocks([
+            ['uid' => 7, 'secret_identifier' => 'a', 'action' => 'read', 'success' => 1, 'actor_uid' => 1, 'crdate' => 100, 'entry_hash' => 'h7', 'previous_hash' => '', 'hmac_key_epoch' => 1],
+        ]);
+
+        $uids = [];
+        foreach ($this->getSubject()->exportIterable() as $entry) {
+            $uids[] = $entry->uid;
+        }
+
+        self::assertSame([7], $uids);
+    }
+
+    // =========================================================================
+    // verifyChainForReseal() — the gate that stops a re-seal from laundering
+    // tampering into a freshly valid chain.
+    // =========================================================================
+
+    /**
+     * A genuinely-legacy keyless chain carries no HMAC evidence to check; the
+     * re-seal is exactly how it FIRST gains protection, so it must be allowed.
+     */
+    #[Test]
+    public function resealVerificationSkipsAChainWithNoHmacRows(): void
+    {
+        $this->setupResealMocks(rows: [], hmacRowCount: 0);
+
+        self::assertNull($this->getSubject()->verifyChainForReseal());
+    }
+
+    #[Test]
+    public function resealVerificationPassesAnIntactHmacChain(): void
+    {
+        $hmacKey = AuditLogService::deriveHmacKey($this->masterKeyProviderMock());
+        $hash1 = AuditLogService::calculateHash(1, 'a', 'create', 1, 100, '', $hmacKey);
+        $hash2 = AuditLogService::calculateHash(2, 'b', 'read', 1, 200, $hash1, $hmacKey);
+
+        $this->setupResealMocks(
+            rows: [
+                ['uid' => 1, 'secret_identifier' => 'a', 'action' => 'create', 'actor_uid' => 1, 'crdate' => 100, 'previous_hash' => '', 'entry_hash' => $hash1, 'hmac_key_epoch' => 1],
+                ['uid' => 2, 'secret_identifier' => 'b', 'action' => 'read', 'actor_uid' => 1, 'crdate' => 200, 'previous_hash' => $hash1, 'entry_hash' => $hash2, 'hmac_key_epoch' => 1],
+            ],
+            hmacRowCount: 2,
+        );
+
+        self::assertNull(
+            $this->getSubject()->verifyChainForReseal(),
+            'an intact HMAC chain must not block its own re-seal',
+        );
+    }
+
+    /**
+     * The security-relevant direction: re-sealing recomputes every hash under the
+     * current key, which would turn a tampered chain into a valid-looking one. So
+     * the tampering has to be REPORTED here, for the caller to refuse on.
+     */
+    #[Test]
+    public function resealVerificationReportsATamperedHmacChainSoTheResealCanBeRefused(): void
+    {
+        $hmacKey = AuditLogService::deriveHmacKey($this->masterKeyProviderMock());
+        $hash1 = AuditLogService::calculateHash(1, 'a', 'create', 1, 100, '', $hmacKey);
+
+        $this->setupResealMocks(
+            rows: [
+                ['uid' => 1, 'secret_identifier' => 'a', 'action' => 'create', 'actor_uid' => 1, 'crdate' => 100, 'previous_hash' => '', 'entry_hash' => $hash1, 'hmac_key_epoch' => 1],
+                // Rewritten identifier: the stored hash no longer matches the payload.
+                ['uid' => 2, 'secret_identifier' => 'rewritten', 'action' => 'read', 'actor_uid' => 1, 'crdate' => 200, 'previous_hash' => $hash1, 'entry_hash' => str_repeat('0', 64), 'hmac_key_epoch' => 1],
+            ],
+            hmacRowCount: 2,
+        );
+
+        $result = $this->getSubject()->verifyChainForReseal();
+
+        self::assertInstanceOf(HashChainVerificationResult::class, $result);
+        self::assertFalse($result->isValid());
+        self::assertArrayHasKey(2, $result->errors);
+    }
+
+    /**
+     * The re-seal check must verify under the chain's OWN stored epochs, not the
+     * configured target: an epoch-1 chain migrating to epoch 2 is legitimate and
+     * must not be reported as a downgrade. The subject here is configured for
+     * epoch 1 while the chain sits at epoch 0 plus HMAC rows.
+     */
+    #[Test]
+    public function resealVerificationDoesNotApplyTheConfiguredEpochFloor(): void
+    {
+        $hmacKey = AuditLogService::deriveHmacKey($this->masterKeyProviderMock());
+        $hash1 = AuditLogService::calculateHash(1, 'a', 'create', 1, 100, '');
+        $hash2 = AuditLogService::calculateHash(2, 'b', 'read', 1, 200, $hash1, $hmacKey);
+
+        $this->setupResealMocks(
+            rows: [
+                ['uid' => 1, 'secret_identifier' => 'a', 'action' => 'create', 'actor_uid' => 1, 'crdate' => 100, 'previous_hash' => '', 'entry_hash' => $hash1, 'hmac_key_epoch' => 0],
+                ['uid' => 2, 'secret_identifier' => 'b', 'action' => 'read', 'actor_uid' => 1, 'crdate' => 200, 'previous_hash' => $hash1, 'entry_hash' => $hash2, 'hmac_key_epoch' => 1],
+            ],
+            hmacRowCount: 1,
+        );
+
+        self::assertNull(
+            $this->getSubject()->verifyChainForReseal(),
+            'a partly-migrated chain must remain re-sealable',
+        );
+    }
+
+    // =========================================================================
+    // Error-message hygiene and the sink fan-out.
+    // =========================================================================
+
+    /**
+     * The audit row is long-retained and frequently exported to lower-privilege
+     * operators, so `error_message` is bounded: the forensic value is the
+     * CATEGORY of failure, not a verbose dump that may carry internal state.
+     */
+    #[Test]
+    public function anOversizedErrorMessageIsTruncatedWithAnEllipsis(): void
+    {
+        $this->setupDatabaseMocks();
+
+        $captured = [];
+        $this->connectionMock()
+            ->expects(self::once())
+            ->method('insert')
+            ->with(
+                'tx_nrvault_audit_log',
+                self::callback(static function (array $data) use (&$captured): bool {
+                    $captured = $data;
+
+                    return true;
+                }),
+            );
+
+        $this->getSubject()->log('api_creds', 'read', false, str_repeat('x', 500));
+
+        self::assertIsString($captured['error_message']);
+        self::assertSame(200, mb_strlen($captured['error_message']));
+        self::assertStringEndsWith('...', $captured['error_message']);
+        self::assertSame(str_repeat('x', 197) . '...', $captured['error_message']);
+    }
+
+    #[Test]
+    public function anErrorMessageAtTheLimitIsStoredWhole(): void
+    {
+        $this->setupDatabaseMocks();
+
+        $message = str_repeat('y', 200);
+        $captured = [];
+        $this->connectionMock()
+            ->expects(self::once())
+            ->method('insert')
+            ->with(
+                'tx_nrvault_audit_log',
+                self::callback(static function (array $data) use (&$captured): bool {
+                    $captured = $data;
+
+                    return true;
+                }),
+            );
+
+        $this->getSubject()->log('api_creds', 'read', false, $message);
+
+        self::assertSame($message, $captured['error_message']);
+    }
+
+    /**
+     * The database row is chain-authoritative and already committed by the time
+     * the sinks run. A broken fan-out must therefore be reported, never allowed
+     * to fail the audited vault operation.
+     */
+    #[Test]
+    public function aBrokenSinkFanOutIsLoggedAndDoesNotFailTheAuditedOperation(): void
+    {
+        $this->setupDatabaseMocks();
+        $this->connectionMock()->method('lastInsertId')->willReturn('42');
+
+        $registry = self::createStub(AuditSinkRegistryInterface::class);
+        $registry->method('dispatch')->willThrowException(new RuntimeException('DI graph broken', 1750000020));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with(
+                self::stringContains('audit sink fan-out failed'),
+                self::callback(static fn (array $context): bool => $context['uid'] === 42
+                    && $context['error'] === 'DI graph broken'
+                    && $context['exception'] === RuntimeException::class),
+            );
+
+        $subject = new AuditLogService(
+            $this->connectionPoolMock(),
+            $this->accessControlMock(),
+            $this->masterKeyProviderMock(),
+            $this->extensionConfigurationMock(),
+            $registry,
+            $logger,
+        );
+
+        $subject->log('api_creds', 'read', true);
+    }
+
+    #[Test]
+    public function aWorkingSinkFanOutReceivesTheCommittedRowAndItsChainTip(): void
+    {
+        $this->setupDatabaseMocks();
+        $this->connectionMock()->method('lastInsertId')->willReturn('42');
+
+        $registry = $this->createMock(AuditSinkRegistryInterface::class);
+        $registry->expects(self::once())
+            ->method('dispatch')
+            ->with(
+                self::callback(static fn (AuditLogEntry $entry): bool => $entry->uid === 42),
+                // The chain tip after this write IS this entry's own hash.
+                self::matchesRegularExpression(self::SHA256_HEX_PATTERN),
+            );
+
+        $subject = new AuditLogService(
+            $this->connectionPoolMock(),
+            $this->accessControlMock(),
+            $this->masterKeyProviderMock(),
+            $this->extensionConfigurationMock(),
+            $registry,
+        );
+
+        $subject->log('api_creds', 'read', true);
+    }
+
+    // =========================================================================
+    // Epoch dispatch on the write path. The stored entry_hash must be the one
+    // the configured epoch's algorithm produces, or every later verification of
+    // the row reports a tamper that never happened.
+    // =========================================================================
+
+    #[Test]
+    public function epochZeroWritesAKeylessSha256EntryHash(): void
+    {
+        [$insertedRow, $storedHash] = $this->captureWriteAtEpoch(0);
+
+        $v1 = AuditLogService::extractHashRow(['uid' => 42] + $insertedRow);
+
+        self::assertSame(
+            AuditLogService::calculateHash(
+                $v1['uid'],
+                $v1['secretId'],
+                $v1['action'],
+                $v1['actorUid'],
+                $v1['crdate'],
+                '',
+            ),
+            $storedHash,
+        );
+    }
+
+    #[Test]
+    public function epochTwoWritesTheExtendedForensicHmacEntryHash(): void
+    {
+        [$insertedRow, $storedHash] = $this->captureWriteAtEpoch(2);
+
+        self::assertSame(
+            AuditLogService::calculateHashV2(
+                AuditLogService::extractV2HashRow(['uid' => 42] + $insertedRow),
+                '',
+                AuditLogService::deriveHmacKey($this->masterKeyProviderMock()),
+            ),
+            $storedHash,
+        );
+    }
+
+    /**
+     * The epochs must not agree: if epoch 0 and epoch 2 produced the same hash
+     * the two tests above would pass without the dispatch working at all.
+     */
+    #[Test]
+    public function theEpochsProduceDifferentEntryHashesForTheSameRow(): void
+    {
+        [, $epochZeroHash] = $this->captureWriteAtEpoch(0);
+        [, $epochTwoHash] = $this->captureWriteAtEpoch(2);
+
+        self::assertNotSame($epochZeroHash, $epochTwoHash);
+    }
+
+    /**
+     * Run one `log()` at the given epoch and return the inserted row plus the
+     * `entry_hash` the second-step UPDATE stored.
+     *
+     * @return array{array<string, mixed>, string}
+     */
+    private function captureWriteAtEpoch(int $epoch): array
+    {
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connection = $this->createMock(Connection::class);
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+
+        $previousHashResult = self::createStub(Result::class);
+        // No prior entry: the previous hash is the empty string.
+        $previousHashResult->method('fetchOne')->willReturn(false);
+
+        $lockResult = self::createStub(Result::class);
+        $lockResult->method('fetchOne')->willReturn(1);
+
+        $connectionPool->method('getConnectionForTable')->willReturn($connection);
+        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
+        $connection->method('executeQuery')->willReturn($lockResult);
+        $connection->method('lastInsertId')->willReturn('42');
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('orderBy')->willReturnSelf();
+        $queryBuilder->method('setMaxResults')->willReturnSelf();
+        $queryBuilder->method('executeQuery')->willReturn($previousHashResult);
+
+        $insertedRow = [];
+        $connection->expects(self::once())
+            ->method('insert')
+            ->with(
+                'tx_nrvault_audit_log',
+                self::callback(static function (array $data) use (&$insertedRow): bool {
+                    $insertedRow = $data;
+
+                    return true;
+                }),
+            );
+
+        $storedHash = null;
+        $connection->expects(self::once())
+            ->method('update')
+            ->with(
+                'tx_nrvault_audit_log',
+                self::callback(static function (array $fields) use (&$storedHash): bool {
+                    $storedHash = $fields['entry_hash'] ?? null;
+
+                    return true;
+                }),
+                self::anything(),
+            );
+
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('getAuditHmacEpoch')->willReturn($epoch);
+
+        $subject = new AuditLogService(
+            $connectionPool,
+            $this->accessControlMock(),
+            $this->masterKeyProviderMock(),
+            $configuration,
+        );
+
+        $subject->log('api_creds', 'read', true);
+
+        self::assertIsString($storedHash);
+
+        $row = $this->asColumnRow($insertedRow);
+        self::assertSame($epoch, $row['hmac_key_epoch']);
+
+        return [$row, $storedHash];
+    }
+
+    /**
+     * Wire the two queries `verifyChainForReseal()` makes: the HMAC-row count and
+     * the full chain scan.
+     *
+     * @param array<int, array<string, mixed>> $rows
+     */
+    private function setupResealMocks(array $rows, int $hmacRowCount): void
+    {
+        $result = $this->createMock(Result::class);
+        $result->method('fetchOne')->willReturn($hmacRowCount);
+        $result->method('fetchAllAssociative')->willReturn($rows);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator($rows));
+
+        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
+
+        $connection = $this->connectionMock();
+        $queryBuilder = $this->queryBuilderMock();
+
+        $this->connectionPoolMock()->method('getConnectionForTable')->willReturn($connection);
+        $connection->method('createQueryBuilder')->willReturn($queryBuilder);
+        $queryBuilder->method('expr')->willReturn($expressionBuilder);
+        $queryBuilder->method('count')->willReturnSelf();
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('orderBy')->willReturnSelf();
+        $queryBuilder->method('setMaxResults')->willReturnSelf();
+        $queryBuilder->method('createNamedParameter')->willReturn('?');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+    }
+
     /**
      * Install a request whose headers the test controls. A mock is used rather
      * than a real PSR-7 request so that byte sequences a PSR-7 implementation
@@ -2741,6 +3193,73 @@ final class AuditLogServiceTest extends TestCase
         self::assertNotNull($this->subject);
 
         return $this->subject;
+    }
+
+    /**
+     * The shared mocks are declared as `?MockObject`, which loses the mocked
+     * type. These accessors restore it so new tests can call `expects()` /
+     * `method()` on a value static analysis knows is non-null and correctly
+     * typed.
+     */
+    private function connectionMock(): Connection&MockObject
+    {
+        self::assertInstanceOf(Connection::class, $this->connection);
+
+        return $this->connection;
+    }
+
+    private function connectionPoolMock(): ConnectionPool&MockObject
+    {
+        self::assertInstanceOf(ConnectionPool::class, $this->connectionPool);
+
+        return $this->connectionPool;
+    }
+
+    private function queryBuilderMock(): QueryBuilder&MockObject
+    {
+        self::assertInstanceOf(QueryBuilder::class, $this->queryBuilder);
+
+        return $this->queryBuilder;
+    }
+
+    private function accessControlMock(): AccessControlServiceInterface&MockObject
+    {
+        self::assertInstanceOf(AccessControlServiceInterface::class, $this->accessControlService);
+
+        return $this->accessControlService;
+    }
+
+    private function masterKeyProviderMock(): MasterKeyProviderInterface&MockObject
+    {
+        self::assertInstanceOf(MasterKeyProviderInterface::class, $this->masterKeyProvider);
+
+        return $this->masterKeyProvider;
+    }
+
+    private function extensionConfigurationMock(): ExtensionConfigurationInterface&MockObject
+    {
+        self::assertInstanceOf(ExtensionConfigurationInterface::class, $this->extensionConfiguration);
+
+        return $this->extensionConfiguration;
+    }
+
+    /**
+     * Re-key an array captured from a `Connection::insert()` argument, whose keys
+     * static analysis only knows as `array-key`, to the string-keyed row shape the
+     * hash extractors require. Audit column names are strings by construction.
+     *
+     * @param array<mixed> $row
+     *
+     * @return array<string, mixed>
+     */
+    private function asColumnRow(array $row): array
+    {
+        $columns = [];
+        foreach ($row as $column => $value) {
+            $columns[(string) $column] = $value;
+        }
+
+        return $columns;
     }
 
     private function setupDatabaseMocks(mixed $previousHashFetchOne = false): void

--- a/Tests/Unit/Audit/Sink/AuditSinkRegistryTest.php
+++ b/Tests/Unit/Audit/Sink/AuditSinkRegistryTest.php
@@ -1,0 +1,539 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit\Sink;
+
+use Error;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Audit\Sink\AuditSinkInterface;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistry;
+use Netresearch\NrVault\Event\AuditIntegrityAlertEvent;
+use Netresearch\NrVault\Exception\AuditSinkException;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use Psr\Log\LoggerInterface;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use Stringable;
+use Throwable;
+
+#[CoversClass(AuditSinkRegistry::class)]
+final class AuditSinkRegistryTest extends TestCase
+{
+    #[Test]
+    public function dispatchDeliversToEveryEnabledSink(): void
+    {
+        $first = new SpyAuditSink('first');
+        $second = new SpyAuditSink('second');
+
+        $accepted = $this->createSubject([$first, $second])->dispatch($this->createEntry(), 'tip');
+
+        self::assertSame(2, $accepted);
+        self::assertSame(1, $first->publishCalls);
+        self::assertSame(1, $second->publishCalls);
+    }
+
+    #[Test]
+    public function disabledSinksAreSkipped(): void
+    {
+        $enabled = new SpyAuditSink('enabled');
+        $disabled = new SpyAuditSink('disabled', enabled: false);
+
+        $accepted = $this->createSubject([$enabled, $disabled])->dispatch($this->createEntry(), 'tip');
+
+        self::assertSame(1, $accepted);
+        self::assertSame(0, $disabled->publishCalls);
+    }
+
+    #[Test]
+    public function dispatchPassesTheChainTipThrough(): void
+    {
+        $sink = new SpyAuditSink('spy');
+
+        $this->createSubject([$sink])->dispatch($this->createEntry(), 'tip-abc');
+
+        self::assertSame(['tip-abc'], $sink->chainTips);
+    }
+
+    /**
+     * The central guarantee: one broken destination must not blind the others.
+     * Partial external evidence beats none.
+     */
+    #[Test]
+    public function aThrowingSinkDoesNotPreventTheRemainingSinksFromReceivingTheEntry(): void
+    {
+        $broken = new SpyAuditSink('broken', throwOnPublish: AuditSinkException::writeFailed('broken', 'disk full'));
+        $healthy = new SpyAuditSink('healthy');
+
+        $accepted = $this->createSubject([$broken, $healthy])->dispatch($this->createEntry(), 'tip');
+
+        self::assertSame(1, $accepted, 'only the healthy sink accepted the record');
+        self::assertSame(1, $healthy->publishCalls, 'the healthy sink was still called');
+    }
+
+    /**
+     * The audited vault operation must survive any sink failure, so no method on
+     * the registry may throw.
+     */
+    #[Test]
+    public function dispatchNeverThrowsEvenWhenEverySinkFails(): void
+    {
+        $registry = $this->createSubject([
+            new SpyAuditSink('a', throwOnPublish: new RuntimeException('boom')),
+            new SpyAuditSink('b', throwOnPublish: new Error('fatal-ish')),
+        ]);
+
+        self::assertSame(0, $registry->dispatch($this->createEntry(), 'tip'));
+    }
+
+    #[Test]
+    public function failuresAreCountedGloballyAndPerSink(): void
+    {
+        $registry = $this->createSubject([
+            new SpyAuditSink('broken', throwOnPublish: new RuntimeException('boom')),
+            new SpyAuditSink('healthy'),
+        ]);
+
+        $registry->dispatch($this->createEntry(), 'tip');
+        $registry->dispatch($this->createEntry(), 'tip');
+
+        self::assertSame(2, $registry->getFailureCount());
+        self::assertSame(['broken' => 2], $registry->getFailureCountsBySink());
+    }
+
+    #[Test]
+    public function failureIsLoggedWithTheSinkIdentifier(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with(
+                self::stringContains('audit sink delivery failed'),
+                self::callback(static fn (array $context): bool => ($context['sink'] ?? null) === 'broken'),
+            );
+
+        $this->createSubject(
+            [new SpyAuditSink('broken', throwOnPublish: new RuntimeException('boom'))],
+            logger: $logger,
+        )->dispatch($this->createEntry(), 'tip');
+    }
+
+    /**
+     * The log line must not name the secret's value or any credential; the uid
+     * and action are enough to correlate with the database row.
+     */
+    #[Test]
+    public function failureLogContextCarriesOnlyNonSensitiveRecordFacts(): void
+    {
+        $captured = [];
+        $logger = self::createStub(LoggerInterface::class);
+        $logger->method('error')->willReturnCallback(
+            static function (string|Stringable $message, array $context) use (&$captured): void {
+                $captured = $context;
+            },
+        );
+
+        $this->createSubject(
+            [new SpyAuditSink('broken', throwOnPublish: new RuntimeException('boom'))],
+            logger: $logger,
+        )->dispatch($this->createEntry(uid: 9), 'tip');
+
+        self::assertSame(9, $captured['uid']);
+        self::assertSame('read', $captured['action']);
+        self::assertSame('broken', $captured['sink']);
+    }
+
+    #[Test]
+    public function failureRaisesASinkFailureIntegrityAlert(): void
+    {
+        $dispatcher = new RecordingEventDispatcher();
+
+        $this->createSubject(
+            [new SpyAuditSink('broken', throwOnPublish: new RuntimeException('boom'))],
+            eventDispatcher: $dispatcher,
+        )->dispatch($this->createEntry(), 'tip');
+
+        self::assertCount(1, $dispatcher->events);
+        self::assertSame(AuditIntegrityReason::SinkFailure, $dispatcher->events[0]->getReason());
+        self::assertFalse($dispatcher->events[0]->isTamperEvidence());
+        self::assertSame('broken', $dispatcher->events[0]->getAlert()->context['sink']);
+    }
+
+    #[Test]
+    public function successfulDispatchRaisesNoAlert(): void
+    {
+        $dispatcher = new RecordingEventDispatcher();
+
+        $this->createSubject([new SpyAuditSink('healthy')], eventDispatcher: $dispatcher)
+            ->dispatch($this->createEntry(), 'tip');
+
+        self::assertSame([], $dispatcher->events);
+    }
+
+    /**
+     * A sink whose `isEnabled()` throws must be treated as disabled, not allowed
+     * to take the audited operation down from outside the per-call try/catch.
+     */
+    #[Test]
+    public function aSinkThatThrowsFromIsEnabledIsTreatedAsDisabledAndCounted(): void
+    {
+        $registry = $this->createSubject([
+            new SpyAuditSink('probe-breaker', throwOnIsEnabled: new RuntimeException('config exploded')),
+            new SpyAuditSink('healthy'),
+        ]);
+
+        self::assertSame(1, $registry->dispatch($this->createEntry(), 'tip'));
+        self::assertSame(['probe-breaker' => 1], $registry->getFailureCountsBySink());
+    }
+
+    #[Test]
+    public function dispatchAnchorDeliversTheAnchorToEveryEnabledSink(): void
+    {
+        $sink = new SpyAuditSink('spy');
+        $anchor = new ChainTipAnchor(42, 'tip', 1_750_000_000, 3);
+
+        $accepted = $this->createSubject([$sink])->dispatchAnchor($anchor);
+
+        self::assertSame(1, $accepted);
+        self::assertSame([$anchor], $sink->anchors);
+    }
+
+    #[Test]
+    public function dispatchAnchorReturnsZeroWhenNoSinkIsEnabled(): void
+    {
+        $registry = $this->createSubject([new SpyAuditSink('off', enabled: false)]);
+
+        self::assertSame(0, $registry->dispatchAnchor(new ChainTipAnchor(1, 'tip', 1, 3)));
+    }
+
+    #[Test]
+    public function dispatchAlertDeliversTheAlertToEveryEnabledSink(): void
+    {
+        $sink = new SpyAuditSink('spy');
+        $alert = AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'chain shrank');
+
+        $accepted = $this->createSubject([$sink])->dispatchAlert($alert);
+
+        self::assertSame(1, $accepted);
+        self::assertSame([$alert], $sink->alerts);
+    }
+
+    /**
+     * Without the reentrancy guard, a sink that fails while delivering an alert
+     * raises a SINK_FAILURE alert, which the listener sends back through
+     * dispatchAlert(), which fails again — unbounded recursion.
+     */
+    #[Test]
+    public function aSinkFailingDuringAlertDeliveryRaisesNoFurtherAlert(): void
+    {
+        $dispatcher = new RecordingEventDispatcher();
+        $registry = $this->createSubject(
+            [new SpyAuditSink('broken', throwOnAlert: new RuntimeException('boom'))],
+            eventDispatcher: $dispatcher,
+        );
+
+        $registry->dispatchAlert(AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'reset'));
+
+        self::assertSame([], $dispatcher->events, 'no nested SINK_FAILURE alert was raised');
+        self::assertSame(1, $registry->getFailureCount(), 'the failure was still counted');
+    }
+
+    /**
+     * Simulates the real wiring: the listener forwards the alert back into the
+     * registry. The guard must break the cycle rather than recursing.
+     */
+    #[Test]
+    public function alertDeliveryTerminatesWhenTheListenerForwardsBackIntoTheRegistry(): void
+    {
+        $sink = new SpyAuditSink('broken', throwOnPublish: new RuntimeException('boom'));
+
+        // The listener needs the registry that constructs the dispatcher, so the
+        // cycle is closed through a mutable holder rather than a captured local
+        // (which would still be null when the closure is built).
+        $holder = new RegistryHolder();
+        $dispatcher = new ForwardingEventDispatcher(static function (AuditIntegrityAlertEvent $event) use ($holder): void {
+            $holder->registry?->dispatchAlert($event->getAlert());
+        });
+
+        $registry = $this->createSubject([$sink], eventDispatcher: $dispatcher);
+        $holder->registry = $registry;
+
+        $registry->dispatch($this->createEntry(), 'tip');
+
+        // publish failed once; the forwarded alert reached publishAlert exactly
+        // once and its own failure did not trigger another round.
+        self::assertSame(1, $sink->publishCalls);
+        self::assertSame(1, $sink->alertCalls);
+    }
+
+    /**
+     * A throwing listener must not escalate into the audited operation.
+     */
+    #[Test]
+    public function aThrowingEventListenerDoesNotBreakTheDispatch(): void
+    {
+        $dispatcher = new ForwardingEventDispatcher(static function (): never {
+            throw new RuntimeException('listener exploded', 6282578635);
+        });
+
+        $registry = $this->createSubject(
+            [new SpyAuditSink('broken', throwOnPublish: new RuntimeException('boom'))],
+            eventDispatcher: $dispatcher,
+        );
+
+        self::assertSame(0, $registry->dispatch($this->createEntry(), 'tip'));
+    }
+
+    #[Test]
+    public function hasExternalAuditSinkIsFalseWithoutSinks(): void
+    {
+        self::assertFalse($this->createSubject([])->hasExternalAuditSink());
+    }
+
+    #[Test]
+    public function hasExternalAuditSinkIsFalseWhenEverySinkIsDisabled(): void
+    {
+        $registry = $this->createSubject([
+            new SpyAuditSink('a', enabled: false),
+            new SpyAuditSink('b', enabled: false),
+        ]);
+
+        self::assertFalse($registry->hasExternalAuditSink());
+    }
+
+    #[Test]
+    public function hasExternalAuditSinkIsTrueWhenAtLeastOneSinkIsEnabled(): void
+    {
+        $registry = $this->createSubject([
+            new SpyAuditSink('a', enabled: false),
+            new SpyAuditSink('b'),
+        ]);
+
+        self::assertTrue($registry->hasExternalAuditSink());
+    }
+
+    #[Test]
+    public function enabledSinkIdentifiersListOnlyTheUsableSinks(): void
+    {
+        $registry = $this->createSubject([
+            new SpyAuditSink('syslog'),
+            new SpyAuditSink('file', enabled: false),
+            new SpyAuditSink('webhook'),
+        ]);
+
+        self::assertSame(['syslog', 'webhook'], $registry->getEnabledSinkIdentifiers());
+    }
+
+    #[Test]
+    public function failureCountsStartAtZero(): void
+    {
+        $registry = $this->createSubject([new SpyAuditSink('a')]);
+
+        self::assertSame(0, $registry->getFailureCount());
+        self::assertSame([], $registry->getFailureCountsBySink());
+    }
+
+    /**
+     * The tagged collection is iterated by several methods, so it must survive
+     * repeated traversal.
+     */
+    #[Test]
+    public function theSinkCollectionCanBeIteratedMoreThanOnce(): void
+    {
+        $registry = $this->createSubject([new SpyAuditSink('a'), new SpyAuditSink('b')]);
+
+        self::assertTrue($registry->hasExternalAuditSink());
+        self::assertSame(['a', 'b'], $registry->getEnabledSinkIdentifiers());
+        self::assertSame(2, $registry->dispatch($this->createEntry(), 'tip'));
+        self::assertSame(2, $registry->dispatchAnchor(new ChainTipAnchor(1, 't', 1, 3)));
+    }
+
+    /**
+     * @param list<AuditSinkInterface> $sinks
+     */
+    private function createSubject(
+        array $sinks,
+        ?LoggerInterface $logger = null,
+        ?EventDispatcherInterface $eventDispatcher = null,
+    ): AuditSinkRegistry {
+        return new AuditSinkRegistry(
+            $sinks,
+            $logger ?? new NullLogger(),
+            $eventDispatcher ?? new RecordingEventDispatcher(),
+        );
+    }
+
+    private function createEntry(int $uid = 1): AuditLogEntry
+    {
+        return new AuditLogEntry(
+            uid: $uid,
+            secretIdentifier: 'api/stripe',
+            action: 'read',
+            success: true,
+            errorMessage: null,
+            reason: null,
+            actorUid: 7,
+            actorType: 'be_user',
+            actorUsername: 'editor',
+            actorRole: 'groups:1',
+            ipAddress: '203.0.113.7',
+            userAgent: 'Mozilla/5.0',
+            requestId: 'req-1',
+            previousHash: 'prev',
+            entryHash: 'hash-' . $uid,
+            hashBefore: '',
+            hashAfter: '',
+            crdate: 1_750_000_000,
+            context: [],
+        );
+    }
+}
+
+/**
+ * A sink that records what it received and optionally fails on demand.
+ *
+ * Hand-written rather than a PHPUnit mock: the tests assert call ORDER and
+ * CUMULATIVE counts across several dispatches, which reads far more clearly as
+ * plain counters than as chained `expects()` constraints.
+ *
+ * @internal test helper
+ */
+final class SpyAuditSink implements AuditSinkInterface
+{
+    public int $publishCalls = 0;
+
+    public int $anchorCalls = 0;
+
+    public int $alertCalls = 0;
+
+    /** @var list<string> */
+    public array $chainTips = [];
+
+    /** @var list<ChainTipAnchor> */
+    public array $anchors = [];
+
+    /** @var list<AuditIntegrityAlert> */
+    public array $alerts = [];
+
+    public function __construct(
+        private readonly string $identifier,
+        private readonly bool $enabled = true,
+        private readonly ?Throwable $throwOnPublish = null,
+        private readonly ?Throwable $throwOnAnchor = null,
+        private readonly ?Throwable $throwOnAlert = null,
+        private readonly ?Throwable $throwOnIsEnabled = null,
+    ) {}
+
+    public function publish(AuditLogEntry $entry, string $chainTip): void
+    {
+        ++$this->publishCalls;
+        $this->chainTips[] = $chainTip;
+
+        if ($this->throwOnPublish instanceof Throwable) {
+            throw $this->throwOnPublish;
+        }
+    }
+
+    public function publishAnchor(ChainTipAnchor $anchor): void
+    {
+        ++$this->anchorCalls;
+        $this->anchors[] = $anchor;
+
+        if ($this->throwOnAnchor instanceof Throwable) {
+            throw $this->throwOnAnchor;
+        }
+    }
+
+    public function publishAlert(AuditIntegrityAlert $alert): void
+    {
+        ++$this->alertCalls;
+        $this->alerts[] = $alert;
+
+        if ($this->throwOnAlert instanceof Throwable) {
+            throw $this->throwOnAlert;
+        }
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function isEnabled(): bool
+    {
+        if ($this->throwOnIsEnabled instanceof Throwable) {
+            throw $this->throwOnIsEnabled;
+        }
+
+        return $this->enabled;
+    }
+}
+
+/**
+ * @internal test helper
+ */
+final class RecordingEventDispatcher implements EventDispatcherInterface
+{
+    /** @var list<AuditIntegrityAlertEvent> */
+    public array $events = [];
+
+    public function dispatch(object $event): object
+    {
+        if ($event instanceof AuditIntegrityAlertEvent) {
+            $this->events[] = $event;
+        }
+
+        return $event;
+    }
+}
+
+/**
+ * Dispatcher that runs a single listener closure — used to model the real
+ * listener forwarding alerts back into the registry.
+ *
+ * @internal test helper
+ */
+final class ForwardingEventDispatcher implements EventDispatcherInterface
+{
+    /** @var callable(AuditIntegrityAlertEvent): void */
+    private $listener;
+
+    /**
+     * @param callable(AuditIntegrityAlertEvent): void $listener
+     */
+    public function __construct(callable $listener)
+    {
+        $this->listener = $listener;
+    }
+
+    public function dispatch(object $event): object
+    {
+        if ($event instanceof AuditIntegrityAlertEvent) {
+            ($this->listener)($event);
+        }
+
+        return $event;
+    }
+}
+
+/**
+ * Mutable holder that lets a listener closure reach the registry that owns the
+ * dispatcher it is registered on.
+ *
+ * @internal test helper
+ */
+final class RegistryHolder
+{
+    public ?AuditSinkRegistry $registry = null;
+}

--- a/Tests/Unit/Audit/Sink/AuditSinkRegistryTest.php
+++ b/Tests/Unit/Audit/Sink/AuditSinkRegistryTest.php
@@ -360,6 +360,51 @@ final class AuditSinkRegistryTest extends TestCase
     }
 
     /**
+     * The guard has a second entry point: a sink that re-enters `dispatchAlert()`
+     * from inside its own `publishAlert()` — what happens when a sink implementation
+     * (or a listener it invokes synchronously) reports its own trouble as an alert.
+     * That call must be dropped, not fanned out again, or the first alert delivery
+     * recurses until the stack runs out.
+     */
+    #[Test]
+    public function reEnteringAlertDispatchFromInsideASinkIsDroppedRatherThanRecursed(): void
+    {
+        $holder = new RegistryHolder();
+        $sink = new ReentrantAlertSink('reentrant', $holder);
+
+        $registry = $this->createSubject([$sink]);
+        $holder->registry = $registry;
+
+        $accepted = $registry->dispatchAlert(
+            AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'chain shrank'),
+        );
+
+        self::assertSame(1, $accepted, 'the outer delivery still succeeds');
+        self::assertSame(1, $sink->alertCalls, 'the sink must be asked exactly once');
+        self::assertSame([0], $sink->reentrantResults, 'the nested delivery reports zero sinks reached');
+    }
+
+    /**
+     * …and the guard is released afterwards: a one-off re-entry must not leave the
+     * registry permanently unable to deliver alerts.
+     */
+    #[Test]
+    public function theReentrancyGuardIsReleasedAfterTheOuterDeliveryCompletes(): void
+    {
+        $holder = new RegistryHolder();
+        $sink = new ReentrantAlertSink('reentrant', $holder);
+
+        $registry = $this->createSubject([$sink]);
+        $holder->registry = $registry;
+
+        $alert = AuditIntegrityAlert::create(AuditIntegrityReason::SinkFailure, 'first');
+        $registry->dispatchAlert($alert);
+
+        self::assertSame(1, $registry->dispatchAlert($alert), 'a later alert must still be delivered');
+        self::assertSame(2, $sink->alertCalls);
+    }
+
+    /**
      * @param list<AuditSinkInterface> $sinks
      */
     private function createSubject(
@@ -536,4 +581,47 @@ final class ForwardingEventDispatcher implements EventDispatcherInterface
 final class RegistryHolder
 {
     public ?AuditSinkRegistry $registry = null;
+}
+
+/**
+ * A sink that calls `dispatchAlert()` back on the registry currently delivering
+ * to it — the reentrancy the guard in `dispatchAlert()` exists to break.
+ *
+ * @internal test helper
+ */
+final class ReentrantAlertSink implements AuditSinkInterface
+{
+    public int $alertCalls = 0;
+
+    /** @var list<int> Return values of the nested dispatchAlert() calls */
+    public array $reentrantResults = [];
+
+    public function __construct(
+        private readonly string $identifier,
+        private readonly RegistryHolder $holder,
+    ) {}
+
+    public function publish(AuditLogEntry $entry, string $chainTip): void {}
+
+    public function publishAnchor(ChainTipAnchor $anchor): void {}
+
+    public function publishAlert(AuditIntegrityAlert $alert): void
+    {
+        ++$this->alertCalls;
+
+        $registry = $this->holder->registry;
+        if ($registry instanceof AuditSinkRegistry) {
+            $this->reentrantResults[] = $registry->dispatchAlert($alert);
+        }
+    }
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function isEnabled(): bool
+    {
+        return true;
+    }
 }

--- a/Tests/Unit/Audit/Sink/JsonFileAuditSinkTest.php
+++ b/Tests/Unit/Audit/Sink/JsonFileAuditSinkTest.php
@@ -16,11 +16,14 @@ use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Audit\Sink\JsonFileAuditSink;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Exception\AuditSinkException;
+use Netresearch\NrVault\Tests\Unit\Fixtures\FailingStreamWrapper;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use Netresearch\NrVault\Tests\Unit\Traits\EnvironmentSandboxTrait;
+use Netresearch\NrVault\Tests\Unit\Traits\ErrorSuppressionTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use TYPO3\CMS\Core\Core\Environment;
 
@@ -43,6 +46,7 @@ use TYPO3\CMS\Core\Core\Environment;
 final class JsonFileAuditSinkTest extends TestCase
 {
     use EnvironmentSandboxTrait;
+    use ErrorSuppressionTrait;
 
     private string $baseDirectory = '';
 
@@ -311,6 +315,287 @@ final class JsonFileAuditSinkTest extends TestCase
         self::assertIsString($record['entry']['userAgent']);
     }
 
+    /**
+     * A pre-existing stream file the process cannot write to (rotated by root,
+     * restrictive umask on a shared host). Caught before `fopen()` so the
+     * exception names the actual problem instead of "cannot open stream".
+     */
+    #[Test]
+    public function existingButUnwritableStreamFileThrowsWithASpecificReason(): void
+    {
+        mkdir($this->baseDirectory, 0o700, true);
+        touch($this->entryPath);
+        chmod($this->entryPath, 0o400);
+
+        try {
+            $this->createSubject()->publish($this->createEntry(), 'tip');
+            self::fail('an unwritable stream file must not be reported as a successful publish');
+        } catch (AuditSinkException $e) {
+            self::assertStringContainsString('stream file is not writable', $e->getMessage());
+        } finally {
+            chmod($this->entryPath, 0o600);
+        }
+    }
+
+    #[Test]
+    public function unwritableStreamDirectoryThrowsWithASpecificReason(): void
+    {
+        mkdir($this->baseDirectory, 0o500, true);
+
+        try {
+            $this->createSubject()->publish($this->createEntry(), 'tip');
+            self::fail('an unwritable stream directory must not be reported as a successful publish');
+        } catch (AuditSinkException $e) {
+            self::assertStringContainsString('stream directory is not writable', $e->getMessage());
+        } finally {
+            chmod($this->baseDirectory, 0o700);
+        }
+    }
+
+    #[Test]
+    public function uncreatableStreamDirectoryThrowsWithASpecificReason(): void
+    {
+        $blocked = Environment::getVarPath() . '/blocked';
+        mkdir($blocked, 0o500, true);
+
+        try {
+            $subject = $this->createSubject(entryPath: $blocked . '/nested/audit.ndjson');
+            $this->withoutPhpDiagnostics(
+                fn (): null => $subject->publish($this->createEntry(), 'tip'),
+            );
+            self::fail('a directory that cannot be created must not be reported as a successful publish');
+        } catch (AuditSinkException $e) {
+            self::assertStringContainsString('cannot create stream directory', $e->getMessage());
+        } finally {
+            chmod($blocked, 0o700);
+        }
+    }
+
+    /**
+     * A payload PHP cannot serialise must surface as a sink failure the registry
+     * counts, not as a half-written line or a silent drop. Excessive nesting is
+     * the reachable case: `json_encode()` has a hard depth limit, and the audit
+     * entry's `context` column is caller-supplied structure.
+     */
+    #[Test]
+    public function unencodablePayloadThrowsAnEncodingFailure(): void
+    {
+        $this->expectException(AuditSinkException::class);
+        $this->expectExceptionMessage('could not encode the record');
+
+        $this->createSubject()->publish(
+            $this->createEntry(context: $this->deeplyNestedContext()),
+            'tip',
+        );
+    }
+
+    #[Test]
+    public function nothingIsWrittenWhenThePayloadCannotBeEncoded(): void
+    {
+        try {
+            $this->createSubject()->publish(
+                $this->createEntry(context: $this->deeplyNestedContext()),
+                'tip',
+            );
+        } catch (AuditSinkException) {
+            // Asserted separately; here only the absence of a partial line matters.
+        }
+
+        self::assertFileDoesNotExist($this->entryPath);
+    }
+
+    /**
+     * `isEnabled()` runs on every audit write. Re-resolving `realpath()` each
+     * time would add syscalls to the hot path of every vault operation, so the
+     * verdict is memoised — observable in that the refusal is logged once, not
+     * once per write.
+     */
+    #[Test]
+    public function theRefusalToUseAWebExposedPathIsLoggedOnceNotPerCall(): void
+    {
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with(self::stringContains('inside the public web root'), self::anything());
+
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('isAuditSinkFileEnabled')->willReturn(true);
+        $configuration->method('getAuditSinkFilePath')
+            ->willReturn(Environment::getPublicPath() . '/fileadmin/audit.ndjson');
+        $configuration->method('getAuditSinkAnchorPath')->willReturn($this->anchorPath);
+
+        $subject = new JsonFileAuditSink($configuration, $logger);
+
+        self::assertFalse($subject->isEnabled());
+        self::assertFalse($subject->isEnabled());
+        self::assertFalse($subject->isEnabled());
+    }
+
+    /**
+     * Without a resolvable document root the sink cannot PROVE the path is
+     * outside it, so it must fail closed rather than assume the best.
+     *
+     * Note on the sibling branch: `resolveAgainstNearestExistingAncestor()` also
+     * refuses when NO ancestor of the configured path exists. That branch is not
+     * reachable from a test on POSIX — the `isAbsolute()` guard only admits paths
+     * whose ancestor walk terminates at `/` (or, for the Windows drive/UNC forms,
+     * at `.`), and `realpath()` resolves both. It would need an `open_basedir`
+     * restriction excluding `/`, which cannot be installed and undone inside a
+     * shared PHPUnit process. Left uncovered rather than reached by weakening the
+     * production guard.
+     */
+    #[Test]
+    public function anUnresolvablePublicWebRootDisablesTheSink(): void
+    {
+        $sandbox = $this->getEnvironmentSandboxPath();
+        $this->initializeEnvironment(
+            $sandbox,
+            $sandbox . '/public-was-removed',
+            $sandbox . '/var',
+            $sandbox . '/config',
+        );
+
+        self::assertFalse($this->createSubject()->isEnabled());
+    }
+
+    // -------------------------------------------------------------------------
+    // Host filesystem failures behind a successful pre-flight check.
+    //
+    // These layers exist for filesystems this code does not own; see
+    // FailingStreamWrapper for why a real file cannot reach them.
+    // -------------------------------------------------------------------------
+
+    #[Test]
+    public function aRefusedOpenThrowsAWriteFailure(): void
+    {
+        FailingStreamWrapper::register(FailingStreamWrapper::MODE_OPEN_REFUSED);
+
+        try {
+            $this->withoutPhpDiagnostics(fn (): null => $this->publishThroughWrapper());
+            self::fail('a stream that cannot be opened must not be reported as a successful publish');
+        } catch (AuditSinkException $e) {
+            self::assertStringContainsString('cannot open stream for appending', $e->getMessage());
+        } finally {
+            FailingStreamWrapper::unregister();
+        }
+    }
+
+    /**
+     * On a host whose error handler promotes warnings to exceptions — TYPO3's
+     * own does — `fopen()` throws instead of returning false. Both must arrive
+     * at the registry as the same failure type.
+     */
+    #[Test]
+    public function aThrowingOpenIsNormalisedIntoTheSameWriteFailure(): void
+    {
+        FailingStreamWrapper::register(FailingStreamWrapper::MODE_OPEN_THROWS);
+
+        try {
+            $this->publishThroughWrapper();
+            self::fail('a throwing fopen() must not be reported as a successful publish');
+        } catch (AuditSinkException $e) {
+            self::assertStringContainsString('cannot open stream for appending', $e->getMessage());
+            self::assertStringContainsString('simulated host failure', $e->getMessage());
+        } finally {
+            FailingStreamWrapper::unregister();
+        }
+    }
+
+    /**
+     * Writing without the exclusive lock would let concurrent workers interleave
+     * half-written lines, breaking the NDJSON contract for every later reader —
+     * so a refused lock aborts rather than writes anyway.
+     */
+    #[Test]
+    public function aRefusedLockAbortsTheWrite(): void
+    {
+        FailingStreamWrapper::register(FailingStreamWrapper::MODE_LOCK_REFUSED);
+
+        try {
+            $this->publishThroughWrapper();
+            self::fail('a refused exclusive lock must not be reported as a successful publish');
+        } catch (AuditSinkException $e) {
+            self::assertStringContainsString('cannot acquire exclusive lock', $e->getMessage());
+        } finally {
+            FailingStreamWrapper::unregister();
+        }
+    }
+
+    /**
+     * A short write (full volume, quota hit) leaves a truncated line that breaks
+     * every later reader of the stream, so it is an error rather than a partial
+     * success.
+     */
+    #[Test]
+    public function aShortWriteIsTreatedAsAFailureNotAPartialSuccess(): void
+    {
+        FailingStreamWrapper::register(FailingStreamWrapper::MODE_SHORT_WRITE);
+
+        try {
+            $this->publishThroughWrapper();
+            self::fail('an incomplete write must not be reported as a successful publish');
+        } catch (AuditSinkException $e) {
+            self::assertStringContainsString('incomplete write', $e->getMessage());
+        } finally {
+            FailingStreamWrapper::unregister();
+        }
+    }
+
+    /**
+     * Baseline for the four tests above: with the wrapper healthy the publish
+     * succeeds, so their failures come from the injected fault and not from the
+     * wrapper failing to model a usable filesystem.
+     */
+    #[Test]
+    public function aHealthyWrapperStreamPublishesWithoutError(): void
+    {
+        FailingStreamWrapper::register(FailingStreamWrapper::MODE_HEALTHY);
+
+        try {
+            $this->publishThroughWrapper();
+
+            $written = FailingStreamWrapper::writtenData();
+            self::assertStringEndsWith("\n", $written, 'the NDJSON line must be terminated');
+            self::assertIsArray(json_decode(trim($written), true, 512, JSON_THROW_ON_ERROR));
+
+            // Append-only by construction: a truncating mode would let one write
+            // erase the evidence of every earlier one.
+            self::assertSame(['ab'], array_column(FailingStreamWrapper::opens(), 'mode'));
+        } finally {
+            FailingStreamWrapper::unregister();
+        }
+    }
+
+    private function publishThroughWrapper(): null
+    {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('isAuditSinkFileEnabled')->willReturn(true);
+        $configuration->method('getAuditSinkFilePath')->willReturn(FailingStreamWrapper::path('audit.ndjson'));
+        $configuration->method('getAuditSinkAnchorPath')->willReturn(FailingStreamWrapper::path('anchor.ndjson'));
+
+        (new JsonFileAuditSink($configuration, new NullLogger()))->publish($this->createEntry(), 'tip');
+
+        return null;
+    }
+
+    /**
+     * Nested past `json_encode()`'s default depth limit of 512.
+     *
+     * @return array<string, mixed>
+     */
+    private function deeplyNestedContext(): array
+    {
+        $context = [];
+        $cursor = &$context;
+        for ($depth = 0; $depth < 600; $depth++) {
+            $cursor['nested'] = [];
+            $cursor = &$cursor['nested'];
+        }
+        unset($cursor);
+
+        return $context;
+    }
+
     private function createSubject(
         bool $enabled = true,
         ?string $entryPath = null,
@@ -324,7 +609,10 @@ final class JsonFileAuditSinkTest extends TestCase
         return new JsonFileAuditSink($configuration, new NullLogger());
     }
 
-    private function createEntry(int $uid = 1, string $userAgent = 'Mozilla/5.0'): AuditLogEntry
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function createEntry(int $uid = 1, string $userAgent = 'Mozilla/5.0', array $context = []): AuditLogEntry
     {
         return new AuditLogEntry(
             uid: $uid,
@@ -345,7 +633,7 @@ final class JsonFileAuditSinkTest extends TestCase
             hashBefore: '',
             hashAfter: '',
             crdate: 1_750_000_000,
-            context: [],
+            context: $context,
         );
     }
 

--- a/Tests/Unit/Audit/Sink/JsonFileAuditSinkTest.php
+++ b/Tests/Unit/Audit/Sink/JsonFileAuditSinkTest.php
@@ -1,0 +1,374 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit\Sink;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Audit\Sink\JsonFileAuditSink;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Exception\AuditSinkException;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\EnvironmentSandboxTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use TYPO3\CMS\Core\Core\Environment;
+
+/**
+ * Unit tests for the append-only NDJSON audit sink.
+ *
+ * These run against a REAL temporary directory rather than vfsStream, on purpose.
+ * Everything worth testing here is genuine filesystem behaviour that a virtual
+ * filesystem only approximates: `fopen('ab')` append semantics, `flock()`,
+ * `chmod()` result bits, and — most importantly — the `realpath()`-based
+ * public-web-root check, which cannot resolve a `vfs://` URL at all. Testing
+ * against vfsStream would have required weakening that check to accept stream
+ * wrappers, i.e. changing production security behaviour to suit the test.
+ *
+ * Each test gets a throwaway project layout under the system temp directory and
+ * points `Environment` at it, so the public-web-root boundary being checked is a
+ * real directory under the test's control. The layout is removed in tearDown.
+ */
+#[CoversClass(JsonFileAuditSink::class)]
+final class JsonFileAuditSinkTest extends TestCase
+{
+    use EnvironmentSandboxTrait;
+
+    private string $baseDirectory = '';
+
+    private string $entryPath = '';
+
+    private string $anchorPath = '';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->setUpEnvironmentSandbox();
+
+        $this->baseDirectory = Environment::getVarPath() . '/log';
+        $this->entryPath = $this->baseDirectory . '/audit.ndjson';
+        $this->anchorPath = $this->baseDirectory . '/anchor.ndjson';
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownEnvironmentSandbox();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function identifierIsStableAndFreeOfPathInformation(): void
+    {
+        $subject = $this->createSubject();
+
+        self::assertSame('file', $subject->getIdentifier());
+        self::assertStringNotContainsString($this->baseDirectory, $subject->getIdentifier());
+    }
+
+    #[Test]
+    public function disabledConfigurationReportsNotEnabled(): void
+    {
+        self::assertFalse($this->createSubject(enabled: false)->isEnabled());
+    }
+
+    #[Test]
+    public function enabledConfigurationWithSafePathsReportsEnabled(): void
+    {
+        self::assertTrue($this->createSubject()->isEnabled());
+    }
+
+    #[Test]
+    public function publishWritesOneJsonObjectPerLine(): void
+    {
+        $subject = $this->createSubject();
+
+        $subject->publish($this->createEntry(uid: 1), 'tip-1');
+        $subject->publish($this->createEntry(uid: 2), 'tip-2');
+
+        $lines = $this->readLines($this->entryPath);
+
+        self::assertCount(2, $lines);
+        foreach ($lines as $line) {
+            self::assertIsArray(json_decode($line, true, 512, JSON_THROW_ON_ERROR));
+        }
+    }
+
+    #[Test]
+    public function publishedLineCarriesTheUidAndChainTip(): void
+    {
+        $this->createSubject()->publish($this->createEntry(uid: 77), 'tip-77');
+
+        $record = $this->decodeFirstLine($this->entryPath);
+
+        self::assertSame('entry', $record['type']);
+        self::assertSame(77, $record['uid']);
+        self::assertSame('tip-77', $record['chainTip']);
+    }
+
+    #[Test]
+    public function publishedLineCarriesTheAuditEntryPayload(): void
+    {
+        $this->createSubject()->publish($this->createEntry(), 'tip');
+
+        $record = $this->decodeFirstLine($this->entryPath);
+
+        self::assertIsArray($record['entry']);
+        self::assertSame('api/stripe', $record['entry']['secretIdentifier']);
+        self::assertSame('read', $record['entry']['action']);
+    }
+
+    /**
+     * Append-only is the whole point: a sink that rewrote the file would let a
+     * single later write erase the evidence of every earlier one.
+     */
+    #[Test]
+    public function writesAppendRatherThanTruncate(): void
+    {
+        mkdir($this->baseDirectory, 0o700, true);
+        file_put_contents($this->entryPath, "pre-existing\n");
+
+        $this->createSubject()->publish($this->createEntry(), 'tip');
+
+        $lines = $this->readLines($this->entryPath);
+
+        self::assertCount(2, $lines);
+        self::assertSame('pre-existing', $lines[0]);
+    }
+
+    /**
+     * The stream names every secret identifier and actor. World-readable would
+     * hand an unprivileged local account a reconnaissance feed.
+     */
+    #[Test]
+    public function createdFileIsOwnerReadWriteOnly(): void
+    {
+        $this->createSubject()->publish($this->createEntry(), 'tip');
+
+        clearstatcache(true, $this->entryPath);
+
+        $permissions = fileperms($this->entryPath);
+        self::assertIsInt($permissions);
+        self::assertSame('0600', substr(\sprintf('%o', $permissions), -4));
+    }
+
+    #[Test]
+    public function missingDirectoryIsCreated(): void
+    {
+        self::assertDirectoryDoesNotExist($this->baseDirectory);
+
+        $this->createSubject()->publish($this->createEntry(), 'tip');
+
+        self::assertFileExists($this->entryPath);
+    }
+
+    #[Test]
+    public function anchorsGoToTheAnchorStreamNotTheEntryStream(): void
+    {
+        $this->createSubject()->publishAnchor(new ChainTipAnchor(5, 'tip', 1_750_000_000, 3));
+
+        self::assertFileExists($this->anchorPath);
+        self::assertFileDoesNotExist($this->entryPath);
+
+        $record = $this->decodeFirstLine($this->anchorPath);
+        self::assertSame('anchor', $record['type']);
+        self::assertSame(5, $record['anchor']['sequence']);
+        self::assertSame('tip', $record['anchor']['chainTip']);
+        self::assertSame(3, $record['anchor']['hmacEpoch']);
+    }
+
+    #[Test]
+    public function alertsGoToTheAnchorStream(): void
+    {
+        $this->createSubject()->publishAlert(
+            AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'chain shrank', ['anchoredSequence' => 9]),
+        );
+
+        $record = $this->decodeFirstLine($this->anchorPath);
+
+        self::assertSame('alert', $record['type']);
+        self::assertSame('TABLE_RESET', $record['alert']['reason']);
+        self::assertTrue($record['alert']['tamperEvidence']);
+    }
+
+    /**
+     * Anchors and alerts share the stream, so a reader must be able to tell them
+     * apart without guessing — the `type` discriminator is load-bearing.
+     */
+    #[Test]
+    public function anchorStreamRecordsAreDistinguishableByType(): void
+    {
+        $subject = $this->createSubject();
+        $subject->publishAnchor(new ChainTipAnchor(1, 'tip', 1, 3));
+        $subject->publishAlert(AuditIntegrityAlert::create(AuditIntegrityReason::SinkFailure, 'x'));
+
+        $types = array_map(
+            static fn (string $line): mixed => json_decode($line, true, 512, JSON_THROW_ON_ERROR)['type'] ?? null,
+            $this->readLines($this->anchorPath),
+        );
+
+        self::assertSame(['anchor', 'alert'], $types);
+    }
+
+    /**
+     * A path under the document root would publish the audit trail over HTTP.
+     * Disabling is the correct outcome — writing anyway is worse than not having
+     * an external sink at all.
+     */
+    #[Test]
+    public function pathInsideThePublicWebRootDisablesTheSink(): void
+    {
+        $subject = $this->createSubject(
+            entryPath: Environment::getPublicPath() . '/fileadmin/audit.ndjson',
+        );
+
+        self::assertFalse($subject->isEnabled());
+    }
+
+    #[Test]
+    public function anchorPathInsideThePublicWebRootDisablesTheSinkEvenWhenTheEntryPathIsSafe(): void
+    {
+        $subject = $this->createSubject(
+            anchorPath: Environment::getPublicPath() . '/fileadmin/anchor.ndjson',
+        );
+
+        self::assertFalse($subject->isEnabled());
+    }
+
+    /**
+     * `..` traversal must be collapsed before the boundary comparison, or a path
+     * that textually starts outside the root can still land inside it.
+     */
+    #[Test]
+    public function traversalIntoThePublicWebRootDisablesTheSink(): void
+    {
+        $subject = $this->createSubject(
+            entryPath: Environment::getVarPath() . '/../' . basename(Environment::getPublicPath()) . '/audit.ndjson',
+        );
+
+        self::assertFalse($subject->isEnabled());
+    }
+
+    #[Test]
+    #[DataProvider('unusablePathProvider')]
+    public function unusablePathDisablesTheSink(string $path): void
+    {
+        self::assertFalse($this->createSubject(entryPath: $path)->isEnabled());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unusablePathProvider(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'relative' => ['var/log/audit.ndjson'];
+        yield 'relative with traversal' => ['../audit.ndjson'];
+    }
+
+    /**
+     * A sink that silently returned on failure would be indistinguishable from a
+     * working one, so failures must surface to the registry.
+     */
+    #[Test]
+    public function unwritableTargetThrowsAuditSinkException(): void
+    {
+        mkdir($this->baseDirectory, 0o700, true);
+        // A directory cannot be opened for appending.
+        mkdir($this->entryPath, 0o700);
+
+        $this->expectException(AuditSinkException::class);
+
+        $this->createSubject()->publish($this->createEntry(), 'tip');
+    }
+
+    /**
+     * Invalid UTF-8 reaches the sink from request headers (user agent), and
+     * `json_encode()` would otherwise fail the whole write on it.
+     */
+    #[Test]
+    public function invalidUtf8InThePayloadIsSubstitutedRatherThanFailingTheWrite(): void
+    {
+        $this->createSubject()->publish(
+            $this->createEntry(userAgent: "Mozilla\xC3\x28"),
+            'tip',
+        );
+
+        $record = $this->decodeFirstLine($this->entryPath);
+
+        self::assertIsArray($record['entry']);
+        self::assertIsString($record['entry']['userAgent']);
+    }
+
+    private function createSubject(
+        bool $enabled = true,
+        ?string $entryPath = null,
+        ?string $anchorPath = null,
+    ): JsonFileAuditSink {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('isAuditSinkFileEnabled')->willReturn($enabled);
+        $configuration->method('getAuditSinkFilePath')->willReturn($entryPath ?? $this->entryPath);
+        $configuration->method('getAuditSinkAnchorPath')->willReturn($anchorPath ?? $this->anchorPath);
+
+        return new JsonFileAuditSink($configuration, new NullLogger());
+    }
+
+    private function createEntry(int $uid = 1, string $userAgent = 'Mozilla/5.0'): AuditLogEntry
+    {
+        return new AuditLogEntry(
+            uid: $uid,
+            secretIdentifier: 'api/stripe',
+            action: 'read',
+            success: true,
+            errorMessage: null,
+            reason: null,
+            actorUid: 7,
+            actorType: 'be_user',
+            actorUsername: 'editor',
+            actorRole: 'groups:1',
+            ipAddress: '203.0.113.7',
+            userAgent: $userAgent,
+            requestId: 'req-1',
+            previousHash: 'prev',
+            entryHash: 'hash-' . $uid,
+            hashBefore: '',
+            hashAfter: '',
+            crdate: 1_750_000_000,
+            context: [],
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function readLines(string $path): array
+    {
+        $contents = file_get_contents($path);
+        self::assertIsString($contents);
+
+        return array_values(array_filter(explode("\n", $contents), static fn (string $l): bool => trim($l) !== ''));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeFirstLine(string $path): array
+    {
+        $decoded = json_decode($this->readLines($path)[0], true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($decoded);
+
+        /** @var array<string, mixed> $decoded */
+        return $decoded;
+    }
+}

--- a/Tests/Unit/Audit/Sink/Rfc5424FormatterTest.php
+++ b/Tests/Unit/Audit/Sink/Rfc5424FormatterTest.php
@@ -1,0 +1,358 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit\Sink;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Audit\Sink\Rfc5424Formatter;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(Rfc5424Formatter::class)]
+final class Rfc5424FormatterTest extends TestCase
+{
+    private Rfc5424Formatter $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->subject = new Rfc5424Formatter();
+    }
+
+    #[Test]
+    public function entryMessageCarriesTheContractedFieldSet(): void
+    {
+        $message = $this->subject->formatEntry($this->createEntry(), 'tip-hash-abc');
+
+        self::assertStringStartsWith('[' . Rfc5424Formatter::SD_ID_ENTRY . ' ', $message);
+        self::assertStringContainsString('uid="42"', $message);
+        self::assertStringContainsString('secret="api/stripe"', $message);
+        self::assertStringContainsString('action="read"', $message);
+        self::assertStringContainsString('actor="editor"', $message);
+        self::assertStringContainsString('actorUid="7"', $message);
+        self::assertStringContainsString('success="true"', $message);
+        self::assertStringContainsString('chainTip="tip-hash-abc"', $message);
+    }
+
+    #[Test]
+    public function failedEntryReportsSuccessFalse(): void
+    {
+        $message = $this->subject->formatEntry($this->createEntry(success: false), 'tip');
+
+        self::assertStringContainsString('success="false"', $message);
+        self::assertStringContainsString('FAILED', $message);
+    }
+
+    #[Test]
+    public function structuredDataElementIsClosedBeforeTheHumanReadableSummary(): void
+    {
+        $message = $this->subject->formatEntry($this->createEntry(), 'tip');
+
+        // `[SD-ELEMENT] free text` — a collector splitting on the first `] `
+        // must get a complete SD element.
+        self::assertMatchesRegularExpression('/^\[[^\]]+\] \S/', $message);
+    }
+
+    /**
+     * RFC 5424 §6.3.3: `"`, `\` and `]` must be backslash-escaped inside a
+     * PARAM-VALUE. Anything less lets a crafted secret identifier terminate the
+     * structured-data element and inject its own fields.
+     */
+    #[Test]
+    #[DataProvider('escapableCharacterProvider')]
+    public function paramValueEscapesRfc5424SpecialCharacters(string $identifier, string $expectedFragment): void
+    {
+        $message = $this->subject->formatEntry(
+            $this->createEntry(secretIdentifier: $identifier),
+            'tip',
+        );
+
+        self::assertStringContainsString($expectedFragment, $message);
+    }
+
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function escapableCharacterProvider(): iterable
+    {
+        yield 'double quote' => ['api"key', 'secret="api\\"key"'];
+        yield 'closing bracket' => ['api]key', 'secret="api\\]key"'];
+        yield 'backslash' => ['api\\key', 'secret="api\\\\key"'];
+        yield 'backslash before quote' => ['a\\"b', 'secret="a\\\\\\"b"'];
+    }
+
+    /**
+     * A newline terminates a syslog record, so an unescaped one in an
+     * attacker-controlled field (user agent, secret identifier) would let the
+     * caller append a second, forged record (CWE-117).
+     */
+    #[Test]
+    #[DataProvider('controlCharacterProvider')]
+    public function controlCharactersAreStrippedFromTheWholeMessage(string $injected): void
+    {
+        $message = $this->subject->formatEntry(
+            $this->createEntry(secretIdentifier: 'api' . $injected . 'key'),
+            'tip',
+        );
+
+        self::assertDoesNotMatchRegularExpression('/[\x00-\x1F\x7F]/', $message);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function controlCharacterProvider(): iterable
+    {
+        yield 'line feed' => ["\n"];
+        yield 'carriage return' => ["\r"];
+        yield 'crlf' => ["\r\n"];
+        yield 'null byte' => ["\0"];
+        yield 'tab' => ["\t"];
+        yield 'delete' => ["\x7F"];
+    }
+
+    #[Test]
+    public function oversizedParamValueIsTruncatedWithAnEllipsis(): void
+    {
+        $message = $this->subject->formatEntry(
+            $this->createEntry(secretIdentifier: str_repeat('a', 500)),
+            'tip',
+        );
+
+        // 200-char cap: 197 characters plus the three-dot marker.
+        self::assertStringContainsString('secret="' . str_repeat('a', 197) . '..."', $message);
+    }
+
+    /**
+     * The free-text summary interpolates the same caller-influenced fields, so it
+     * needs its own cap — otherwise one oversized identifier inflates the record
+     * however carefully the structured-data params were trimmed.
+     */
+    #[Test]
+    public function oversizedSummaryIsTruncated(): void
+    {
+        $message = $this->subject->formatEntry(
+            $this->createEntry(secretIdentifier: str_repeat('a', 5000)),
+            'tip',
+        );
+
+        $summary = substr($message, (int) strpos($message, '] ') + 2);
+
+        self::assertLessThanOrEqual(300, mb_strlen($summary, 'UTF-8'));
+        self::assertStringEndsWith('...', $summary);
+    }
+
+    /**
+     * Guards the whole record, not just its parts: a receiver is only required to
+     * accept 2048 bytes, and every field here is bounded, so a pathological input
+     * must not produce a record a collector will truncate or drop.
+     */
+    #[Test]
+    public function recordStaysWithinTheSyslogSizeThatReceiversMustAccept(): void
+    {
+        $message = $this->subject->formatEntry(
+            new AuditLogEntry(
+                uid: PHP_INT_MAX,
+                secretIdentifier: str_repeat('s', 5000),
+                action: str_repeat('a', 5000),
+                success: true,
+                errorMessage: null,
+                reason: null,
+                actorUid: PHP_INT_MAX,
+                actorType: str_repeat('t', 5000),
+                actorUsername: str_repeat('u', 5000),
+                actorRole: '',
+                ipAddress: '',
+                userAgent: str_repeat('g', 5000),
+                requestId: '',
+                previousHash: '',
+                entryHash: '',
+                hashBefore: '',
+                hashAfter: '',
+                crdate: 0,
+                context: [],
+            ),
+            str_repeat('c', 5000),
+        );
+
+        self::assertLessThanOrEqual(2048, \strlen($message));
+    }
+
+    #[Test]
+    public function invalidUtf8IsRepairedRatherThanEmitted(): void
+    {
+        $message = $this->subject->formatEntry(
+            $this->createEntry(secretIdentifier: "api\xC3\x28key"),
+            'tip',
+        );
+
+        self::assertTrue(mb_check_encoding($message, 'UTF-8'));
+    }
+
+    #[Test]
+    public function emptyChainTipIsEmittedAsAnEmptyValueRatherThanOmitted(): void
+    {
+        $message = $this->subject->formatEntry($this->createEntry(), '');
+
+        self::assertStringContainsString('chainTip=""', $message);
+    }
+
+    #[Test]
+    public function anchorMessageCarriesSequenceTipAndEpoch(): void
+    {
+        $message = $this->subject->formatAnchor(new ChainTipAnchor(
+            sequence: 128,
+            chainTip: 'anchor-tip',
+            timestamp: 1_750_000_000,
+            hmacEpoch: 3,
+        ));
+
+        self::assertStringStartsWith('[' . Rfc5424Formatter::SD_ID_ANCHOR . ' ', $message);
+        self::assertStringContainsString('sequence="128"', $message);
+        self::assertStringContainsString('chainTip="anchor-tip"', $message);
+        self::assertStringContainsString('hmacEpoch="3"', $message);
+        self::assertStringContainsString('anchoredAt="1750000000"', $message);
+    }
+
+    #[Test]
+    public function alertMessageCarriesReasonAndTamperFlag(): void
+    {
+        $message = $this->subject->formatAlert(AuditIntegrityAlert::create(
+            AuditIntegrityReason::TableReset,
+            'chain shrank',
+            ['anchoredSequence' => 99],
+        ));
+
+        self::assertStringStartsWith('[' . Rfc5424Formatter::SD_ID_ALERT . ' ', $message);
+        self::assertStringContainsString('reason="TABLE_RESET"', $message);
+        self::assertStringContainsString('tamperEvidence="true"', $message);
+        self::assertStringContainsString('ctx_anchoredSequence="99"', $message);
+        self::assertStringContainsString('chain shrank', $message);
+    }
+
+    #[Test]
+    public function nonTamperAlertReportsTamperEvidenceFalse(): void
+    {
+        $message = $this->subject->formatAlert(AuditIntegrityAlert::create(
+            AuditIntegrityReason::SinkFailure,
+            'webhook unreachable',
+        ));
+
+        self::assertStringContainsString('tamperEvidence="false"', $message);
+    }
+
+    /**
+     * Context keys are caller-supplied. An unfiltered key containing `="` would
+     * close the current param and inject a new one, so keys are sanitised too.
+     */
+    #[Test]
+    public function alertContextKeysAreSanitisedIntoValidParamNames(): void
+    {
+        $message = $this->subject->formatAlert(AuditIntegrityAlert::create(
+            AuditIntegrityReason::SinkFailure,
+            'detail',
+            ['bad key="injected' => 'value'],
+        ));
+
+        self::assertStringContainsString('ctx_bad_key__injected="value"', $message);
+    }
+
+    #[Test]
+    public function alertContextBooleansAreRenderedAsTrueFalseNotOneZero(): void
+    {
+        $message = $this->subject->formatAlert(AuditIntegrityAlert::create(
+            AuditIntegrityReason::SinkFailure,
+            'detail',
+            ['retried' => true, 'fatal' => false],
+        ));
+
+        self::assertStringContainsString('ctx_retried="true"', $message);
+        self::assertStringContainsString('ctx_fatal="false"', $message);
+    }
+
+    /**
+     * The three record kinds must be distinguishable by SD-ID so a collector can
+     * route them without parsing the free-text summary.
+     */
+    #[Test]
+    public function eachRecordKindUsesItsOwnStructuredDataId(): void
+    {
+        $sdIds = [
+            Rfc5424Formatter::SD_ID_ENTRY,
+            Rfc5424Formatter::SD_ID_ANCHOR,
+            Rfc5424Formatter::SD_ID_ALERT,
+        ];
+
+        self::assertSameSize($sdIds, array_unique($sdIds));
+    }
+
+    /**
+     * RFC 5424 §6.3.2 requires a non-IANA SD-ID to be `name@<enterprise-number>`.
+     */
+    #[Test]
+    #[DataProvider('structuredDataIdProvider')]
+    public function structuredDataIdsFollowThePrivateEnterpriseNumberForm(string $sdId): void
+    {
+        self::assertMatchesRegularExpression('/^[A-Za-z][A-Za-z0-9]*@\d+$/', $sdId);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function structuredDataIdProvider(): iterable
+    {
+        yield 'entry' => [Rfc5424Formatter::SD_ID_ENTRY];
+        yield 'anchor' => [Rfc5424Formatter::SD_ID_ANCHOR];
+        yield 'alert' => [Rfc5424Formatter::SD_ID_ALERT];
+    }
+
+    #[Test]
+    public function summaryFallsBackToActorUidWhenTheUsernameIsUnknown(): void
+    {
+        $message = $this->subject->formatEntry(
+            $this->createEntry(actorUsername: ''),
+            'tip',
+        );
+
+        self::assertStringContainsString('by uid:7', $message);
+    }
+
+    private function createEntry(
+        string $secretIdentifier = 'api/stripe',
+        bool $success = true,
+        string $actorUsername = 'editor',
+    ): AuditLogEntry {
+        return new AuditLogEntry(
+            uid: 42,
+            secretIdentifier: $secretIdentifier,
+            action: 'read',
+            success: $success,
+            errorMessage: null,
+            reason: null,
+            actorUid: 7,
+            actorType: 'be_user',
+            actorUsername: $actorUsername,
+            actorRole: 'groups:1',
+            ipAddress: '203.0.113.7',
+            userAgent: 'Mozilla/5.0',
+            requestId: 'req-1',
+            previousHash: 'prev',
+            entryHash: 'tip-hash-abc',
+            hashBefore: '',
+            hashAfter: '',
+            crdate: 1_750_000_000,
+            context: [],
+        );
+    }
+}

--- a/Tests/Unit/Audit/Sink/SyslogAuditSinkTest.php
+++ b/Tests/Unit/Audit/Sink/SyslogAuditSinkTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit\Sink;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Audit\Sink\Rfc5424Formatter;
+use Netresearch\NrVault\Audit\Sink\SyslogAuditSink;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * `syslog()` writes to a process-global handle whose output a unit test cannot
+ * read back, so the message CONTENT is asserted where it is pure and
+ * observable — {@see Rfc5424FormatterTest} — and this class covers what remains
+ * observable about the sink itself: enablement, the identifier, and that each
+ * publish path runs the real `openlog()`/`syslog()`/`closelog()` sequence to
+ * completion without throwing.
+ *
+ * The publish tests do write to the host's syslog. That is intentional: it is the
+ * only way to exercise the real emit path, and one `LOG_LOCAL0` line per test is
+ * harmless.
+ */
+#[CoversClass(SyslogAuditSink::class)]
+final class SyslogAuditSinkTest extends TestCase
+{
+    #[Test]
+    public function identifierIsStable(): void
+    {
+        self::assertSame('syslog', $this->createSubject()->getIdentifier());
+    }
+
+    #[Test]
+    public function disabledConfigurationReportsNotEnabled(): void
+    {
+        self::assertFalse($this->createSubject(enabled: false)->isEnabled());
+    }
+
+    #[Test]
+    public function enabledConfigurationReportsEnabled(): void
+    {
+        self::assertTrue($this->createSubject()->isEnabled());
+    }
+
+    #[Test]
+    public function publishCompletesTheEmitSequence(): void
+    {
+        $this->createSubject()->publish($this->createEntry(), 'tip-abc');
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function publishAnchorCompletesTheEmitSequence(): void
+    {
+        $this->createSubject()->publishAnchor(new ChainTipAnchor(9, 'tip', 1_750_000_000, 3));
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    #[Test]
+    public function publishAlertCompletesTheEmitSequence(): void
+    {
+        $this->createSubject()->publishAlert(
+            AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'chain shrank'),
+        );
+
+        $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * `openlog()` mutates process-global state, so the ident must be taken from
+     * the configuration layer (which substitutes the default for a blank value)
+     * on every emit rather than captured once.
+     */
+    #[Test]
+    public function identIsReadFromConfigurationOnEveryEmit(): void
+    {
+        $configuration = $this->createMock(ExtensionConfigurationInterface::class);
+        $configuration->method('isAuditSinkSyslogEnabled')->willReturn(true);
+        $configuration->expects(self::exactly(2))
+            ->method('getAuditSinkSyslogIdent')
+            ->willReturn('nr-vault');
+
+        $sink = new SyslogAuditSink($configuration, new Rfc5424Formatter());
+        $sink->publish($this->createEntry(), 'tip');
+        $sink->publishAnchor(new ChainTipAnchor(1, 'tip', 1, 3));
+    }
+
+    private function createSubject(bool $enabled = true): SyslogAuditSink
+    {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('isAuditSinkSyslogEnabled')->willReturn($enabled);
+        $configuration->method('getAuditSinkSyslogIdent')->willReturn('nr-vault-test');
+
+        return new SyslogAuditSink($configuration, new Rfc5424Formatter());
+    }
+
+    private function createEntry(): AuditLogEntry
+    {
+        return new AuditLogEntry(
+            uid: 1,
+            secretIdentifier: 'api/stripe',
+            action: 'read',
+            success: true,
+            errorMessage: null,
+            reason: null,
+            actorUid: 7,
+            actorType: 'be_user',
+            actorUsername: 'editor',
+            actorRole: 'groups:1',
+            ipAddress: '203.0.113.7',
+            userAgent: 'Mozilla/5.0',
+            requestId: 'req-1',
+            previousHash: 'prev',
+            entryHash: 'hash-1',
+            hashBefore: '',
+            hashAfter: '',
+            crdate: 1_750_000_000,
+            context: [],
+        );
+    }
+}

--- a/Tests/Unit/Audit/Sink/WebhookAuditSinkTest.php
+++ b/Tests/Unit/Audit/Sink/WebhookAuditSinkTest.php
@@ -1,0 +1,398 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit\Sink;
+
+use GuzzleHttp\Psr7\HttpFactory;
+use GuzzleHttp\Psr7\Response;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Audit\Sink\WebhookAuditSink;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Exception\AuditSinkException;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use RuntimeException;
+use Throwable;
+
+#[CoversClass(WebhookAuditSink::class)]
+final class WebhookAuditSinkTest extends TestCase
+{
+    private const ENDPOINT = 'https://siem.example.com/ingest';
+
+    #[Test]
+    public function identifierIsStable(): void
+    {
+        self::assertSame('webhook', $this->createSubject()->getIdentifier());
+    }
+
+    #[Test]
+    public function disabledConfigurationReportsNotEnabled(): void
+    {
+        self::assertFalse($this->createSubject(enabled: false)->isEnabled());
+    }
+
+    #[Test]
+    public function enabledConfigurationWithHttpsUrlReportsEnabled(): void
+    {
+        self::assertTrue($this->createSubject()->isEnabled());
+    }
+
+    /**
+     * An enabled-but-unconfigured webhook would report itself as external
+     * evidence while delivering nothing — exactly the false confidence the
+     * hardened-profile check exists to catch.
+     */
+    #[Test]
+    #[DataProvider('unusableUrlProvider')]
+    public function unusableUrlReportsNotEnabled(string $url): void
+    {
+        self::assertFalse($this->createSubject(url: $url)->isEnabled());
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unusableUrlProvider(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'no scheme' => ['siem.example.com/ingest'];
+        yield 'no host' => ['https://'];
+        yield 'file scheme' => ['file:///etc/passwd'];
+        yield 'php wrapper' => ['php://output'];
+        yield 'data uri' => ['data://text/plain,x'];
+        yield 'ftp scheme' => ['ftp://siem.example.com/ingest'];
+    }
+
+    #[Test]
+    public function plainHttpIsAcceptedForOnPremiseCollectors(): void
+    {
+        self::assertTrue($this->createSubject(url: 'http://collector.internal/ingest')->isEnabled());
+    }
+
+    #[Test]
+    public function publishPostsJsonToTheConfiguredEndpoint(): void
+    {
+        $client = new RecordingClient(new Response(202));
+
+        $this->createSubject(client: $client)->publish($this->createEntry(), 'tip-1');
+
+        $request = $client->lastRequest;
+        self::assertInstanceOf(RequestInterface::class, $request);
+        self::assertSame('POST', $request->getMethod());
+        self::assertSame(self::ENDPOINT, (string) $request->getUri());
+        self::assertSame('application/json', $request->getHeaderLine('Content-Type'));
+    }
+
+    #[Test]
+    public function entryPayloadCarriesTypeUidAndChainTip(): void
+    {
+        $client = new RecordingClient(new Response(200));
+
+        $this->createSubject(client: $client)->publish($this->createEntry(uid: 55), 'tip-55');
+
+        $payload = $client->decodeBody();
+        self::assertSame('entry', $payload['type']);
+        self::assertSame('nr-vault', $payload['source']);
+        self::assertSame(55, $payload['uid']);
+        self::assertSame('tip-55', $payload['chainTip']);
+        self::assertIsArray($payload['entry']);
+    }
+
+    #[Test]
+    public function anchorPayloadCarriesTheAnchorFields(): void
+    {
+        $client = new RecordingClient(new Response(200));
+
+        $this->createSubject(client: $client)->publishAnchor(
+            new ChainTipAnchor(sequence: 12, chainTip: 'anchor-tip', timestamp: 1_750_000_000, hmacEpoch: 3),
+        );
+
+        $payload = $client->decodeBody();
+        self::assertSame('anchor', $payload['type']);
+        self::assertSame(12, $payload['anchor']['sequence']);
+        self::assertSame('anchor-tip', $payload['anchor']['chainTip']);
+        self::assertSame(3, $payload['anchor']['hmacEpoch']);
+    }
+
+    #[Test]
+    public function alertPayloadCarriesReasonCodeAndTamperFlag(): void
+    {
+        $client = new RecordingClient(new Response(200));
+
+        $this->createSubject(client: $client)->publishAlert(
+            AuditIntegrityAlert::create(AuditIntegrityReason::UidGap, '3 rows missing', ['missingUidCount' => 3]),
+        );
+
+        $payload = $client->decodeBody();
+        self::assertSame('alert', $payload['type']);
+        self::assertSame('UID_GAP', $payload['alert']['reason']);
+        self::assertTrue($payload['alert']['tamperEvidence']);
+        self::assertSame(3, $payload['alert']['context']['missingUidCount']);
+    }
+
+    /**
+     * Every record kind must be routable by a single collector endpoint, so the
+     * discriminator has to be present on all three.
+     */
+    #[Test]
+    public function everyRecordKindIsTaggedWithItsType(): void
+    {
+        $client = new RecordingClient(new Response(200));
+        $subject = $this->createSubject(client: $client);
+
+        $subject->publish($this->createEntry(), 'tip');
+        $entryType = $client->decodeBody()['type'];
+
+        $subject->publishAnchor(new ChainTipAnchor(1, 'tip', 1, 3));
+        $anchorType = $client->decodeBody()['type'];
+
+        $subject->publishAlert(AuditIntegrityAlert::create(AuditIntegrityReason::SinkFailure, 'x'));
+        $alertType = $client->decodeBody()['type'];
+
+        self::assertSame(['entry', 'anchor', 'alert'], [$entryType, $anchorType, $alertType]);
+    }
+
+    #[Test]
+    #[DataProvider('acceptedStatusProvider')]
+    public function twoHundredRangeResponsesAreAccepted(int $status): void
+    {
+        $subject = $this->createSubject(client: new RecordingClient(new Response($status)));
+
+        $subject->publish($this->createEntry(), 'tip');
+
+        // No exception thrown — the record was accepted.
+        $this->expectNotToPerformAssertions();
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function acceptedStatusProvider(): iterable
+    {
+        yield '200 OK' => [200];
+        yield '201 Created' => [201];
+        yield '202 Accepted' => [202];
+        yield '204 No Content' => [204];
+    }
+
+    /**
+     * A rejected record must surface. Treating a 4xx/5xx as delivered would mean
+     * the audit trail silently stops reaching the SIEM.
+     */
+    #[Test]
+    #[DataProvider('rejectedStatusProvider')]
+    public function nonSuccessResponseThrowsWithTheStatusCode(int $status): void
+    {
+        $subject = $this->createSubject(client: new RecordingClient(new Response($status)));
+
+        $this->expectException(AuditSinkException::class);
+        $this->expectExceptionMessage((string) $status);
+
+        $subject->publish($this->createEntry(), 'tip');
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function rejectedStatusProvider(): iterable
+    {
+        yield '301 redirect' => [301];
+        yield '400 bad request' => [400];
+        yield '401 unauthorized' => [401];
+        yield '404 not found' => [404];
+        yield '500 server error' => [500];
+    }
+
+    #[Test]
+    public function transportFailureIsWrappedInAnAuditSinkException(): void
+    {
+        $subject = $this->createSubject(
+            client: new ThrowingClient(new TestClientException('connection refused')),
+        );
+
+        $this->expectException(AuditSinkException::class);
+        $this->expectExceptionMessage('transport failed');
+
+        $subject->publish($this->createEntry(), 'tip');
+    }
+
+    /**
+     * The SSRF guard rejects a request before the socket opens, and a
+     * PSR-17 implementation can reject a malformed URI with a plain
+     * InvalidArgumentException. Neither is a ClientExceptionInterface, so both
+     * must still be normalised rather than escaping as a foreign type.
+     */
+    #[Test]
+    public function nonPsrThrowableFromTheClientIsAlsoNormalised(): void
+    {
+        $subject = $this->createSubject(
+            client: new ThrowingClient(new RuntimeException('resolves to a disallowed IP range')),
+        );
+
+        $this->expectException(AuditSinkException::class);
+        $this->expectExceptionMessage('disallowed IP range');
+
+        $subject->publish($this->createEntry(), 'tip');
+    }
+
+    /**
+     * A URL carrying a collector token must not reach the log through the
+     * exception message.
+     */
+    #[Test]
+    public function exceptionMessageDoesNotLeakTheEndpointUrl(): void
+    {
+        $subject = $this->createSubject(
+            url: 'https://siem.example.com/ingest?token=super-secret-token',
+            client: new ThrowingClient(new TestClientException('connection refused')),
+        );
+
+        try {
+            $subject->publish($this->createEntry(), 'tip');
+            self::fail('Expected AuditSinkException');
+        } catch (AuditSinkException $e) {
+            self::assertStringNotContainsString('super-secret-token', $e->getMessage());
+            self::assertStringNotContainsString('siem.example.com', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function publishingWithAnUnusableUrlThrowsRatherThanSendingNowhere(): void
+    {
+        $subject = $this->createSubject(url: '', client: new RecordingClient(new Response(200)));
+
+        $this->expectException(AuditSinkException::class);
+
+        $subject->publish($this->createEntry(), 'tip');
+    }
+
+    /**
+     * Invalid UTF-8 arrives from request headers (user agent). Failing the whole
+     * delivery on it would drop a legitimate audit record.
+     */
+    #[Test]
+    public function invalidUtf8IsSubstitutedRatherThanFailingTheDelivery(): void
+    {
+        $client = new RecordingClient(new Response(200));
+
+        $this->createSubject(client: $client)->publish(
+            $this->createEntry(userAgent: "Mozilla\xC3\x28"),
+            'tip',
+        );
+
+        self::assertIsString($client->decodeBody()['entry']['userAgent']);
+    }
+
+    private function createSubject(
+        bool $enabled = true,
+        string $url = self::ENDPOINT,
+        ?ClientInterface $client = null,
+    ): WebhookAuditSink {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('isAuditSinkWebhookEnabled')->willReturn($enabled);
+        $configuration->method('getAuditSinkWebhookUrl')->willReturn($url);
+
+        $factory = new HttpFactory();
+
+        return new WebhookAuditSink(
+            $configuration,
+            $client ?? new RecordingClient(new Response(200)),
+            $factory,
+            $factory,
+        );
+    }
+
+    private function createEntry(int $uid = 1, string $userAgent = 'Mozilla/5.0'): AuditLogEntry
+    {
+        return new AuditLogEntry(
+            uid: $uid,
+            secretIdentifier: 'api/stripe',
+            action: 'read',
+            success: true,
+            errorMessage: null,
+            reason: null,
+            actorUid: 7,
+            actorType: 'be_user',
+            actorUsername: 'editor',
+            actorRole: 'groups:1',
+            ipAddress: '203.0.113.7',
+            userAgent: $userAgent,
+            requestId: 'req-1',
+            previousHash: 'prev',
+            entryHash: 'hash-' . $uid,
+            hashBefore: '',
+            hashAfter: '',
+            crdate: 1_750_000_000,
+            context: [],
+        );
+    }
+}
+
+/**
+ * Records the last request and returns a canned response.
+ *
+ * A hand-written stub rather than a PHPUnit mock: the assertions here are about
+ * the request that was BUILT (method, URI, headers, body), and capturing it in a
+ * property reads better than an `->with()` callback that has to assert inside
+ * itself.
+ *
+ * @internal test helper
+ */
+final class RecordingClient implements ClientInterface
+{
+    public ?RequestInterface $lastRequest = null;
+
+    public function __construct(private readonly ResponseInterface $response) {}
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        $this->lastRequest = $request;
+
+        return $this->response;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function decodeBody(): array
+    {
+        $body = (string) $this->lastRequest?->getBody();
+        $decoded = json_decode($body, true, 512, JSON_THROW_ON_ERROR);
+
+        /** @var array<string, mixed> $decoded */
+        return \is_array($decoded) ? $decoded : [];
+    }
+}
+
+/**
+ * @internal test helper
+ */
+final readonly class ThrowingClient implements ClientInterface
+{
+    public function __construct(private Throwable $error) {}
+
+    public function sendRequest(RequestInterface $request): ResponseInterface
+    {
+        throw $this->error;
+    }
+}
+
+/**
+ * @internal test helper
+ */
+final class TestClientException extends RuntimeException implements ClientExceptionInterface {}

--- a/Tests/Unit/Audit/Sink/WebhookAuditSinkTest.php
+++ b/Tests/Unit/Audit/Sink/WebhookAuditSinkTest.php
@@ -81,7 +81,12 @@ final class WebhookAuditSinkTest extends TestCase
     #[Test]
     public function plainHttpIsAcceptedForOnPremiseCollectors(): void
     {
-        self::assertTrue($this->createSubject(url: 'http://collector.internal/ingest')->isEnabled());
+        // NOSONAR php:S5332 — this test deliberately asserts that plain HTTP is
+        // accepted for on-premise (RFC1918) collectors on an operator-controlled
+        // network; using https here would negate the behaviour under test. The
+        // sink is SSRF-guarded and the scheme choice is a documented operator
+        // decision, not a fixture that should be silently upgraded.
+        self::assertTrue($this->createSubject(url: 'http://collector.internal/ingest')->isEnabled()); // NOSONAR
     }
 
     #[Test]

--- a/Tests/Unit/Audit/Sink/WebhookAuditSinkTest.php
+++ b/Tests/Unit/Audit/Sink/WebhookAuditSinkTest.php
@@ -298,6 +298,49 @@ final class WebhookAuditSinkTest extends TestCase
         self::assertIsString($client->decodeBody()['entry']['userAgent']);
     }
 
+    /**
+     * A payload PHP cannot serialise must be reported before any request is
+     * attempted, so the registry counts it as a sink failure instead of the
+     * collector receiving a truncated body. Excessive nesting is the reachable
+     * case: `json_encode()` has a hard depth limit and the audit entry's
+     * `context` is caller-supplied structure.
+     */
+    #[Test]
+    public function unencodablePayloadThrowsBeforeAnyRequestIsSent(): void
+    {
+        $client = new RecordingClient(new Response(200));
+
+        try {
+            $this->createSubject(client: $client)->publish(
+                $this->createEntry(context: $this->deeplyNestedContext()),
+                'tip',
+            );
+            self::fail('an unencodable payload must not be reported as delivered');
+        } catch (AuditSinkException $e) {
+            self::assertStringContainsString('could not encode the record', $e->getMessage());
+        }
+
+        self::assertNull($client->lastRequest, 'nothing may be sent when the body cannot be built');
+    }
+
+    /**
+     * Nested past `json_encode()`'s default depth limit of 512.
+     *
+     * @return array<string, mixed>
+     */
+    private function deeplyNestedContext(): array
+    {
+        $context = [];
+        $cursor = &$context;
+        for ($depth = 0; $depth < 600; $depth++) {
+            $cursor['nested'] = [];
+            $cursor = &$cursor['nested'];
+        }
+        unset($cursor);
+
+        return $context;
+    }
+
     private function createSubject(
         bool $enabled = true,
         string $url = self::ENDPOINT,
@@ -317,7 +360,10 @@ final class WebhookAuditSinkTest extends TestCase
         );
     }
 
-    private function createEntry(int $uid = 1, string $userAgent = 'Mozilla/5.0'): AuditLogEntry
+    /**
+     * @param array<string, mixed> $context
+     */
+    private function createEntry(int $uid = 1, string $userAgent = 'Mozilla/5.0', array $context = []): AuditLogEntry
     {
         return new AuditLogEntry(
             uid: $uid,
@@ -338,7 +384,7 @@ final class WebhookAuditSinkTest extends TestCase
             hashBefore: '',
             hashAfter: '',
             crdate: 1_750_000_000,
-            context: [],
+            context: $context,
         );
     }
 }

--- a/Tests/Unit/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/Configuration/ExtensionConfigurationTest.php
@@ -15,8 +15,10 @@ use Netresearch\NrVault\Configuration\ExtensionConfiguration;
 use Netresearch\NrVault\Configuration\SecurityProfile;
 use Netresearch\NrVault\Exception\ConfigurationException;
 use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\EnvironmentSandboxTrait;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Configuration\ExtensionConfiguration as Typo3ExtensionConfiguration;
@@ -25,12 +27,26 @@ use TYPO3\CMS\Core\Configuration\ExtensionConfiguration as Typo3ExtensionConfigu
 #[AllowMockObjectsWithoutExpectations]
 final class ExtensionConfigurationTest extends TestCase
 {
+    use EnvironmentSandboxTrait;
+
     private Typo3ExtensionConfiguration&MockObject $typo3Config;
 
     protected function setUp(): void
     {
         parent::setUp();
         $this->typo3Config = $this->createMock(Typo3ExtensionConfiguration::class);
+
+        // The path getters (auto key path, audit sink paths) resolve their
+        // defaults through Environment, which the unit bootstrap leaves
+        // uninitialised.
+        $this->setUpEnvironmentSandbox();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownEnvironmentSandbox();
+
+        parent::tearDown();
     }
 
     #[Test]
@@ -605,5 +621,241 @@ final class ExtensionConfigurationTest extends TestCase
         $config = new ExtensionConfiguration($this->typo3Config);
 
         self::assertSame(SecurityProfile::Standard, $config->getSecurityProfile());
+    }
+
+    // ------------------------------------------------------------------
+    // Audit sinks
+    // ------------------------------------------------------------------
+
+    /**
+     * External sinks are opt-in: a default installation must not start writing
+     * audit copies to the filesystem or the network without being asked.
+     */
+    /**
+     * @param callable(ExtensionConfiguration): bool $read
+     */
+    #[Test]
+    #[DataProvider('auditSinkToggleProvider')]
+    public function auditSinkTogglesDefaultToDisabled(callable $read): void
+    {
+        $this->typo3Config->method('get')->willReturn([]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertFalse($read($config));
+    }
+
+    /**
+     * The toggles are passed as closures rather than method-name strings: a
+     * dynamic `$config->{$name}()` call is invisible to static analysis, so a
+     * renamed getter would silently stop being covered.
+     *
+     * @return iterable<string, array{callable(ExtensionConfiguration): bool}>
+     */
+    public static function auditSinkToggleProvider(): iterable
+    {
+        yield 'syslog' => [static fn (ExtensionConfiguration $c): bool => $c->isAuditSinkSyslogEnabled()];
+        yield 'file' => [static fn (ExtensionConfiguration $c): bool => $c->isAuditSinkFileEnabled()];
+        yield 'webhook' => [static fn (ExtensionConfiguration $c): bool => $c->isAuditSinkWebhookEnabled()];
+    }
+
+    /**
+     * @param callable(ExtensionConfiguration): bool $read
+     */
+    #[Test]
+    #[DataProvider('auditSinkToggleConfigurationProvider')]
+    public function auditSinkTogglesReflectConfiguration(string $key, callable $read, mixed $value, bool $expected): void
+    {
+        $this->typo3Config->method('get')->willReturn([$key => $value]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame($expected, $read($config));
+    }
+
+    /**
+     * @return iterable<string, array{string, callable(ExtensionConfiguration): bool, mixed, bool}>
+     */
+    public static function auditSinkToggleConfigurationProvider(): iterable
+    {
+        $syslog = static fn (ExtensionConfiguration $c): bool => $c->isAuditSinkSyslogEnabled();
+        $file = static fn (ExtensionConfiguration $c): bool => $c->isAuditSinkFileEnabled();
+        $webhook = static fn (ExtensionConfiguration $c): bool => $c->isAuditSinkWebhookEnabled();
+
+        // The extension configuration backend stores checkboxes as '1'/'0' strings.
+        yield 'syslog on' => ['auditSinkSyslogEnabled', $syslog, '1', true];
+        yield 'syslog off' => ['auditSinkSyslogEnabled', $syslog, '0', false];
+        yield 'file on' => ['auditSinkFileEnabled', $file, '1', true];
+        yield 'file off' => ['auditSinkFileEnabled', $file, '0', false];
+        yield 'webhook on' => ['auditSinkWebhookEnabled', $webhook, '1', true];
+        yield 'webhook off' => ['auditSinkWebhookEnabled', $webhook, '0', false];
+    }
+
+    #[Test]
+    public function syslogIdentReturnsConfiguredValue(): void
+    {
+        $this->typo3Config->method('get')->willReturn(['auditSinkSyslogIdent' => 'vault-prod']);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame('vault-prod', $config->getAuditSinkSyslogIdent());
+    }
+
+    /**
+     * A blank ident makes every syslog line unattributable, which defeats the
+     * point of the sink — so it falls back rather than passing '' to openlog().
+     */
+    #[Test]
+    #[DataProvider('unusableIdentProvider')]
+    public function unusableSyslogIdentFallsBackToTheDefault(mixed $value): void
+    {
+        $this->typo3Config->method('get')->willReturn(['auditSinkSyslogIdent' => $value]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame(
+            ExtensionConfiguration::DEFAULT_AUDIT_SINK_SYSLOG_IDENT,
+            $config->getAuditSinkSyslogIdent(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function unusableIdentProvider(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'whitespace only' => ['   '];
+        yield 'null' => [null];
+        yield 'non-string' => [42];
+    }
+
+    #[Test]
+    public function syslogIdentIsTrimmed(): void
+    {
+        $this->typo3Config->method('get')->willReturn(['auditSinkSyslogIdent' => "  vault-prod\n"]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame('vault-prod', $config->getAuditSinkSyslogIdent());
+    }
+
+    #[Test]
+    public function auditSinkFilePathReturnsConfiguredAbsolutePath(): void
+    {
+        $this->typo3Config->method('get')->willReturn(['auditSinkFilePath' => '/srv/audit/vault.ndjson']);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame('/srv/audit/vault.ndjson', $config->getAuditSinkFilePath());
+    }
+
+    /**
+     * The default must land outside the public web root, which `<var>/log/` does
+     * on every Composer-based installation — the sink refuses to run otherwise.
+     */
+    #[Test]
+    public function auditSinkFilePathDefaultsBelowTheVarLogDirectory(): void
+    {
+        $this->typo3Config->method('get')->willReturn([]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertStringEndsWith(
+            '/log/' . ExtensionConfiguration::DEFAULT_AUDIT_SINK_FILE_BASENAME,
+            $config->getAuditSinkFilePath(),
+        );
+    }
+
+    #[Test]
+    #[DataProvider('blankPathProvider')]
+    public function blankAuditSinkFilePathFallsBackToTheDefault(mixed $value): void
+    {
+        $this->typo3Config->method('get')->willReturn(['auditSinkFilePath' => $value]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertStringEndsWith(
+            '/log/' . ExtensionConfiguration::DEFAULT_AUDIT_SINK_FILE_BASENAME,
+            $config->getAuditSinkFilePath(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{mixed}>
+     */
+    public static function blankPathProvider(): iterable
+    {
+        yield 'empty string' => [''];
+        yield 'whitespace only' => ['  '];
+        yield 'null' => [null];
+        yield 'non-string' => [123];
+    }
+
+    #[Test]
+    public function auditSinkAnchorPathReturnsConfiguredAbsolutePath(): void
+    {
+        $this->typo3Config->method('get')->willReturn(['auditSinkAnchorPath' => '/mnt/wormfs/anchor.ndjson']);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame('/mnt/wormfs/anchor.ndjson', $config->getAuditSinkAnchorPath());
+    }
+
+    #[Test]
+    public function auditSinkAnchorPathDefaultsBelowTheVarLogDirectory(): void
+    {
+        $this->typo3Config->method('get')->willReturn([]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertStringEndsWith(
+            '/log/' . ExtensionConfiguration::DEFAULT_AUDIT_SINK_ANCHOR_BASENAME,
+            $config->getAuditSinkAnchorPath(),
+        );
+    }
+
+    /**
+     * The anchor stream is the evidence that survives a table reset, so it must be
+     * separately configurable rather than derived from the entry stream's path.
+     */
+    #[Test]
+    public function entryAndAnchorPathsAreIndependentByDefault(): void
+    {
+        $this->typo3Config->method('get')->willReturn([]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertNotSame($config->getAuditSinkFilePath(), $config->getAuditSinkAnchorPath());
+    }
+
+    #[Test]
+    public function webhookUrlReturnsConfiguredValueTrimmed(): void
+    {
+        $this->typo3Config->method('get')->willReturn(['auditSinkWebhookUrl' => '  https://siem.example.com/ingest  ']);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame('https://siem.example.com/ingest', $config->getAuditSinkWebhookUrl());
+    }
+
+    #[Test]
+    public function webhookUrlDefaultsToEmpty(): void
+    {
+        $this->typo3Config->method('get')->willReturn([]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame('', $config->getAuditSinkWebhookUrl());
+    }
+
+    #[Test]
+    public function nonStringWebhookUrlFallsBackToEmpty(): void
+    {
+        $this->typo3Config->method('get')->willReturn(['auditSinkWebhookUrl' => ['https://x']]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame('', $config->getAuditSinkWebhookUrl());
     }
 }

--- a/Tests/Unit/Fixtures/AuditChainLockHost.php
+++ b/Tests/Unit/Fixtures/AuditChainLockHost.php
@@ -1,0 +1,50 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Fixtures;
+
+use Netresearch\NrVault\Audit\AuditChainLockTrait;
+use TYPO3\CMS\Core\Database\Connection;
+
+/**
+ * Minimal host for {@see AuditChainLockTrait} so its lock primitives can be
+ * exercised directly.
+ *
+ * The trait's methods are private by design — the three production consumers
+ * (audit writer, migrate command, upgrade wizard) each reach them from inside
+ * their own class. Testing them through any one consumer would drag that
+ * consumer's whole write path into every lock assertion; this host isolates the
+ * lock protocol itself.
+ *
+ * @internal test fixture
+ */
+final class AuditChainLockHost
+{
+    use AuditChainLockTrait;
+
+    public function acquire(Connection $connection, bool $isSQLite): void
+    {
+        $this->acquireAuditLock($connection, $isSQLite);
+    }
+
+    public function commit(Connection $connection, bool $isSQLite): void
+    {
+        $this->commitAuditLock($connection, $isSQLite);
+    }
+
+    public function rollback(Connection $connection, bool $isSQLite): void
+    {
+        $this->rollbackAuditLock($connection, $isSQLite);
+    }
+
+    public function release(Connection $connection, bool $isSQLite): void
+    {
+        $this->releaseAuditLock($connection, $isSQLite);
+    }
+}

--- a/Tests/Unit/Fixtures/FailingStreamWrapper.php
+++ b/Tests/Unit/Fixtures/FailingStreamWrapper.php
@@ -1,0 +1,226 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Fixtures;
+
+use RuntimeException;
+
+/**
+ * A stream wrapper that reports a perfectly healthy, writable regular file and
+ * then fails at a chosen point of the write.
+ *
+ * ## Why a wrapper and not a real file
+ *
+ * The audit sinks guard their writes in layers: a pre-flight `assertAppendable()`
+ * check, then `fopen()`, then `flock()`, then a short-write check. The later
+ * layers are unreachable on a real filesystem *precisely because* the earlier
+ * ones work — a file that `fopen()` refuses is a file that `is_writable()`
+ * already rejected, and `flock()` does not fail on a local file that opened
+ * successfully. Short writes need a full disk.
+ *
+ * Those layers exist for hosts this code does not control (NFS with locking
+ * disabled, a full volume, a quota hit mid-write). A wrapper is the only way to
+ * put the production code in front of that filesystem without needing one, and
+ * it keeps the assertions on behaviour: which `AuditSinkException` message comes
+ * out, and whether the failure is contained.
+ *
+ * `url_stat()` deliberately reports a mode-0666 regular file (and a mode-0777
+ * directory for any path without a file extension) so that `file_exists()`,
+ * `is_file()`, `is_writable()` and `is_dir()` all succeed regardless of the
+ * running uid, and the sink's own guards pass.
+ *
+ * Usage:
+ *
+ * ```php
+ * FailingStreamWrapper::register(FailingStreamWrapper::MODE_LOCK_REFUSED);
+ * // … exercise code against FailingStreamWrapper::path('audit.ndjson') …
+ * FailingStreamWrapper::unregister();
+ * ```
+ *
+ * @internal test fixture
+ */
+final class FailingStreamWrapper
+{
+    public const SCHEME = 'nrvaultfail';
+
+    /** `fopen()` returns false, the classic "cannot open stream". */
+    public const MODE_OPEN_REFUSED = 'open-refused';
+
+    /**
+     * `fopen()` throws — what a host error handler that promotes warnings to
+     * exceptions (TYPO3's own does) produces instead of a false return.
+     */
+    public const MODE_OPEN_THROWS = 'open-throws';
+
+    /** The advisory lock cannot be taken (NFS without lock daemon, …). */
+    public const MODE_LOCK_REFUSED = 'lock-refused';
+
+    /** A short write — a full volume or an exceeded quota mid-line. */
+    public const MODE_SHORT_WRITE = 'short-write';
+
+    /** Everything succeeds; the baseline that proves the wrapper itself works. */
+    public const MODE_HEALTHY = 'healthy';
+
+    /** @var resource|null set by PHP when the wrapper is used */
+    public $context;
+
+    private static string $mode = self::MODE_HEALTHY;
+
+    private static string $written = '';
+
+    /** @var list<array{path: string, mode: string}> */
+    private static array $opens = [];
+
+    public static function register(string $mode): void
+    {
+        self::$mode = $mode;
+        self::$written = '';
+        self::$opens = [];
+
+        if (\in_array(self::SCHEME, stream_get_wrappers(), true)) {
+            stream_wrapper_unregister(self::SCHEME);
+        }
+
+        stream_wrapper_register(self::SCHEME, self::class);
+        clearstatcache(true);
+    }
+
+    public static function unregister(): void
+    {
+        if (\in_array(self::SCHEME, stream_get_wrappers(), true)) {
+            stream_wrapper_unregister(self::SCHEME);
+        }
+
+        self::$mode = self::MODE_HEALTHY;
+        clearstatcache(true);
+    }
+
+    /**
+     * Every `fopen()` seen since the last `register()`, with its mode.
+     *
+     * @return list<array{path: string, mode: string}>
+     */
+    public static function opens(): array
+    {
+        return self::$opens;
+    }
+
+    /**
+     * Everything handed to `stream_write()` since the last `register()`.
+     */
+    public static function writtenData(): string
+    {
+        return self::$written;
+    }
+
+    /**
+     * Absolute wrapper URL for a stream file inside a (virtual) directory.
+     */
+    public static function path(string $fileName): string
+    {
+        return self::SCHEME . '://streams/' . $fileName;
+    }
+
+    /**
+     * @param string $path Wrapper URL fopen() was called with
+     * @param string $mode The fopen() mode — recorded so a test can assert that
+     *                     the sink opens append-only rather than truncating
+     */
+    public function stream_open(string $path, string $mode): bool
+    {
+        self::$opens[] = ['path' => $path, 'mode' => $mode];
+
+        if (self::$mode === self::MODE_OPEN_THROWS) {
+            throw new RuntimeException('fopen(): failed to open stream: simulated host failure', 1750000001);
+        }
+
+        return self::$mode !== self::MODE_OPEN_REFUSED;
+    }
+
+    /**
+     * @param int $operation
+     */
+    public function stream_lock($operation): bool
+    {
+        // Unlocking always succeeds; only the exclusive acquisition is refused,
+        // which is the failure mode the sink guards against.
+        if (($operation & LOCK_UN) === LOCK_UN) {
+            return true;
+        }
+
+        return self::$mode !== self::MODE_LOCK_REFUSED;
+    }
+
+    /**
+     * @param string $data
+     *
+     * @return int Bytes "written"
+     */
+    public function stream_write($data): int
+    {
+        self::$written .= $data;
+
+        if (self::$mode === self::MODE_SHORT_WRITE) {
+            // One byte short of the line: enough to break the NDJSON contract.
+            return max(0, \strlen($data) - 1);
+        }
+
+        return \strlen($data);
+    }
+
+    public function stream_read(): string
+    {
+        return '';
+    }
+
+    public function stream_eof(): bool
+    {
+        return true;
+    }
+
+    public function stream_flush(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<int|string, int>
+     */
+    public function stream_stat(): array
+    {
+        return $this->statFor(self::SCHEME . '://streams/file.ndjson');
+    }
+
+    /**
+     * @return array<int|string, int>
+     */
+    public function url_stat(string $path): array
+    {
+        return $this->statFor($path);
+    }
+
+    /**
+     * A regular, world-writable file — unless the path has no extension, in
+     * which case it is the containing directory the sink probes with `is_dir()`.
+     *
+     * @return array<int|string, int>
+     */
+    private function statFor(string $path): array
+    {
+        $isDirectory = !str_contains(basename($path), '.');
+        $mode = $isDirectory ? 0o040777 : 0o100666;
+
+        return [
+            'dev' => 0, 'ino' => 0, 'mode' => $mode, 'nlink' => 1,
+            'uid' => 0, 'gid' => 0, 'rdev' => 0, 'size' => 0,
+            'atime' => 0, 'mtime' => 0, 'ctime' => 0,
+            'blksize' => -1, 'blocks' => -1,
+        ];
+    }
+}

--- a/Tests/Unit/Task/AuditAnchorTaskTest.php
+++ b/Tests/Unit/Task/AuditAnchorTaskTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Task;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Task\AuditAnchorTask;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+
+#[CoversClass(AuditAnchorTask::class)]
+final class AuditAnchorTaskTest extends TestCase
+{
+    #[Test]
+    public function successfulAnchoringReportsSuccess(): void
+    {
+        $service = self::createStub(ChainTipAnchorServiceInterface::class);
+        $service->method('capture')->willReturn(new ChainTipAnchor(10, 'tip', 1_750_000_000, 3));
+        $service->method('publish')->willReturn(2);
+
+        self::assertTrue((new AuditAnchorTask($service))->execute());
+    }
+
+    /**
+     * An anchor that reached no external sink gives no table-reset protection. A
+     * green scheduler entry would misreport that as working tamper evidence, so
+     * the task must fail.
+     */
+    #[Test]
+    public function anchoringThatReachedNoSinkFails(): void
+    {
+        $service = self::createStub(ChainTipAnchorServiceInterface::class);
+        $service->method('capture')->willReturn(new ChainTipAnchor(10, 'tip', 1_750_000_000, 3));
+        $service->method('publish')->willReturn(0);
+
+        self::assertFalse((new AuditAnchorTask($service))->execute());
+    }
+
+    #[Test]
+    public function captureFailureIsContainedAndReportedAsFailure(): void
+    {
+        $service = self::createStub(ChainTipAnchorServiceInterface::class);
+        $service->method('capture')->willThrowException(new RuntimeException('database unavailable'));
+
+        self::assertFalse((new AuditAnchorTask($service))->execute());
+    }
+
+    #[Test]
+    public function publishFailureIsContainedAndReportedAsFailure(): void
+    {
+        $service = self::createStub(ChainTipAnchorServiceInterface::class);
+        $service->method('capture')->willReturn(new ChainTipAnchor(10, 'tip', 1_750_000_000, 3));
+        $service->method('publish')->willThrowException(new RuntimeException('sink exploded'));
+
+        self::assertFalse((new AuditAnchorTask($service))->execute());
+    }
+
+    #[Test]
+    public function additionalInformationReportsTheCurrentSequence(): void
+    {
+        $service = self::createStub(ChainTipAnchorServiceInterface::class);
+        $service->method('capture')->willReturn(new ChainTipAnchor(128, 'tip', 1_750_000_000, 3));
+
+        self::assertStringContainsString('128', (new AuditAnchorTask($service))->getAdditionalInformation());
+    }
+
+    /**
+     * The scheduler list view must render even when the vault is misconfigured —
+     * otherwise an operator cannot reach the task to fix or disable it.
+     */
+    #[Test]
+    public function additionalInformationSurvivesAnUnavailableVault(): void
+    {
+        $service = self::createStub(ChainTipAnchorServiceInterface::class);
+        $service->method('capture')->willThrowException(new RuntimeException('no master key'));
+
+        self::assertNotSame('', (new AuditAnchorTask($service))->getAdditionalInformation());
+    }
+}

--- a/Tests/Unit/Task/AuditAnchorTaskTest.php
+++ b/Tests/Unit/Task/AuditAnchorTaskTest.php
@@ -16,10 +16,26 @@ use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Scheduler;
 
 #[CoversClass(AuditAnchorTask::class)]
 final class AuditAnchorTaskTest extends TestCase
 {
+    protected bool $resetSingletonInstances = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // TYPO3 v13's AbstractTask::__construct() resolves the Scheduler via
+        // GeneralUtility::makeInstance(); its 3-argument constructor is not
+        // autowirable in a unit-test context (no DI container), so register a
+        // stand-in. v14's AbstractTask no longer does this, but the mock is
+        // harmless there.
+        GeneralUtility::setSingletonInstance(Scheduler::class, $this->createMock(Scheduler::class));
+    }
+
     #[Test]
     public function successfulAnchoringReportsSuccess(): void
     {

--- a/Tests/Unit/Task/AuditVerifyTaskTest.php
+++ b/Tests/Unit/Task/AuditVerifyTaskTest.php
@@ -19,10 +19,24 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+use TYPO3\CMS\Scheduler\Scheduler;
 
 #[CoversClass(AuditVerifyTask::class)]
 final class AuditVerifyTaskTest extends TestCase
 {
+    protected bool $resetSingletonInstances = true;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // See AuditAnchorTaskTest::setUp() — v13's AbstractTask resolves the
+        // Scheduler through GeneralUtility, whose 3-arg constructor is not
+        // autowirable in a unit test.
+        GeneralUtility::setSingletonInstance(Scheduler::class, $this->createMock(Scheduler::class));
+    }
+
     #[Test]
     public function cleanReportReportsSuccess(): void
     {

--- a/Tests/Unit/Task/AuditVerifyTaskTest.php
+++ b/Tests/Unit/Task/AuditVerifyTaskTest.php
@@ -1,0 +1,164 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Task;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditIntegrityReport;
+use Netresearch\NrVault\Task\AuditVerifyTask;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+
+#[CoversClass(AuditVerifyTask::class)]
+final class AuditVerifyTaskTest extends TestCase
+{
+    #[Test]
+    public function cleanReportReportsSuccess(): void
+    {
+        $task = $this->createTask($this->report());
+
+        self::assertTrue($task->execute());
+    }
+
+    #[Test]
+    #[DataProvider('tamperReasonProvider')]
+    public function tamperEvidenceFailsRegardlessOfTheTamperOnlySetting(AuditIntegrityReason $reason, bool $tamperOnly): void
+    {
+        $task = $this->createTask($this->report($reason));
+        $task->setTaskParameters(['nr_vault_tamper_only' => $tamperOnly ? 1 : 0]);
+
+        self::assertFalse($task->execute());
+    }
+
+    /**
+     * @return iterable<string, array{AuditIntegrityReason, bool}>
+     */
+    public static function tamperReasonProvider(): iterable
+    {
+        foreach ([true, false] as $tamperOnly) {
+            $suffix = $tamperOnly ? ' (tamper-only)' : ' (strict)';
+            yield 'hash mismatch' . $suffix => [AuditIntegrityReason::HashMismatch, $tamperOnly];
+            yield 'uid gap' . $suffix => [AuditIntegrityReason::UidGap, $tamperOnly];
+            yield 'table reset' . $suffix => [AuditIntegrityReason::TableReset, $tamperOnly];
+            yield 'epoch downgrade' . $suffix => [AuditIntegrityReason::EpochDowngrade, $tamperOnly];
+        }
+    }
+
+    #[Test]
+    public function configurationFindingFailsByDefault(): void
+    {
+        $task = $this->createTask($this->report(AuditIntegrityReason::NoExternalSink));
+
+        self::assertFalse($task->execute());
+    }
+
+    /**
+     * The rollout escape hatch: while sinks are still being wired up, a pending
+     * integration must not keep the task permanently red — that would train
+     * operators to ignore it and mask a real tamper alarm.
+     */
+    #[Test]
+    public function configurationFindingPassesWhenTamperOnlyIsSet(): void
+    {
+        $task = $this->createTask($this->report(AuditIntegrityReason::NoExternalSink));
+        $task->setTaskParameters(['nr_vault_tamper_only' => 1]);
+
+        self::assertTrue($task->execute());
+    }
+
+    #[Test]
+    public function sinkFailureFindingPassesWhenTamperOnlyIsSet(): void
+    {
+        $task = $this->createTask($this->report(AuditIntegrityReason::SinkFailure));
+        $task->setTaskParameters(['nr_vault_tamper_only' => 1]);
+
+        self::assertTrue($task->execute());
+    }
+
+    /**
+     * A verification that could not run must never look like a verification that
+     * found nothing.
+     */
+    #[Test]
+    public function verificationThatCannotRunFails(): void
+    {
+        $service = self::createStub(ChainTipAnchorServiceInterface::class);
+        $service->method('verify')->willThrowException(new RuntimeException('database unavailable'));
+
+        self::assertFalse((new AuditVerifyTask($service))->execute());
+    }
+
+    #[Test]
+    public function verificationThatCannotRunFailsEvenInTamperOnlyMode(): void
+    {
+        $service = self::createStub(ChainTipAnchorServiceInterface::class);
+        $service->method('verify')->willThrowException(new RuntimeException('database unavailable'));
+
+        $task = new AuditVerifyTask($service);
+        $task->setTaskParameters(['nr_vault_tamper_only' => 1]);
+
+        self::assertFalse($task->execute());
+    }
+
+    #[Test]
+    public function taskParametersRoundTripThroughTheTcaField(): void
+    {
+        $task = $this->createTask($this->report());
+
+        $task->setTaskParameters(['nr_vault_tamper_only' => 1]);
+        self::assertSame(['nr_vault_tamper_only' => 1], $task->getTaskParameters());
+
+        $task->setTaskParameters(['nr_vault_tamper_only' => 0]);
+        self::assertSame(['nr_vault_tamper_only' => 0], $task->getTaskParameters());
+    }
+
+    #[Test]
+    public function absentParameterDefaultsToStrictMode(): void
+    {
+        $task = $this->createTask($this->report(AuditIntegrityReason::NoExternalSink));
+
+        $task->setTaskParameters([]);
+
+        self::assertSame(['nr_vault_tamper_only' => 0], $task->getTaskParameters());
+        self::assertFalse($task->execute(), 'strict mode fails on a configuration finding');
+    }
+
+    #[Test]
+    public function additionalInformationDistinguishesTheTwoModes(): void
+    {
+        $task = $this->createTask($this->report());
+
+        $strict = $task->getAdditionalInformation();
+        $task->setTaskParameters(['nr_vault_tamper_only' => 1]);
+
+        self::assertNotSame($strict, $task->getAdditionalInformation());
+    }
+
+    private function createTask(AuditIntegrityReport $report): AuditVerifyTask
+    {
+        $service = self::createStub(ChainTipAnchorServiceInterface::class);
+        $service->method('verify')->willReturn($report);
+
+        return new AuditVerifyTask($service);
+    }
+
+    private function report(?AuditIntegrityReason $reason = null): AuditIntegrityReport
+    {
+        return new AuditIntegrityReport(
+            findings: $reason instanceof AuditIntegrityReason ? [AuditIntegrityAlert::create($reason, 'detail')] : [],
+            chainValid: !$reason instanceof AuditIntegrityReason,
+            currentSequence: 10,
+        );
+    }
+}

--- a/Tests/Unit/Traits/EnvironmentSandboxTrait.php
+++ b/Tests/Unit/Traits/EnvironmentSandboxTrait.php
@@ -1,0 +1,128 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Traits;
+
+use TYPO3\CMS\Core\Core\ApplicationContext;
+use TYPO3\CMS\Core\Core\Environment;
+
+/**
+ * Gives a unit test a throwaway TYPO3 project layout and points
+ * {@see Environment} at it.
+ *
+ * Needed by anything that resolves a path through `Environment::getVarPath()` or
+ * checks a boundary against `Environment::getPublicPath()` — the audit file sink
+ * and the extension-configuration path defaults. `Environment` is a static
+ * singleton that the unit bootstrap leaves uninitialised, so those methods throw
+ * a `TypeError` until something initialises it.
+ *
+ * A real directory rather than vfsStream: the consumers use `realpath()`, which
+ * cannot resolve a stream-wrapper URL, so a virtual filesystem would force the
+ * production code to be loosened to suit the test.
+ *
+ * Usage: call `setUpEnvironmentSandbox()` from `setUp()` and
+ * `tearDownEnvironmentSandbox()` from `tearDown()`.
+ */
+trait EnvironmentSandboxTrait
+{
+    private string $environmentSandbox = '';
+
+    /**
+     * Create `<sandbox>/{public,var,config}` and point Environment at it.
+     */
+    private function setUpEnvironmentSandbox(): void
+    {
+        $this->environmentSandbox = sys_get_temp_dir() . '/nr-vault-env-' . bin2hex(random_bytes(6));
+
+        mkdir($this->environmentSandbox . '/public/fileadmin', 0o700, true);
+        mkdir($this->environmentSandbox . '/var', 0o700, true);
+        mkdir($this->environmentSandbox . '/config', 0o700, true);
+
+        $this->initializeEnvironment(
+            $this->environmentSandbox,
+            $this->environmentSandbox . '/public',
+            $this->environmentSandbox . '/var',
+            $this->environmentSandbox . '/config',
+        );
+    }
+
+    /**
+     * Remove the sandbox and re-point Environment at a path that still exists.
+     *
+     * Leaving the singleton referencing a deleted directory would give a later
+     * test in the same process a confusing failure far from its cause.
+     */
+    private function tearDownEnvironmentSandbox(): void
+    {
+        $this->removeSandboxDirectory($this->environmentSandbox);
+        $this->environmentSandbox = '';
+
+        $fallback = sys_get_temp_dir();
+        $this->initializeEnvironment($fallback, $fallback, $fallback, $fallback);
+    }
+
+    /**
+     * Absolute path of the sandbox root ('' before setUp / after tearDown).
+     */
+    private function getEnvironmentSandboxPath(): string
+    {
+        return $this->environmentSandbox;
+    }
+
+    private function initializeEnvironment(
+        string $projectPath,
+        string $publicPath,
+        string $varPath,
+        string $configPath,
+    ): void {
+        Environment::initialize(
+            new ApplicationContext('Testing'),
+            true,
+            true,
+            $projectPath,
+            $publicPath,
+            $varPath,
+            $configPath,
+            '',
+            'UNIX',
+        );
+    }
+
+    private function removeSandboxDirectory(string $directory): void
+    {
+        if ($directory === '' || !is_dir($directory)) {
+            return;
+        }
+
+        $items = scandir($directory);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.') {
+                continue;
+            }
+            if ($item === '..') {
+                continue;
+            }
+            $path = $directory . '/' . $item;
+            if (is_dir($path)) {
+                $this->removeSandboxDirectory($path);
+
+                continue;
+            }
+
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned temp path
+            unlink($path);
+        }
+
+        rmdir($directory);
+    }
+}

--- a/Tests/Unit/Traits/ErrorSuppressionTrait.php
+++ b/Tests/Unit/Traits/ErrorSuppressionTrait.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Traits;
+
+/**
+ * Runs a callable with PHP's diagnostics silenced.
+ *
+ * Needed where production code deliberately handles a native failure by
+ * inspecting the RETURN value rather than by suppressing the diagnostic: the
+ * audit sinks avoid `@` (the project's PHPStan ruleset forbids it) and instead
+ * check `fopen()`/`mkdir()` for `false` while normalising the throwing variant a
+ * host error handler would produce. Exercising the false-return branch therefore
+ * emits a genuine PHP warning, which PHPUnit escalates into a failing test under
+ * `failOnWarning`.
+ *
+ * Suppressing it here keeps the assertion on the behaviour under test (which
+ * exception the sink raises) instead of on the host's error-reporting
+ * configuration. Use it ONLY around the single call that is expected to warn.
+ */
+trait ErrorSuppressionTrait
+{
+    /**
+     * @template TReturn
+     *
+     * @param callable(): TReturn $callback
+     *
+     * @return TReturn
+     */
+    private function withoutPhpDiagnostics(callable $callback): mixed
+    {
+        set_error_handler(static fn (): bool => true);
+
+        try {
+            return $callback();
+        } finally {
+            restore_error_handler();
+        }
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -48,6 +48,36 @@ auditReads = 1
 # cat=Security; type=int+; label=Audit HMAC Epoch: Hash algorithm version marker for the audit log hash chain (0 = legacy SHA-256 without HMAC, 1 = HMAC-SHA256 over identity fields only, 2 = HMAC-SHA256 over identity + forensic fields including success/error_message/reason/ip_address/user_agent/context, 3 = additionally binds the epoch selector hmac_key_epoch plus the attribution fields actor_type/actor_username/actor_role/request_id). Default 3 closes the algorithm-downgrade forgery (a DB-write attacker can no longer downgrade a row to keyless SHA-256 and re-sign it) and makes actor attribution tamper-evident. Run the install-tool "Migrate audit hash chain" wizard after bumping.
 auditHmacEpoch = 3
 
+####################
+### AUDIT SINKS ###
+####################
+# External copies of the audit chain. The database table stays the ONE
+# chain-authoritative sink; these are additional, best-effort destinations that
+# put audit evidence beyond the reach of a database-write attacker. A sink that
+# fails NEVER fails the audited vault operation — the failure is logged, counted
+# and surfaced by "vault:audit-verify".
+
+# cat=Audit Sinks; type=boolean; label=Syslog Sink: Mirror every audit entry to the local syslog as an RFC 5424 structured-data message (facility local0). The cheapest way to get audit evidence off the TYPO3 database and into a log shipper.
+auditSinkSyslogEnabled = 0
+
+# cat=Audit Sinks; type=string; label=Syslog Ident: openlog() ident prefixed to every syslog line. Empty falls back to "nr-vault".
+auditSinkSyslogIdent = nr-vault
+
+# cat=Audit Sinks; type=boolean; label=NDJSON File Sink: Append every audit entry as one JSON object per line to an append-only file. Also writes the chain-tip anchors that let "vault:audit-verify" detect a full audit table reset.
+auditSinkFileEnabled = 0
+
+# cat=Audit Sinks; type=string; label=NDJSON File Path: Absolute path of the append-only audit file. Empty uses <var>/log/nr-vault-audit.ndjson. The sink refuses to run (and reports itself as disabled) when the path resolves inside the public web root.
+auditSinkFilePath =
+
+# cat=Audit Sinks; type=string; label=Anchor File Path: Absolute path of the append-only chain-tip anchor file written by "vault:audit-anchor" and read back by "vault:audit-verify". Empty uses <var>/log/nr-vault-audit-anchor.ndjson. Point this at a write-once / off-host location for real tamper evidence.
+auditSinkAnchorPath =
+
+# cat=Audit Sinks; type=boolean; label=Webhook Sink: POST every audit entry (and every integrity alert) as JSON to an HTTP endpoint — e.g. a SIEM collector.
+auditSinkWebhookEnabled = 0
+
+# cat=Audit Sinks; type=string; label=Webhook URL: https:// endpoint receiving the JSON payloads. Outbound calls go through the hardened HTTP client, so a collector on a private/RFC1918 address must be allow-listed literally in $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'] (a filesystem-bound setting, deliberately out of reach of the backend Settings module).
+auditSinkWebhookUrl =
+
 ##################
 ### PERFORMANCE ###
 ##################

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -84,6 +84,19 @@ parameters:
             message: '#Unknown parameter .* in call to method .*::setShortcutContext\(\)#'
             reportUnmatched: false
 
+        # Environment::initialize() carries @internal, but its own docblock reads
+        # "only used within the very early Set up of TYPO3, OR TO BE USED WITHIN
+        # TESTS" — and TYPO3's own testing framework calls it for exactly this
+        # purpose (UnitTestCase::restoreEnvironment()). There is no public
+        # alternative: getVarPath()/getPublicPath() throw a TypeError until the
+        # singleton is initialised, so a unit test covering a path default or the
+        # public-web-root boundary cannot run without it. Scoped to the one test
+        # helper that does this, so no production code can quietly follow suit.
+        -
+            message: '#Call to internal static method TYPO3\\CMS\\Core\\Core\\Environment::initialize\(\) from outside its root namespace TYPO3\.#'
+            path: Tests/Unit/Traits/EnvironmentSandboxTrait.php
+            reportUnmatched: false
+
     # PHP version targeting
     phpVersion: 80200
 


### PR DESCRIPTION
## Summary

P0 item 4 of the hardened-profile roadmap: the HMAC hash chain is tamper-**evident**, not tamper-**proof** — an attacker with DB write access can drop and re-seed the table. This PR anchors the audit log outside the database and makes manipulation externally detectable and alertable. Stacked on #237.

- **`AuditSinkInterface`** + three sinks: syslog (RFC 5424 structured data, SD-IDs under the IANA documentation PEN, control chars stripped against log forging), append-only NDJSON file (0600, `LOCK_EX`, refuses paths inside the public web root — resolved against the nearest existing ancestor so `..`/symlinks can't bypass), HTTP webhook (SSRF-guarded client, 3 s timeout).
- **Fan-out after commit + lock release:** the DB chain write stays authoritative; a slow sink can never serialize vault operations behind the advisory lock, and a sink failure never fails or rolls back the audited operation (logged, counted, surfaced as `SINK_FAILURE`).
- **Chain-tip anchoring:** `vault:audit-anchor` exports `{sequence, chainTip, timestamp, hmacEpoch}` through the sinks; the reader takes the **highest** anchored sequence, so appending a low anchor cannot weaken the baseline.
- **`vault:audit-verify`** = hash-chain verification **+** anchor comparison: a full table reset re-seeded with a valid-but-different chain is reported as `TABLE_RESET` even though the chain itself verifies (covered by a functional test that really truncates + re-seeds, incl. the longer-than-anchor and deleted-anchored-row variants). Machine-readable reason codes: `HASH_MISMATCH`, `UID_GAP`, `TABLE_RESET`, `EPOCH_DOWNGRADE`, `SINK_FAILURE`, `NO_EXTERNAL_SINK` (hardened finding), `BREAK_GLASS` (reserved for #240-line work).
- Scheduler tasks for both; non-zero exit / failed task on findings; PSR-14 `AuditIntegrityAlertEvent` forwarded through enabled sinks for SIEM pickup.
- New config category "Audit Sinks" (7 keys, all off by default).

**Operational note:** the webhook sink uses the SSRF-guarded HTTP client — an on-prem RFC1918 collector needs an explicit `HTTP.allowed_hosts` entry; the refusal is loud (logged + counted + finding). Documented in the configuration reference.

## Test plan
- `composer ci` exit 0 (2415 unit + 1514 fuzz), PHPStan 10 clean (one scoped, documented ignore for `Environment::initialize()` in a **test-only** sandbox trait), Rector clean, full functional suite green locally (212 tests, sqlite), CLI docs check green (15 commands).
- 175 new unit tests + 14 functional (incl. the real table-reset detection matrix).

Roadmap: PR 5 of 10 — follows #237; independent of #238.
