### PR TITLE
Make the admin override disableable with an audited break-glass window

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -98,6 +98,11 @@ This extension handles sensitive data. Non-negotiable rules:
 5. **Audit every access** — reads/writes/rotations/deletes all create audit log entries.
 6. **Access control** — respect backend user groups & ownership via `AccessControlServiceInterface`.
 7. **Tamper-evident audit log** — HMAC hash chain; verify on schedule (see `VaultAuditCommand`).
+8. **One admin-bypass seam** — every "admins may do anything" decision goes through the private
+   `AccessControlService::adminBypassActive()`. Never inline `isAdmin()`/`isSystemMaintainer()` in a
+   caller, and never route a grant lookup through `BackendUserAuthentication::check()` (core
+   short-circuits it to `true` for admins). The hardened profile can disable the bypass
+   (`disableAdminOverride`); a half-disabled override is worse than none.
 
 ## Key Interfaces
 > Authoritative source: the `*Interface.php` files. This is a cheat-sheet — read the PHP for full docblocks.
@@ -130,6 +135,13 @@ MasterKeyProviderInterface::getMasterKey(): string
 TechnicalActorContextInterface::runAs(int $beUserUid, callable $fn): mixed
 TechnicalActorContextInterface::getCurrentActor(): ?TechnicalActor
 
+// Break-glass (time-boxed restore of the admin override) — Classes/Security/BreakGlassServiceInterface.php
+BreakGlassServiceInterface::activate(string $reason, int $minutes = 15): BreakGlassSession
+BreakGlassServiceInterface::deactivate(string $reason): void
+// Read-only seam consumed by AccessControlService — Classes/Security/BreakGlassStateInterface.php
+BreakGlassStateInterface::getActiveSession(): ?BreakGlassSession
+BreakGlassStateInterface::isActive(): bool
+
 // Audit logging — Classes/Audit/AuditLogServiceInterface.php
 AuditLogServiceInterface::log(
     string $secretIdentifier, string $action, bool $success,
@@ -142,7 +154,7 @@ AuditLogServiceInterface::verifyHashChain(?int $fromUid = null, ?int $toUid = nu
 ```
 
 ## CLI Commands (TYPO3 `vendor/bin/typo3`)
-> All 13 registered `vault:*` commands. Full options/examples in
+> All 14 registered `vault:*` commands. Full options/examples in
 > `Documentation/Developer/Commands.rst`.
 ```
 vault:init                 # Initialize the vault (generate master key, verify configuration)
@@ -157,6 +169,7 @@ vault:audit                # View / verify audit log entries
 vault:audit-migrate-hmac   # Migrate audit log hash chain from SHA-256 to HMAC-SHA256
 vault:rotate-master-key    # Re-encrypt all secrets with a new master key
 vault:cleanup-orphans      # Clean up orphaned vault entries (scheduled task wrapper)
+vault:break-glass          # Open/close/inspect a time-boxed break-glass window (restores the admin override)
 vault:seed-demo            # Seed demo secrets + audit history (development only)
 ```
 

--- a/Build/phpunit.xml
+++ b/Build/phpunit.xml
@@ -55,6 +55,8 @@
             <file>../Classes/Domain/Repository/SecretRepositoryInterface.php</file>
             <file>../Classes/Http/VaultHttpClientInterface.php</file>
             <file>../Classes/Security/AccessControlServiceInterface.php</file>
+            <file>../Classes/Security/BreakGlassServiceInterface.php</file>
+            <file>../Classes/Security/BreakGlassStateInterface.php</file>
             <file>../Classes/Service/SecretDetectionServiceInterface.php</file>
             <file>../Classes/Service/VaultServiceInterface.php</file>
             <file>../Classes/Service/Detection/SecretFinding.php</file>

--- a/Classes/Audit/AuditAction.php
+++ b/Classes/Audit/AuditAction.php
@@ -39,6 +39,8 @@ enum AuditAction: string
     case OAuthFallbackClientCredentials = 'oauth_fallback_client_credentials';
     case OAuthRefreshStoreFailed = 'oauth_refresh_store_failed';
     case AuditReadLoggingChanged = 'audit_read_logging_changed';
+    case BreakGlassActivated = 'break_glass_activated';
+    case BreakGlassDeactivated = 'break_glass_deactivated';
 
     /**
      * Human-readable label for backend filter dropdowns.

--- a/Classes/Command/VaultBreakGlassCommand.php
+++ b/Classes/Command/VaultBreakGlassCommand.php
@@ -1,0 +1,228 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Command;
+
+use DateTimeImmutable;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Exception\VaultException;
+use Netresearch\NrVault\Security\BreakGlassServiceInterface;
+use Netresearch\NrVault\Security\BreakGlassSession;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+/**
+ * CLI command to open, close and inspect a break-glass window.
+ *
+ * The CLI is the primary surface on purpose: `disableAdminOverride` is meant to
+ * be pinned in :file:`config/system/additional.php`, so the recovery path must
+ * not depend on a backend module an admin may have just locked themselves out
+ * of. A shell on the host is already root-equivalent for the vault.
+ *
+ * Usage:
+ *   vendor/bin/typo3 vault:break-glass --status
+ *   vendor/bin/typo3 vault:break-glass --activate --reason "INC-1234 rotate leaked key" --minutes=30
+ *   vendor/bin/typo3 vault:break-glass --deactivate --reason "INC-1234 closed"
+ */
+#[AsCommand(
+    name: 'vault:break-glass',
+    description: 'Open, close or inspect a time-boxed break-glass window that restores the admin override',
+)]
+final class VaultBreakGlassCommand extends Command
+{
+    public function __construct(
+        private readonly BreakGlassServiceInterface $breakGlassService,
+        private readonly ExtensionConfigurationInterface $configuration,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'activate',
+                'a',
+                InputOption::VALUE_NONE,
+                'Open a break-glass window (requires --reason)',
+            )
+            ->addOption(
+                'deactivate',
+                'd',
+                InputOption::VALUE_NONE,
+                'Close the open break-glass window early (requires --reason)',
+            )
+            ->addOption(
+                'status',
+                's',
+                InputOption::VALUE_NONE,
+                'Show the current break-glass state (default when no action is given)',
+            )
+            ->addOption(
+                'reason',
+                'r',
+                InputOption::VALUE_REQUIRED,
+                'Justification recorded in the audit log — mandatory for --activate and --deactivate',
+            )
+            ->addOption(
+                'minutes',
+                'm',
+                InputOption::VALUE_REQUIRED,
+                \sprintf(
+                    'Window length in minutes, clamped to %d..%d',
+                    BreakGlassServiceInterface::MIN_TTL_MINUTES,
+                    BreakGlassServiceInterface::MAX_TTL_MINUTES,
+                ),
+                BreakGlassServiceInterface::DEFAULT_TTL_MINUTES,
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        $activate = (bool) $input->getOption('activate');
+        $deactivate = (bool) $input->getOption('deactivate');
+        $status = (bool) $input->getOption('status');
+
+        $actions = \count(array_filter([$activate, $deactivate, $status]));
+        if ($actions > 1) {
+            $io->error('Choose exactly one of --activate, --deactivate or --status.');
+
+            return Command::INVALID;
+        }
+
+        if ($activate) {
+            return $this->activate($io, $input);
+        }
+
+        if ($deactivate) {
+            return $this->deactivate($io, $input);
+        }
+
+        // No action given: report state. Reading the state is the safe default
+        // for a command whose other modes change the security posture.
+        return $this->status($io);
+    }
+
+    private function activate(SymfonyStyle $io, InputInterface $input): int
+    {
+        $reasonOption = $input->getOption('reason');
+        $reason = \is_string($reasonOption) ? $reasonOption : '';
+        $minutesOption = $input->getOption('minutes');
+        $minutes = is_numeric($minutesOption)
+            ? (int) $minutesOption
+            : BreakGlassServiceInterface::DEFAULT_TTL_MINUTES;
+
+        try {
+            $session = $this->breakGlassService->activate($reason, $minutes);
+        } catch (VaultException $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $io->warning('Break-glass mode is ACTIVE — the admin override is restored for this window.');
+        $this->printSession($io, $session);
+
+        if (!$this->overrideIsEffectivelyDisabled()) {
+            $io->note(
+                'Note: the admin override was not disabled to begin with '
+                . '(disableAdminOverride is off, or the security profile is not "hardened"), '
+                . 'so this window grants no additional power. It is still logged.',
+            );
+        }
+
+        return Command::SUCCESS;
+    }
+
+    private function deactivate(SymfonyStyle $io, InputInterface $input): int
+    {
+        $reasonOption = $input->getOption('reason');
+        $reason = \is_string($reasonOption) ? $reasonOption : '';
+
+        $wasActive = $this->breakGlassService->isActive();
+
+        try {
+            $this->breakGlassService->deactivate($reason);
+        } catch (VaultException $e) {
+            $io->error($e->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        if ($wasActive) {
+            $io->success('Break-glass window closed. The admin override is disabled again.');
+        } else {
+            $io->text('status: inactive');
+            $io->success('No break-glass window was open — nothing to close.');
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Report state. Always exits 0: "no window is open" is a successful answer,
+     * not a failure, and a monitoring probe should distinguish the two states by
+     * parsing `status:` rather than by an exit code that also means "the command
+     * broke".
+     */
+    private function status(SymfonyStyle $io): int
+    {
+        $session = $this->breakGlassService->getActiveSession();
+
+        $io->definitionList(
+            ['securityProfile' => $this->configuration->getSecurityProfile()->value],
+            ['disableAdminOverride' => $this->configuration->isAdminOverrideDisabled() ? 'yes' : 'no'],
+            ['adminOverrideDisabledEffective' => $this->overrideIsEffectivelyDisabled() ? 'yes' : 'no'],
+        );
+
+        if (!$session instanceof BreakGlassSession) {
+            $io->text('status: inactive');
+
+            return Command::SUCCESS;
+        }
+
+        $io->text('status: active');
+        $this->printSession($io, $session);
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * Is the override actually off right now — i.e. is break-glass load-bearing
+     * in this installation, or merely recorded?
+     *
+     * Mirrors the profile gate in
+     * `AccessControlService::adminBypassActive()`; the flag alone does nothing
+     * outside the hardened profile.
+     */
+    private function overrideIsEffectivelyDisabled(): bool
+    {
+        return $this->configuration->isAdminOverrideDisabled()
+            && $this->configuration->getSecurityProfile()->isHardened();
+    }
+
+    private function printSession(SymfonyStyle $io, BreakGlassSession $session): void
+    {
+        $remaining = $session->remainingSeconds(new DateTimeImmutable());
+
+        $io->definitionList(
+            ['activatedBy' => \sprintf('%s (uid %d)', $session->activatedByUsername, $session->activatedByUid)],
+            ['reason' => $session->reason],
+            ['activatedAt' => $session->activatedAt->format(DateTimeImmutable::ATOM)],
+            ['expiresAt' => $session->expiresAt->format(DateTimeImmutable::ATOM)],
+            ['remainingSeconds' => (string) $remaining],
+        );
+    }
+}

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -38,6 +38,8 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
 
     public const DEFAULT_AUDIT_READS = true;
 
+    public const DEFAULT_DISABLE_ADMIN_OVERRIDE = false;
+
     public const DEFAULT_PREFER_XCHACHA20 = false;
 
     /**
@@ -205,15 +207,31 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
      */
     public function isAuditReadsEnabled(): bool
     {
-        $sys = \is_array($GLOBALS['TYPO3_CONF_VARS'] ?? null)
-            && \is_array($GLOBALS['TYPO3_CONF_VARS']['SYS'] ?? null)
-                ? $GLOBALS['TYPO3_CONF_VARS']['SYS'] : [];
-        $nrVault = \is_array($sys['nrVault'] ?? null) ? $sys['nrVault'] : [];
-        if (\array_key_exists('auditReads', $nrVault)) {
-            return (bool) $nrVault['auditReads'];
-        }
+        return $this->pinnedOverride('auditReads')
+            ?? (bool) ($this->configuration['auditReads'] ?? self::DEFAULT_AUDIT_READS);
+    }
 
-        return (bool) ($this->configuration['auditReads'] ?? self::DEFAULT_AUDIT_READS);
+    /**
+     * Is the admin / system-maintainer bypass disabled?
+     *
+     * Resolution order is identical to {@see self::isAuditReadsEnabled()} —
+     * the `$TYPO3_CONF_VARS[SYS][nrVault][disableAdminOverride]` override wins
+     * over the BE-editable extension configuration — and for the same reason,
+     * only sharper here: a compromised admin must not be able to silently
+     * re-enable their own bypass from the backend Settings module. Pin the
+     * value in `config/system/additional.php` and the only way back is
+     * filesystem access (or a time-boxed, audited break-glass session).
+     *
+     * The flag is only EFFECTIVE in the Hardened security profile — see
+     * {@see \Netresearch\NrVault\Security\AccessControlService} for the
+     * footgun-lockout rationale. This getter reports the raw configuration, so
+     * a diagnostic tool can pair it with {@see self::getSecurityProfile()} and
+     * report the "flag set but profile is standard" mismatch.
+     */
+    public function isAdminOverrideDisabled(): bool
+    {
+        return $this->pinnedOverride('disableAdminOverride')
+            ?? (bool) ($this->configuration['disableAdminOverride'] ?? self::DEFAULT_DISABLE_ADMIN_OVERRIDE);
     }
 
     /**
@@ -318,5 +336,26 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
     public function getAutoKeyPath(): string
     {
         return Environment::getVarPath() . '/secrets/vault-master.key';
+    }
+
+    /**
+     * Read a boolean setting pinned in
+     * `$TYPO3_CONF_VARS[SYS][nrVault][<key>]` — typically set in
+     * `LocalConfiguration.php` / `additional.php`, where it is NOT reachable
+     * from the BE Settings module. (Other `ext_localconf.php` files can
+     * technically write it too; treat the override as filesystem-bound only
+     * when the rest of the bootstrap is trusted.)
+     *
+     * Returns null when the key is absent, so callers fall through to the
+     * BE-editable extension configuration.
+     */
+    private function pinnedOverride(string $key): ?bool
+    {
+        $sys = \is_array($GLOBALS['TYPO3_CONF_VARS'] ?? null)
+            && \is_array($GLOBALS['TYPO3_CONF_VARS']['SYS'] ?? null)
+                ? $GLOBALS['TYPO3_CONF_VARS']['SYS'] : [];
+        $nrVault = \is_array($sys['nrVault'] ?? null) ? $sys['nrVault'] : [];
+
+        return \array_key_exists($key, $nrVault) ? (bool) $nrVault[$key] : null;
     }
 }

--- a/Classes/Configuration/ExtensionConfigurationInterface.php
+++ b/Classes/Configuration/ExtensionConfigurationInterface.php
@@ -70,6 +70,21 @@ interface ExtensionConfigurationInterface
     public function isAuditReadsEnabled(): bool;
 
     /**
+     * Is the unconditional admin / system-maintainer bypass disabled?
+     *
+     * Honours a `$TYPO3_CONF_VARS[SYS][nrVault][disableAdminOverride]`
+     * filesystem override ahead of the BE-editable extension configuration, so
+     * a compromised admin cannot re-enable their own bypass from the Settings
+     * module.
+     *
+     * Reports the raw configuration. The flag only takes EFFECT in the
+     * {@see SecurityProfile::Hardened} profile; pair this with
+     * {@see self::getSecurityProfile()} to detect the "flag set while the
+     * profile is standard" mismatch.
+     */
+    public function isAdminOverrideDisabled(): bool;
+
+    /**
      * Check if XChaCha20-Poly1305 should be preferred over AES-256-GCM.
      *
      * Only consulted for legacy (encryption version 1) envelopes without a

--- a/Classes/Controller/AuditController.php
+++ b/Classes/Controller/AuditController.php
@@ -428,6 +428,10 @@ final readonly class AuditController
             'delete' => 'danger',
             'rotate' => 'info',
             'access_denied' => 'danger',
+            // A break-glass activation is the most review-worthy row in the
+            // log; it must not blend into the grey default.
+            'break_glass_activated' => 'danger',
+            'break_glass_deactivated' => 'success',
             default => 'secondary',
         };
     }

--- a/Classes/Controller/BreakGlassBannerProvider.php
+++ b/Classes/Controller/BreakGlassBannerProvider.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Controller;
+
+use DateTimeImmutable;
+use Netresearch\NrVault\Security\BreakGlassSession;
+use Netresearch\NrVault\Security\BreakGlassStateInterface;
+
+/**
+ * View model for the break-glass warning banner.
+ *
+ * Centralised in one collaborator (same reasoning as {@see ModuleAccessGuard})
+ * so every vault module renders the identical warning from the identical data,
+ * and so the shaping stays unit-testable without booting a backend module.
+ */
+final readonly class BreakGlassBannerProvider
+{
+    private const DATE_FORMAT = 'Y-m-d H:i';
+
+    public function __construct(
+        private BreakGlassStateInterface $breakGlassState,
+    ) {}
+
+    /**
+     * Banner data for `Partials/BreakGlassBanner.html`.
+     *
+     * `active => false` is returned as a complete shape rather than an empty
+     * array so the Fluid partial always has every key it reads — a missing key
+     * would render as an empty string and could turn a live warning into a
+     * half-blank box.
+     *
+     * @return array{active: bool, username: string, uid: int, reason: string, expiresAt: string, remainingMinutes: int}
+     */
+    public function forView(): array
+    {
+        $session = $this->breakGlassState->getActiveSession();
+        if (!$session instanceof BreakGlassSession) {
+            return [
+                'active' => false,
+                'username' => '',
+                'uid' => 0,
+                'reason' => '',
+                'expiresAt' => '',
+                'remainingMinutes' => 0,
+            ];
+        }
+
+        $remainingSeconds = $session->remainingSeconds(new DateTimeImmutable());
+
+        return [
+            'active' => true,
+            'username' => $session->activatedByUsername,
+            'uid' => $session->activatedByUid,
+            'reason' => $session->reason,
+            'expiresAt' => $session->expiresAt->format(self::DATE_FORMAT),
+            // Round UP: showing "0 minutes left" while the bypass is still live
+            // understates the exposure the operator is being warned about.
+            'remainingMinutes' => (int) ceil($remainingSeconds / 60),
+        ];
+    }
+}

--- a/Classes/Controller/OverviewController.php
+++ b/Classes/Controller/OverviewController.php
@@ -37,6 +37,7 @@ final readonly class OverviewController
         private BackendUriBuilder $backendUriBuilder,
         private PageRenderer $pageRenderer,
         private ModuleAccessGuard $accessGuard,
+        private BreakGlassBannerProvider $breakGlassBanner,
     ) {}
 
     /**
@@ -78,6 +79,7 @@ final readonly class OverviewController
             'stats' => $stats,
             'healthChecks' => $healthChecks,
             'submodules' => $this->getAccessibleSubmodules($lang),
+            'breakGlass' => $this->breakGlassBanner->forView(),
         ]);
 
         return $moduleTemplate->renderResponse('Overview/Index');

--- a/Classes/Controller/SecretsController.php
+++ b/Classes/Controller/SecretsController.php
@@ -61,6 +61,7 @@ final readonly class SecretsController
         private ConnectionPool $connectionPool,
         private AuditLogServiceInterface $auditLogService,
         private ModuleAccessGuard $accessGuard,
+        private BreakGlassBannerProvider $breakGlassBanner,
     ) {}
 
     /**
@@ -149,6 +150,7 @@ final readonly class SecretsController
             'canRotate' => $this->accessGuard->isGranted(VaultPermission::SecretRotate),
             'canDelete' => $this->accessGuard->isGranted(VaultPermission::SecretDelete),
             'canManagePolicy' => $this->accessGuard->isGranted(VaultPermission::SecretManagePolicy),
+            'breakGlass' => $this->breakGlassBanner->forView(),
         ]);
 
         $moduleTemplate->setTitle(

--- a/Classes/Event/BreakGlassActivatedEvent.php
+++ b/Classes/Event/BreakGlassActivatedEvent.php
@@ -1,0 +1,57 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Event;
+
+use DateTimeImmutable;
+
+/**
+ * Event dispatched when a break-glass window is opened.
+ *
+ * Dispatched AFTER the window is persisted and its audit row written, so a
+ * listener never announces a window that failed to open. This is the hook for
+ * out-of-band alerting — paging the security channel, opening an incident
+ * ticket, mailing the compliance mailbox: the vault's own audit log proves what
+ * happened, but a listener is what makes someone LOOK.
+ */
+final readonly class BreakGlassActivatedEvent
+{
+    public function __construct(
+        private int $actorUid,
+        private string $actorUsername,
+        private string $reason,
+        private DateTimeImmutable $expiresAt,
+    ) {}
+
+    public function getActorUid(): int
+    {
+        return $this->actorUid;
+    }
+
+    public function getActorUsername(): string
+    {
+        return $this->actorUsername;
+    }
+
+    /**
+     * The operator's mandatory justification.
+     */
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    /**
+     * When the window closes on its own, with no further action.
+     */
+    public function getExpiresAt(): DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+}

--- a/Classes/Event/BreakGlassDeactivatedEvent.php
+++ b/Classes/Event/BreakGlassDeactivatedEvent.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Event;
+
+use DateTimeImmutable;
+
+/**
+ * Event dispatched when a break-glass window is closed early.
+ *
+ * Only an explicit `deactivate()` dispatches this. A window that simply runs
+ * out does NOT — expiry is evaluated at read time and involves no code running
+ * at the moment it lapses, so there is nothing to dispatch from. Listeners that
+ * need to know a window is no longer open must compare
+ * {@see BreakGlassActivatedEvent::getExpiresAt()} against the clock rather than
+ * wait for this event.
+ */
+final readonly class BreakGlassDeactivatedEvent
+{
+    public function __construct(
+        private int $actorUid,
+        private string $actorUsername,
+        private string $reason,
+        private DateTimeImmutable $expiresAt,
+    ) {}
+
+    public function getActorUid(): int
+    {
+        return $this->actorUid;
+    }
+
+    public function getActorUsername(): string
+    {
+        return $this->actorUsername;
+    }
+
+    /**
+     * The mandatory justification given for closing the window.
+     */
+    public function getReason(): string
+    {
+        return $this->reason;
+    }
+
+    /**
+     * When the closed window WOULD have expired on its own.
+     */
+    public function getExpiresAt(): DateTimeImmutable
+    {
+        return $this->expiresAt;
+    }
+}

--- a/Classes/Exception/AccessDeniedException.php
+++ b/Classes/Exception/AccessDeniedException.php
@@ -28,4 +28,24 @@ final class AccessDeniedException extends VaultException
     {
         return new self('CLI access to vault is disabled', 1703800004);
     }
+
+    /**
+     * Only a real backend admin / system maintainer or a real CLI operator may
+     * open or close a break-glass window.
+     *
+     * Deliberately NOT gated on a `VaultPermission`: break-glass exists to
+     * recover from a state where the granular grants are what is missing, so
+     * gating it on one of them would make it unreachable exactly when it is
+     * needed.
+     */
+    public static function breakGlassRequiresAdmin(string $operation): self
+    {
+        return new self(
+            \sprintf(
+                'Break-glass %s requires an authenticated backend administrator or a CLI context',
+                $operation,
+            ),
+            1753900001,
+        );
+    }
 }

--- a/Classes/Exception/ValidationException.php
+++ b/Classes/Exception/ValidationException.php
@@ -34,4 +34,17 @@ final class ValidationException extends VaultException
             1703800014,
         );
     }
+
+    /**
+     * A justification that only exists in the audit log is worthless if it is
+     * empty, so the reason is a hard precondition rather than an optional
+     * annotation.
+     */
+    public static function missingReason(string $operation): self
+    {
+        return new self(
+            \sprintf('A non-empty reason is required for %s', $operation),
+            1753900002,
+        );
+    }
 }

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -21,6 +21,7 @@ use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Http\ApplicationType;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
  * Access control service implementation.
@@ -58,6 +59,14 @@ final class AccessControlService implements AccessControlServiceInterface
         private readonly ExtensionConfigurationInterface $configuration,
         private readonly ?ConnectionPool $connectionPool = null,
         private readonly ?TechnicalActorContextInterface $technicalActorContext = null,
+        /**
+         * Read-only view of the break-glass window (never the full service —
+         * see {@see BreakGlassStateInterface} for the DI-cycle reason).
+         * Optional so the ~40 unit tests that construct this service with a
+         * configuration mock alone keep working: absent state means "no window
+         * open", which is the fail-closed answer.
+         */
+        private readonly ?BreakGlassStateInterface $breakGlassState = null,
     ) {}
 
     public function canRead(Secret $secret): bool
@@ -148,14 +157,11 @@ final class AccessControlService implements AccessControlServiceInterface
                 return false;
             }
 
-            if ($this->adminOverrideGrants($backendUser)) {
+            if ($this->adminBypassActive($this->isPrivilegedBackendUser($backendUser))) {
                 return true;
             }
 
-            return $backendUser->check(
-                'custom_options',
-                self::PERM_OPTION_GROUP . ':' . $permission->value,
-            );
+            return $this->hasCustomPermissionOption($backendUser, $permission);
         }
 
         // No backend user at all but a real CLI context (no BE_USER global
@@ -172,7 +178,7 @@ final class AccessControlService implements AccessControlServiceInterface
     {
         $technicalActor = $this->getTechnicalActor();
         if ($technicalActor instanceof TechnicalActor) {
-            return $technicalActor->admin;
+            return $this->adminBypassActive($technicalActor->admin);
         }
 
         $backendUser = $this->getBackendUser();
@@ -183,7 +189,14 @@ final class AccessControlService implements AccessControlServiceInterface
             return false;
         }
 
-        return $backendUser->isAdmin();
+        // Every caller of this method uses it as an authorization bypass — the
+        // privileged-column policy in `SecretTcaHook`, the `secret.use`
+        // exemption and the owner_uid / frontend_accessible coercions in
+        // `VaultService`. So it must answer "does the admin bypass apply",
+        // not the raw role: a disabled override that still let admins claim
+        // ownership of any secret and read plaintext without `secret.use`
+        // would be disabled in name only.
+        return $this->adminBypassActive($backendUser->isAdmin());
     }
 
     public function getCurrentActorUid(): int
@@ -541,7 +554,7 @@ final class AccessControlService implements AccessControlServiceInterface
         Secret $secret,
         string $permission,
     ): bool {
-        if ($actor->admin) {
+        if ($this->adminBypassActive($actor->admin)) {
             return true;
         }
 
@@ -579,7 +592,7 @@ final class AccessControlService implements AccessControlServiceInterface
      */
     private function hasTechnicalActorGrant(TechnicalActor $actor, VaultPermission $permission): bool
     {
-        if ($actor->admin) {
+        if ($this->adminBypassActive($actor->admin)) {
             return true;
         }
 
@@ -587,19 +600,98 @@ final class AccessControlService implements AccessControlServiceInterface
     }
 
     /**
-     * The unconditional admin / system-maintainer override for operation
-     * permissions.
+     * THE seam for "admins and system maintainers may do anything".
      *
-     * Isolated in one seam on purpose: the hardened security profile will make
-     * this override disableable in a follow-up (break-glass mode), so that a
-     * TYPO3 admin no longer automatically holds every vault permission. Every
-     * "admins may do anything" decision for operation permissions must flow
-     * through here — never inline `isAdmin()` in a caller.
+     * Every such decision in this class flows through here — the operation
+     * permissions in `isGranted()`, the per-secret tiers in
+     * `hasBackendUserAccess()`, their technical-actor counterparts, and the
+     * privileged-column / interactive-use exemptions callers reach via
+     * `isCurrentActorAdmin()`. Never inline `isAdmin()` in a caller: an
+     * override that is only half-disabled is worse than one that is not
+     * disabled at all, because the deployment believes it is protected.
+     *
+     * Three gates, in the order that keeps the default path cheap and total:
+     *
+     * 1. Not privileged at all → no bypass, nothing else matters.
+     * 2. `disableAdminOverride` off (the default) → bypass, and we never even
+     *    resolve the security profile. This deliberately keeps
+     *    `getSecurityProfile()` — which THROWS on an unknown profile string —
+     *    off the hot path of every existing installation.
+     * 3. Profile is Standard → bypass anyway. The flag is inert outside the
+     *    Hardened profile ON PURPOSE: setting it alone, without the rest of the
+     *    hardened policy (external master-key provider, no TYPO3-key fallback),
+     *    is far more likely to be a misunderstanding than a decision, and its
+     *    failure mode is locking every administrator out of the vault. Hardened
+     *    is the explicit statement "I have read the fail-closed contract".
+     *    A `vault:doctor`-style check can surface the mismatch by pairing
+     *    `isAdminOverrideDisabled()` with `getSecurityProfile()`.
+     * 4. Hardened AND disabled → bypass only inside an open break-glass
+     *    window. No window, or no state seam wired at all → no bypass.
+     */
+    private function adminBypassActive(bool $actorIsPrivileged): bool
+    {
+        if (!$actorIsPrivileged) {
+            return false;
+        }
+
+        if (!$this->configuration->isAdminOverrideDisabled()) {
+            return true;
+        }
+
+        if (!$this->configuration->getSecurityProfile()->isHardened()) {
+            return true;
+        }
+
+        return $this->breakGlassState?->isActive() ?? false;
+    }
+
+    /**
+     * Does one of the user's groups carry this custom permission option?
+     *
+     * Deliberately NOT `BackendUserAuthentication::check()`, even though that is
+     * the documented API for custom permission options. Core's implementation is
+     *
+     *     isset($this->groupData[$type])
+     *         && ($this->isAdmin() || GeneralUtility::inList(...))
+     *
+     * — an unconditional `true` for any admin. Routing the grant lookup through
+     * it would hand the override straight back to the privileged user whose
+     * bypass {@see self::adminBypassActive()} just decided to withhold, leaving
+     * `disableAdminOverride` effective on the per-secret tiers and inert on the
+     * operation permissions: disabled in name only, which is worse than not
+     * disabled, because the deployment believes it is protected.
+     *
+     * What remains is exactly the list core evaluates for a non-admin, minus the
+     * short-circuit — so a non-admin's result is unchanged, and an admin without
+     * the override is treated like any other user: they hold what their groups
+     * were granted, and nothing more.
+     */
+    private function hasCustomPermissionOption(
+        BackendUserAuthentication $backendUser,
+        VaultPermission $permission,
+    ): bool {
+        /** @phpstan-ignore property.internal */
+        $granted = $backendUser->groupData['custom_options'] ?? null;
+
+        if (!\is_string($granted) || $granted === '') {
+            return false;
+        }
+
+        return GeneralUtility::inList(
+            $granted,
+            self::PERM_OPTION_GROUP . ':' . $permission->value,
+        );
+    }
+
+    /**
+     * Does this backend user carry the admin / system-maintainer role?
      *
      * `isSystemMaintainer()` is checked explicitly even though it implies the
-     * admin flag in core, mirroring `hasBackendUserAccess()`.
+     * admin flag in core, mirroring `hasBackendUserAccess()`. This answers the
+     * ROLE question only — whether the role currently grants a bypass is
+     * {@see self::adminBypassActive()}.
      */
-    private function adminOverrideGrants(BackendUserAuthentication $backendUser): bool
+    private function isPrivilegedBackendUser(BackendUserAuthentication $backendUser): bool
     {
         if ($backendUser->isAdmin()) {
             return true;
@@ -631,13 +723,12 @@ final class AccessControlService implements AccessControlServiceInterface
             return false;
         }
 
-        // Admin access — full access to every tier.
-        if ($backendUser->isAdmin()) {
-            return true;
-        }
-
-        // System maintainer access — full access to every tier.
-        if ($backendUser->isSystemMaintainer()) {
+        // Admin / system-maintainer access — full access to every tier, unless
+        // the override is disabled (hardened profile) and no break-glass window
+        // is open. Routed through the shared seam so a disabled override really
+        // removes the global bypass instead of only the operation permissions:
+        // an "admin" who still reads every colleague's secret is not restricted.
+        if ($this->adminBypassActive($this->isPrivilegedBackendUser($backendUser))) {
             return true;
         }
 

--- a/Classes/Security/AccessControlServiceInterface.php
+++ b/Classes/Security/AccessControlServiceInterface.php
@@ -72,16 +72,27 @@ interface AccessControlServiceInterface
      *   everything, anyone else needs the matching custom permission option
      *   (`tx_nrvault:<permission>`) on one of their groups;
      * - disabled user, no user at all → `false`.
+     *
+     * The admin / system-maintainer bypass — here and in every per-secret tier
+     * above — is removable: in the {@see SecurityProfile::Hardened} profile with
+     * `disableAdminOverride` set, privileged users hold only what their groups
+     * grant, unless a {@see BreakGlassServiceInterface} window is open.
      */
     public function isGranted(VaultPermission $permission): bool;
 
     /**
-     * Is the current actor a TYPO3 backend admin?
+     * Does the current actor hold the admin bypass?
      *
      * Returns `true` for BE users where `BackendUserAuthentication::isAdmin()`
      * is true. Non-BE actor types (CLI / scheduler / API) MUST return `false`
      * — callers that legitimately need to bypass admin gates should handle
      * actor type explicitly, not rely on this method.
+     *
+     * This is a bypass question, not a role lookup: in the hardened profile
+     * with `disableAdminOverride` set, a real TYPO3 admin answers `false`
+     * unless a break-glass window is open. Do not use it to label a user in
+     * output or to derive audit attribution — use the role/actor accessors for
+     * that.
      */
     public function isCurrentActorAdmin(): bool;
 

--- a/Classes/Security/BreakGlassService.php
+++ b/Classes/Security/BreakGlassService.php
@@ -1,0 +1,229 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Security;
+
+use DateTimeImmutable;
+use Netresearch\NrVault\Audit\AuditAction;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\GenericContext;
+use Netresearch\NrVault\Event\BreakGlassActivatedEvent;
+use Netresearch\NrVault\Event\BreakGlassDeactivatedEvent;
+use Netresearch\NrVault\Exception\AccessDeniedException;
+use Netresearch\NrVault\Exception\ValidationException;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Opens and closes break-glass windows.
+ *
+ * Everything that makes break-glass accountable lives here — the activation
+ * policy, the mandatory justification, the TTL clamp, the audit row and the
+ * PSR-14 event. {@see BreakGlassState} only stores bytes.
+ */
+final readonly class BreakGlassService implements BreakGlassServiceInterface
+{
+    /**
+     * Pseudo-identifier for the audit rows. Break-glass is not about one
+     * secret — it is about all of them — so it follows the `__master_key__`
+     * convention already established by `vault:rotate-master-key`.
+     */
+    public const AUDIT_PSEUDO_IDENTIFIER = '__break_glass__';
+
+    public function __construct(
+        private BreakGlassState $state,
+        private AccessControlServiceInterface $accessControlService,
+        private AuditLogServiceInterface $auditLogService,
+        private EventDispatcherInterface $eventDispatcher,
+    ) {}
+
+    public function activate(string $reason, int $minutes = self::DEFAULT_TTL_MINUTES): BreakGlassSession
+    {
+        $reason = $this->requireReason($reason, 'break-glass activation');
+        $this->assertMayOperate('activation');
+
+        $ttlMinutes = $this->clampTtl($minutes);
+        $now = new DateTimeImmutable();
+        $session = new BreakGlassSession(
+            activatedByUid: $this->accessControlService->getCurrentActorUid(),
+            activatedByUsername: $this->accessControlService->getCurrentActorUsername(),
+            reason: $reason,
+            activatedAt: $now,
+            expiresAt: $now->setTimestamp($now->getTimestamp() + ($ttlMinutes * 60)),
+        );
+
+        // Audit BEFORE granting the power. The two stores cannot be written
+        // atomically, so the order decides which half-failure is possible: this
+        // one can leave an audit row for a window that never opened (visible,
+        // harmless — the operator simply has no bypass and retries), while the
+        // reverse could leave a window OPEN with no evidence, which is the one
+        // outcome break-glass exists to make impossible. `log()` throws on
+        // failure, so a failed audit write aborts activation.
+        $this->auditLogService->log(
+            self::AUDIT_PSEUDO_IDENTIFIER,
+            AuditAction::BreakGlassActivated->value,
+            true,
+            null,
+            $reason,
+            null,
+            null,
+            new GenericContext([
+                'actorUid' => $session->activatedByUid,
+                'actorUsername' => $session->activatedByUsername,
+                'expiresAt' => $session->expiresAt->getTimestamp(),
+                'ttlMinutes' => $ttlMinutes,
+            ]),
+        );
+
+        $this->state->store($session);
+
+        $this->eventDispatcher->dispatch(new BreakGlassActivatedEvent(
+            $session->activatedByUid,
+            $session->activatedByUsername,
+            $reason,
+            $session->expiresAt,
+        ));
+
+        return $session;
+    }
+
+    public function deactivate(string $reason): void
+    {
+        $reason = $this->requireReason($reason, 'break-glass deactivation');
+        $this->assertMayOperate('deactivation');
+
+        $session = $this->state->getActiveSession();
+        if (!$session instanceof BreakGlassSession) {
+            // Already closed (explicitly or by expiry). Clear any expired
+            // leftover so the registry does not accumulate dead entries, then
+            // stay silent: no audit row may imply a window that was not open.
+            $this->state->clear();
+
+            return;
+        }
+
+        // Revoke BEFORE logging, for the mirror-image reason: an audit row
+        // claiming the window is closed while it is still open would be a lie
+        // in the direction that matters.
+        $this->state->clear();
+
+        $this->auditLogService->log(
+            self::AUDIT_PSEUDO_IDENTIFIER,
+            AuditAction::BreakGlassDeactivated->value,
+            true,
+            null,
+            $reason,
+            null,
+            null,
+            new GenericContext([
+                'actorUid' => $this->accessControlService->getCurrentActorUid(),
+                'actorUsername' => $this->accessControlService->getCurrentActorUsername(),
+                'activatedByUid' => $session->activatedByUid,
+                'activatedByUsername' => $session->activatedByUsername,
+                'activationReason' => $session->reason,
+                'expiresAt' => $session->expiresAt->getTimestamp(),
+            ]),
+        );
+
+        $this->eventDispatcher->dispatch(new BreakGlassDeactivatedEvent(
+            $this->accessControlService->getCurrentActorUid(),
+            $this->accessControlService->getCurrentActorUsername(),
+            $reason,
+            $session->expiresAt,
+        ));
+    }
+
+    public function getActiveSession(): ?BreakGlassSession
+    {
+        return $this->state->getActiveSession();
+    }
+
+    public function isActive(): bool
+    {
+        return $this->state->isActive();
+    }
+
+    /**
+     * Only a real backend administrator or a real CLI operator may open or
+     * close a window.
+     *
+     * "Real" means the TYPO3 `isAdmin()` / `isSystemMaintainer()` flag on a live
+     * session — read here directly rather than through
+     * {@see AccessControlServiceInterface::isCurrentActorAdmin()}, which now
+     * reports whether the admin BYPASS is active and answers false in exactly
+     * the situation break-glass exists to escape.
+     *
+     * A `TechnicalActorContext::runAs()` scope is deliberately NOT sufficient,
+     * even for an actor whose snapshot carries the admin flag: `runAs()` is not
+     * an authentication boundary (any code with DI access can open a scope), so
+     * accepting it would let arbitrary extension code mint its own bypass with
+     * a synthetic justification. Such a scope reports actor type `technical`,
+     * which reaches neither branch below.
+     *
+     * @throws AccessDeniedException
+     */
+    private function assertMayOperate(string $operation): void
+    {
+        // A shell on the host is already root-equivalent with respect to the
+        // vault (the master key and settings.php are both reachable), so CLI is
+        // trusted here and deliberately NOT gated on `allowCliAccess`: that
+        // switch governs whether unattended jobs may read secrets, a different
+        // question from whether an operator at a terminal may declare an
+        // emergency.
+        if ($this->accessControlService->getCurrentActorType() === 'cli') {
+            return;
+        }
+
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+        if (!$backendUser instanceof BackendUserAuthentication) {
+            throw AccessDeniedException::breakGlassRequiresAdmin($operation);
+        }
+
+        // Defence-in-depth, mirroring AccessControlService: a stale session for
+        // a disabled account must not reach this.
+        /** @phpstan-ignore property.internal */
+        $userRecord = $backendUser->user;
+        /** @var array<string, mixed> $userRecordTyped */
+        $userRecordTyped = \is_array($userRecord) ? $userRecord : [];
+        $disable = $userRecordTyped['disable'] ?? 0;
+        if (is_numeric($disable) && (int) $disable !== 0) {
+            throw AccessDeniedException::breakGlassRequiresAdmin($operation);
+        }
+
+        if ($backendUser->isAdmin() || $backendUser->isSystemMaintainer()) {
+            return;
+        }
+
+        throw AccessDeniedException::breakGlassRequiresAdmin($operation);
+    }
+
+    /**
+     * @throws ValidationException
+     */
+    private function requireReason(string $reason, string $operation): string
+    {
+        $trimmed = trim($reason);
+        if ($trimmed === '') {
+            throw ValidationException::missingReason($operation);
+        }
+
+        return $trimmed;
+    }
+
+    /**
+     * Clamp rather than reject: a fat-fingered `--minutes 600` during an
+     * incident should yield the one-hour ceiling, not an error the operator has
+     * to re-read under pressure. The ceiling is what carries the security
+     * property, and clamping enforces it either way.
+     */
+    private function clampTtl(int $minutes): int
+    {
+        return min(self::MAX_TTL_MINUTES, max(self::MIN_TTL_MINUTES, $minutes));
+    }
+}

--- a/Classes/Security/BreakGlassServiceInterface.php
+++ b/Classes/Security/BreakGlassServiceInterface.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Security;
+
+use Netresearch\NrVault\Exception\AccessDeniedException;
+use Netresearch\NrVault\Exception\ValidationException;
+
+/**
+ * Break-glass mode: a deliberate, justified, time-boxed restoration of the
+ * admin bypass that `disableAdminOverride` removed.
+ *
+ * Honest framing: while a window is open, an admin has exactly the power they
+ * had before the override was disabled — every operation permission and the
+ * per-secret tiers on every secret. Break-glass does not PREVENT anything. Its
+ * value is that using that power now requires a named actor, a typed
+ * justification, an audit row sealed into the hash chain, a PSR-14 event
+ * observers can alert on, a banner every backend user sees, and an expiry the
+ * operator cannot forget to close.
+ *
+ * @see BreakGlassStateInterface for the read-only seam consumed by access control
+ */
+interface BreakGlassServiceInterface extends BreakGlassStateInterface
+{
+    /** Minutes a window stays open when the caller does not choose. */
+    public const DEFAULT_TTL_MINUTES = 15;
+
+    public const MIN_TTL_MINUTES = 1;
+
+    /**
+     * Hard ceiling. A break-glass window that can outlast a working day is not
+     * an emergency measure, it is the override switched back on.
+     */
+    public const MAX_TTL_MINUTES = 60;
+
+    /**
+     * Open a break-glass window, replacing any window already open.
+     *
+     * @param string $reason Mandatory justification. Recorded verbatim in the
+     *                       audit row and shown in the backend banner
+     * @param int $minutes Requested TTL, clamped to
+     *                     {@see self::MIN_TTL_MINUTES}..{@see self::MAX_TTL_MINUTES}
+     *
+     * @throws ValidationException if the reason is empty after trimming
+     * @throws AccessDeniedException if the actor is neither a real backend
+     *                               admin / system maintainer nor a real CLI
+     *                               operator
+     */
+    public function activate(string $reason, int $minutes = self::DEFAULT_TTL_MINUTES): BreakGlassSession;
+
+    /**
+     * Close the open window early.
+     *
+     * A no-op when no window is open — closing an already-closed window is the
+     * desired end state, not an error worth aborting a cleanup script for. No
+     * audit row and no event are produced in that case, so the log never
+     * implies a window existed.
+     *
+     * @param string $reason Mandatory justification (same policy as activation)
+     *
+     * @throws ValidationException
+     * @throws AccessDeniedException
+     */
+    public function deactivate(string $reason): void;
+}

--- a/Classes/Security/BreakGlassSession.php
+++ b/Classes/Security/BreakGlassSession.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Security;
+
+use DateTimeImmutable;
+
+/**
+ * An active (or expired) break-glass window.
+ *
+ * The record of a deliberate, time-boxed restoration of the admin bypass that
+ * {@see \Netresearch\NrVault\Configuration\ExtensionConfigurationInterface::isAdminOverrideDisabled()}
+ * removed. It is evidence first and mechanism second: who opened the window,
+ * the justification they typed, when it opened and when it closes.
+ *
+ * Persisted as scalars in TYPO3's `sys_registry` (see {@see BreakGlassState}),
+ * never as a serialized object graph — the stored shape must stay readable by
+ * an auditor with SQL access and survive a class rename.
+ */
+final readonly class BreakGlassSession
+{
+    public function __construct(
+        public int $activatedByUid,
+        public string $activatedByUsername,
+        public string $reason,
+        public DateTimeImmutable $activatedAt,
+        public DateTimeImmutable $expiresAt,
+    ) {}
+
+    /**
+     * Rehydrate from the registry payload, or null when the payload is not a
+     * complete session.
+     *
+     * Fail-closed on anything unexpected: a half-written or hand-edited
+     * registry row must read as "no break-glass session", never as an
+     * open-ended one.
+     *
+     * @param array<array-key, mixed> $payload
+     */
+    public static function fromArray(array $payload): ?self
+    {
+        $uid = $payload['activatedByUid'] ?? null;
+        $username = $payload['activatedByUsername'] ?? null;
+        $reason = $payload['reason'] ?? null;
+        $activatedAt = $payload['activatedAt'] ?? null;
+        $expiresAt = $payload['expiresAt'] ?? null;
+
+        if (!is_numeric($uid) || !\is_string($username) || !\is_string($reason)) {
+            return null;
+        }
+        if (!is_numeric($activatedAt) || !is_numeric($expiresAt)) {
+            return null;
+        }
+
+        return new self(
+            activatedByUid: (int) $uid,
+            activatedByUsername: $username,
+            reason: $reason,
+            activatedAt: (new DateTimeImmutable())->setTimestamp((int) $activatedAt),
+            expiresAt: (new DateTimeImmutable())->setTimestamp((int) $expiresAt),
+        );
+    }
+
+    /**
+     * The registry payload — scalars only.
+     *
+     * @return array{activatedByUid: int, activatedByUsername: string, reason: string, activatedAt: int, expiresAt: int}
+     */
+    public function toArray(): array
+    {
+        return [
+            'activatedByUid' => $this->activatedByUid,
+            'activatedByUsername' => $this->activatedByUsername,
+            'reason' => $this->reason,
+            'activatedAt' => $this->activatedAt->getTimestamp(),
+            'expiresAt' => $this->expiresAt->getTimestamp(),
+        ];
+    }
+
+    /**
+     * Has the window closed as of $now?
+     *
+     * Expiry is a read-time comparison — no cron, no scheduled task, and no
+     * way for a stalled cleanup job to silently extend an operator's bypass.
+     */
+    public function isExpiredAt(DateTimeImmutable $now): bool
+    {
+        return $this->expiresAt->getTimestamp() <= $now->getTimestamp();
+    }
+
+    /**
+     * Seconds left in the window (0 once expired).
+     */
+    public function remainingSeconds(DateTimeImmutable $now): int
+    {
+        return max(0, $this->expiresAt->getTimestamp() - $now->getTimestamp());
+    }
+}

--- a/Classes/Security/BreakGlassState.php
+++ b/Classes/Security/BreakGlassState.php
@@ -1,0 +1,104 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Security;
+
+use DateTimeImmutable;
+use Throwable;
+use TYPO3\CMS\Core\Registry;
+
+/**
+ * Break-glass state persisted in TYPO3's `sys_registry`.
+ *
+ * The registry is the right store here: the window must outlive the request
+ * that opened it (an operator activates on the CLI and then works in the
+ * backend), must NOT expire on its own like a cache entry, and must be a
+ * single global fact rather than per-session state — a break-glass window is a
+ * property of the installation, not of a browser session.
+ *
+ * Reads are pure: an expired entry is reported as "no session" and left in
+ * place (the next activation overwrites it, `deactivate()` removes it). That
+ * keeps `canRead()` — a hot path reached from the frontend — free of a DB
+ * write, which a lazy-purge-on-read would introduce.
+ */
+final readonly class BreakGlassState implements BreakGlassStateInterface
+{
+    /**
+     * Registry namespace. Matches the extension's table prefix so an auditor
+     * grepping `sys_registry` for `tx_nrvault` finds this alongside the rest.
+     */
+    public const REGISTRY_NAMESPACE = 'tx_nrvault';
+
+    public const REGISTRY_KEY = 'breakGlassSession';
+
+    public function __construct(
+        private Registry $registry,
+    ) {}
+
+    public function getActiveSession(): ?BreakGlassSession
+    {
+        $session = $this->readSession();
+        if (!$session instanceof BreakGlassSession) {
+            return null;
+        }
+
+        return $session->isExpiredAt(new DateTimeImmutable()) ? null : $session;
+    }
+
+    public function isActive(): bool
+    {
+        return $this->getActiveSession() instanceof BreakGlassSession;
+    }
+
+    /**
+     * Persist a window, replacing any previous one.
+     *
+     * Internal to the Security namespace — activation policy and the audit
+     * trail live in {@see BreakGlassService}, which is the only intended
+     * caller. Writing here directly would produce an unaudited window.
+     *
+     * @internal
+     */
+    public function store(BreakGlassSession $session): void
+    {
+        $this->registry->set(self::REGISTRY_NAMESPACE, self::REGISTRY_KEY, $session->toArray());
+    }
+
+    /**
+     * Drop the stored window (whether or not it had already expired).
+     *
+     * @internal
+     */
+    public function clear(): void
+    {
+        $this->registry->remove(self::REGISTRY_NAMESPACE, self::REGISTRY_KEY);
+    }
+
+    /**
+     * The stored window regardless of expiry, or null when nothing valid is
+     * stored.
+     *
+     * A registry read hits the database. It is wrapped because this runs on
+     * every access-control decision, including bootstrap-time ones (install
+     * tool, upgrade wizards) and CLI contexts where `sys_registry` may not
+     * exist yet: an unreadable registry must mean "no break-glass window", not
+     * a fatal error in an unrelated code path. Fail-closed — an unreadable
+     * store never grants the bypass.
+     */
+    private function readSession(): ?BreakGlassSession
+    {
+        try {
+            $raw = $this->registry->get(self::REGISTRY_NAMESPACE, self::REGISTRY_KEY);
+        } catch (Throwable) {
+            return null;
+        }
+
+        return \is_array($raw) ? BreakGlassSession::fromArray($raw) : null;
+    }
+}

--- a/Classes/Security/BreakGlassStateInterface.php
+++ b/Classes/Security/BreakGlassStateInterface.php
@@ -1,0 +1,38 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Security;
+
+/**
+ * Read-only view of the break-glass window.
+ *
+ * Deliberately narrower than {@see BreakGlassServiceInterface}: the access
+ * control layer must be able to ASK whether a window is open without being
+ * able to open one, and — the reason this seam exists at all — without pulling
+ * the audit log into its own dependency graph.
+ * {@see \Netresearch\NrVault\Audit\AuditLogService} already depends on
+ * {@see AccessControlServiceInterface}, so an AccessControlService that
+ * depended on the full break-glass service (which writes audit rows) would
+ * close a DI cycle.
+ */
+interface BreakGlassStateInterface
+{
+    /**
+     * The currently OPEN window, or null when none is open.
+     *
+     * Returns null for an expired window: expiry is evaluated at read time,
+     * so a session can never outlive its TTL through a missed cleanup run.
+     */
+    public function getActiveSession(): ?BreakGlassSession;
+
+    /**
+     * Is a non-expired break-glass window open?
+     */
+    public function isActive(): bool;
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -11,6 +11,7 @@ services:
       - '../Classes/Exception/*'
       - '../Classes/Http/OAuth/OAuthConfig.php'
       - '../Classes/Security/TechnicalActor.php'
+      - '../Classes/Security/BreakGlassSession.php'
       # Widgets depend on typo3/cms-dashboard classes (a "suggest", not a
       # requirement) — they are registered by Services.Dashboard.php, imported
       # from Services.php only when EXT:dashboard is installed.
@@ -66,6 +67,20 @@ services:
 
   Netresearch\NrVault\Security\TechnicalActorContextInterface:
     alias: Netresearch\NrVault\Security\TechnicalActorContext
+
+  # Two implementations exist for the read-only state contract
+  # (BreakGlassState and BreakGlassService, which extends it), so autowiring
+  # cannot pick one — both aliases must be explicit.
+  #
+  # AccessControlService MUST receive the narrow BreakGlassState, not the full
+  # service: the service writes audit rows, AuditLogService depends on
+  # AccessControlService, and injecting the service here would close that DI
+  # cycle. It also means access control cannot open a window, only observe one.
+  Netresearch\NrVault\Security\BreakGlassStateInterface:
+    alias: Netresearch\NrVault\Security\BreakGlassState
+
+  Netresearch\NrVault\Security\BreakGlassServiceInterface:
+    alias: Netresearch\NrVault\Security\BreakGlassService
 
   Netresearch\NrVault\Audit\AuditLogServiceInterface:
     alias: Netresearch\NrVault\Audit\AuditLogService

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -32,6 +32,31 @@ Configure nr-vault in :guilabel:`Admin Tools > Settings > Extension Configuratio
       is implemented. See :ref:`developer-custom-adapters` for information on
       implementing custom adapters.
 
+.. confval:: securityProfile
+   :name: ext-nrvault-securityProfile
+   :type: string
+   :Default: standard
+   :Options: standard, hardened
+
+   The vault's operating profile — a single, internally consistent policy
+   rather than a bag of independent toggles. Enforcement happens in code
+   (provider selection, access control, audit anchoring), never only in
+   documentation.
+
+   standard
+      Secure defaults with zero-configuration TYPO3 integration.
+
+   hardened
+      Fail-closed and audit-ready. Requires an explicit external
+      master-key provider (``file`` or ``env``), disables provider
+      auto-detection and any fallback to the TYPO3 encryption key, and
+      makes vault operations refuse to run on a misconfigured or
+      unavailable provider. It is also the prerequisite for
+      :ref:`disableAdminOverride <ext-nrvault-disableAdminOverride>`.
+
+   An unrecognised value throws rather than degrading to ``standard`` — a
+   typo in a hardened deployment must never weaken the effective policy.
+
 .. confval:: masterKeyProvider
    :name: ext-nrvault-masterKeyProvider
    :type: string
@@ -104,6 +129,42 @@ Configure nr-vault in :guilabel:`Admin Tools > Settings > Extension Configuratio
       .. code-block:: php
 
          $GLOBALS['TYPO3_CONF_VARS']['SYS']['nrVault']['auditReads'] = true;
+
+.. confval:: disableAdminOverride
+   :name: ext-nrvault-disableAdminOverride
+   :type: boolean
+   :Default: false
+
+   Remove the unconditional "administrators and system maintainers may do
+   anything" bypass — both the operation permissions and the per-secret
+   read/write/delete tiers. Administrators then hold exactly what their
+   groups were granted and reach only the secrets they own or share a
+   group with.
+
+   **Only effective when** :ref:`securityProfile
+   <ext-nrvault-securityProfile>` **is** ``hardened``. In the standard
+   profile the flag is inert — a lockout guard, since setting it without
+   the rest of the hardened policy is more likely a misunderstanding than
+   a decision. ``vault:break-glass --status`` reports
+   ``adminOverrideDisabledEffective`` so the mismatch is visible.
+
+   .. warning::
+
+      Removing the override without an escape hatch turns the first
+      genuine incident into an outage. The hatch is
+      :ref:`break-glass mode <security-break-glass>`
+      (:ref:`vault:break-glass <command-break-glass>`) — a justified,
+      audited, time-boxed window that restores full admin power.
+
+      Pin the value out of admin reach in
+      :file:`config/system/additional.php`, or a compromised admin can
+      simply untick it in the backend Settings module:
+
+      .. code-block:: php
+
+         $GLOBALS['TYPO3_CONF_VARS']['SYS']['nrVault']['disableAdminOverride'] = true;
+
+   See :ref:`security-disable-admin-override` for what exactly is removed.
 
 .. confval:: auditHmacEpoch
    :name: ext-nrvault-auditHmacEpoch

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -659,3 +659,86 @@ Example
 
    Development only. The command refuses to run in a Production application
    context and creates dummy secrets with obviously-fake values.
+
+.. _command-break-glass:
+
+vault:break-glass
+=================
+
+Open, close or inspect a time-boxed break-glass window that temporarily
+restores the administrator override removed by
+:ref:`disableAdminOverride <ext-nrvault-disableAdminOverride>`.
+
+Only a real backend administrator or system maintainer — or an operator with
+CLI access to the host — may open or close a window. A justification is
+mandatory, both transitions are written to the tamper-evident audit log, and
+the window expires on its own. See :ref:`security-break-glass` for the full
+operational contract.
+
+.. code-block:: bash
+   :caption: Command syntax
+
+   vendor/bin/typo3 vault:break-glass [options]
+
+.. _command-break-glass-options:
+
+Options
+-------
+
+--activate, -a
+   Open a break-glass window. Requires ``--reason``.
+
+--deactivate, -d
+   Close the open window early. Requires ``--reason``. A no-op when no window
+   is open.
+
+--status, -s
+   Show the current state. This is the default when no action is given.
+
+--reason, -r
+   Justification recorded in the audit log and shown in the backend warning
+   banner. Mandatory for ``--activate`` and ``--deactivate``; an empty or
+   whitespace-only value is rejected.
+
+--minutes, -m
+   Window length in minutes (default: 15). Values are clamped to the range
+   1..60 rather than rejected.
+
+.. _command-break-glass-example:
+
+Example
+-------
+
+.. code-block:: bash
+   :caption: vault:break-glass examples
+
+   # Is a window open, and is the override disabled at all?
+   vendor/bin/typo3 vault:break-glass --status
+
+   # Open a 30-minute window for an incident
+   vendor/bin/typo3 vault:break-glass --activate --reason="INC-4711 rotate leaked deploy key" --minutes=30
+
+   # Close it as soon as the work is done
+   vendor/bin/typo3 vault:break-glass --deactivate --reason="INC-4711 closed"
+
+The ``--status`` output is line-oriented for monitoring probes and always
+exits ``0`` — a closed window is a successful answer, not a failure:
+
+.. code-block:: text
+   :caption: --status output while a window is open
+
+   securityProfile                  hardened
+   disableAdminOverride             yes
+   adminOverrideDisabledEffective   yes
+   status: active
+   activatedBy                      admin (uid 1)
+   reason                           INC-4711 rotate leaked deploy key
+   activatedAt                      2026-07-31T09:12:04+00:00
+   expiresAt                        2026-07-31T09:42:04+00:00
+   remainingSeconds                 1738
+
+.. attention::
+
+   While a window is open, administrators hold **every** vault permission and
+   full access to **every** secret. Close it as soon as the work is done
+   rather than waiting for the expiry.

--- a/Documentation/Security/Index.rst
+++ b/Documentation/Security/Index.rst
@@ -233,22 +233,6 @@ Permission                          Governs
 ``tx_nrvault:master_key.rotate``    Rotating the master key.
 ``tx_nrvault:vault.configure``      Running the migration wizard.
 =================================== ==============================================================
-``tx_nrvault:secret.use``       Programmatic consumption of a plaintext value
-                                (FormEngine vault widgets, FlexForm/TCA
-                                placeholders, site config, HTTP clients).
-``tx_nrvault:secret.reveal``    Displaying a plaintext to a human (the
-                                ``vault_reveal`` endpoint, ``vault:retrieve``).
-``tx_nrvault:secret.create``    Creating new secrets.
-``tx_nrvault:secret.rotate``    Replacing the value of an existing secret.
-``tx_nrvault:secret.delete``    Deleting secrets.
-``tx_nrvault:secret.manage_policy`` Enabling/disabling secrets and editing
-                                their ``allowed_groups`` / ``write_groups``.
-``tx_nrvault:audit.view``       Reading the audit log, its usage analytics,
-                                and verifying the hash chain.
-``tx_nrvault:audit.export``     Downloading the audit log (JSON / CSV).
-``tx_nrvault:master_key.rotate`` Rotating the master key.
-``tx_nrvault:vault.configure``  Running the migration wizard.
-=============================== ==============================================
 
 Notes on the model:
 
@@ -262,9 +246,10 @@ Notes on the model:
    TypoScript placeholder resolution. Grant it to the groups whose
    editors work with vault-backed fields.
 -  **Admins and system maintainers hold every permission**
-   unconditionally. That override lives in a single seam
-   (``AccessControlService::adminOverrideGrants()``) so a future hardened
-   profile can disable it.
+   unconditionally, and have full per-secret access to every secret.
+   That override lives in a single seam
+   (``AccessControlService::adminBypassActive()``) and can be removed —
+   see :ref:`security-disable-admin-override`.
 -  **The backend modules are registered ``access => 'user'``.** That is
    deliberate: authorization is asserted by each controller action, not
    by the module registration, so granular grants are usable by
@@ -280,6 +265,200 @@ Notes on the model:
    a property of the secret (``frontend_accessible``) alone.
 -  **Non-admin technical actors** (``runAs()`` scopes) hold only
    ``secret.use``; their reach stays bounded by the per-secret tiers.
+
+.. _security-disable-admin-override:
+
+Disabling the admin override
+----------------------------
+
+By default a TYPO3 administrator holds every vault permission and full
+read/write/delete access to every secret. For most installations that is
+the right answer: an admin already controls :file:`settings.php`, the
+master-key provider and the extension configuration, so withholding
+vault permissions from them would be theatre.
+
+It stops being theatre in two situations: an installation where "TYPO3
+administrator" and "may read production credentials" are genuinely
+different roles, and an audit regime that requires every plaintext
+access to be attributable to a *granted* permission rather than to a
+role. For those, set
+
+.. code-block:: none
+   :caption: Extension configuration
+
+   securityProfile = hardened
+   disableAdminOverride = 1
+
+and administrators are treated like every other backend user: they hold
+exactly the operation permissions their groups were granted, and reach
+only the secrets they own or share a group with.
+
+What is removed
+~~~~~~~~~~~~~~~
+
+Both gates, in one place. The override is a single private seam
+(``AccessControlService::adminBypassActive()``) consulted by:
+
+-  ``isGranted()`` — the operation permissions;
+-  ``canRead()`` / ``canWrite()`` / ``canDelete()`` — the per-secret tiers;
+-  ``isCurrentActorAdmin()`` — the privileged-column policy in the TCA
+   hook and the ``secret.use`` / ``owner_uid`` / ``frontend_accessible``
+   exemptions in ``VaultService``;
+-  the technical-actor equivalents of all of the above, so a
+   ``runAs()`` snapshot carrying the admin flag does not keep what the
+   interactive admin lost.
+
+An override that were removed from only some of these would be worse
+than none, because the deployment would believe it is protected.
+
+.. note::
+
+   Ownership still applies. An administrator keeps full access to the
+   secrets they own, exactly like any other user — which is what makes
+   the disabled state workable day to day.
+
+Two deliberate constraints
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+**The flag only takes effect in the hardened profile.** In the standard
+profile it is inert. Setting it alone, without the rest of the hardened
+policy (an explicit external master-key provider, no fallback to the
+TYPO3 encryption key), is far more likely to be a misunderstanding than
+a decision — and its failure mode is locking every administrator out of
+the vault. Choosing ``hardened`` is the explicit statement that the
+fail-closed contract has been read. Run
+:ref:`vault:break-glass --status <command-break-glass>` to see whether
+the flag is effective; it reports ``adminOverrideDisabledEffective``
+alongside the raw setting, so a "flag set, profile standard" mismatch is
+visible rather than silent.
+
+**Pin the value outside the backend.** The setting is editable in
+:guilabel:`Admin Tools > Settings`, which means a compromised admin
+could untick it. Pin it in :file:`config/system/additional.php`, where
+only filesystem access can change it:
+
+.. code-block:: php
+
+   $GLOBALS['TYPO3_CONF_VARS']['SYS']['nrVault']['disableAdminOverride'] = true;
+
+The pinned value wins in both directions and is the same mechanism
+:ref:`auditReads <ext-nrvault-auditReads>` uses.
+
+.. _security-break-glass:
+
+Break-glass mode
+----------------
+
+A disabled override needs an escape hatch, or the first genuine incident
+becomes an outage. Break-glass mode is that hatch: a deliberate,
+justified, time-boxed restoration of the admin override.
+
+.. code-block:: bash
+   :caption: The full flow
+
+   # 1. Confirm the state
+   vendor/bin/typo3 vault:break-glass --status
+
+   # 2. Open a window with a justification
+   vendor/bin/typo3 vault:break-glass --activate --reason="INC-4711 rotate leaked deploy key" --minutes=30
+
+   # 3. Do the work in the backend or on the CLI
+
+   # 4. Close it — do not wait for the expiry
+   vendor/bin/typo3 vault:break-glass --deactivate --reason="INC-4711 closed"
+
+Who may open a window
+~~~~~~~~~~~~~~~~~~~~~
+
+Only a real backend administrator or system maintainer — the actual
+TYPO3 ``isAdmin()`` flag, checked independently of the disabled override
+so the escape hatch is reachable in the very state it exists for — or an
+operator in a real CLI context. Break-glass is deliberately **not**
+gated on a ``VaultPermission``: it exists to recover from a state where
+the granular grants are what is missing, so gating it on one would make
+it unreachable exactly when it is needed. CLI is likewise not gated on
+:ref:`allowCliAccess <ext-nrvault-allowCliAccess>` — a shell on the host
+already reaches the master key.
+
+A ``TechnicalActorContext::runAs()`` scope may **never** open a window,
+even for an actor whose snapshot carries the admin flag. ``runAs()`` is
+not an authentication boundary (any code with DI access can open a
+scope), so accepting it would let arbitrary extension code mint its own
+bypass with a synthetic justification.
+
+Mandatory justification
+~~~~~~~~~~~~~~~~~~~~~~~
+
+``--reason`` is required for both activation and deactivation, and an
+empty or whitespace-only value is rejected. The reason is stored
+verbatim in the audit row, carried in the PSR-14 event, and displayed in
+the backend banner. Reference the incident, ticket or change record —
+"testing" tells a later reviewer nothing.
+
+Time boxing
+~~~~~~~~~~~
+
+The window defaults to 15 minutes and is clamped to 1..60. Out-of-range
+values are clamped rather than rejected: a fat-fingered ``--minutes=600``
+during an incident should yield the one-hour ceiling, not an error to
+re-read under pressure.
+
+Expiry is evaluated **at read time**, on every access-control decision.
+There is no scheduled task to close a window, and therefore no stalled
+cron job that can silently extend one. A forgotten window stops granting
+anything the moment it lapses.
+
+Audit evidence
+~~~~~~~~~~~~~~
+
+Activation and deactivation each write one row to the tamper-evident
+audit log under the pseudo-identifier ``__break_glass__`` (the same
+convention ``vault:rotate-master-key`` uses for ``__master_key__``):
+
+===================================== ========================================
+Action                                Written when
+===================================== ========================================
+``break_glass_activated``             A window is opened. Context carries the
+                                      actor, the expiry and the TTL.
+``break_glass_deactivated``           A window is closed early. Context also
+                                      carries the original activation reason.
+===================================== ========================================
+
+Both rows are sealed into the HMAC hash chain like any other entry, so
+the evidence cannot be edited away without breaking verification. The
+activation row is written **before** the window opens: the two stores
+cannot be updated atomically, and only that order makes "window open
+without evidence" impossible.
+
+A window that simply expires writes **no** row — nothing runs at the
+moment it lapses. Reconstruct the closed interval from the activation
+row's ``expiresAt`` context value.
+
+For alerting, listen to
+``Netresearch\NrVault\Event\BreakGlassActivatedEvent`` and
+``BreakGlassDeactivatedEvent``. The audit log proves what happened; a
+listener is what makes someone *look*.
+
+Visible warning
+~~~~~~~~~~~~~~~
+
+While a window is open, the vault Overview and Secrets modules show a
+danger callout naming who opened it, the stated reason, and when it
+expires. Visibility is half the control — a window nobody notices is
+just the admin override with extra steps.
+
+.. warning::
+
+   **Break-glass restores full admin power.** While a window is open, an
+   administrator has exactly what they had before the override was
+   disabled: every operation permission, and read/write/delete on every
+   secret. Break-glass prevents nothing.
+
+   Its value is evidence and time boxing — a named actor, a typed
+   justification, a hash-chained audit row, an event observers can alert
+   on, a banner every operator sees, and an expiry nobody has to
+   remember. Treat an activation as an incident to review, not as
+   routine maintenance.
 
 Technical actors
 ----------------

--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -462,6 +462,9 @@
       <trans-unit id="overview.cli.cleanup_orphans">
         <source>Remove orphaned secrets</source>
       </trans-unit>
+      <trans-unit id="overview.cli.break_glass">
+        <source>Open, close or inspect a time-boxed break-glass window</source>
+      </trans-unit>
       <trans-unit id="overview.cli.help_hint">
         <source>Run bin/typo3 vault:&lt;command&gt; --help for detailed usage.</source>
       </trans-unit>
@@ -1134,6 +1137,29 @@
       </trans-unit>
       <trans-unit id="permissions.vault.configure.description">
         <source>Run the migration wizard, which scans the database for plaintext secrets and moves them into the vault.</source>
+      </trans-unit>
+
+      <!-- Break-glass warning banner (Partials/BreakGlassBanner.html) -->
+      <trans-unit id="breakGlass.banner.title">
+        <source>Break-glass mode is active</source>
+      </trans-unit>
+      <trans-unit id="breakGlass.banner.description">
+        <source>The administrator override has been temporarily restored. While this window is open, administrators and system maintainers hold every vault permission and can read, change and delete every secret. Every action is recorded in the audit log.</source>
+      </trans-unit>
+      <trans-unit id="breakGlass.banner.activatedBy">
+        <source>Activated by</source>
+      </trans-unit>
+      <trans-unit id="breakGlass.banner.reason">
+        <source>Stated reason</source>
+      </trans-unit>
+      <trans-unit id="breakGlass.banner.expiresAt">
+        <source>Expires at</source>
+      </trans-unit>
+      <trans-unit id="breakGlass.banner.remaining">
+        <source>%s minute(s) remaining</source>
+      </trans-unit>
+      <trans-unit id="breakGlass.banner.close">
+        <source>Close the window as soon as the work is done:</source>
       </trans-unit>
 
       <!-- Access denied (module-level operation permission missing) -->

--- a/Resources/Private/Partials/BreakGlassBanner.html
+++ b/Resources/Private/Partials/BreakGlassBanner.html
@@ -1,0 +1,44 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<!--
+    Break-glass warning banner.
+
+    Rendered on every vault surface an operator can reach while a window is
+    open. Visibility is half the control: a window nobody notices is just the
+    admin override with extra steps, so this is a loud danger callout naming
+    who opened it, why, and when it closes — not a subtle badge.
+
+    Expects `breakGlass` = {active, username, reason, expiresAt (already
+    formatted for display), remainingMinutes} as assigned by the controllers.
+    Renders nothing when no window is open.
+-->
+<f:if condition="{breakGlass.active}">
+    <div class="alert alert-danger mb-4" role="alert" data-testid="vault-break-glass-banner">
+        <h2 class="alert-heading h4">
+            <core:icon identifier="actions-exclamation-triangle" size="small" />
+            <f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:breakGlass.banner.title" />
+        </h2>
+        <p class="mb-2">
+            <f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:breakGlass.banner.description" />
+        </p>
+        <dl class="mb-2">
+            <dt><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:breakGlass.banner.activatedBy" /></dt>
+            <dd data-testid="vault-break-glass-user">{breakGlass.username}</dd>
+            <dt><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:breakGlass.banner.reason" /></dt>
+            <dd data-testid="vault-break-glass-reason">{breakGlass.reason}</dd>
+            <dt><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:breakGlass.banner.expiresAt" /></dt>
+            <dd data-testid="vault-break-glass-expires">
+                {breakGlass.expiresAt}
+                (<f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:breakGlass.banner.remaining" arguments="{0: breakGlass.remainingMinutes}" />)
+            </dd>
+        </dl>
+        <p class="mb-0">
+            <f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:breakGlass.banner.close" />
+            <code>vendor/bin/typo3 vault:break-glass --deactivate --reason "…"</code>
+        </p>
+    </div>
+</f:if>
+
+</html>

--- a/Resources/Private/Templates/Overview/Index.html
+++ b/Resources/Private/Templates/Overview/Index.html
@@ -10,6 +10,8 @@
         {f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.subtitle')}
     </p>
 
+    <f:render partial="BreakGlassBanner" arguments="{breakGlass: breakGlass}" />
+
     <!-- Health Check Alerts -->
     <f:if condition="{healthChecks.hasIssues}">
         <div class="alert alert-danger mb-4" role="alert">
@@ -271,6 +273,7 @@ lib.mapsKey.stdWrap.cache.disable = 1</code></pre>
                 <tr><td><code>vault:migrate-field</code></td><td>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.cli.migrate_field')}</td></tr>
                 <tr><td><code>vault:rotate-master-key</code></td><td>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.cli.rotate_master_key')}</td></tr>
                 <tr><td><code>vault:cleanup-orphans</code></td><td>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.cli.cleanup_orphans')}</td></tr>
+                <tr><td><code>vault:break-glass</code></td><td>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.cli.break_glass')}</td></tr>
             </tbody>
         </table>
         <small class="text-muted">{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.cli.help_hint')}</small>

--- a/Resources/Private/Templates/Secrets/List.html
+++ b/Resources/Private/Templates/Secrets/List.html
@@ -11,6 +11,8 @@
 <f:section name="Content">
     <h1><f:translate key="LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.title" /></h1>
 
+    <f:render partial="BreakGlassBanner" arguments="{breakGlass: breakGlass}" />
+
     <!-- Filter Bar - TYPO3 v14 native form-row style -->
         <form method="post" action="{f:be.uri(route: 'admin_vault_secrets')}" role="search" aria-label="Filter secrets" class="mb-4" data-testid="secret-filter-form">
             <div class="form-row">

--- a/Tests/Functional/Security/BreakGlassServiceTest.php
+++ b/Tests/Functional/Security/BreakGlassServiceTest.php
@@ -1,0 +1,373 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Security;
+
+use Closure;
+use DateTimeImmutable;
+use Netresearch\NrVault\Audit\AuditAction;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Domain\Model\Secret;
+use Netresearch\NrVault\Event\BreakGlassActivatedEvent;
+use Netresearch\NrVault\Event\BreakGlassDeactivatedEvent;
+use Netresearch\NrVault\Exception\AccessDeniedException;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\BreakGlassService;
+use Netresearch\NrVault\Security\BreakGlassSession;
+use Netresearch\NrVault\Security\BreakGlassState;
+use Netresearch\NrVault\Security\VaultPermission;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+
+/**
+ * Break-glass end to end: real `sys_registry` state, real HMAC-chained audit
+ * rows, and the access-control integration that is the whole point.
+ *
+ * Runs in the hardened profile with `disableAdminOverride` set — the only
+ * configuration where break-glass changes any outcome — so the tests assert the
+ * real recovery path rather than a simulation of it.
+ *
+ * @see \Netresearch\NrVault\Tests\Unit\Security\BreakGlassServiceTest for the policy matrix
+ */
+#[CoversClass(BreakGlassService::class)]
+final class BreakGlassServiceTest extends AbstractVaultFunctionalTestCase
+{
+    private const AUDIT_TABLE = 'tx_nrvault_audit_log';
+
+    private const ADMIN_UID = 1;
+
+    private const EDITOR_UID = 2;
+
+    private const FOREIGN_OWNER_UID = 999;
+
+    protected ?string $backendUserFixture = __DIR__ . '/../Fixtures/Users/be_users.csv';
+
+    /** Log in explicitly per test — the actor is what is under test. */
+    protected ?int $backendUserUid = null;
+
+    /**
+     * The hardened profile refuses the `typo3` master-key provider, so the file
+     * provider the base class already wires up must be selected explicitly.
+     *
+     * @var array<string, mixed>
+     */
+    protected array $extensionConfiguration = [
+        'securityProfile' => 'hardened',
+        'masterKeyProvider' => 'file',
+        'disableAdminOverride' => 1,
+    ];
+
+    /** @var list<object> */
+    private array $dispatchedEvents = [];
+
+    #[Test]
+    public function activationWritesExactlyOneAuditRowCarryingTheReason(): void
+    {
+        $this->setUpBackendUser(self::ADMIN_UID);
+
+        $this->createSubject()->activate('INC-4711 rotate leaked deploy key', 20);
+
+        self::assertSame(
+            1,
+            $this->countAudit(AuditAction::BreakGlassActivated->value),
+            'exactly one activation row',
+        );
+
+        $row = $this->latestAuditRow();
+        self::assertSame(BreakGlassService::AUDIT_PSEUDO_IDENTIFIER, $row['secret_identifier']);
+        self::assertSame('INC-4711 rotate leaked deploy key', $row['reason']);
+        self::assertSame(1, (int) $row['success']);
+        self::assertSame('admin', $row['actor_username']);
+    }
+
+    #[Test]
+    public function theActivationRowIsSealedIntoTheHashChain(): void
+    {
+        // The evidence is only worth anything if it cannot be edited away, so
+        // the new action value must verify under the configured HMAC epoch like
+        // any other row.
+        $this->setUpBackendUser(self::ADMIN_UID);
+
+        $this->createSubject()->activate('INC-4711');
+
+        $result = $this->get(AuditLogServiceInterface::class)->verifyHashChain();
+
+        self::assertTrue($result->isValid(), 'the audit chain must verify after a break-glass row');
+    }
+
+    #[Test]
+    public function deactivationWritesExactlyOneAuditRow(): void
+    {
+        $this->setUpBackendUser(self::ADMIN_UID);
+        $subject = $this->createSubject();
+
+        $subject->activate('INC-4711');
+        $subject->deactivate('INC-4711 closed');
+
+        self::assertSame(1, $this->countAudit(AuditAction::BreakGlassDeactivated->value));
+
+        $row = $this->latestAuditRow();
+        self::assertSame('INC-4711 closed', $row['reason']);
+    }
+
+    #[Test]
+    public function deactivatingAClosedWindowWritesNoAuditRow(): void
+    {
+        $this->setUpBackendUser(self::ADMIN_UID);
+
+        $this->createSubject()->deactivate('nothing to do');
+
+        self::assertSame(0, $this->countAudit(AuditAction::BreakGlassDeactivated->value));
+    }
+
+    #[Test]
+    public function bothTransitionsDispatchTheirEvent(): void
+    {
+        $this->setUpBackendUser(self::ADMIN_UID);
+        $subject = $this->createSubject();
+
+        $session = $subject->activate('INC-4711', 20);
+        $subject->deactivate('INC-4711 closed');
+
+        self::assertCount(2, $this->dispatchedEvents);
+
+        $activated = $this->dispatchedEvents[0];
+        self::assertInstanceOf(BreakGlassActivatedEvent::class, $activated);
+        self::assertSame('INC-4711', $activated->getReason());
+        self::assertSame('admin', $activated->getActorUsername());
+        self::assertSame(self::ADMIN_UID, $activated->getActorUid());
+        self::assertSame($session->expiresAt->getTimestamp(), $activated->getExpiresAt()->getTimestamp());
+
+        self::assertInstanceOf(BreakGlassDeactivatedEvent::class, $this->dispatchedEvents[1]);
+    }
+
+    #[Test]
+    public function theSessionIsPersistedForALaterRequest(): void
+    {
+        // The operator activates on the CLI and then works in the backend, so
+        // the window has to outlive the request that opened it. Asserted against
+        // the `sys_registry` ROW rather than through the Registry service, whose
+        // in-process entry cache would answer from memory and prove nothing
+        // about what was actually written.
+        $this->setUpBackendUser(self::ADMIN_UID);
+        $this->createSubject()->activate('INC-4711', 20);
+
+        $stored = $this->readRegistryRow();
+
+        self::assertIsString($stored);
+        self::assertStringContainsString('INC-4711', $stored);
+    }
+
+    #[Test]
+    public function aNonAdminHoldingEveryOperationPermissionStillCannotActivate(): void
+    {
+        $this->setUpBackendUser(self::EDITOR_UID);
+        $this->grantEveryCustomOption();
+
+        // Sanity: the grants really are in place, so the refusal below is about
+        // the admin role and not about a missing permission.
+        self::assertTrue(
+            $this->get(AccessControlServiceInterface::class)->isGranted(VaultPermission::VaultConfigure),
+            'the editor must actually hold the operation permissions for this test to mean anything',
+        );
+
+        $this->expectException(AccessDeniedException::class);
+
+        $this->createSubject()->activate('I would like more power');
+    }
+
+    #[Test]
+    public function aNonAdminCannotCloseAWindowEither(): void
+    {
+        $this->setUpBackendUser(self::ADMIN_UID);
+        $this->createSubject()->activate('INC-4711');
+
+        $this->setUpBackendUser(self::EDITOR_UID);
+        $this->grantEveryCustomOption();
+
+        $this->expectException(AccessDeniedException::class);
+
+        $this->createSubject()->deactivate('let me hide this');
+    }
+
+    #[Test]
+    public function anOpenWindowRestoresTheAdminBypassEndToEnd(): void
+    {
+        $this->setUpBackendUser(self::ADMIN_UID);
+        $accessControl = $this->get(AccessControlServiceInterface::class);
+        $foreign = new Secret(identifier: 'someone-elses-secret', ownerUid: self::FOREIGN_OWNER_UID);
+
+        // Baseline: hardened + disabled really did remove the bypass.
+        self::assertFalse($accessControl->isGranted(VaultPermission::SecretReveal));
+        self::assertFalse($accessControl->canRead($foreign));
+
+        $this->createSubject()->activate('INC-4711', 20);
+
+        self::assertTrue($accessControl->isGranted(VaultPermission::SecretReveal));
+        self::assertTrue($accessControl->canRead($foreign));
+        self::assertTrue($accessControl->canDelete($foreign));
+    }
+
+    #[Test]
+    public function closingTheWindowRemovesTheBypassAgain(): void
+    {
+        $this->setUpBackendUser(self::ADMIN_UID);
+        $accessControl = $this->get(AccessControlServiceInterface::class);
+        $subject = $this->createSubject();
+
+        $subject->activate('INC-4711', 20);
+        self::assertTrue($accessControl->isGranted(VaultPermission::SecretReveal));
+
+        $subject->deactivate('INC-4711 closed');
+
+        self::assertFalse($accessControl->isGranted(VaultPermission::SecretReveal));
+    }
+
+    #[Test]
+    public function anExpiredWindowGrantsNothing(): void
+    {
+        // Time is frozen by writing an already-lapsed expiry straight into the
+        // registry: that is exactly the state a forgotten window leaves behind,
+        // and read-time expiry has to handle it with no cleanup job involved.
+        $this->setUpBackendUser(self::ADMIN_UID);
+        $this->writeExpiredSessionToRegistry();
+
+        $accessControl = $this->get(AccessControlServiceInterface::class);
+
+        self::assertFalse($accessControl->isGranted(VaultPermission::SecretReveal));
+        self::assertFalse($accessControl->isCurrentActorAdmin());
+        self::assertFalse(
+            $accessControl->canRead(new Secret(identifier: 'foreign', ownerUid: self::FOREIGN_OWNER_UID)),
+        );
+    }
+
+    /**
+     * A service instance whose event dispatcher records what was dispatched.
+     * Every other collaborator is the real container service.
+     */
+    private function createSubject(): BreakGlassService
+    {
+        $record = function (object $event): void {
+            $this->dispatchedEvents[] = $event;
+        };
+
+        $recordingDispatcher = new class ($record) implements EventDispatcherInterface {
+            /**
+             * @param Closure(object): void $record
+             */
+            public function __construct(private readonly Closure $record) {}
+
+            public function dispatch(object $event): object
+            {
+                ($this->record)($event);
+
+                return $event;
+            }
+        };
+
+        return new BreakGlassService(
+            $this->get(BreakGlassState::class),
+            $this->get(AccessControlServiceInterface::class),
+            $this->get(AuditLogServiceInterface::class),
+            $recordingDispatcher,
+        );
+    }
+
+    /**
+     * Grant every vault operation permission to the logged-in user by writing
+     * the merged group data core's `check('custom_options', …)` reads.
+     */
+    private function grantEveryCustomOption(): void
+    {
+        $backendUser = $GLOBALS['BE_USER'] ?? null;
+        self::assertInstanceOf(BackendUserAuthentication::class, $backendUser);
+
+        $options = array_map(
+            static fn (VaultPermission $permission): string => 'tx_nrvault:' . $permission->value,
+            VaultPermission::cases(),
+        );
+        /** @phpstan-ignore property.internal */
+        $backendUser->groupData['custom_options'] = implode(',', $options);
+    }
+
+    private function writeExpiredSessionToRegistry(): void
+    {
+        $this->get(BreakGlassState::class)->store(new BreakGlassSession(
+            activatedByUid: self::ADMIN_UID,
+            activatedByUsername: 'admin',
+            reason: 'INC-4711 forgotten',
+            activatedAt: (new DateTimeImmutable())->setTimestamp(time() - 3600),
+            expiresAt: (new DateTimeImmutable())->setTimestamp(time() - 60),
+        ));
+    }
+
+    /**
+     * The raw serialized `sys_registry` value for the break-glass entry.
+     */
+    private function readRegistryRow(): mixed
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable('sys_registry');
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return $queryBuilder
+            ->select('entry_value')
+            ->from('sys_registry')
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'entry_namespace',
+                    $queryBuilder->createNamedParameter(BreakGlassState::REGISTRY_NAMESPACE),
+                ),
+                $queryBuilder->expr()->eq(
+                    'entry_key',
+                    $queryBuilder->createNamedParameter(BreakGlassState::REGISTRY_KEY),
+                ),
+            )
+            ->executeQuery()
+            ->fetchOne();
+    }
+
+    private function countAudit(string $action): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::AUDIT_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $count = $queryBuilder
+            ->count('uid')
+            ->from(self::AUDIT_TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('action', $queryBuilder->createNamedParameter($action)),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($count) ? (int) $count : 0;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function latestAuditRow(): array
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::AUDIT_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $row = $queryBuilder
+            ->select('*')
+            ->from(self::AUDIT_TABLE)
+            ->orderBy('uid', 'DESC')
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        self::assertIsArray($row, 'expected at least one audit row');
+
+        return $row;
+    }
+}

--- a/Tests/Unit/Command/VaultBreakGlassCommandTest.php
+++ b/Tests/Unit/Command/VaultBreakGlassCommandTest.php
@@ -1,0 +1,232 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Command;
+
+use DateTimeImmutable;
+use Netresearch\NrVault\Command\VaultBreakGlassCommand;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Exception\AccessDeniedException;
+use Netresearch\NrVault\Exception\ValidationException;
+use Netresearch\NrVault\Security\BreakGlassServiceInterface;
+use Netresearch\NrVault\Security\BreakGlassSession;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+#[CoversClass(VaultBreakGlassCommand::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class VaultBreakGlassCommandTest extends TestCase
+{
+    private BreakGlassServiceInterface&MockObject $breakGlassService;
+
+    private ExtensionConfigurationInterface&MockObject $configuration;
+
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->breakGlassService = $this->createMock(BreakGlassServiceInterface::class);
+        $this->configuration = $this->createMock(ExtensionConfigurationInterface::class);
+        $this->configuration->method('getSecurityProfile')->willReturn(SecurityProfile::Hardened);
+        $this->configuration->method('isAdminOverrideDisabled')->willReturn(true);
+
+        $this->commandTester = new CommandTester(new VaultBreakGlassCommand(
+            $this->breakGlassService,
+            $this->configuration,
+        ));
+    }
+
+    #[Test]
+    public function statusIsTheDefaultActionWhenNoneIsGiven(): void
+    {
+        // Reading the state is the safe default for a command whose other modes
+        // change the security posture.
+        $this->breakGlassService->expects(self::once())->method('getActiveSession')->willReturn(null);
+        $this->breakGlassService->expects(self::never())->method('activate');
+        $this->breakGlassService->expects(self::never())->method('deactivate');
+
+        self::assertSame(Command::SUCCESS, $this->commandTester->execute([]));
+        self::assertStringContainsString('status: inactive', $this->commandTester->getDisplay());
+    }
+
+    #[Test]
+    public function statusExitsZeroWhenAWindowIsOpen(): void
+    {
+        // Exit 0 for both states on purpose: a probe distinguishes them by
+        // parsing `status:`, so a non-zero code stays reserved for "the command
+        // broke" rather than overloading it with "a window is open".
+        $this->breakGlassService->method('getActiveSession')->willReturn($this->session());
+
+        $exitCode = $this->commandTester->execute(['--status' => true]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        $display = $this->commandTester->getDisplay();
+        self::assertStringContainsString('status: active', $display);
+        self::assertStringContainsString('alice', $display);
+        self::assertStringContainsString('INC-4711', $display);
+    }
+
+    #[Test]
+    public function statusReportsWhetherTheOverrideIsEffectivelyDisabled(): void
+    {
+        $this->breakGlassService->method('getActiveSession')->willReturn(null);
+
+        $this->commandTester->execute(['--status' => true]);
+
+        $display = $this->commandTester->getDisplay();
+        self::assertStringContainsString('hardened', $display);
+        self::assertMatchesRegularExpression('/adminOverrideDisabledEffective\s+yes/', $display);
+    }
+
+    #[Test]
+    public function activatePassesTheReasonAndTheClampedMinutes(): void
+    {
+        $this->breakGlassService
+            ->expects(self::once())
+            ->method('activate')
+            ->with('INC-4711 rotate leaked key', 30)
+            ->willReturn($this->session());
+
+        $exitCode = $this->commandTester->execute([
+            '--activate' => true,
+            '--reason' => 'INC-4711 rotate leaked key',
+            '--minutes' => '30',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('ACTIVE', $this->commandTester->getDisplay());
+    }
+
+    #[Test]
+    public function activateFallsBackToTheDefaultTtl(): void
+    {
+        $this->breakGlassService
+            ->expects(self::once())
+            ->method('activate')
+            ->with('incident', BreakGlassServiceInterface::DEFAULT_TTL_MINUTES)
+            ->willReturn($this->session());
+
+        $this->commandTester->execute(['--activate' => true, '--reason' => 'incident']);
+    }
+
+    #[Test]
+    public function activateFailsWithoutAReason(): void
+    {
+        $this->breakGlassService
+            ->method('activate')
+            ->willThrowException(ValidationException::missingReason('break-glass activation'));
+
+        $exitCode = $this->commandTester->execute(['--activate' => true]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('reason is required', $this->commandTester->getDisplay());
+    }
+
+    #[Test]
+    public function activateFailsForANonAdminActor(): void
+    {
+        $this->breakGlassService
+            ->method('activate')
+            ->willThrowException(AccessDeniedException::breakGlassRequiresAdmin('activation'));
+
+        $exitCode = $this->commandTester->execute(['--activate' => true, '--reason' => 'incident']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString('administrator', $this->commandTester->getDisplay());
+    }
+
+    #[Test]
+    public function activateWarnsWhenTheOverrideWasNotDisabledAnyway(): void
+    {
+        // Activating with the override still in place grants nothing extra. Say
+        // so, or the operator walks away believing the flag is live.
+        $configuration = $this->createMock(ExtensionConfigurationInterface::class);
+        $configuration->method('getSecurityProfile')->willReturn(SecurityProfile::Standard);
+        $configuration->method('isAdminOverrideDisabled')->willReturn(true);
+
+        $this->breakGlassService->method('activate')->willReturn($this->session());
+        $tester = new CommandTester(new VaultBreakGlassCommand($this->breakGlassService, $configuration));
+
+        $tester->execute(['--activate' => true, '--reason' => 'incident']);
+
+        self::assertStringContainsString('grants no additional power', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function deactivateClosesAnOpenWindow(): void
+    {
+        $this->breakGlassService->method('isActive')->willReturn(true);
+        $this->breakGlassService->expects(self::once())->method('deactivate')->with('INC-4711 closed');
+
+        $exitCode = $this->commandTester->execute([
+            '--deactivate' => true,
+            '--reason' => 'INC-4711 closed',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('closed', $this->commandTester->getDisplay());
+    }
+
+    #[Test]
+    public function deactivateReportsWhenNothingWasOpen(): void
+    {
+        $this->breakGlassService->method('isActive')->willReturn(false);
+
+        $exitCode = $this->commandTester->execute(['--deactivate' => true, '--reason' => 'cleanup']);
+
+        self::assertSame(Command::SUCCESS, $exitCode);
+        self::assertStringContainsString('No break-glass window was open', $this->commandTester->getDisplay());
+    }
+
+    #[Test]
+    public function deactivateFailsWithoutAReason(): void
+    {
+        $this->breakGlassService
+            ->method('deactivate')
+            ->willThrowException(ValidationException::missingReason('break-glass deactivation'));
+
+        $exitCode = $this->commandTester->execute(['--deactivate' => true]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+    }
+
+    #[Test]
+    public function rejectsMoreThanOneAction(): void
+    {
+        $this->breakGlassService->expects(self::never())->method('activate');
+        $this->breakGlassService->expects(self::never())->method('deactivate');
+
+        $exitCode = $this->commandTester->execute([
+            '--activate' => true,
+            '--deactivate' => true,
+            '--reason' => 'incident',
+        ]);
+
+        self::assertSame(Command::INVALID, $exitCode);
+    }
+
+    private function session(): BreakGlassSession
+    {
+        return new BreakGlassSession(
+            activatedByUid: 7,
+            activatedByUsername: 'alice',
+            reason: 'INC-4711 rotate leaked key',
+            activatedAt: new DateTimeImmutable(),
+            expiresAt: (new DateTimeImmutable())->setTimestamp(time() + 900),
+        );
+    }
+}

--- a/Tests/Unit/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/Configuration/ExtensionConfigurationTest.php
@@ -260,6 +260,71 @@ final class ExtensionConfigurationTest extends TestCase
     }
 
     #[Test]
+    public function isAdminOverrideDisabledReturnsFalseByDefault(): void
+    {
+        // The admin bypass is on unless a deployment explicitly removes it —
+        // an extension update must never silently lock administrators out.
+        $this->typo3Config->method('get')->willReturn([]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertFalse($config->isAdminOverrideDisabled());
+    }
+
+    #[Test]
+    public function isAdminOverrideDisabledReturnsTrueWhenConfigured(): void
+    {
+        $this->typo3Config->method('get')->willReturn(['disableAdminOverride' => true]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertTrue($config->isAdminOverrideDisabled());
+    }
+
+    #[Test]
+    public function isAdminOverrideDisabledRespectsFilesystemOverrideTrue(): void
+    {
+        // The point of the pin: a compromised admin who unticks the box in the
+        // BE Settings module must not thereby restore their own bypass.
+        $original = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $GLOBALS['TYPO3_CONF_VARS'] = ['SYS' => ['nrVault' => ['disableAdminOverride' => true]]];
+
+        $this->typo3Config->method('get')->willReturn(['disableAdminOverride' => false]);
+
+        try {
+            $config = new ExtensionConfiguration($this->typo3Config);
+            self::assertTrue($config->isAdminOverrideDisabled());
+        } finally {
+            if ($original !== null) {
+                $GLOBALS['TYPO3_CONF_VARS'] = $original;
+            } else {
+                unset($GLOBALS['TYPO3_CONF_VARS']);
+            }
+        }
+    }
+
+    #[Test]
+    public function isAdminOverrideDisabledRespectsFilesystemOverrideFalse(): void
+    {
+        // The pin wins in both directions — it is the authority, not a floor.
+        $original = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $GLOBALS['TYPO3_CONF_VARS'] = ['SYS' => ['nrVault' => ['disableAdminOverride' => false]]];
+
+        $this->typo3Config->method('get')->willReturn(['disableAdminOverride' => true]);
+
+        try {
+            $config = new ExtensionConfiguration($this->typo3Config);
+            self::assertFalse($config->isAdminOverrideDisabled());
+        } finally {
+            if ($original !== null) {
+                $GLOBALS['TYPO3_CONF_VARS'] = $original;
+            } else {
+                unset($GLOBALS['TYPO3_CONF_VARS']);
+            }
+        }
+    }
+
+    #[Test]
     public function preferXChaCha20ReturnsFalseByDefault(): void
     {
         $this->typo3Config->method('get')

--- a/Tests/Unit/Controller/BreakGlassBannerProviderTest.php
+++ b/Tests/Unit/Controller/BreakGlassBannerProviderTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Controller;
+
+use DateTimeImmutable;
+use Netresearch\NrVault\Controller\BreakGlassBannerProvider;
+use Netresearch\NrVault\Security\BreakGlassSession;
+use Netresearch\NrVault\Security\BreakGlassStateInterface;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(BreakGlassBannerProvider::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class BreakGlassBannerProviderTest extends TestCase
+{
+    #[Test]
+    public function reportsInactiveWithACompleteShape(): void
+    {
+        // The Fluid partial reads every key unconditionally; a missing one would
+        // render as an empty string and could turn a live warning into a
+        // half-blank box.
+        $banner = $this->createSubject(null)->forView();
+
+        self::assertFalse($banner['active']);
+        self::assertSame(
+            ['active', 'username', 'uid', 'reason', 'expiresAt', 'remainingMinutes'],
+            array_keys($banner),
+        );
+    }
+
+    #[Test]
+    public function exposesTheOpenWindowForTheBanner(): void
+    {
+        $expiresAt = time() + 601;
+        $banner = $this->createSubject($this->session($expiresAt))->forView();
+
+        self::assertTrue($banner['active']);
+        self::assertSame('alice', $banner['username']);
+        self::assertSame(7, $banner['uid']);
+        self::assertSame('INC-4711 rotate leaked key', $banner['reason']);
+        self::assertSame(date('Y-m-d H:i', $expiresAt), $banner['expiresAt']);
+    }
+
+    #[Test]
+    public function roundsTheRemainingMinutesUp(): void
+    {
+        // Showing "0 minutes left" while the bypass is still live understates
+        // the exposure the banner exists to warn about.
+        $banner = $this->createSubject($this->session(time() + 1))->forView();
+
+        self::assertSame(1, $banner['remainingMinutes']);
+    }
+
+    private function createSubject(?BreakGlassSession $session): BreakGlassBannerProvider
+    {
+        $state = $this->createMock(BreakGlassStateInterface::class);
+        $state->method('getActiveSession')->willReturn($session);
+
+        return new BreakGlassBannerProvider($state);
+    }
+
+    private function session(int $expiresAt): BreakGlassSession
+    {
+        return new BreakGlassSession(
+            activatedByUid: 7,
+            activatedByUsername: 'alice',
+            reason: 'INC-4711 rotate leaked key',
+            activatedAt: new DateTimeImmutable(),
+            expiresAt: (new DateTimeImmutable())->setTimestamp($expiresAt),
+        );
+    }
+}

--- a/Tests/Unit/Security/AccessControlServiceAdminOverrideTest.php
+++ b/Tests/Unit/Security/AccessControlServiceAdminOverrideTest.php
@@ -1,0 +1,360 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Security;
+
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Domain\Model\Secret;
+use Netresearch\NrVault\Security\AccessControlService;
+use Netresearch\NrVault\Security\BreakGlassStateInterface;
+use Netresearch\NrVault\Security\TechnicalActor;
+use Netresearch\NrVault\Security\TechnicalActorContextInterface;
+use Netresearch\NrVault\Security\VaultPermission;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * The disableable admin override.
+ *
+ * These are the invariants the feature exists for, and they are asserted across
+ * BOTH gates on purpose: an override that is removed from the operation
+ * permissions but left intact on the per-secret tiers (or vice versa) is
+ * disabled in name only, and the deployment would believe it is protected while
+ * an admin still reads every colleague's secret.
+ *
+ * @see AccessControlServiceIsGrantedTest for the permission matrix with the override in place
+ */
+#[CoversClass(AccessControlService::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class AccessControlServiceAdminOverrideTest extends TestCase
+{
+    private const ADMIN_UID = 5;
+
+    private const FOREIGN_OWNER_UID = 999;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER'], $GLOBALS['TYPO3_REQUEST']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function hardenedAndDisabledRevokesEveryOperationPermissionFromAnAdmin(VaultPermission $permission): void
+    {
+        $this->setAdminBackendUser();
+        $subject = $this->createSubject(SecurityProfile::Hardened, overrideDisabled: true);
+
+        self::assertFalse($subject->isGranted($permission));
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function hardenedAndDisabledRevokesEveryOperationPermissionFromASystemMaintainer(
+        VaultPermission $permission,
+    ): void {
+        // The maintainer role is checked separately from `admin` throughout the
+        // service, so it needs its own assertion — a bypass that survives only
+        // for maintainers is still a bypass.
+        $this->setAdminBackendUser(isAdmin: false, isSystemMaintainer: true);
+        $subject = $this->createSubject(SecurityProfile::Hardened, overrideDisabled: true);
+
+        self::assertFalse($subject->isGranted($permission));
+    }
+
+    #[Test]
+    public function hardenedAndDisabledRevokesPerSecretAccessToAForeignSecret(): void
+    {
+        $this->setAdminBackendUser();
+        $subject = $this->createSubject(SecurityProfile::Hardened, overrideDisabled: true);
+        $foreign = $this->createSecret(self::FOREIGN_OWNER_UID);
+
+        self::assertFalse($subject->canRead($foreign), 'admin must not read a foreign secret');
+        self::assertFalse($subject->canWrite($foreign));
+        self::assertFalse($subject->canDelete($foreign));
+    }
+
+    #[Test]
+    public function hardenedAndDisabledLeavesTheOwnerTierIntact(): void
+    {
+        // The override is what is removed — not every path an admin has. An
+        // admin who owns a secret keeps it, exactly like any other user, which
+        // is what makes the disabled state survivable at all.
+        $this->setAdminBackendUser();
+        $subject = $this->createSubject(SecurityProfile::Hardened, overrideDisabled: true);
+        $own = $this->createSecret(self::ADMIN_UID);
+
+        self::assertTrue($subject->canRead($own));
+        self::assertTrue($subject->canWrite($own));
+        self::assertTrue($subject->canDelete($own));
+    }
+
+    #[Test]
+    public function hardenedAndDisabledRevokesTheAdminBypassReportedToCallers(): void
+    {
+        // `isCurrentActorAdmin()` is consumed as an authorization bypass by
+        // SecretTcaHook (privileged columns) and VaultService (the `secret.use`
+        // exemption, owner_uid / frontend_accessible coercion). If it kept
+        // answering "yes" the override would still be live on those paths.
+        $this->setAdminBackendUser();
+        $subject = $this->createSubject(SecurityProfile::Hardened, overrideDisabled: true);
+
+        self::assertFalse($subject->isCurrentActorAdmin());
+    }
+
+    #[Test]
+    public function hardenedAndDisabledStillHonoursAnExplicitGroupGrant(): void
+    {
+        // Losing the override does not exile the admin from the vault: they can
+        // be granted the same custom permission options as anyone else.
+        $this->setAdminBackendUser(grantedOptions: [VaultPermission::SecretUse]);
+        $subject = $this->createSubject(SecurityProfile::Hardened, overrideDisabled: true);
+
+        self::assertTrue($subject->isGranted(VaultPermission::SecretUse));
+        self::assertFalse($subject->isGranted(VaultPermission::SecretDelete));
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function standardProfileIgnoresTheFlagEntirely(VaultPermission $permission): void
+    {
+        // Lockout guard: the flag alone, without the rest of the hardened
+        // policy, is far more likely to be a misunderstanding than a decision,
+        // and its failure mode locks every administrator out of the vault.
+        $this->setAdminBackendUser();
+        $subject = $this->createSubject(SecurityProfile::Standard, overrideDisabled: true);
+
+        self::assertTrue($subject->isGranted($permission));
+    }
+
+    #[Test]
+    public function standardProfileIgnoresTheFlagForPerSecretAccessToo(): void
+    {
+        $this->setAdminBackendUser();
+        $subject = $this->createSubject(SecurityProfile::Standard, overrideDisabled: true);
+
+        self::assertTrue($subject->canRead($this->createSecret(self::FOREIGN_OWNER_UID)));
+        self::assertTrue($subject->isCurrentActorAdmin());
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function hardenedProfileWithoutTheFlagKeepsTheOverride(VaultPermission $permission): void
+    {
+        $this->setAdminBackendUser();
+        $subject = $this->createSubject(SecurityProfile::Hardened, overrideDisabled: false);
+
+        self::assertTrue($subject->isGranted($permission));
+    }
+
+    #[Test]
+    public function hardenedProfileWithoutTheFlagKeepsPerSecretAccess(): void
+    {
+        $this->setAdminBackendUser();
+        $subject = $this->createSubject(SecurityProfile::Hardened, overrideDisabled: false);
+
+        self::assertTrue($subject->canRead($this->createSecret(self::FOREIGN_OWNER_UID)));
+        self::assertTrue($subject->isCurrentActorAdmin());
+    }
+
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function anOpenBreakGlassWindowRestoresEveryOperationPermission(VaultPermission $permission): void
+    {
+        $this->setAdminBackendUser();
+        $subject = $this->createSubject(
+            SecurityProfile::Hardened,
+            overrideDisabled: true,
+            breakGlassActive: true,
+        );
+
+        self::assertTrue($subject->isGranted($permission));
+    }
+
+    #[Test]
+    public function anOpenBreakGlassWindowRestoresPerSecretAccessAndTheReportedBypass(): void
+    {
+        $this->setAdminBackendUser();
+        $subject = $this->createSubject(
+            SecurityProfile::Hardened,
+            overrideDisabled: true,
+            breakGlassActive: true,
+        );
+        $foreign = $this->createSecret(self::FOREIGN_OWNER_UID);
+
+        self::assertTrue($subject->canRead($foreign));
+        self::assertTrue($subject->canWrite($foreign));
+        self::assertTrue($subject->canDelete($foreign));
+        self::assertTrue($subject->isCurrentActorAdmin());
+    }
+
+    #[Test]
+    public function aClosedBreakGlassWindowLeavesTheOverrideDisabled(): void
+    {
+        // The state seam reports expiry itself (read-time comparison), so
+        // "expired" reaches access control as plain `isActive() === false`.
+        $this->setAdminBackendUser();
+        $subject = $this->createSubject(
+            SecurityProfile::Hardened,
+            overrideDisabled: true,
+            breakGlassActive: false,
+        );
+
+        self::assertFalse($subject->isGranted(VaultPermission::SecretReveal));
+        self::assertFalse($subject->canRead($this->createSecret(self::FOREIGN_OWNER_UID)));
+    }
+
+    #[Test]
+    public function aMissingBreakGlassSeamFailsClosed(): void
+    {
+        // Nothing wired (the service constructed without the optional seam):
+        // the absence of a break-glass store must read as "no window open",
+        // never as "cannot tell, so allow".
+        $this->setAdminBackendUser();
+        $subject = new AccessControlService(
+            $this->createConfiguration(SecurityProfile::Hardened, overrideDisabled: true),
+        );
+
+        self::assertFalse($subject->isGranted(VaultPermission::SecretReveal));
+        self::assertFalse($subject->canRead($this->createSecret(self::FOREIGN_OWNER_UID)));
+    }
+
+    #[Test]
+    public function anAdminTechnicalActorLosesItsBypassToo(): void
+    {
+        // A `runAs()` snapshot carrying the admin flag is the same override
+        // wearing a different hat — headless code must not keep what the
+        // interactive admin lost.
+        $subject = $this->createSubject(
+            SecurityProfile::Hardened,
+            overrideDisabled: true,
+            technicalActorAdmin: true,
+        );
+
+        self::assertFalse($subject->canRead($this->createSecret(self::FOREIGN_OWNER_UID)));
+        self::assertFalse($subject->isGranted(VaultPermission::SecretDelete));
+        self::assertTrue(
+            $subject->isGranted(VaultPermission::SecretUse),
+            'secret.use stays granted to every technical actor — its per-secret tier still gates it',
+        );
+    }
+
+    #[Test]
+    public function anOpenWindowRestoresTheTechnicalActorBypass(): void
+    {
+        $subject = $this->createSubject(
+            SecurityProfile::Hardened,
+            overrideDisabled: true,
+            breakGlassActive: true,
+            technicalActorAdmin: true,
+        );
+
+        self::assertTrue($subject->canRead($this->createSecret(self::FOREIGN_OWNER_UID)));
+        self::assertTrue($subject->isGranted(VaultPermission::SecretDelete));
+    }
+
+    #[Test]
+    public function aNonAdminIsUnaffectedByTheFlag(): void
+    {
+        // Regression guard on the first gate of the seam: the flag must not
+        // change anything for users who never had a bypass.
+        $this->setAdminBackendUser(isAdmin: false, grantedOptions: [VaultPermission::SecretUse]);
+        $subject = $this->createSubject(SecurityProfile::Hardened, overrideDisabled: true);
+
+        self::assertTrue($subject->isGranted(VaultPermission::SecretUse));
+        self::assertFalse($subject->isGranted(VaultPermission::SecretRotate));
+        self::assertTrue($subject->canRead($this->createSecret(self::ADMIN_UID)), 'owner tier unchanged');
+    }
+
+    /**
+     * @return iterable<string, array{VaultPermission}>
+     */
+    public static function allPermissionsProvider(): iterable
+    {
+        foreach (VaultPermission::cases() as $permission) {
+            yield $permission->value => [$permission];
+        }
+    }
+
+    private function createSubject(
+        SecurityProfile $profile,
+        bool $overrideDisabled,
+        bool $breakGlassActive = false,
+        ?bool $technicalActorAdmin = null,
+    ): AccessControlService {
+        $breakGlass = $this->createMock(BreakGlassStateInterface::class);
+        $breakGlass->method('isActive')->willReturn($breakGlassActive);
+
+        $technicalActorContext = null;
+        if ($technicalActorAdmin !== null) {
+            $technicalActorContext = $this->createMock(TechnicalActorContextInterface::class);
+            $technicalActorContext
+                ->method('getCurrentActor')
+                ->willReturn(new TechnicalActor(
+                    uid: 10,
+                    username: 'tech_indexer',
+                    admin: $technicalActorAdmin,
+                    groupIds: [],
+                ));
+        }
+
+        return new AccessControlService(
+            $this->createConfiguration($profile, $overrideDisabled),
+            null,
+            $technicalActorContext,
+            $breakGlass,
+        );
+    }
+
+    private function createConfiguration(
+        SecurityProfile $profile,
+        bool $overrideDisabled,
+    ): ExtensionConfigurationInterface&MockObject {
+        $configuration = $this->createMock(ExtensionConfigurationInterface::class);
+        $configuration->method('getSecurityProfile')->willReturn($profile);
+        $configuration->method('isAdminOverrideDisabled')->willReturn($overrideDisabled);
+
+        return $configuration;
+    }
+
+    /**
+     * @param list<VaultPermission> $grantedOptions
+     */
+    private function setAdminBackendUser(
+        bool $isAdmin = true,
+        bool $isSystemMaintainer = false,
+        array $grantedOptions = [],
+    ): void {
+        $GLOBALS['BE_USER'] = $this->createMockBackendUser(
+            uid: self::ADMIN_UID,
+            isAdmin: $isAdmin,
+            isSystemMaintainer: $isSystemMaintainer,
+            grantedPermissions: $grantedOptions,
+        );
+    }
+
+    private function createSecret(int $ownerUid): Secret
+    {
+        return new Secret(
+            identifier: 'test-secret',
+            ownerUid: $ownerUid,
+        );
+    }
+}

--- a/Tests/Unit/Security/AccessControlServiceIsGrantedTest.php
+++ b/Tests/Unit/Security/AccessControlServiceIsGrantedTest.php
@@ -35,8 +35,6 @@ use TYPO3\CMS\Core\Http\ServerRequest;
 #[AllowMockObjectsWithoutExpectations]
 final class AccessControlServiceIsGrantedTest extends TestCase
 {
-    private const OPTION_PREFIX = 'tx_nrvault:';
-
     private AccessControlService $subject;
 
     private ExtensionConfigurationInterface&MockObject $configuration;
@@ -203,11 +201,11 @@ final class AccessControlServiceIsGrantedTest extends TestCase
     }
 
     /**
-     * Install a backend user whose `check('custom_options', ...)` answers for
-     * exactly the given permissions.
+     * Install a backend user whose groups grant exactly the given permissions.
      *
-     * Mirrors TYPO3 core semantics: `check()` consults the merged group data,
-     * so a grant is present or it is not — there is no per-user override.
+     * Mirrors TYPO3 core storage: the grants live in the merged
+     * `groupData['custom_options']` list, so a grant is present or it is not —
+     * there is no per-user override.
      *
      * @param list<VaultPermission> $grantedOptions
      */
@@ -217,28 +215,13 @@ final class AccessControlServiceIsGrantedTest extends TestCase
         bool $isSystemMaintainer = false,
         int $disable = 0,
     ): void {
-        $granted = array_map(
-            static fn (VaultPermission $permission): string => self::OPTION_PREFIX . $permission->value,
-            $grantedOptions,
-        );
-
-        // The shared trait owns the `user` record / `userGroupsUID` / role
-        // wiring; only the group-data lookup that carries the custom permission
-        // options is specific to this test.
-        $backendUser = $this->createMockBackendUser(
+        $GLOBALS['BE_USER'] = $this->createMockBackendUser(
             uid: 5,
             isAdmin: $isAdmin,
             disabled: $disable !== 0,
             isSystemMaintainer: $isSystemMaintainer,
+            grantedPermissions: $grantedOptions,
         );
-        $backendUser
-            ->method('check')
-            ->willReturnCallback(
-                static fn (string $type, string $value): bool => $type === 'custom_options'
-                    && \in_array($value, $granted, true),
-            );
-
-        $GLOBALS['BE_USER'] = $backendUser;
     }
 
     /**

--- a/Tests/Unit/Security/BreakGlassServiceTest.php
+++ b/Tests/Unit/Security/BreakGlassServiceTest.php
@@ -1,0 +1,461 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Security;
+
+use DateTimeImmutable;
+use Netresearch\NrVault\Audit\AuditAction;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Event\BreakGlassActivatedEvent;
+use Netresearch\NrVault\Event\BreakGlassDeactivatedEvent;
+use Netresearch\NrVault\Exception\AccessDeniedException;
+use Netresearch\NrVault\Exception\ValidationException;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\BreakGlassService;
+use Netresearch\NrVault\Security\BreakGlassServiceInterface;
+use Netresearch\NrVault\Security\BreakGlassSession;
+use Netresearch\NrVault\Security\BreakGlassState;
+use Netresearch\NrVault\Security\VaultPermission;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\EventDispatcher\EventDispatcherInterface;
+use TYPO3\CMS\Core\Registry;
+
+/**
+ * Activation policy, mandatory justification, TTL clamp and evidence trail.
+ *
+ * The audit row and the event are asserted here rather than left to the
+ * functional suite because they are not decoration: a break-glass window that
+ * opens without them is the plain admin override with extra steps.
+ *
+ * @see \Netresearch\NrVault\Tests\Functional\Security\BreakGlassServiceTest for the
+ *      end-to-end persistence, hash chain and access-control integration
+ */
+#[CoversClass(BreakGlassService::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class BreakGlassServiceTest extends TestCase
+{
+    private Registry&MockObject $registry;
+
+    private AccessControlServiceInterface&MockObject $accessControlService;
+
+    private AuditLogServiceInterface&MockObject $auditLogService;
+
+    private EventDispatcherInterface&MockObject $eventDispatcher;
+
+    private BreakGlassService $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // `BreakGlassState` is final and stays real: the only thing worth
+        // faking is the database behind it, so the Registry mock IS the seam.
+        // That also makes the persistence assertions below observe exactly what
+        // production writes.
+        $this->registry = $this->createMock(Registry::class);
+        $this->accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        $this->auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $this->eventDispatcher = $this->createMock(EventDispatcherInterface::class);
+
+        $this->subject = new BreakGlassService(
+            new BreakGlassState($this->registry),
+            $this->accessControlService,
+            $this->auditLogService,
+            $this->eventDispatcher,
+        );
+
+        unset($GLOBALS['BE_USER']);
+    }
+
+    protected function tearDown(): void
+    {
+        unset($GLOBALS['BE_USER']);
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function anAdminMayActivate(): void
+    {
+        $this->givenBackendActor(isAdmin: true);
+        $this->registry->expects(self::once())->method('set');
+
+        $session = $this->subject->activate('INC-4711 rotate leaked key');
+
+        self::assertSame('INC-4711 rotate leaked key', $session->reason);
+        self::assertSame(5, $session->activatedByUid);
+        self::assertSame('alice', $session->activatedByUsername);
+    }
+
+    #[Test]
+    public function aSystemMaintainerMayActivate(): void
+    {
+        $this->givenBackendActor(isAdmin: false, isSystemMaintainer: true);
+        $this->registry->expects(self::once())->method('set');
+
+        $this->subject->activate('incident');
+    }
+
+    #[Test]
+    public function aRealCliOperatorMayActivate(): void
+    {
+        // A shell on the host already reaches the master key and settings.php,
+        // so CLI is trusted — and deliberately not gated on `allowCliAccess`,
+        // which governs unattended secret reads, a different question.
+        $this->accessControlService->method('getCurrentActorType')->willReturn('cli');
+        $this->accessControlService->method('getCurrentActorUid')->willReturn(0);
+        $this->accessControlService->method('getCurrentActorUsername')->willReturn('CLI');
+        $this->registry->expects(self::once())->method('set');
+
+        $session = $this->subject->activate('incident');
+
+        self::assertSame('CLI', $session->activatedByUsername);
+    }
+
+    #[Test]
+    public function aNonAdminBackendUserMayNotActivate(): void
+    {
+        // Even holding every `custom_options` grant: break-glass is not one of
+        // the granular permissions, it is the thing that restores them.
+        $this->givenBackendActor(isAdmin: false);
+        $this->registry->expects(self::never())->method('set');
+
+        $this->expectException(AccessDeniedException::class);
+        $this->expectExceptionCode(1753900001);
+
+        $this->subject->activate('incident');
+    }
+
+    #[Test]
+    public function aDisabledAdminMayNotActivate(): void
+    {
+        $this->givenBackendActor(isAdmin: true, disabled: true);
+        $this->registry->expects(self::never())->method('set');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $this->subject->activate('incident');
+    }
+
+    #[Test]
+    public function noActorAtAllMayNotActivate(): void
+    {
+        $this->accessControlService->method('getCurrentActorType')->willReturn('api');
+        $this->registry->expects(self::never())->method('set');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $this->subject->activate('incident');
+    }
+
+    #[Test]
+    public function aTechnicalActorScopeMayNotActivate(): void
+    {
+        // `runAs()` is explicitly NOT an authentication boundary — any code with
+        // DI access can open a scope, so accepting it would let arbitrary
+        // extension code mint its own bypass with a synthetic justification.
+        $this->accessControlService->method('getCurrentActorType')->willReturn('technical');
+        $this->registry->expects(self::never())->method('set');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $this->subject->activate('incident');
+    }
+
+    #[Test]
+    #[DataProvider('emptyReasonProvider')]
+    public function activationRequiresANonEmptyReason(string $reason): void
+    {
+        $this->givenBackendActor(isAdmin: true);
+        $this->registry->expects(self::never())->method('set');
+
+        $this->expectException(ValidationException::class);
+        $this->expectExceptionCode(1753900002);
+
+        $this->subject->activate($reason);
+    }
+
+    #[Test]
+    #[DataProvider('emptyReasonProvider')]
+    public function deactivationRequiresANonEmptyReason(string $reason): void
+    {
+        $this->givenBackendActor(isAdmin: true);
+        $this->registry->expects(self::never())->method('remove');
+
+        $this->expectException(ValidationException::class);
+
+        $this->subject->deactivate($reason);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function emptyReasonProvider(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'spaces' => ['   '];
+        yield 'tab and newline' => ["\t\n"];
+    }
+
+    #[Test]
+    public function theReasonIsStoredTrimmed(): void
+    {
+        $this->givenBackendActor(isAdmin: true);
+
+        $session = $this->subject->activate('  INC-4711  ');
+
+        self::assertSame('INC-4711', $session->reason);
+    }
+
+    /**
+     * Clamping rather than rejecting: a fat-fingered value during an incident
+     * should yield the ceiling, not an error the operator re-reads under
+     * pressure. The ceiling is what carries the security property.
+     */
+    #[Test]
+    #[DataProvider('ttlProvider')]
+    public function clampsTheTtl(int $requested, int $expectedMinutes): void
+    {
+        $this->givenBackendActor(isAdmin: true);
+
+        $session = $this->subject->activate('incident', $requested);
+
+        self::assertSame(
+            $expectedMinutes * 60,
+            $session->expiresAt->getTimestamp() - $session->activatedAt->getTimestamp(),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{int, int}>
+     */
+    public static function ttlProvider(): iterable
+    {
+        yield 'zero clamps to the floor' => [0, BreakGlassServiceInterface::MIN_TTL_MINUTES];
+        yield 'negative clamps to the floor' => [-30, BreakGlassServiceInterface::MIN_TTL_MINUTES];
+        yield 'floor is honoured' => [1, 1];
+        yield 'in range' => [30, 30];
+        yield 'ceiling is honoured' => [60, 60];
+        yield 'above the ceiling clamps down' => [600, BreakGlassServiceInterface::MAX_TTL_MINUTES];
+    }
+
+    #[Test]
+    public function defaultsToTheDocumentedTtl(): void
+    {
+        $this->givenBackendActor(isAdmin: true);
+
+        $session = $this->subject->activate('incident');
+
+        self::assertSame(
+            BreakGlassServiceInterface::DEFAULT_TTL_MINUTES * 60,
+            $session->expiresAt->getTimestamp() - $session->activatedAt->getTimestamp(),
+        );
+    }
+
+    #[Test]
+    public function activationAuditsBeforeGrantingThePower(): void
+    {
+        // Order matters: the two stores cannot be written atomically, and only
+        // this order makes "window open without evidence" impossible.
+        $this->givenBackendActor(isAdmin: true);
+
+        $calls = [];
+        $this->auditLogService
+            ->method('log')
+            ->willReturnCallback(static function () use (&$calls): void {
+                $calls[] = 'audit';
+            });
+        $this->registry
+            ->method('set')
+            ->willReturnCallback(static function () use (&$calls): void {
+                $calls[] = 'store';
+            });
+
+        $this->subject->activate('incident');
+
+        self::assertSame(['audit', 'store'], $calls);
+    }
+
+    #[Test]
+    public function activationWritesTheAuditRowWithTheActionAndReason(): void
+    {
+        $this->givenBackendActor(isAdmin: true);
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with(
+                BreakGlassService::AUDIT_PSEUDO_IDENTIFIER,
+                AuditAction::BreakGlassActivated->value,
+                true,
+                null,
+                'INC-4711',
+            );
+
+        $this->subject->activate('INC-4711');
+    }
+
+    #[Test]
+    public function activationDispatchesTheEvent(): void
+    {
+        $this->givenBackendActor(isAdmin: true);
+
+        $dispatched = null;
+        $this->eventDispatcher
+            ->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $event) use (&$dispatched): object {
+                $dispatched = $event;
+
+                return $event;
+            });
+
+        $session = $this->subject->activate('INC-4711');
+
+        self::assertInstanceOf(BreakGlassActivatedEvent::class, $dispatched);
+        self::assertSame('INC-4711', $dispatched->getReason());
+        self::assertSame('alice', $dispatched->getActorUsername());
+        self::assertSame(5, $dispatched->getActorUid());
+        self::assertSame($session->expiresAt->getTimestamp(), $dispatched->getExpiresAt()->getTimestamp());
+    }
+
+    #[Test]
+    public function deactivationRevokesBeforeLogging(): void
+    {
+        $this->givenBackendActor(isAdmin: true);
+        $this->givenOpenWindow();
+
+        $calls = [];
+        $this->registry
+            ->method('remove')
+            ->willReturnCallback(static function () use (&$calls): void {
+                $calls[] = 'clear';
+            });
+        $this->auditLogService
+            ->method('log')
+            ->willReturnCallback(static function () use (&$calls): void {
+                $calls[] = 'audit';
+            });
+
+        $this->subject->deactivate('done');
+
+        self::assertSame(['clear', 'audit'], $calls);
+    }
+
+    #[Test]
+    public function deactivationWritesTheAuditRowWithTheActionAndReason(): void
+    {
+        $this->givenBackendActor(isAdmin: true);
+        $this->givenOpenWindow();
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with(
+                BreakGlassService::AUDIT_PSEUDO_IDENTIFIER,
+                AuditAction::BreakGlassDeactivated->value,
+                true,
+                null,
+                'INC-4711 closed',
+            );
+
+        $this->subject->deactivate('INC-4711 closed');
+    }
+
+    #[Test]
+    public function deactivationDispatchesTheEvent(): void
+    {
+        $this->givenBackendActor(isAdmin: true);
+        $this->givenOpenWindow();
+
+        $dispatched = null;
+        $this->eventDispatcher
+            ->expects(self::once())
+            ->method('dispatch')
+            ->willReturnCallback(static function (object $event) use (&$dispatched): object {
+                $dispatched = $event;
+
+                return $event;
+            });
+
+        $this->subject->deactivate('INC-4711 closed');
+
+        self::assertInstanceOf(BreakGlassDeactivatedEvent::class, $dispatched);
+        self::assertSame('INC-4711 closed', $dispatched->getReason());
+    }
+
+    #[Test]
+    public function deactivatingAClosedWindowLeavesNoTrace(): void
+    {
+        // Closing an already-closed window is the desired end state, not an
+        // error — but no audit row and no event may imply a window that was not
+        // open.
+        $this->givenBackendActor(isAdmin: true);
+        $this->registry->method('get')->willReturn(null);
+
+        $this->auditLogService->expects(self::never())->method('log');
+        $this->eventDispatcher->expects(self::never())->method('dispatch');
+        $this->registry->expects(self::once())->method('remove');
+
+        $this->subject->deactivate('cleanup');
+    }
+
+    #[Test]
+    public function readAccessorsDelegateToTheState(): void
+    {
+        $this->givenOpenWindow();
+
+        $session = $this->subject->getActiveSession();
+
+        self::assertInstanceOf(BreakGlassSession::class, $session);
+        self::assertSame('INC-4711', $session->reason);
+        self::assertTrue($this->subject->isActive());
+    }
+
+    private function givenOpenWindow(): void
+    {
+        $this->registry->method('get')->willReturn($this->openSession()->toArray());
+    }
+
+    private function openSession(): BreakGlassSession
+    {
+        return new BreakGlassSession(
+            activatedByUid: 5,
+            activatedByUsername: 'alice',
+            reason: 'INC-4711',
+            activatedAt: new DateTimeImmutable(),
+            expiresAt: (new DateTimeImmutable())->setTimestamp(time() + 600),
+        );
+    }
+
+    private function givenBackendActor(
+        bool $isAdmin,
+        bool $isSystemMaintainer = false,
+        bool $disabled = false,
+    ): void {
+        $this->accessControlService->method('getCurrentActorType')->willReturn('backend');
+        $this->accessControlService->method('getCurrentActorUid')->willReturn(5);
+        $this->accessControlService->method('getCurrentActorUsername')->willReturn('alice');
+
+        // Every operation permission granted, to prove the activation policy
+        // does not read the granular grants at all — break-glass is not one of
+        // them, it is what restores them.
+        $GLOBALS['BE_USER'] = $this->createMockBackendUser(
+            uid: 5,
+            isAdmin: $isAdmin,
+            disabled: $disabled,
+            isSystemMaintainer: $isSystemMaintainer,
+            grantedPermissions: VaultPermission::cases(),
+        );
+    }
+}

--- a/Tests/Unit/Security/BreakGlassSessionTest.php
+++ b/Tests/Unit/Security/BreakGlassSessionTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Security;
+
+use DateTimeImmutable;
+use Netresearch\NrVault\Security\BreakGlassSession;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(BreakGlassSession::class)]
+final class BreakGlassSessionTest extends TestCase
+{
+    #[Test]
+    public function roundTripsThroughTheRegistryPayload(): void
+    {
+        $session = new BreakGlassSession(
+            activatedByUid: 7,
+            activatedByUsername: 'alice',
+            reason: 'INC-4711 rotate leaked deploy key',
+            activatedAt: (new DateTimeImmutable())->setTimestamp(1_760_000_000),
+            expiresAt: (new DateTimeImmutable())->setTimestamp(1_760_000_900),
+        );
+
+        $restored = BreakGlassSession::fromArray($session->toArray());
+
+        self::assertInstanceOf(BreakGlassSession::class, $restored);
+        self::assertSame(7, $restored->activatedByUid);
+        self::assertSame('alice', $restored->activatedByUsername);
+        self::assertSame('INC-4711 rotate leaked deploy key', $restored->reason);
+        self::assertSame(1_760_000_000, $restored->activatedAt->getTimestamp());
+        self::assertSame(1_760_000_900, $restored->expiresAt->getTimestamp());
+    }
+
+    #[Test]
+    public function storesOnlyScalarsSoAnAuditorCanReadTheRegistryRow(): void
+    {
+        $session = $this->createSession(expiresAt: 1_760_000_900);
+
+        foreach ($session->toArray() as $key => $value) {
+            self::assertIsScalar($value, \sprintf('payload key "%s" must be scalar', $key));
+        }
+    }
+
+    /**
+     * A malformed payload must read as "no session", never as an open-ended
+     * one: a half-written or hand-edited registry row is exactly the input an
+     * attacker would try to widen into a permanent bypass.
+     *
+     * @param array<array-key, mixed> $payload
+     */
+    #[Test]
+    #[DataProvider('malformedPayloadProvider')]
+    public function rejectsAMalformedPayload(array $payload): void
+    {
+        self::assertNull(BreakGlassSession::fromArray($payload));
+    }
+
+    /**
+     * @return iterable<string, array{array<array-key, mixed>}>
+     */
+    public static function malformedPayloadProvider(): iterable
+    {
+        $valid = [
+            'activatedByUid' => 1,
+            'activatedByUsername' => 'alice',
+            'reason' => 'incident',
+            'activatedAt' => 1_760_000_000,
+            'expiresAt' => 1_760_000_900,
+        ];
+
+        yield 'empty' => [[]];
+
+        foreach (array_keys($valid) as $missing) {
+            $payload = $valid;
+            unset($payload[$missing]);
+
+            yield 'missing ' . $missing => [$payload];
+        }
+
+        yield 'non-numeric expiry' => [[...$valid, 'expiresAt' => 'never']];
+        yield 'non-string reason' => [[...$valid, 'reason' => ['incident']]];
+        yield 'non-string username' => [[...$valid, 'activatedByUsername' => 42]];
+        yield 'non-numeric uid' => [[...$valid, 'activatedByUid' => 'alice']];
+    }
+
+    #[Test]
+    public function acceptsNumericStringsBecauseTheRegistryMayReturnThem(): void
+    {
+        $restored = BreakGlassSession::fromArray([
+            'activatedByUid' => '7',
+            'activatedByUsername' => 'alice',
+            'reason' => 'incident',
+            'activatedAt' => '1760000000',
+            'expiresAt' => '1760000900',
+        ]);
+
+        self::assertInstanceOf(BreakGlassSession::class, $restored);
+        self::assertSame(7, $restored->activatedByUid);
+        self::assertSame(1_760_000_900, $restored->expiresAt->getTimestamp());
+    }
+
+    #[Test]
+    public function isExpiredWhenTheExpiryHasPassed(): void
+    {
+        $session = $this->createSession(expiresAt: 1_760_000_900);
+
+        self::assertTrue($session->isExpiredAt($this->at(1_760_000_901)));
+    }
+
+    #[Test]
+    public function isExpiredExactlyAtTheExpiry(): void
+    {
+        // Inclusive on purpose: the window is closed at the instant it lapses,
+        // not one second later.
+        $session = $this->createSession(expiresAt: 1_760_000_900);
+
+        self::assertTrue($session->isExpiredAt($this->at(1_760_000_900)));
+    }
+
+    #[Test]
+    public function isNotExpiredBeforeTheExpiry(): void
+    {
+        $session = $this->createSession(expiresAt: 1_760_000_900);
+
+        self::assertFalse($session->isExpiredAt($this->at(1_760_000_899)));
+    }
+
+    #[Test]
+    public function reportsTheRemainingSeconds(): void
+    {
+        $session = $this->createSession(expiresAt: 1_760_000_900);
+
+        self::assertSame(300, $session->remainingSeconds($this->at(1_760_000_600)));
+    }
+
+    #[Test]
+    public function clampsTheRemainingSecondsToZeroOnceExpired(): void
+    {
+        $session = $this->createSession(expiresAt: 1_760_000_900);
+
+        self::assertSame(0, $session->remainingSeconds($this->at(1_760_009_999)));
+    }
+
+    private function createSession(int $expiresAt): BreakGlassSession
+    {
+        return new BreakGlassSession(
+            activatedByUid: 1,
+            activatedByUsername: 'alice',
+            reason: 'incident',
+            activatedAt: $this->at($expiresAt - 900),
+            expiresAt: $this->at($expiresAt),
+        );
+    }
+
+    private function at(int $timestamp): DateTimeImmutable
+    {
+        return (new DateTimeImmutable())->setTimestamp($timestamp);
+    }
+}

--- a/Tests/Unit/Security/BreakGlassStateTest.php
+++ b/Tests/Unit/Security/BreakGlassStateTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Security;
+
+use DateTimeImmutable;
+use Netresearch\NrVault\Security\BreakGlassSession;
+use Netresearch\NrVault\Security\BreakGlassState;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use RuntimeException;
+use TYPO3\CMS\Core\Registry;
+
+/**
+ * Registry-backed break-glass state.
+ *
+ * Time is frozen by crafting the stored expiry relative to `time()` rather than
+ * by injecting a clock: expiry is a read-time comparison against the real clock
+ * by design (no cron can stall and silently extend a window), so the test
+ * exercises the same comparison production does.
+ */
+#[CoversClass(BreakGlassState::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class BreakGlassStateTest extends TestCase
+{
+    private Registry&MockObject $registry;
+
+    private BreakGlassState $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->registry = $this->createMock(Registry::class);
+        $this->subject = new BreakGlassState($this->registry);
+    }
+
+    #[Test]
+    public function reportsAnUnexpiredSessionAsActive(): void
+    {
+        $this->givenStoredPayload($this->payload(expiresIn: 600));
+
+        $session = $this->subject->getActiveSession();
+
+        self::assertInstanceOf(BreakGlassSession::class, $session);
+        self::assertSame('alice', $session->activatedByUsername);
+        self::assertSame('INC-4711', $session->reason);
+        self::assertTrue($this->subject->isActive());
+    }
+
+    #[Test]
+    public function reportsAnExpiredSessionAsInactive(): void
+    {
+        // The whole point of read-time expiry: no cleanup job ran, the row is
+        // still there, and the bypass is nonetheless gone.
+        $this->givenStoredPayload($this->payload(expiresIn: -1));
+
+        self::assertNull($this->subject->getActiveSession());
+        self::assertFalse($this->subject->isActive());
+    }
+
+    #[Test]
+    public function readsAreFreeOfSideEffects(): void
+    {
+        // `canRead()` reaches this on every secret access, including in the
+        // frontend — a lazy purge-on-read would put a DB write on that path.
+        $this->givenStoredPayload($this->payload(expiresIn: -1));
+        $this->registry->expects(self::never())->method('remove');
+        $this->registry->expects(self::never())->method('set');
+
+        $this->subject->isActive();
+    }
+
+    #[Test]
+    public function reportsInactiveWhenNothingIsStored(): void
+    {
+        $this->givenStoredPayload(null);
+
+        self::assertNull($this->subject->getActiveSession());
+        self::assertFalse($this->subject->isActive());
+    }
+
+    #[Test]
+    public function reportsInactiveForAMalformedPayload(): void
+    {
+        $this->givenStoredPayload(['reason' => 'incident']);
+
+        self::assertFalse($this->subject->isActive());
+    }
+
+    #[Test]
+    public function reportsInactiveForANonArrayPayload(): void
+    {
+        $this->givenStoredPayload('yes');
+
+        self::assertFalse($this->subject->isActive());
+    }
+
+    #[Test]
+    public function failsClosedWhenTheRegistryIsUnreadable(): void
+    {
+        // Bootstrap contexts (install tool, upgrade wizards, a CLI run before
+        // the schema exists) must not turn an unreadable `sys_registry` into
+        // either a fatal error in an unrelated code path or an open window.
+        $this->registry
+            ->method('get')
+            ->willThrowException(new RuntimeException('sys_registry missing', 1753900099));
+
+        self::assertFalse($this->subject->isActive());
+    }
+
+    #[Test]
+    public function readsTheVaultNamespace(): void
+    {
+        $this->registry
+            ->expects(self::once())
+            ->method('get')
+            ->with(BreakGlassState::REGISTRY_NAMESPACE, BreakGlassState::REGISTRY_KEY)
+            ->willReturn(null);
+
+        self::assertFalse($this->subject->isActive());
+    }
+
+    #[Test]
+    public function storesTheSessionPayloadUnderTheVaultNamespace(): void
+    {
+        $session = new BreakGlassSession(
+            activatedByUid: 7,
+            activatedByUsername: 'alice',
+            reason: 'INC-4711',
+            activatedAt: (new DateTimeImmutable())->setTimestamp(1_760_000_000),
+            expiresAt: (new DateTimeImmutable())->setTimestamp(1_760_000_900),
+        );
+
+        $this->registry
+            ->expects(self::once())
+            ->method('set')
+            ->with(
+                BreakGlassState::REGISTRY_NAMESPACE,
+                BreakGlassState::REGISTRY_KEY,
+                $session->toArray(),
+            );
+
+        $this->subject->store($session);
+    }
+
+    #[Test]
+    public function clearRemovesTheRegistryEntry(): void
+    {
+        $this->registry
+            ->expects(self::once())
+            ->method('remove')
+            ->with(BreakGlassState::REGISTRY_NAMESPACE, BreakGlassState::REGISTRY_KEY);
+
+        $this->subject->clear();
+    }
+
+    private function givenStoredPayload(mixed $payload): void
+    {
+        // No `with()` constraint here — the namespace/key contract of the read
+        // is asserted once in `readsTheVaultNamespace()`; repeating it in every
+        // stub only adds mock configuration noise.
+        $this->registry
+            ->method('get')
+            ->willReturn($payload);
+    }
+
+    /**
+     * @return array<string, int|string>
+     */
+    private function payload(int $expiresIn): array
+    {
+        $now = time();
+
+        return [
+            'activatedByUid' => 7,
+            'activatedByUsername' => 'alice',
+            'reason' => 'INC-4711',
+            'activatedAt' => $now - 60,
+            'expiresAt' => $now + $expiresIn,
+        ];
+    }
+}

--- a/Tests/Unit/Traits/BackendUserMockTrait.php
+++ b/Tests/Unit/Traits/BackendUserMockTrait.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Traits;
 
+use Netresearch\NrVault\Security\VaultPermission;
 use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
@@ -33,11 +34,21 @@ trait BackendUserMockTrait
      * a boolean `disabled` flag via the `user['disable']` column (mirroring the
      * TYPO3 `be_users.disable` field).
      *
+     * Vault operation permissions are wired the way TYPO3 stores them: as the
+     * comma-separated `groupData['custom_options']` list that
+     * `AccessControlService` evaluates. Do NOT stub `check()` instead — core's
+     * `check()` returns true unconditionally for admins, so a test that stubs it
+     * cannot tell a real group grant from the admin override and would pass
+     * while the override is disabled.
+     *
      * @param list<int> $groupIds backend user group UIDs (populates `userGroupsUID`)
      * @param bool $isSystemMaintainer answer for `isSystemMaintainer()` — core
      *                                 treats the role as strictly stronger than
      *                                 `admin`, and the vault's permission gates
      *                                 must honour it independently
+     * @param list<VaultPermission> $grantedPermissions vault operation
+     *                                                  permissions granted via
+     *                                                  the user's groups
      */
     protected function createMockBackendUser(
         int $uid = 1,
@@ -45,6 +56,7 @@ trait BackendUserMockTrait
         array $groupIds = [],
         bool $disabled = false,
         bool $isSystemMaintainer = false,
+        array $grantedPermissions = [],
     ): BackendUserAuthentication&MockObject {
         /** @var BackendUserAuthentication&MockObject $backendUser */
         $backendUser = $this->createMock(BackendUserAuthentication::class);
@@ -57,6 +69,11 @@ trait BackendUserMockTrait
             'disable' => $disabled ? 1 : 0,
         ];
         $backendUser->userGroupsUID = $groupIds;
+        /** @phpstan-ignore property.internal */
+        $backendUser->groupData['custom_options'] = implode(',', array_map(
+            static fn (VaultPermission $permission): string => 'tx_nrvault:' . $permission->value,
+            $grantedPermissions,
+        ));
 
         return $backendUser;
     }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -45,6 +45,9 @@ auditLogRetention = 365
 # cat=Security; type=boolean; label=Audit Read Operations: Log every secret read to the audit log. Disable for high-throughput scenarios where read logging is not required.
 auditReads = 1
 
+# cat=Security; type=boolean; label=Disable Admin Override (Hardened profile only): Remove the unconditional "admins and system maintainers may do anything" bypass — both the operation permissions and the per-secret read/write/delete tiers. Admins then need the same group grants as everyone else and can only read secrets they own or share a group with. Requires securityProfile = hardened; in the standard profile this flag has no effect (lockout guard). Recover full admin power for a time-boxed, audited window with "vault:break-glass --activate". Pin the value out of admin reach in config/system/additional.php via $GLOBALS['TYPO3_CONF_VARS']['SYS']['nrVault']['disableAdminOverride'].
+disableAdminOverride = 0
+
 # cat=Security; type=int+; label=Audit HMAC Epoch: Hash algorithm version marker for the audit log hash chain (0 = legacy SHA-256 without HMAC, 1 = HMAC-SHA256 over identity fields only, 2 = HMAC-SHA256 over identity + forensic fields including success/error_message/reason/ip_address/user_agent/context, 3 = additionally binds the epoch selector hmac_key_epoch plus the attribution fields actor_type/actor_username/actor_role/request_id). Default 3 closes the algorithm-downgrade forgery (a DB-write attacker can no longer downgrade a row to keyless SHA-256 and re-sign it) and makes actor attribution tamper-evident. Run the install-tool "Migrate audit hash chain" wizard after bumping.
 auditHmacEpoch = 3
 


### PR DESCRIPTION
## Summary

P0 item (roadmap PR 4): the global admin bypass becomes disableable in the hardened profile, with an audited, time-boxed break-glass window as the escape hatch. Stacked on #238 (uses the `adminOverrideGrants` seam introduced there, now generalized).

**Disableable admin override**
- `disableAdminOverride` (hardened profile only; inert in standard as a lockout guard) removes the admin/system-maintainer bypass from **both** layers — operation permissions *and* the per-secret read/write/delete tiers — via the single seam `AccessControlService::adminBypassActive()`. Pinnable out of admin reach via `$GLOBALS['TYPO3_CONF_VARS']['SYS']['nrVault']['disableAdminOverride']` (same pattern as the `auditReads` pin).
- **Key finding during implementation:** core's `BackendUserAuthentication::check()` short-circuits to `true` for any admin — routing grants through it would have produced a half-disabled override (per-secret tiers hardened, operation permissions still bypassed). The grant lookup now reads the same `groupData['custom_options']` list core evaluates, minus the short-circuit; non-admin behavior is byte-identical. Caught by an end-to-end functional test, not unit mocks.
- `isCurrentActorAdmin()` now answers "does the admin bypass apply" (all consumers use it as an authorization bypass; details in the commit message).

**Break-glass**
- `vault:break-glass --activate --reason "…" [--minutes N]` (1–60, clamped, default 15): mandatory justification, **audit row written before power is granted** (an open window without evidence must be impossible; a logged failed opening is harmless), new hash-chain-safe `AuditAction` cases, PSR-14 `BreakGlassActivated/DeactivatedEvent`, danger banner in the vault backend modules while active, `--status` machine-readable (incl. `adminOverrideDisabledEffective` — the flag-set-but-profile-standard detector for `vault:doctor`).
- Activation only by a real backend admin or the trusted CLI — a `runAs()` technical-actor scope may **not** (not an authentication boundary).
- Read path is side-effect free (expiry is a read-time comparison; no purge-on-read DB writes from the frontend).
- DI: access control consumes a read-only `BreakGlassStateInterface`; only `BreakGlassServiceInterface` can open a window (no dependency cycle, no self-service bypass).

**Known gap:** the warning banner render itself is not automatically tested (backend module rendering is E2E-only per existing test docblocks); provider data shape is unit-tested. Needs a Playwright spec or manual DDEV check before release.

## Test plan
- `composer ci` exit 0 (2473 unit+fuzz tests, +138), PHPStan 10 clean (no baseline additions), Rector clean, functional suite green (196 tests) — verified locally.
- 62-case admin-override matrix; functional break-glass suite (hardened + file provider): exactly one audit row per transition, chain verifies, events dispatched, non-admin with every grant refused, expired window grants nothing.

Roadmap: PR 4 of 10 — follows #238.
