### PR TITLE
Add security-invariant tests and blocking quality gates

### DIFF
--- a/.github/workflows/security-gates.yml
+++ b/.github/workflows/security-gates.yml
@@ -1,0 +1,210 @@
+name: Security Gates
+
+# Mutation ratchet for the security-critical directories (Classes/Crypto,
+# Classes/Security, Classes/Audit) via `infection-security.json5`.
+#
+# WHY A STANDALONE WORKFLOW
+# =========================
+# `checks.yml` is the natural home for a quality job, but it is byte-identical
+# and drift-enforced across every netresearch typo3-extension (see
+# check-template-drift.yml) — adding an extension-specific job there would break
+# that check. `ci.yml` is the extension-specific file, but it is a thin call into
+# the shared `typo3-ci-workflows/ci.yml` matrix and the upstream mutation job in
+# `extended-testing.yml` hardcodes the default `infection.json5` plus testsuite
+# and config paths this repo does not use. So the gate lives here until an
+# upstream reusable accepts a custom Infection configuration.
+#
+# WHY THE THREE-JOB SHAPE
+# =======================
+# The expensive job must only run when the security-critical code changes, but a
+# workflow-level `paths:` filter cannot be combined with a REQUIRED status check:
+# on a PR that touches nothing else, the check would never report and the PR
+# would sit "expected — waiting for status" forever (and `merge_group` does not
+# support `paths` at all). Instead every job is always triggered, `detect`
+# decides whether the mutation run is needed, and `security-gates` always reports
+# — so it can be marked required in branch protection while unrelated PRs still
+# pass immediately. The gate FAILS when mutation fails; it does not "continue on
+# error".
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  merge_group:
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect:
+    name: Detect security-critical changes
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    outputs:
+      security-changed: ${{ steps.filter.outputs.security-changed }}
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Plain git rather than a third-party paths-filter action: one less
+      # third-party dependency to pin and audit for a ten-line diff check.
+      - name: Check whether security-critical paths changed
+        id: filter
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+        run: |
+          set -euo pipefail
+
+          # Anything outside a pull request (push to main, merge queue) always
+          # runs the gate: there is no meaningful "changed files" base, and
+          # failing closed is the right default for a security check.
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo 'security-changed=true' >> "$GITHUB_OUTPUT"
+            echo "Event '$EVENT_NAME' always runs the security mutation gate."
+            exit 0
+          fi
+
+          git fetch --no-tags origin "$BASE_REF"
+          changed="$(git diff --name-only "origin/${BASE_REF}...HEAD")"
+          echo "Changed files:"
+          echo "$changed"
+
+          # The gate's own inputs count as security-critical: a PR that lowers
+          # the ratchet, rewrites the config or edits the crypto/audit tests must
+          # be measured, not waved through.
+          if echo "$changed" | grep -qE '^(Classes/(Crypto|Security|Audit)/|Tests/(Fuzz|Unit/(Crypto|Security|Audit)|Functional/(Crypto|Security|Audit))/|infection-security\.json5$|infection\.json5$|composer\.json$|Build/phpunit\.xml$|\.github/workflows/security-gates\.yml$)'; then
+            echo 'security-changed=true' >> "$GITHUB_OUTPUT"
+            echo "Security-critical paths changed — running the mutation gate."
+          else
+            echo 'security-changed=false' >> "$GITHUB_OUTPUT"
+            echo "No security-critical paths changed — skipping the mutation run."
+          fi
+
+  mutation:
+    name: Security mutation ratchet
+    needs: detect
+    if: needs.detect.outputs.security-changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    permissions:
+      contents: read
+    steps:
+      - name: Harden runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
+        with:
+          php-version: '8.5'
+          # sodium is not optional here — every mutant under test is crypto.
+          extensions: intl, mbstring, xml, sodium, json, pcov
+          coverage: pcov
+          tools: composer:v2
+
+      - name: Install dependencies
+        env:
+          # CaptainHook's post-install hook installer is pointless on a CI
+          # checkout and fails in a detached worktree.
+          CAPTAINHOOK_DISABLE: 'true'
+        run: composer install --prefer-dist --no-progress
+
+      # Coverage over Unit AND Fuzz, matching `testFrameworkOptions` in
+      # infection-security.json5. The crypto boundary is covered by property/fuzz
+      # tests, so measuring the Unit suite alone would understate the real MSI and
+      # make the ratchet meaningless.
+      - name: Generate coverage for Infection
+        run: |
+          set -euo pipefail
+          mkdir -p .Build/logs-security
+          .Build/bin/phpunit -c Build/phpunit.xml \
+            --testsuite Unit,Fuzz \
+            --coverage-xml=.Build/logs-security/coverage-xml \
+            --log-junit=.Build/logs-security/junit.xml
+
+      # Fails the job when MSI drops below the ratchet in
+      # infection-security.json5. Escaped mutants are annotated onto the diff by
+      # the config's `logs.github` logger.
+      - name: Run security mutation ratchet
+        run: |
+          set -euo pipefail
+          .Build/bin/infection \
+            --configuration=infection-security.json5 \
+            --threads=max \
+            --skip-initial-tests \
+            --coverage=.Build/logs-security \
+            --no-progress
+
+      - name: Upload mutation report
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: infection-security-report
+          path: |
+            .Build/infection-security/infection.log
+            .Build/infection-security/infection.html
+            .Build/infection-security/summary.log
+            .Build/infection-security/per-mutator.md
+          if-no-files-found: warn
+          retention-days: 14
+
+  security-gates:
+    name: Security gates
+    needs: [detect, mutation]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions: {}
+    steps:
+      # The stable check to mark required in branch protection. It reports on
+      # every PR — success when the mutation run was legitimately skipped,
+      # failure whenever the run itself failed or was cancelled.
+      - name: Evaluate gate result
+        env:
+          DETECT_RESULT: ${{ needs.detect.result }}
+          MUTATION_RESULT: ${{ needs.mutation.result }}
+          SECURITY_CHANGED: ${{ needs.detect.outputs.security-changed }}
+        run: |
+          set -euo pipefail
+          echo "detect=$DETECT_RESULT security-changed=$SECURITY_CHANGED mutation=$MUTATION_RESULT"
+
+          if [ "$DETECT_RESULT" != "success" ]; then
+            echo "::error::Change detection failed ($DETECT_RESULT) — refusing to pass the security gate."
+            exit 1
+          fi
+
+          if [ "$SECURITY_CHANGED" != "true" ]; then
+            if [ "$MUTATION_RESULT" != "skipped" ]; then
+              echo "::error::Inconsistent state: no security-critical change but mutation result is '$MUTATION_RESULT'."
+              exit 1
+            fi
+            echo "No security-critical changes — gate passes without a mutation run."
+            exit 0
+          fi
+
+          if [ "$MUTATION_RESULT" != "success" ]; then
+            echo "::error::Security mutation ratchet did not pass ($MUTATION_RESULT). The mutation score index for Classes/{Crypto,Security,Audit} dropped below the floor in infection-security.json5, or the run failed. Kill the escaped mutants listed in the job annotations; lowering the ratchet needs security-team sign-off."
+            exit 1
+          fi
+
+          echo "Security mutation ratchet passed."

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,15 @@ Thumbs.db
 !.env.example
 !.env.dist
 
+# Auto-generated master keys. `masterKeySource` defaults to the bare relative
+# name `NR_VAULT_MASTER_KEY` (ExtensionConfiguration::DEFAULT_MASTER_KEY_SOURCE),
+# so FileMasterKeyProvider's auto-generate path can write a REAL 32-byte master
+# key into whatever the working directory happens to be — the repository root for
+# a CLI or test run. Never committable.
+/NR_VAULT_MASTER_KEY
+*.key
+!Tests/**/Fixtures/*.key
+
 # Build artifacts
 /vendor/
 /var/

--- a/Classes/Crypto/EncryptionService.php
+++ b/Classes/Crypto/EncryptionService.php
@@ -259,7 +259,13 @@ final readonly class EncryptionService implements EncryptionServiceInterface
     /**
      * Resolve the algorithm to use for an existing envelope.
      *
-     * Version 2+: the stored marker is authoritative. An unknown or empty
+     * Unknown versions are a hard error: a version this reader does not
+     * implement may change framing, key derivation or the authenticated
+     * data, so opening it under version-2 rules would decrypt with the
+     * wrong recipe rather than refuse. Forward compatibility must be a
+     * deliberate code change, never an accident of a `>=` comparison.
+     *
+     * Version 2: the stored marker is authoritative. An unknown or empty
      * marker is a hard error — guessing an algorithm for a version-2 row
      * could silently decrypt with the wrong primitive on a different host,
      * which is exactly the implicitness the marker exists to remove.
@@ -270,6 +276,18 @@ final readonly class EncryptionService implements EncryptionServiceInterface
      */
     private function resolveAlgorithm(int $encryptionVersion, string $encryptionAlgorithm): EncryptionAlgorithm
     {
+        if (
+            $encryptionVersion < EncryptionServiceInterface::ENCRYPTION_VERSION_LEGACY
+            || $encryptionVersion > EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT
+        ) {
+            throw EncryptionException::decryptionFailed(\sprintf(
+                'Unsupported encryption version %d (this reader implements %d..%d)',
+                $encryptionVersion,
+                EncryptionServiceInterface::ENCRYPTION_VERSION_LEGACY,
+                EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT,
+            ));
+        }
+
         if ($encryptionVersion >= EncryptionServiceInterface::ENCRYPTION_VERSION_CURRENT) {
             $algorithm = EncryptionAlgorithm::tryFrom($encryptionAlgorithm);
             if (!$algorithm instanceof EncryptionAlgorithm) {

--- a/Tests/Functional/Crypto/MasterKeyRotationAbortTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationAbortTest.php
@@ -1,0 +1,342 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Crypto;
+
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Command\VaultRotateMasterKeyCommand;
+use Netresearch\NrVault\Crypto\FileMasterKeyProvider;
+use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
+use Netresearch\NrVault\Exception\EncryptionException;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Throwable;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Abort safety of `vault:rotate-master-key` when a secret cannot be re-wrapped.
+ *
+ * {@see MasterKeyRotationTest} covers the SUCCESS paths end-to-end plus an
+ * atomicity property proven against a hand-rolled transaction loop that mirrors
+ * the command. What it does not exercise is the REAL command's two abort points,
+ * which is where a partial rotation would actually be produced:
+ *
+ *  1. the pre-transaction smoke test ({@see VaultRotateMasterKeyCommand::verifyOldKey()}),
+ *     which re-wraps the FIRST secret to prove the old key before anything is
+ *     written — a failure here must leave the vault completely untouched;
+ *  2. the in-transaction batch loop, where a failure on a LATER secret must roll
+ *     back the secrets already re-wrapped in the same transaction.
+ *
+ * Both are driven here through {@see CommandTester} with one envelope
+ * deliberately made undecryptable in the database, and both assert the same
+ * property from two directions: the stored `encrypted_dek`/`dek_nonce` columns of
+ * every healthy secret are byte-identical to the pre-run snapshot (nothing was
+ * committed), AND every healthy secret still decrypts to its original plaintext
+ * under the unchanged master key (nothing was corrupted). Checking only
+ * retrievability would pass even if the rotation had silently committed a
+ * consistent-but-rotated state, so the column snapshot is what actually proves
+ * the rollback.
+ */
+#[CoversClass(VaultRotateMasterKeyCommand::class)]
+final class MasterKeyRotationAbortTest extends AbstractVaultFunctionalTestCase
+{
+    private const SECRET_TABLE = 'tx_nrvault_secret';
+
+    protected ?string $backendUserFixture = __DIR__ . '/../Hook/Fixtures/be_users.csv';
+
+    /**
+     * The provider MUST be pinned to `file`. `AbstractVaultFunctionalTestCase`
+     * writes a key file and wires `masterKeySource`/`autoKeyPath`, but the
+     * `masterKeyProvider` setting defaults to `typo3` — so without this the
+     * secrets would be sealed under the TYPO3 encryption key while
+     * `--old-key <file>` supplied a completely different one, and every
+     * assertion below would be testing a wrong-key abort instead of the
+     * undecryptable-envelope abort it means to test.
+     *
+     * @var array<string, mixed>
+     */
+    protected array $extensionConfiguration = [
+        'masterKeyProvider' => 'file',
+    ];
+
+    /**
+     * Abort point 2 — failure inside the transaction.
+     *
+     * The first secret stays healthy so the smoke test passes and the command
+     * commits to the transactional loop; a later secret is undecryptable, so the
+     * batch must roll back the ones already re-wrapped.
+     */
+    #[Test]
+    public function aFailureInsideTheTransactionRollsBackAlreadyRewrappedSecrets(): void
+    {
+        $seeded = $this->seedSecrets(5);
+        $identifiers = $this->orderedIdentifiers();
+        self::assertCount(5, $identifiers);
+
+        // Corrupt a secret the batch reaches AFTER it has already re-wrapped
+        // several others, so a missing rollback would leave a mixed state.
+        $sabotaged = $identifiers[3];
+        $this->corruptWrappedDek($sabotaged);
+
+        $before = $this->snapshotDekColumns();
+
+        $tester = $this->runRotation();
+
+        self::assertSame(
+            Command::FAILURE,
+            $tester->getStatusCode(),
+            'Rotation must fail when a secret cannot be re-wrapped. Output: ' . $tester->getDisplay(),
+        );
+        self::assertStringContainsString(
+            'Transaction rolled back',
+            $tester->getDisplay(),
+            'The operator must be told the batch was rolled back',
+        );
+        self::assertStringContainsString(
+            $sabotaged,
+            $tester->getDisplay(),
+            'The failing secret must be named in the failure report',
+        );
+
+        $this->assertDekColumnsUnchanged($before, 'a rolled-back rotation must not commit any DEK re-wrap');
+        $this->assertHealthySecretsStillDecrypt($seeded, $sabotaged);
+
+        self::assertTrue(
+            $this->get(AuditLogServiceInterface::class)->verifyHashChain()->isValid(),
+            'The audit hash chain must remain verifiable after a rolled-back rotation',
+        );
+    }
+
+    /**
+     * Abort point 1 — failure in the pre-transaction smoke test.
+     *
+     * Corrupting the FIRST secret makes `verifyOldKey()` fail, so the command
+     * must bail out before opening a transaction at all: no secret, healthy or
+     * not, may be modified.
+     */
+    #[Test]
+    public function aFailedOldKeySmokeTestLeavesTheVaultUntouched(): void
+    {
+        $seeded = $this->seedSecrets(4);
+        $identifiers = $this->orderedIdentifiers();
+
+        // The command smoke-tests $identifiers[0] before writing anything.
+        $sabotaged = $identifiers[0];
+        $this->corruptWrappedDek($sabotaged);
+
+        $before = $this->snapshotDekColumns();
+
+        $tester = $this->runRotation();
+
+        self::assertSame(
+            Command::FAILURE,
+            $tester->getStatusCode(),
+            'A failed old-key smoke test must abort the rotation. Output: ' . $tester->getDisplay(),
+        );
+        self::assertStringContainsString(
+            'Failed to decrypt with old master key',
+            $tester->getDisplay(),
+            'The smoke-test failure must be reported as a key problem',
+        );
+        self::assertStringNotContainsString(
+            'Audit chain re-keyed',
+            $tester->getDisplay(),
+            'The audit chain must not be re-keyed when the rotation never started',
+        );
+
+        $this->assertDekColumnsUnchanged($before, 'an aborted smoke test must not modify any secret');
+        $this->assertHealthySecretsStillDecrypt($seeded, $sabotaged);
+
+        self::assertTrue(
+            $this->get(AuditLogServiceInterface::class)->verifyHashChain()->isValid(),
+            'The audit hash chain must remain verifiable after an aborted rotation',
+        );
+    }
+
+    /**
+     * Store $count secrets and return them as identifier => plaintext.
+     *
+     * @return array<string, string>
+     */
+    private function seedSecrets(int $count): array
+    {
+        $vaultService = $this->get(VaultServiceInterface::class);
+
+        $seeded = [];
+        for ($i = 0; $i < $count; ++$i) {
+            $identifier = $this->generateUuidV7();
+            $value = 'abort-safety-value-' . $i;
+            $vaultService->store($identifier, $value);
+            $seeded[$identifier] = $value;
+        }
+
+        return $seeded;
+    }
+
+    /**
+     * Identifiers in the order the command will process them — read from the
+     * repository rather than assumed, because `findIdentifiers()` applies no
+     * explicit ORDER BY and the command smoke-tests whichever comes first.
+     *
+     * @return list<string>
+     */
+    private function orderedIdentifiers(): array
+    {
+        return $this->get(SecretRepositoryInterface::class)->findIdentifiers();
+    }
+
+    /**
+     * Make one secret's wrapped DEK undecryptable by flipping a bit of the
+     * sealed key material, leaving everything else (including valid base64)
+     * intact. This is the "one envelope cannot be re-wrapped" condition the
+     * rotation has to survive, and it is written straight to the column so the
+     * damage predates the command run.
+     */
+    private function corruptWrappedDek(string $identifier): void
+    {
+        $connection = $this->get(ConnectionPool::class)->getConnectionForTable(self::SECRET_TABLE);
+
+        $encodedDek = $connection->fetchOne(
+            'SELECT encrypted_dek FROM ' . self::SECRET_TABLE . ' WHERE identifier = ?',
+            [$identifier],
+        );
+        self::assertIsString($encodedDek);
+
+        $raw = base64_decode($encodedDek, true);
+        self::assertIsString($raw);
+        self::assertNotSame('', $raw);
+
+        $raw[0] = \chr(\ord($raw[0]) ^ 0xFF);
+
+        $connection->update(
+            self::SECRET_TABLE,
+            ['encrypted_dek' => base64_encode($raw)],
+            ['identifier' => $identifier],
+        );
+    }
+
+    /**
+     * Snapshot the DEK columns of every secret, keyed by identifier.
+     *
+     * @return array<string, array{encrypted_dek: string, dek_nonce: string}>
+     */
+    private function snapshotDekColumns(): array
+    {
+        $rows = $this->get(ConnectionPool::class)
+            ->getConnectionForTable(self::SECRET_TABLE)
+            ->fetchAllAssociative(
+                'SELECT identifier, encrypted_dek, dek_nonce FROM ' . self::SECRET_TABLE . ' WHERE deleted = 0',
+            );
+
+        $snapshot = [];
+        foreach ($rows as $row) {
+            $snapshot[$this->asString($row['identifier'])] = [
+                'encrypted_dek' => $this->asString($row['encrypted_dek']),
+                'dek_nonce' => $this->asString($row['dek_nonce']),
+            ];
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * Narrow a DBAL column value to string. Asserting rather than casting keeps
+     * the failure at the row that surprised us instead of silently stringifying
+     * a null the schema says cannot happen.
+     */
+    private function asString(mixed $value): string
+    {
+        self::assertIsString($value);
+
+        return $value;
+    }
+
+    /**
+     * @param array<string, array{encrypted_dek: string, dek_nonce: string}> $before
+     */
+    private function assertDekColumnsUnchanged(array $before, string $why): void
+    {
+        self::assertSame($before, $this->snapshotDekColumns(), $why);
+    }
+
+    /**
+     * Every seeded secret except the sabotaged one must still decrypt to its
+     * original plaintext under the unchanged master key. The sabotaged one is
+     * expected to stay broken — its damage was inflicted by the test, not by
+     * the rotation, and the rotation must not have "fixed" or replaced it.
+     *
+     * @param array<string, string> $seeded
+     */
+    private function assertHealthySecretsStillDecrypt(array $seeded, string $sabotaged): void
+    {
+        FileMasterKeyProvider::clearCachedKey();
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $vaultService->clearCache();
+
+        foreach ($seeded as $identifier => $expected) {
+            if ($identifier === $sabotaged) {
+                continue;
+            }
+
+            self::assertSame(
+                $expected,
+                $vaultService->retrieve($identifier),
+                \sprintf(
+                    'Secret "%s" MUST still decrypt with the original master key — '
+                    . 'a partially rotated vault is the failure this test exists to catch',
+                    $identifier,
+                ),
+            );
+        }
+
+        try {
+            $vaultService->retrieve($sabotaged);
+            self::fail('The sabotaged secret must remain undecryptable, not silently repaired');
+        } catch (EncryptionException) {
+            // Expected: the corrupted wrapped DEK still fails authentication.
+        }
+    }
+
+    /**
+     * Run the real command from the configured key file to a fresh new key.
+     */
+    private function runRotation(): CommandTester
+    {
+        self::assertIsString($this->masterKeyPath);
+
+        $newKeyPath = $this->instancePath . '/master-abort-target.key';
+        file_put_contents($newKeyPath, sodium_crypto_secretbox_keygen());
+
+        $tester = new CommandTester($this->get(VaultRotateMasterKeyCommand::class));
+
+        try {
+            $tester->execute([
+                '--old-key' => $this->masterKeyPath,
+                '--new-key' => $newKeyPath,
+                '--confirm' => true,
+            ]);
+        } catch (Throwable $exception) {
+            self::fail(
+                'The rotation command must handle an undecryptable envelope itself, '
+                . 'not escape as ' . $exception::class . ': ' . $exception->getMessage(),
+            );
+        } finally {
+            if (file_exists($newKeyPath)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
+                unlink($newKeyPath);
+            }
+        }
+
+        return $tester;
+    }
+}

--- a/Tests/Functional/Crypto/WrongMasterKeyRestoreTest.php
+++ b/Tests/Functional/Crypto/WrongMasterKeyRestoreTest.php
@@ -1,0 +1,244 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Crypto;
+
+use Netresearch\NrVault\Crypto\EncryptionService;
+use Netresearch\NrVault\Crypto\FileMasterKeyProvider;
+use Netresearch\NrVault\Exception\EncryptionException;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+
+/**
+ * Restoring a vault under the WRONG master key.
+ *
+ * The disaster-recovery scenario: a database backup is restored on a host whose
+ * master key is not the one the secrets were sealed with — a stale key file, the
+ * wrong environment's key, or a zeroed/placeholder key. Every read must then fail
+ * closed, and it must fail as a clean domain exception rather than returning a
+ * truncated or garbage plaintext that a caller would happily write to a config
+ * file or send to a third party.
+ *
+ * {@see MasterKeyRotationTest} proves the happy path (secrets survive a key
+ * change when the DEKs are re-wrapped) and the unit suite covers wrong-key
+ * decryption at the {@see EncryptionService} boundary with stub providers. What
+ * is asserted here is the end-to-end operator-visible behaviour through
+ * {@see VaultServiceInterface} against real stored rows, plus the property that
+ * matters most for recovery: a failed decrypt under the wrong key is
+ * NON-DESTRUCTIVE — putting the correct key back makes every secret readable
+ * again.
+ */
+#[CoversClass(EncryptionService::class)]
+final class WrongMasterKeyRestoreTest extends AbstractVaultFunctionalTestCase
+{
+    private const SECRET_COUNT = 3;
+
+    protected ?string $backendUserFixture = __DIR__ . '/../Hook/Fixtures/be_users.csv';
+
+    /**
+     * Pin the file provider — the `masterKeyProvider` setting defaults to
+     * `typo3`, so without this the key file written by the base class would not
+     * be the key the secrets are sealed with and swapping it would prove nothing.
+     *
+     * @var array<string, mixed>
+     */
+    protected array $extensionConfiguration = [
+        'masterKeyProvider' => 'file',
+    ];
+
+    /**
+     * Wrong keys that are all structurally VALID (exactly 32 bytes), so the
+     * failure has to come from authentication and not from a length check.
+     *
+     * @return iterable<string, array{string}>
+     */
+    public static function wrongMasterKeyProvider(): iterable
+    {
+        yield 'a different random key' => [sodium_crypto_secretbox_keygen()];
+        yield 'all-zero key' => [str_repeat("\x00", SODIUM_CRYPTO_SECRETBOX_KEYBYTES)];
+        yield 'all-0xff key' => [str_repeat("\xff", SODIUM_CRYPTO_SECRETBOX_KEYBYTES)];
+    }
+
+    #[Test]
+    #[DataProvider('wrongMasterKeyProvider')]
+    public function readingSecretsUnderAWrongMasterKeyFailsCleanly(string $wrongKey): void
+    {
+        $seeded = $this->seedSecrets();
+
+        $this->installMasterKey($wrongKey);
+
+        $vaultService = $this->get(VaultServiceInterface::class);
+
+        foreach ($seeded as $identifier => $plaintext) {
+            try {
+                $leaked = $vaultService->retrieve($identifier);
+
+                self::fail(\sprintf(
+                    'Reading "%s" under a wrong master key must throw, but it returned %s',
+                    $identifier,
+                    $leaked === null ? 'null' : 'a value of ' . \strlen($leaked) . ' bytes',
+                ));
+            } catch (EncryptionException $exception) {
+                self::assertStringNotContainsString(
+                    $plaintext,
+                    $exception->getMessage(),
+                    'A failed decrypt must not echo the protected value in its message',
+                );
+                self::assertStringNotContainsString(
+                    $wrongKey,
+                    $exception->getMessage(),
+                    'A failed decrypt must not echo key material in its message',
+                );
+            }
+        }
+    }
+
+    /**
+     * The recovery property: a wrong-key read must not mutate anything, so
+     * restoring the correct key restores access. If a failed decrypt damaged the
+     * stored envelope — or a read-counter update ran before authentication — this
+     * is what would catch it.
+     */
+    #[Test]
+    public function restoringTheCorrectMasterKeyMakesEverySecretReadableAgain(): void
+    {
+        $seeded = $this->seedSecrets();
+
+        self::assertIsString($this->masterKeyPath);
+        $correctKey = (string) file_get_contents($this->masterKeyPath);
+        $storedBefore = $this->snapshotEnvelopeColumns();
+
+        $this->installMasterKey(sodium_crypto_secretbox_keygen());
+
+        $vaultService = $this->get(VaultServiceInterface::class);
+        foreach (array_keys($seeded) as $identifier) {
+            try {
+                $vaultService->retrieve($identifier);
+                self::fail('Expected the wrong key to be refused for ' . $identifier);
+            } catch (EncryptionException) {
+                // Expected.
+            }
+        }
+
+        self::assertSame(
+            $storedBefore,
+            $this->snapshotEnvelopeColumns(),
+            'A failed decrypt must not modify the stored envelope',
+        );
+
+        $this->installMasterKey($correctKey);
+
+        foreach ($seeded as $identifier => $plaintext) {
+            self::assertSame(
+                $plaintext,
+                $this->get(VaultServiceInterface::class)->retrieve($identifier),
+                'Restoring the correct master key must make "' . $identifier . '" readable again',
+            );
+        }
+    }
+
+    /**
+     * "Audit every access" applies to the failures too: a read that could not be
+     * decrypted must leave a failed entry behind, otherwise a wrong-key restore
+     * is invisible to whoever reviews the log.
+     *
+     * The hash chain itself is deliberately NOT verified here — the chain HMAC is
+     * derived from the master key, so entries written while the wrong key is
+     * configured are expected to be keyed differently. Chain integrity across a
+     * key change is {@see MasterKeyRotationTest}'s subject.
+     */
+    #[Test]
+    public function aFailedDecryptIsRecordedInTheAuditLog(): void
+    {
+        $seeded = $this->seedSecrets();
+        $identifier = array_key_first($seeded);
+        self::assertIsString($identifier);
+
+        $failuresBefore = $this->countFailedAuditEntries($identifier);
+
+        $this->installMasterKey(sodium_crypto_secretbox_keygen());
+
+        try {
+            $this->get(VaultServiceInterface::class)->retrieve($identifier);
+            self::fail('Expected the wrong key to be refused');
+        } catch (EncryptionException) {
+            // Expected.
+        }
+
+        self::assertGreaterThan(
+            $failuresBefore,
+            $this->countFailedAuditEntries($identifier),
+            'A decryption failure must be recorded as a failed audit entry',
+        );
+    }
+
+    /**
+     * Store the test secrets under the ORIGINAL master key.
+     *
+     * @return array<string, string>
+     */
+    private function seedSecrets(): array
+    {
+        $vaultService = $this->get(VaultServiceInterface::class);
+
+        $seeded = [];
+        for ($i = 0; $i < self::SECRET_COUNT; ++$i) {
+            $identifier = $this->generateUuidV7();
+            $value = 'restore-canary-value-' . $i;
+            $vaultService->store($identifier, $value);
+            $seeded[$identifier] = $value;
+        }
+
+        return $seeded;
+    }
+
+    /**
+     * Write $key to the configured key file and drop every cache, so the next
+     * read genuinely resolves the new key instead of a memoised one.
+     */
+    private function installMasterKey(string $key): void
+    {
+        self::assertIsString($this->masterKeyPath);
+        file_put_contents($this->masterKeyPath, $key);
+        chmod($this->masterKeyPath, 0o600);
+
+        FileMasterKeyProvider::clearCachedKey();
+        $this->get(VaultServiceInterface::class)->clearCache();
+    }
+
+    /**
+     * Snapshot the stored envelope columns of every secret.
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function snapshotEnvelopeColumns(): array
+    {
+        return $this->get(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrvault_secret')
+            ->fetchAllAssociative(
+                'SELECT identifier, encrypted_value, encrypted_dek, dek_nonce, value_nonce, '
+                . 'encryption_version, encryption_algorithm, value_checksum '
+                . 'FROM tx_nrvault_secret WHERE deleted = 0 ORDER BY uid',
+            );
+    }
+
+    private function countFailedAuditEntries(string $identifier): int
+    {
+        return (int) $this->get(ConnectionPool::class)
+            ->getConnectionForTable('tx_nrvault_audit_log')
+            ->fetchOne(
+                'SELECT COUNT(*) FROM tx_nrvault_audit_log WHERE secret_identifier = ? AND success = 0',
+                [$identifier],
+            );
+    }
+}

--- a/Tests/Fuzz/CryptoFuzzTest.php
+++ b/Tests/Fuzz/CryptoFuzzTest.php
@@ -87,6 +87,30 @@ final class CryptoFuzzTest extends TestCase
             'cr lf' => ["\r\n\t", '01937b6e-4b6c-7abc-8def-000000000008'],
             'all zero bytes 16' => [str_repeat("\x00", 16), '01937b6e-4b6c-7abc-8def-000000000009'],
             'all 0xff bytes 16' => [str_repeat("\xff", 16), '01937b6e-4b6c-7abc-8def-000000000010'],
+            // Every byte value exactly once: catches any accidental
+            // encoding/escaping step that is not binary-transparent.
+            'full binary byte range' => [
+                implode('', array_map(chr(...), range(0, 255))),
+                '01937b6e-4b6c-7abc-8def-000000000011',
+            ],
+            // Astral-plane codepoints, a combining mark and the highest legal
+            // codepoint — multi-byte sequences that a naive substr() would split.
+            'high unicode' => [
+                "\u{1F510}\u{10FFFF}a\u{0301}\u{0928}\u{094D}\u{0937}\u{20AC}",
+                '01937b6e-4b6c-7abc-8def-000000000012',
+            ],
+            // 1 MiB payloads under BOTH algorithms (the dedicated
+            // oneMegabytePlaintextRoundTrips() case covers XChaCha20 only).
+            // All-zero bytes additionally rule out any length/padding shortcut
+            // that happens to work for high-entropy input.
+            'one mebibyte of zero bytes' => [
+                str_repeat("\x00", 1024 * 1024),
+                '01937b6e-4b6c-7abc-8def-000000000013',
+            ],
+            'one mebibyte of random bytes' => [
+                random_bytes(1024 * 1024),
+                '01937b6e-4b6c-7abc-8def-000000000014',
+            ],
         ];
 
         // Add 50 random plaintext cases seeded for reproducibility

--- a/Tests/Fuzz/EnvelopeRobustnessFuzzTest.php
+++ b/Tests/Fuzz/EnvelopeRobustnessFuzzTest.php
@@ -1,0 +1,606 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Fuzz;
+
+use ErrorException;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Crypto\EncryptionService;
+use Netresearch\NrVault\Crypto\EnvelopeCodec;
+use Netresearch\NrVault\Crypto\EnvelopeCodecInterface;
+use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
+use Netresearch\NrVault\Exception\EncryptionException;
+use Netresearch\NrVault\Exception\EnvelopeFormatException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Throwable;
+
+/**
+ * Robustness properties of the sealed-envelope wire format.
+ *
+ * {@see CryptoFuzzTest} fuzzes the {@see EncryptionService} boundary (bit flips
+ * in the four base64 columns, wrong identifier, invalid base64). This suite
+ * attacks the layer ABOVE it — the `nrv1:` + base64(JSON) framing parsed by
+ * {@see EnvelopeCodec} — where a malformed input reaches `substr()`,
+ * `base64_decode()` and `json_decode()` before any key material is touched.
+ *
+ * The invariant defended here is deliberately phrased in terms of what the
+ * AEAD actually authenticates:
+ *
+ *   Corrupting a sealed envelope MUST either fail loudly — EnvelopeFormatException
+ *   (framing broken) or EncryptionException (framing intact, authentication
+ *   failed) — or return the ORIGINAL plaintext unchanged. It must never return a
+ *   different value, and never surface as a raw PHP warning/notice instead of a
+ *   domain exception.
+ *
+ * The "or return the original plaintext" arm is not slack in the crypto, it is
+ * slack in the FRAMING, and two sources of it are real and by design:
+ *
+ *  1. base64 padding is malleable — `…fQ==` and `…fQ` decode to identical bytes,
+ *     so trimming padding produces a different envelope STRING for the same
+ *     authenticated bytes ({@see droppingBase64PaddingStillOpensTheSameEnvelope}).
+ *  2. `value_checksum` is optional and unknown fields are ignored by
+ *     {@see EnvelopeCodec}, so damage confined to them changes nothing the
+ *     codec reads ({@see damageConfinedToTheOptionalChecksumStillOpens}).
+ *
+ * Neither weakens confidentiality or integrity: the payload, the wrapped DEK,
+ * both nonces, the identifier (AAD) and the algorithm marker are all covered by
+ * the AEAD tag, and {@see aBitFlipInAnyAuthenticatedFieldIsAlwaysRejected} pins
+ * that any change to them is refused unconditionally.
+ *
+ * The no-PHP-diagnostic half is enforced twice over: `Build/phpunit.xml` sets
+ * `failOnWarning="true"`, and the sweeps below additionally install an error
+ * handler that promotes any diagnostic to {@see ErrorException}, so a warning
+ * raised inside the codec fails on the exception TYPE at the call site instead
+ * of being attributed to the test run at large.
+ */
+#[CoversClass(EnvelopeCodec::class)]
+final class EnvelopeRobustnessFuzzTest extends TestCase
+{
+    private const IDENTIFIER = '01937b6e-4b6c-7abc-8def-e0e0e0e0e001';
+
+    private const PLAINTEXT = 'envelope-robustness-canary-value';
+
+    /** Fields covered by the AEAD tag — damage to any of them must be refused. */
+    private const AUTHENTICATED_FIELDS = [
+        'encrypted_value',
+        'encrypted_dek',
+        'dek_nonce',
+        'value_nonce',
+    ];
+
+    private EnvelopeCodec $subject;
+
+    private string $sealed;
+
+    /** Value returned by the most recent successful {@see captureFailure()} call. */
+    private ?string $opened = null;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $provider = self::createStub(MasterKeyProviderInterface::class);
+        $provider->method('getMasterKey')->willReturn(random_bytes(SODIUM_CRYPTO_AEAD_AES256GCM_KEYBYTES));
+
+        // Pin XChaCha20 for BOTH the new-envelope marker and the legacy
+        // host-derived path, so a mutated version marker cannot change which
+        // algorithm the codec picks as a side effect of test configuration.
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('preferXChaCha20')->willReturn(true);
+        $configuration->method('getEncryptionAlgorithm')->willReturn('xchacha20poly1305');
+
+        $this->subject = new EnvelopeCodec(new EncryptionService($provider, $configuration));
+        $this->sealed = $this->subject->seal(self::PLAINTEXT, self::IDENTIFIER);
+    }
+
+    /**
+     * Truncation sweep: cutting a sealed envelope at EVERY byte offset — one
+     * byte short, halfway, marker-only, empty — must never yield a foreign
+     * plaintext, and anything that cuts into the encoded body must be refused
+     * outright.
+     *
+     * A single loop rather than ~560 data-provider rows: the assertion is one
+     * property over the whole offset range, and the sweep is the cheapest way
+     * to prove there is no "lucky" length that parses into a partial decrypt.
+     */
+    #[Test]
+    public function everyTruncationOfASealedEnvelopeIsRejected(): void
+    {
+        $length = \strlen($this->sealed);
+        self::assertGreaterThan(\strlen(EnvelopeCodecInterface::MARKER), $length);
+
+        $openedAt = [];
+
+        for ($cut = 0; $cut < $length; $cut++) {
+            if ($this->assertNeverYieldsForeignPlaintext(
+                substr($this->sealed, 0, $cut),
+                \sprintf('envelope truncated to %d of %d bytes', $cut, $length),
+            )) {
+                $openedAt[] = $cut;
+            }
+        }
+
+        // The only truncations allowed to open are those that remove nothing but
+        // base64 padding, i.e. the last two bytes of the envelope. A cut further
+        // left that still opens would mean the body is being parsed loosely.
+        foreach ($openedAt as $cut) {
+            self::assertGreaterThanOrEqual(
+                $length - 2,
+                $cut,
+                \sprintf(
+                    'Truncation to %d of %d bytes opened the envelope — only base64 padding '
+                    . '(the final two bytes) may be droppable without changing the decoded body',
+                    $cut,
+                    $length,
+                ),
+            );
+        }
+    }
+
+    /**
+     * Truncation from the FRONT (marker eaten) and from the MIDDLE (a byte
+     * excised from an otherwise complete body) are separate framing attacks:
+     * the first loses the marker, the second keeps a valid-looking prefix.
+     */
+    #[Test]
+    public function envelopesMissingLeadingOrInteriorBytesAreRejected(): void
+    {
+        $length = \strlen($this->sealed);
+        $half = (int) ($length / 2);
+
+        $mutilated = [
+            'leading byte removed' => substr($this->sealed, 1),
+            'marker removed' => substr($this->sealed, \strlen(EnvelopeCodecInterface::MARKER)),
+            'interior byte excised' => substr($this->sealed, 0, $half) . substr($this->sealed, $half + 1),
+            'body halved' => substr($this->sealed, 0, $half),
+        ];
+
+        foreach ($mutilated as $label => $candidate) {
+            self::assertFalse(
+                $this->assertNeverYieldsForeignPlaintext($candidate, $label),
+                $label . ' must not open',
+            );
+        }
+    }
+
+    /**
+     * Bit-flip sweep over the SEALED STRING (not the decoded columns): flipping
+     * any single bit of the marker, the base64 alphabet or the encoded JSON must
+     * never produce a foreign plaintext. Most offsets break framing
+     * (EnvelopeFormatException) or authentication (EncryptionException); the
+     * handful that land in the optional checksum or in base64 padding slack
+     * legitimately return the original value unchanged.
+     */
+    #[Test]
+    public function noSingleBitFlipInASealedEnvelopeYieldsAForeignPlaintext(): void
+    {
+        $length = \strlen($this->sealed);
+
+        for ($offset = 0; $offset < $length; $offset++) {
+            foreach ([0x01, 0x20, 0x80] as $mask) {
+                $flipped = $this->sealed;
+                $flipped[$offset] = \chr(\ord($flipped[$offset]) ^ $mask);
+
+                if ($flipped === $this->sealed) {
+                    continue;
+                }
+
+                $this->assertNeverYieldsForeignPlaintext(
+                    $flipped,
+                    \sprintf('bit flip at offset %d (mask 0x%02x)', $offset, $mask),
+                );
+            }
+        }
+    }
+
+    /**
+     * The strong form of the tamper property, on the fields the AEAD actually
+     * covers: flipping a bit anywhere inside the ciphertext, the wrapped DEK or
+     * either nonce must ALWAYS be refused — no framing slack applies here.
+     *
+     * Flips are applied to the DECODED bytes and re-encoded, so each case
+     * exercises authentication rather than base64 validation.
+     *
+     * @return iterable<string, array{string, int, int}>
+     */
+    public static function authenticatedFieldFlipProvider(): iterable
+    {
+        foreach (self::AUTHENTICATED_FIELDS as $field) {
+            foreach ([0, 1, 7, 11, 15, 23, 31, 47] as $position) {
+                foreach ([0x01, 0x80] as $mask) {
+                    yield \sprintf('%s byte %d xor 0x%02x', $field, $position, $mask) => [$field, $position, $mask];
+                }
+            }
+        }
+    }
+
+    #[Test]
+    #[DataProvider('authenticatedFieldFlipProvider')]
+    public function aBitFlipInAnyAuthenticatedFieldIsAlwaysRejected(string $field, int $position, int $mask): void
+    {
+        $tampered = $this->rewriteEnvelope(static function (array $envelope) use ($field, $position, $mask): array {
+            $encoded = $envelope[$field];
+            self::assertIsString($encoded, $field . ' must be a string');
+
+            $raw = base64_decode($encoded, true);
+            self::assertIsString($raw, $field . ' must be decodable');
+            self::assertNotSame('', $raw, $field . ' must not be empty');
+
+            $index = $position % \strlen($raw);
+            $raw[$index] = \chr(\ord($raw[$index]) ^ $mask);
+            $envelope[$field] = base64_encode($raw);
+
+            return $envelope;
+        });
+
+        $thrown = $this->captureFailure($tampered);
+
+        self::assertInstanceOf(
+            EncryptionException::class,
+            $thrown,
+            \sprintf(
+                'Flipping byte %d of %s must fail authentication, got %s',
+                $position,
+                $field,
+                $thrown instanceof Throwable ? $thrown::class : 'PLAINTEXT (envelope opened!)',
+            ),
+        );
+    }
+
+    /**
+     * CHARACTERISATION — base64 padding is not canonical.
+     *
+     * `…fQ==` and `…fQ` decode to the same bytes, so an envelope has more than
+     * one valid string form. Harmless for confidentiality and integrity (the
+     * AEAD authenticates the decoded bytes, not their encoding), but it means a
+     * sealed string is NOT a canonical identity: anything that compares,
+     * de-duplicates or keys a cache on the envelope string must normalise it
+     * first rather than assume byte equality implies value equality.
+     *
+     * Whether a given envelope carries padding depends on its body length mod 3,
+     * and the class-level {@see PLAINTEXT} happens to encode without any — so
+     * this seals progressively longer payloads until a padded envelope appears
+     * instead of skipping. Three extra bytes are always enough to cycle the
+     * remainder, so the loop cannot silently degrade into a no-op.
+     */
+    #[Test]
+    public function droppingBase64PaddingStillOpensTheSameEnvelope(): void
+    {
+        for ($extra = 0; $extra <= 3; $extra++) {
+            $plaintext = self::PLAINTEXT . str_repeat('.', $extra);
+            $sealed = $this->subject->seal($plaintext, self::IDENTIFIER);
+            $unpadded = rtrim($sealed, '=');
+
+            if ($unpadded === $sealed) {
+                continue;
+            }
+
+            self::assertSame(
+                $plaintext,
+                $this->subject->open($unpadded, self::IDENTIFIER),
+                'Stripping base64 padding must not change the decoded envelope',
+            );
+
+            return;
+        }
+
+        self::fail('No padded envelope found in four consecutive payload lengths — base64 framing changed');
+    }
+
+    /**
+     * CHARACTERISATION — `value_checksum` is a change-detection token, not an
+     * integrity mechanism (ADR-002 / SEC-CRYPTO-1). {@see EnvelopeCodec} treats
+     * it as optional and ignores unknown fields, so corrupting it, renaming its
+     * key or deleting it outright still opens the envelope. Integrity is the
+     * AEAD tag's job, which
+     * {@see aBitFlipInAnyAuthenticatedFieldIsAlwaysRejected} covers.
+     *
+     * @return iterable<string, array{'replace'|'rename'|'remove'}>
+     */
+    public static function checksumDamageProvider(): iterable
+    {
+        yield 'checksum value replaced' => ['replace'];
+        yield 'checksum key renamed' => ['rename'];
+        yield 'checksum removed' => ['remove'];
+    }
+
+    /**
+     * @param 'remove'|'rename'|'replace' $damage
+     */
+    #[Test]
+    #[DataProvider('checksumDamageProvider')]
+    public function damageConfinedToTheOptionalChecksumStillOpens(string $damage): void
+    {
+        $tampered = $this->rewriteEnvelope(static function (array $envelope) use ($damage): array {
+            unset($envelope['value_checksum']);
+
+            if ($damage === 'replace') {
+                $envelope['value_checksum'] = str_repeat('0', 64);
+            } elseif ($damage === 'rename') {
+                // A renamed key is an UNKNOWN field, which the codec ignores.
+                $envelope['valte_checksum'] = str_repeat('a', 64);
+            }
+
+            return $envelope;
+        });
+
+        self::assertSame(
+            self::PLAINTEXT,
+            $this->subject->open($tampered, self::IDENTIFIER),
+            'The checksum is a change detector, not an integrity check — the AEAD tag protects the payload',
+        );
+    }
+
+    /**
+     * Field-swap provider: the envelope's four base64 columns are all
+     * structurally interchangeable strings, so a confused writer (or an
+     * attacker with write access to the row) can swap them without breaking
+     * the framing. Each swap must fail authentication.
+     *
+     * @return iterable<string, array{string, string}>
+     */
+    public static function swappedFieldProvider(): iterable
+    {
+        yield 'ciphertext and wrapped DEK exchanged' => ['encrypted_value', 'encrypted_dek'];
+        yield 'DEK nonce and value nonce exchanged' => ['dek_nonce', 'value_nonce'];
+    }
+
+    #[Test]
+    #[DataProvider('swappedFieldProvider')]
+    public function swappingTwoEnvelopeFieldsIsRejected(string $first, string $second): void
+    {
+        $tampered = $this->rewriteEnvelope(static function (array $envelope) use ($first, $second): array {
+            [$envelope[$first], $envelope[$second]] = [$envelope[$second], $envelope[$first]];
+
+            return $envelope;
+        });
+
+        $thrown = $this->captureFailure($tampered);
+
+        self::assertInstanceOf(
+            EncryptionException::class,
+            $thrown,
+            \sprintf(
+                'Swapping %s with %s must fail authentication, got %s',
+                $first,
+                $second,
+                $thrown instanceof Throwable ? $thrown::class : 'PLAINTEXT (envelope opened!)',
+            ),
+        );
+    }
+
+    /**
+     * Copying one field over another (rather than exchanging them) is the other
+     * half of the confusion attack — notably reusing the value nonce as the DEK
+     * nonce, which is what a nonce-reuse bug would look like on the wire.
+     *
+     * @return iterable<string, array{string, string}>
+     */
+    public static function overwrittenFieldProvider(): iterable
+    {
+        yield 'value nonce reused as DEK nonce' => ['dek_nonce', 'value_nonce'];
+        yield 'DEK nonce reused as value nonce' => ['value_nonce', 'dek_nonce'];
+        yield 'wrapped DEK written over ciphertext' => ['encrypted_value', 'encrypted_dek'];
+        yield 'ciphertext written over wrapped DEK' => ['encrypted_dek', 'encrypted_value'];
+    }
+
+    #[Test]
+    #[DataProvider('overwrittenFieldProvider')]
+    public function overwritingOneEnvelopeFieldWithAnotherIsRejected(string $target, string $source): void
+    {
+        $tampered = $this->rewriteEnvelope(static function (array $envelope) use ($target, $source): array {
+            $envelope[$target] = $envelope[$source];
+
+            return $envelope;
+        });
+
+        $thrown = $this->captureFailure($tampered);
+
+        self::assertInstanceOf(
+            EncryptionException::class,
+            $thrown,
+            \sprintf(
+                'Writing %s over %s must fail authentication, got %s',
+                $source,
+                $target,
+                $thrown instanceof Throwable ? $thrown::class : 'PLAINTEXT (envelope opened!)',
+            ),
+        );
+    }
+
+    /**
+     * Unknown algorithm markers on a version-2-or-newer envelope. The marker is
+     * authoritative for version >= 2 ({@see EncryptionService::resolveAlgorithm()}),
+     * so an unrecognised or empty id must abort instead of falling back to a
+     * host-derived guess.
+     *
+     * @return iterable<string, array{int, string}>
+     */
+    public static function unknownAlgorithmMarkerProvider(): iterable
+    {
+        yield 'current version, unknown id' => [2, 'rot13'];
+        yield 'current version, empty id' => [2, ''];
+        yield 'current version, near-miss id' => [2, 'xchacha20poly1306'];
+        yield 'current version, wrong case' => [2, 'XChaCha20Poly1305'];
+        yield 'current version, legacy openssl name' => [2, 'aes-256-gcm'];
+        yield 'future version, unknown id' => [3, 'rot13'];
+        yield 'far-future version, unknown id' => [99, 'some-future-aead'];
+    }
+
+    #[Test]
+    #[DataProvider('unknownAlgorithmMarkerProvider')]
+    public function anUnknownAlgorithmMarkerIsRejected(int $version, string $algorithm): void
+    {
+        $tampered = $this->rewriteEnvelope(static function (array $envelope) use ($version, $algorithm): array {
+            $envelope['encryption_version'] = $version;
+            $envelope['encryption_algorithm'] = $algorithm;
+
+            return $envelope;
+        });
+
+        $thrown = $this->captureFailure($tampered);
+
+        self::assertInstanceOf(
+            EncryptionException::class,
+            $thrown,
+            \sprintf(
+                'Envelope claiming version %d with algorithm "%s" must be refused, got %s',
+                $version,
+                $algorithm,
+                $thrown instanceof Throwable ? $thrown::class : 'PLAINTEXT (envelope opened!)',
+            ),
+        );
+        self::assertStringNotContainsString(
+            self::PLAINTEXT,
+            $thrown->getMessage(),
+            'The refusal message must not leak the protected value',
+        );
+    }
+
+    /**
+     * A marker naming a REAL but different algorithm must fail authentication
+     * rather than decrypt: the recorded algorithm is what the payload was
+     * sealed with, and disagreeing with it is indistinguishable from tampering.
+     */
+    #[Test]
+    public function aValidButMismatchedAlgorithmMarkerFailsAuthentication(): void
+    {
+        if (!sodium_crypto_aead_aes256gcm_is_available()) {
+            self::markTestSkipped('AES-256-GCM not available on this platform');
+        }
+
+        $tampered = $this->rewriteEnvelope(static function (array $envelope): array {
+            // Sealed with XChaCha20-Poly1305; claim AES-256-GCM instead.
+            $envelope['encryption_algorithm'] = 'aes256gcm';
+
+            return $envelope;
+        });
+
+        self::assertInstanceOf(
+            EncryptionException::class,
+            $this->captureFailure($tampered),
+            'A mismatched-but-known algorithm marker must fail authentication, not decrypt',
+        );
+    }
+
+    /**
+     * An envelope claiming a version this build does not implement must be
+     * refused, never opened under the current version's rules: a future
+     * version may change the framing, the KDF or the AAD, and decrypting it
+     * with the wrong recipe is worse than failing. Forward compatibility has
+     * to be a deliberate code change, not an accident of a `>=` comparison.
+     */
+    #[Test]
+    public function anEnvelopeClaimingAnUnimplementedVersionIsRefused(): void
+    {
+        foreach ([0, 3, 99, \PHP_INT_MAX] as $version) {
+            $tampered = $this->rewriteEnvelope(static function (array $envelope) use ($version): array {
+                $envelope['encryption_version'] = $version;
+
+                return $envelope;
+            });
+
+            $refused = false;
+
+            try {
+                $this->subject->open($tampered, self::IDENTIFIER);
+            } catch (EncryptionException|EnvelopeFormatException) {
+                $refused = true;
+            }
+
+            self::assertTrue(
+                $refused,
+                \sprintf('Envelope claiming unimplemented version %d was opened.', $version),
+            );
+        }
+    }
+
+    /**
+     * Assert the corrupted candidate either fails with a domain exception or
+     * returns the ORIGINAL plaintext (framing slack only) — never a foreign
+     * value, never a PHP diagnostic.
+     *
+     * @return bool whether the envelope opened (true) or was refused (false)
+     */
+    private function assertNeverYieldsForeignPlaintext(string $candidate, string $label): bool
+    {
+        $thrown = $this->captureFailure($candidate);
+
+        if (!$thrown instanceof Throwable) {
+            self::assertSame(
+                self::PLAINTEXT,
+                $this->opened,
+                \sprintf('%s opened and returned a value other than the sealed plaintext', $label),
+            );
+
+            return true;
+        }
+
+        self::assertThat(
+            $thrown,
+            self::logicalOr(
+                self::isInstanceOf(EnvelopeFormatException::class),
+                self::isInstanceOf(EncryptionException::class),
+            ),
+            \sprintf('%s must raise a domain exception, got %s: %s', $label, $thrown::class, $thrown->getMessage()),
+        );
+
+        return false;
+    }
+
+    /**
+     * Open the candidate and return the exception it raised, or null if it
+     * opened successfully (in which case the plaintext is in {@see $opened}).
+     *
+     * Any PHP diagnostic raised inside the codec is promoted to
+     * {@see ErrorException} so it is reported as a wrong exception TYPE at the
+     * call site instead of a detached test-run warning.
+     */
+    private function captureFailure(string $candidate): ?Throwable
+    {
+        $this->opened = null;
+
+        set_error_handler(
+            static function (int $severity, string $message, string $file, int $line): bool {
+                throw new ErrorException($message, 0, $severity, $file, $line);
+            },
+        );
+
+        try {
+            $this->opened = $this->subject->open($candidate, self::IDENTIFIER);
+
+            return null;
+        } catch (Throwable $exception) {
+            return $exception;
+        } finally {
+            restore_error_handler();
+        }
+    }
+
+    /**
+     * Decode the sealed envelope, hand its fields to $mutate, re-encode.
+     *
+     * @param callable(array<string, mixed>): array<string, mixed> $mutate
+     */
+    private function rewriteEnvelope(callable $mutate): string
+    {
+        $body = base64_decode(substr($this->sealed, \strlen(EnvelopeCodecInterface::MARKER)), true);
+        self::assertIsString($body);
+
+        $envelope = json_decode($body, true, 8, JSON_THROW_ON_ERROR);
+        self::assertIsArray($envelope);
+
+        /** @var array<string, mixed> $envelope */
+        return EnvelopeCodecInterface::MARKER
+            . base64_encode(json_encode($mutate($envelope), JSON_THROW_ON_ERROR));
+    }
+}

--- a/Tests/Unit/Crypto/EncryptionServiceTest.php
+++ b/Tests/Unit/Crypto/EncryptionServiceTest.php
@@ -128,6 +128,50 @@ final class EncryptionServiceTest extends TestCase
     }
 
     #[Test]
+    public function decryptRefusesAnUnimplementedEncryptionVersion(): void
+    {
+        $plaintext = 'version-guard';
+        $identifier = 'version-guard-test';
+
+        $encrypted = $this->subject->encrypt($plaintext, $identifier);
+
+        // A version above the current one may change framing, KDF or AAD; the
+        // reader must refuse it rather than decrypt under version-2 rules.
+        $this->expectException(EncryptionException::class);
+
+        $this->subject->decrypt(
+            $encrypted->encryptedValue,
+            $encrypted->encryptedDek,
+            $encrypted->dekNonce,
+            $encrypted->valueNonce,
+            $identifier,
+            $encrypted->encryptionVersion + 1,
+            $encrypted->encryptionAlgorithm->value,
+        );
+    }
+
+    #[Test]
+    public function decryptRefusesAnEncryptionVersionBelowLegacy(): void
+    {
+        $plaintext = 'version-floor';
+        $identifier = 'version-floor-test';
+
+        $encrypted = $this->subject->encrypt($plaintext, $identifier);
+
+        $this->expectException(EncryptionException::class);
+
+        $this->subject->decrypt(
+            $encrypted->encryptedValue,
+            $encrypted->encryptedDek,
+            $encrypted->dekNonce,
+            $encrypted->valueNonce,
+            $identifier,
+            0,
+            $encrypted->encryptionAlgorithm->value,
+        );
+    }
+
+    #[Test]
     public function decryptWithWrongIdentifierThrowsException(): void
     {
         $plaintext = 'secret-with-aad';

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,5 +1,17 @@
 # Codecov configuration
 # https://docs.codecov.com/docs/codecovyml-reference
+#
+# Coverage is BLOCKING. Every status below sets `informational: false`, so a drop
+# fails the check instead of posting a note nobody reads. Two tiers:
+#
+#   * repo-wide defaults (`coverage.status`) — the floor for ordinary changes;
+#   * per-component statuses (`component_management`) — a stricter floor for the
+#     security-critical directories, where an untested line is a latent
+#     vulnerability rather than a coverage statistic.
+#
+# The project status uses `target: auto` with a 0.5% threshold: a ratchet.
+# Coverage may not fall below the base commit by more than rounding noise, so the
+# number only moves upward over time.
 
 coverage:
   precision: 2
@@ -10,17 +22,56 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 5%
-        informational: true
+        # Ratchet: at most 0.5% below the base commit. Deliberately tight —
+        # anything larger is a real regression, not measurement jitter.
+        threshold: 0.5%
+        informational: false
     patch:
       default:
+        # New and changed lines must be 80% covered repo-wide.
         target: 80%
-        threshold: 5%
-        informational: true
+        threshold: 2%
+        informational: false
 
 # Branch / path coverage for PHP is derived from Clover XML automatically by
 # Codecov — no parser tweaks needed. (The legacy `parsers.gcov.*` block only
 # applies to C/C++ coverage sources and is ignored for PHP uploads.)
+
+# ---------------------------------------------------------------------------
+# Security-critical components.
+#
+# Patch coverage on these paths must be 90%: envelope encryption and master-key
+# handling (Crypto), authorization and technical-actor context (Security), and
+# the tamper-evident audit chain (Audit). The 1% threshold absorbs rounding on
+# small diffs without opening a meaningful gap.
+#
+# Raising a target is always fine. LOWERING one — or dropping a path from a
+# component — needs security-team sign-off recorded in the PR description, the
+# same rule the mutation ratchet in `infection-security.json5` follows.
+# ---------------------------------------------------------------------------
+component_management:
+  default_rules:
+    statuses:
+      - type: patch
+        target: 90%
+        threshold: 1%
+        informational: false
+
+  individual_components:
+    - component_id: crypto
+      name: crypto
+      paths:
+        - Classes/Crypto/**
+
+    - component_id: security
+      name: security
+      paths:
+        - Classes/Security/**
+
+    - component_id: audit
+      name: audit
+      paths:
+        - Classes/Audit/**
 
 flags:
   unit:
@@ -33,7 +84,7 @@ flags:
     carryforward: true
 
 comment:
-  layout: "reach,diff,flags,files"
+  layout: "reach,diff,flags,components,files"
   behavior: default
   require_changes: true
 

--- a/composer.json
+++ b/composer.json
@@ -103,6 +103,7 @@
         "ci:test:php:functional": "phpunit -c Build/FunctionalTests.xml",
         "ci:test:php:fuzz": "phpunit -c Build/phpunit.xml --testsuite Fuzz",
         "ci:test:php:mutation": "infection --configuration=infection.json5 --threads=4",
+        "ci:test:php:mutation:security": "infection --configuration=infection-security.json5 --threads=max --no-progress",
         "ci:test:php:phpstan": "phpstan analyse",
         "ci:test:php:rector": "rector process --dry-run",
         "ci:test:php:unit": "phpunit -c Build/phpunit.xml --testsuite Unit",

--- a/infection-security.json5
+++ b/infection-security.json5
@@ -1,0 +1,77 @@
+{
+    "$schema": "https://raw.githubusercontent.com/infection/infection/0.32.0/resources/schema.json",
+    // ------------------------------------------------------------------------
+    // SECURITY-CRITICAL mutation gate.
+    //
+    // A narrowed sibling of `infection.json5`: same tooling, same mutators, but
+    // scoped to the three directories where an escaped mutant is a security
+    // defect rather than a coverage gap — envelope encryption and master-key
+    // handling (Crypto), authorization and actor context (Security), and the
+    // tamper-evident audit chain (Audit).
+    //
+    // Run via: composer ci:test:php:mutation:security
+    // ------------------------------------------------------------------------
+    "source": {
+        "directories": [
+            "Classes/Crypto",
+            "Classes/Security",
+            "Classes/Audit"
+        ]
+    },
+    "logs": {
+        "text": ".Build/infection-security/infection.log",
+        "html": ".Build/infection-security/infection.html",
+        "json": ".Build/infection-security/infection.json",
+        "summary": ".Build/infection-security/summary.log",
+        // GitHub Actions annotation logger — surfaces escaped mutants in the PR UI
+        "github": true,
+        "perMutator": ".Build/infection-security/per-mutator.md"
+    },
+    // A separate tmpDir from the full run so the two configurations can be
+    // executed back to back without clobbering each other's state.
+    "tmpDir": ".Build/infection-security/tmp",
+    "phpUnit": {
+        "configDir": "Build",
+        "customPath": ".Build/bin/phpunit"
+    },
+    "testFramework": "phpunit",
+    // Unit AND Fuzz, unlike `infection.json5` which measures the Unit suite
+    // only. The crypto boundary is deliberately covered by property/fuzz tests
+    // (nonce uniqueness, envelope robustness, tamper rejection); measuring these
+    // directories against the Unit suite alone would understate the real mutant
+    // coverage and set the ratchet far below what the suite actually achieves.
+    "testFrameworkOptions": "--testsuite=Unit,Fuzz",
+    "mutators": {
+        "@default": true,
+        // Kept identical to infection.json5 so the two runs stay comparable.
+        "CastString": false,
+        "UnwrapArrayMerge": false
+    },
+    // ------------------------------------------------------------------------
+    // RATCHET POLICY — raise only.
+    //
+    // These thresholds are a floor, not a target. The rules are:
+    //
+    //   * RAISING minMsi / minCoveredMsi is always allowed and encouraged; do it
+    //     in the same PR that kills the mutants.
+    //   * LOWERING either value requires explicit security-team sign-off
+    //     recorded in the PR description. "The gate is red and I need to merge"
+    //     is not sign-off — kill the mutant or get the exemption reviewed.
+    //   * Deleting or excluding a file/directory from `source` above has the
+    //     same effect as lowering the threshold and needs the same sign-off.
+    //
+    // MEASUREMENT (2026-07-31, PHP 8.5, Unit+Fuzz):
+    //   909 mutants — 681 killed, 227 escaped, 1 timed out, 0 not covered
+    //   MSI 75.03 %, covered-code MSI 75.03 %, mutation code coverage 100 %
+    //   wall time 50 s at --threads=max
+    //
+    // The thresholds sit ~1 point under the measurement so run-to-run jitter in
+    // timing-sensitive tests cannot fail an unrelated PR, while any real
+    // regression (a deleted assertion, a weakened test) still trips the gate.
+    // Mutation code coverage is already 100 % here: every mutant is reached by a
+    // test, so the 227 escapes are assertion gaps, not coverage gaps — which is
+    // exactly the kind of weakness this gate is meant to hold the line on.
+    // ------------------------------------------------------------------------
+    "minMsi": 74,
+    "minCoveredMsi": 74
+}


### PR DESCRIPTION
## Summary

P1 item (roadmap PR 7): security invariants become tested properties, and the quality gates on security-critical code become blocking. Based directly on `main` (independent of the profile stack).

**New invariant tests** (details in the commit message): envelope-robustness fuzz suite (truncation/bit-flip/field-swap sweeps — 86 tests / ~4900 assertions), rotation-abort atomicity against the real `vault:rotate-master-key`, wrong-master-key restore behavior, edge-case plaintext round trips under both algorithms. Already-covered invariants (nonce uniqueness at 1000 iterations, tampered components, unknown algorithm markers) were **not** duplicated.

**Production fix the suite surfaced:** `EncryptionService::resolveAlgorithm()` accepted **any** `encryption_version >= 2` and opened it under version-2 rules. An envelope claiming version 99 decrypted "successfully" — forward compatibility by accident. Unimplemented versions are now refused loudly; versions 1/2 unchanged.

**Gates**
- `codecov.yml` → blocking: components `Classes/Crypto|Security|Audit` at **90% patch** (1% threshold), default patch 80%, project ratchet 0.5% (was 5% informational slack). Validated against Codecov's API ("Valid!").
- `infection-security.json5`: mutation gate over the security dirs, measured MSI **75.03%** (909 mutants, mutation coverage 100% — every escape is an assertion gap, not uncovered code), ratchet `minMsi: 74`, raise-only policy in the config.
- `security-gates.yml`: detect (plain `git diff`) → conditional mutation run → always-reporting required check (a workflow-level `paths:` filter can't be combined with a required status check). The gate treats its own inputs as security-critical: a PR lowering the ratchet is measured, not waved through. Pinned SHAs, harden-runner not applicable (no third-party actions beyond the pinned set).
- `.gitignore`: `NR_VAULT_MASTER_KEY` + `*.key` (with fixture negation) — an **untracked live master key** was found in the repo root during this work (auto-generate path writes to CWD) and securely deleted.

**Known caveats:** the upstream coverage upload sends Unit+Functional clover only, so the fuzz suite's crypto coverage doesn't count toward the 90% component gate yet (fix = fuzz clover upload in typo3-ci-workflows). The base functional test class leaves `masterKeyProvider` at `typo3` while wiring a key file — both new functional tests pin `file` explicitly; consider fixing the base class separately.

## Test plan
- `composer ci` exit 0 (1612 fuzz tests / 7144+ assertions), PHPStan 10 clean, Rector clean, functional suite green (189 tests, sqlite), security mutation gate exit 0 at the ratchet, actionlint clean, codecov.yml validated.

Roadmap: PR 7 of 10 — base `main`. After merging, mark the `security-gates` check as required in branch protection.
