### PR TITLE
Add vault:doctor readiness command and backend security status

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,7 +154,7 @@ AuditLogServiceInterface::verifyHashChain(?int $fromUid = null, ?int $toUid = nu
 ```
 
 ## CLI Commands (TYPO3 `vendor/bin/typo3`)
-> All 16 registered `vault:*` commands. Full options/examples in
+> All 17 registered `vault:*` commands. Full options/examples in
 > `Documentation/Developer/Commands.rst`.
 ```
 vault:init                 # Initialize the vault (generate master key, verify configuration)
@@ -172,6 +172,7 @@ vault:audit-migrate-hmac   # Migrate audit log hash chain from SHA-256 to HMAC-S
 vault:rotate-master-key    # Re-encrypt all secrets with a new master key
 vault:cleanup-orphans      # Clean up orphaned vault entries (scheduled task wrapper)
 vault:break-glass          # Open/close/inspect a time-boxed break-glass window (restores the admin override)
+vault:doctor               # Check the configuration for deployment/audit readiness (exit 0 clean / 1 warnings / 2 critical)
 vault:seed-demo            # Seed demo secrets + audit history (development only)
 ```
 

--- a/Build/phpunit.xml
+++ b/Build/phpunit.xml
@@ -59,12 +59,17 @@
             <file>../Classes/Security/BreakGlassStateInterface.php</file>
             <file>../Classes/Service/SecretDetectionServiceInterface.php</file>
             <file>../Classes/Service/VaultServiceInterface.php</file>
+            <file>../Classes/Service/Doctor/ReadinessCheckInterface.php</file>
+            <file>../Classes/Service/Doctor/VaultDoctorServiceInterface.php</file>
+            <!-- Constant holder for documentation deep links: no executable code. -->
+            <file>../Classes/Service/Doctor/DocsLink.php</file>
             <file>../Classes/Service/Detection/SecretFinding.php</file>
             <!-- Enums: PHPUnit 12 cannot attribute coverage to enum classes -->
             <file>../Classes/Http/SecretPlacement.php</file>
             <file>../Classes/Service/Detection/Severity.php</file>
             <file>../Classes/Service/VaultFieldPermission.php</file>
             <file>../Classes/Security/VaultPermission.php</file>
+            <file>../Classes/Service/Doctor/FindingSeverity.php</file>
             <!-- Interfaces and enums added with ADR-031/032/033: no executable
                  code to cover, and declaring CoversClass on an excluded target
                  raises a warning that failOnWarning turns into a failure. -->

--- a/Classes/Command/VaultDoctorCommand.php
+++ b/Classes/Command/VaultDoctorCommand.php
@@ -1,0 +1,255 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Command;
+
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\DoctorReport;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Service\Doctor\VaultDoctorServiceInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Throwable;
+
+/**
+ * Deployment-readiness gate for the vault.
+ *
+ * Evaluates every readiness control and reports each one with the risk it
+ * carries and the command that fixes it. Designed to be the last step of a
+ * deployment pipeline, which drives two decisions:
+ *
+ * **Exit codes are the contract, not the text.**
+ *
+ *   0 — every control passed; the configuration is audit-ready
+ *   1 — warnings only; deployable, worth fixing before an audit
+ *   2 — at least one critical finding
+ *
+ * Worst-severity-wins (see {@see DoctorReport}), so a long list of passes can
+ * never average a critical finding away. `Command::INVALID` (2) coincides with
+ * the critical code, which is deliberate: a gate given an unusable `--profile`
+ * value must not be readable as "checked and fine".
+ *
+ * **`--profile` changes the question, never the configuration.** `--profile=
+ * hardened` on a standard installation answers "would this pass if we hardened
+ * it?" without writing anything, so the migration can be planned from the real
+ * finding list instead of by flipping the switch on production and seeing what
+ * breaks.
+ *
+ * Usage:
+ *   vendor/bin/typo3 vault:doctor
+ *   vendor/bin/typo3 vault:doctor --profile=hardened
+ *   vendor/bin/typo3 vault:doctor --format=json
+ */
+#[AsCommand(
+    name: 'vault:doctor',
+    description: 'Check the vault configuration for deployment and audit readiness',
+)]
+final class VaultDoctorCommand extends Command
+{
+    public function __construct(
+        private readonly VaultDoctorServiceInterface $doctor,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption(
+                'profile',
+                'p',
+                InputOption::VALUE_REQUIRED,
+                'Security profile to check against: standard or hardened. '
+                . 'Defaults to the configured profile. Does NOT change any configuration.',
+            )
+            ->addOption(
+                'format',
+                'f',
+                InputOption::VALUE_REQUIRED,
+                'Output format: text (default) or json',
+                'text',
+            );
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+        $formatOption = $input->getOption('format');
+        $json = \is_string($formatOption) && strtolower($formatOption) === 'json';
+
+        $profileOption = $input->getOption('profile');
+        $targetProfile = null;
+
+        if (\is_string($profileOption) && trim($profileOption) !== '') {
+            $targetProfile = SecurityProfile::tryFrom(strtolower(trim($profileOption)));
+
+            if (!$targetProfile instanceof SecurityProfile) {
+                $this->renderInvalidProfile($io, $output, $profileOption, $json);
+
+                return Command::INVALID;
+            }
+        }
+
+        try {
+            $report = $this->doctor->run($targetProfile);
+        } catch (Throwable $e) {
+            // A gate that cannot run must never look like a gate that found
+            // nothing — same stance as vault:audit-verify.
+            $this->renderCrash($io, $output, $e, $json);
+
+            return 2;
+        }
+
+        if ($json) {
+            $output->writeln(json_encode($report->toArray(), JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+
+            return $report->exitCode();
+        }
+
+        $this->renderText($io, $report);
+
+        return $report->exitCode();
+    }
+
+    private function renderInvalidProfile(
+        SymfonyStyle $io,
+        OutputInterface $output,
+        string $given,
+        bool $json,
+    ): void {
+        $message = \sprintf(
+            'Unknown profile "%s". Valid profiles: %s, %s.',
+            $given,
+            SecurityProfile::Standard->value,
+            SecurityProfile::Hardened->value,
+        );
+
+        if ($json) {
+            $output->writeln(json_encode(
+                ['error' => $message, 'exitCode' => Command::INVALID],
+                JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR,
+            ));
+
+            return;
+        }
+
+        $io->error($message);
+    }
+
+    private function renderCrash(SymfonyStyle $io, OutputInterface $output, Throwable $e, bool $json): void
+    {
+        if ($json) {
+            $output->writeln(json_encode(
+                ['error' => $e->getMessage(), 'exitCode' => 2],
+                JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR,
+            ));
+
+            return;
+        }
+
+        $io->error('vault:doctor could not complete: ' . $e->getMessage());
+    }
+
+    private function renderText(SymfonyStyle $io, DoctorReport $report): void
+    {
+        $io->title('Vault Readiness Report');
+
+        $context = $report->context;
+        $definitions = [
+            ['Checked against profile' => $context->profile->value],
+        ];
+        if ($context->isProfileOverridden()) {
+            $definitions[] = ['Configured profile' => \sprintf(
+                '%s (NOT changed by this command)',
+                $context->configuredProfile->value,
+            )];
+        }
+        $definitions[] = ['Controls passed' => \sprintf(
+            '%d of %d',
+            $report->passedControls(),
+            $report->totalControls(),
+        )];
+        $io->definitionList(...$definitions);
+
+        $problems = $report->problems();
+
+        if ($problems === []) {
+            $io->success(\sprintf(
+                'All %d controls passed — the configuration is audit-ready for the %s profile.',
+                $report->totalControls(),
+                $context->profile->value,
+            ));
+
+            return;
+        }
+
+        foreach ($problems as $finding) {
+            $this->renderFinding($io, $finding);
+        }
+
+        $criticalCount = \count($report->findingsOfSeverity(FindingSeverity::Critical));
+        $warningCount = \count($report->findingsOfSeverity(FindingSeverity::Warning));
+
+        if ($criticalCount > 0) {
+            $io->error(\sprintf(
+                'NOT audit-ready for the %s profile: %d critical, %d warning.',
+                $context->profile->value,
+                $criticalCount,
+                $warningCount,
+            ));
+
+            return;
+        }
+
+        $io->warning(\sprintf(
+            'Deployable with %d warning(s) — no critical findings for the %s profile.',
+            $warningCount,
+            $context->profile->value,
+        ));
+    }
+
+    /**
+     * One finding as a labelled block.
+     *
+     * Sections rather than a table: the remediation text is a shell command an
+     * operator has to be able to copy, and table borders wrap it into something
+     * unpasteable.
+     */
+    private function renderFinding(SymfonyStyle $io, Finding $finding): void
+    {
+        $io->section(\sprintf(
+            '[%s] %s',
+            strtoupper($finding->severity->value),
+            $finding->id,
+        ));
+        $io->writeln($finding->summary);
+
+        if ($finding->risk !== '') {
+            $io->newLine();
+            $io->writeln('<comment>Risk:</comment> ' . $finding->risk);
+        }
+
+        if ($finding->remediation !== '') {
+            $io->newLine();
+            $io->writeln('<info>Fix:</info> ' . $finding->remediation);
+        }
+
+        if ($finding->docsUrl !== '') {
+            $io->newLine();
+            $io->writeln('<comment>Docs:</comment> ' . $finding->docsUrl);
+        }
+
+        $io->newLine();
+    }
+}

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -436,7 +436,6 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
         return Environment::getVarPath() . '/secrets/vault-master.key';
     }
 
-
     /**
      * Read a boolean setting pinned in
      * `$TYPO3_CONF_VARS[SYS][nrVault][<key>]` — typically set in
@@ -457,6 +456,7 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
 
         return \array_key_exists($key, $nrVault) ? (bool) $nrVault[$key] : null;
     }
+
     /**
      * Resolve a configured audit-sink file path, falling back to
      * `<var>/log/<basename>` when unset or empty.
@@ -473,5 +473,4 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
 
         return Environment::getVarPath() . '/log/' . $defaultBasename;
     }
-
 }

--- a/Classes/Controller/OverviewController.php
+++ b/Classes/Controller/OverviewController.php
@@ -38,6 +38,7 @@ final readonly class OverviewController
         private PageRenderer $pageRenderer,
         private ModuleAccessGuard $accessGuard,
         private BreakGlassBannerProvider $breakGlassBanner,
+        private SecurityStatusProvider $securityStatus,
     ) {}
 
     /**
@@ -80,6 +81,10 @@ final readonly class OverviewController
             'healthChecks' => $healthChecks,
             'submodules' => $this->getAccessibleSubmodules($lang),
             'breakGlass' => $this->breakGlassBanner->forView(),
+            // Readiness controls with the profile badge and pass ratio. The
+            // detailed finding list inside is gated on VaultConfigure by the
+            // provider, not by the template.
+            'securityStatus' => $this->securityStatus->forView(),
         ]);
 
         return $moduleTemplate->renderResponse('Overview/Index');

--- a/Classes/Controller/SecurityStatusProvider.php
+++ b/Classes/Controller/SecurityStatusProvider.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Controller;
+
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Service\Doctor\VaultDoctorServiceInterface;
+use Throwable;
+
+/**
+ * View model for the Overview module's security status panel.
+ *
+ * ## Why a collaborator and not controller code
+ *
+ * Same reasoning as {@see BreakGlassBannerProvider}: the shaping is real logic
+ * with a permission decision in it, and {@see OverviewController} renders a
+ * `ModuleTemplate` built from final TYPO3 classes and is therefore excluded from
+ * unit coverage. Putting the decision here keeps it unit-testable without booting
+ * a backend module.
+ *
+ * ## What each audience sees
+ *
+ * The pass ratio and the profile badge are visible to anyone who can open the
+ * module. The finding list — which names the exact weakness, the risk it carries
+ * and the file to edit — is gated behind {@see VaultPermission::VaultConfigure},
+ * the permission that already governs vault configuration. An editor who holds
+ * `secret.use` because their forms consume vault-backed credentials has no reason
+ * to receive a prioritised list of this installation's weak points; knowing
+ * *that* something is unresolved is enough for them to escalate.
+ *
+ * ## Cost
+ *
+ * Building this runs every readiness check, which includes a bounded audit-chain
+ * pass and an inventory scan. That is acceptable for an admin landing page and it
+ * is the honest price of a status panel that cannot go stale — but it is why
+ * `vault:doctor` rather than this panel is the surface to put on a schedule or in
+ * a monitoring probe.
+ *
+ * @phpstan-type ShapedFinding array{
+ *     id: string,
+ *     severity: string,
+ *     context: string,
+ *     summary: string,
+ *     risk: string,
+ *     remediation: string,
+ *     docsUrl: string,
+ * }
+ * @phpstan-type SecurityStatusView array{
+ *     available: bool,
+ *     profile: string,
+ *     auditReady: bool,
+ *     severity: string,
+ *     context: string,
+ *     passed: int,
+ *     total: int,
+ *     criticalCount: int,
+ *     warningCount: int,
+ *     detailed: bool,
+ *     findings: list<ShapedFinding>,
+ * }
+ */
+final readonly class SecurityStatusProvider
+{
+    public function __construct(
+        private VaultDoctorServiceInterface $doctor,
+        // The permission authority directly rather than via ModuleAccessGuard:
+        // this provider only needs the boolean, never the guard's rendered 403,
+        // and the guard's ModuleTemplateFactory dependency is a final core class
+        // that cannot be stood up in a unit test.
+        private AccessControlServiceInterface $accessControlService,
+    ) {}
+
+    /**
+     * Status data for `Partials/SecurityStatus.html`.
+     *
+     * Always returns the complete shape — including on failure — so the Fluid
+     * partial never reads a missing key and renders a half-blank panel where a
+     * warning belongs.
+     *
+     * @return SecurityStatusView
+     */
+    public function forView(): array
+    {
+        try {
+            $report = $this->doctor->run();
+        } catch (Throwable) {
+            // The doctor service contains per-check crashes itself, so reaching
+            // here means the run could not start at all. Report the gap rather
+            // than an empty panel: "we could not check" must not look like "there
+            // is nothing to report".
+            return $this->unavailable();
+        }
+
+        $detailed = $this->accessControlService->isGranted(VaultPermission::VaultConfigure);
+        $severity = $report->highestSeverity();
+
+        return [
+            'available' => true,
+            'profile' => $report->context->profile->value,
+            'auditReady' => $report->isAuditReady(),
+            'severity' => $severity->value,
+            'context' => $severity->bootstrapContext(),
+            'passed' => $report->passedControls(),
+            'total' => $report->totalControls(),
+            'criticalCount' => \count($report->findingsOfSeverity(FindingSeverity::Critical)),
+            'warningCount' => \count($report->findingsOfSeverity(FindingSeverity::Warning)),
+            'detailed' => $detailed,
+            'findings' => $detailed ? $this->shapeFindings($report->problems()) : [],
+        ];
+    }
+
+    /**
+     * @param list<Finding> $findings
+     *
+     * @return list<ShapedFinding>
+     */
+    private function shapeFindings(array $findings): array
+    {
+        return array_map(
+            static fn (Finding $finding): array => [
+                'id' => $finding->id,
+                'severity' => $finding->severity->value,
+                'context' => $finding->severity->bootstrapContext(),
+                'summary' => $finding->summary,
+                'risk' => $finding->risk,
+                'remediation' => $finding->remediation,
+                'docsUrl' => $finding->docsUrl,
+            ],
+            $findings,
+        );
+    }
+
+    /**
+     * @return SecurityStatusView
+     */
+    private function unavailable(): array
+    {
+        return [
+            'available' => false,
+            'profile' => '',
+            'auditReady' => false,
+            'severity' => '',
+            'context' => 'warning',
+            'passed' => 0,
+            'total' => 0,
+            'criticalCount' => 0,
+            'warningCount' => 0,
+            'detailed' => false,
+            'findings' => [],
+        ];
+    }
+}

--- a/Classes/Service/Doctor/Check/AuditCheck.php
+++ b/Classes/Service/Doctor/Check/AuditCheck.php
@@ -1,0 +1,435 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor\Check;
+
+use Netresearch\NrVault\Audit\Anchor\AnchorReaderInterface;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\DocsLink;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
+
+/**
+ * Is the audit trail being written, kept, verifiable, and witnessed externally?
+ *
+ * ## Why this check is bounded and `vault:audit-verify` is not
+ *
+ * The chain pass here covers only the newest {@see self::CHAIN_TAIL_SIZE}
+ * entries, and the anchor comparison covers only chain *shrinkage* — not the
+ * per-row hash substitution check. Both limits are deliberate: this check runs
+ * inside a deployment gate and on every render of the backend status panel, and
+ * a full-table HMAC recomputation on a multi-million-row audit log is not
+ * something to put on a page load.
+ *
+ * The consequence is stated in the findings themselves: a passing
+ * `audit.hash_chain` means "the recent tail verifies", never "the chain is
+ * intact". {@see \Netresearch\NrVault\Command\VaultAuditVerifyCommand} is the
+ * authoritative full-range verifier and belongs on a schedule. A gate that
+ * silently implied full coverage would be worse than one that admits its scope.
+ */
+final readonly class AuditCheck implements ReadinessCheckInterface
+{
+    /**
+     * Number of trailing audit entries the bounded chain pass covers.
+     *
+     * Large enough to catch a fresh tampering attempt (the attacker's own rows
+     * are at the tip), small enough to stay cheap on a page load.
+     */
+    private const CHAIN_TAIL_SIZE = 1000;
+
+    /**
+     * Retention floor, in days, for a trail that has to survive an annual audit
+     * cycle. Below this a reviewer cannot see the previous cycle's activity.
+     */
+    private const RETENTION_FLOOR_DAYS = 365;
+
+    public function __construct(
+        private ExtensionConfigurationInterface $configuration,
+        private AuditLogServiceInterface $auditLogService,
+        private AuditSinkRegistryInterface $sinkRegistry,
+        private ChainTipAnchorServiceInterface $anchorService,
+        private AnchorReaderInterface $anchorReader,
+    ) {}
+
+    public function getId(): string
+    {
+        return 'audit';
+    }
+
+    public function appliesTo(SecurityProfile $profile): bool
+    {
+        return true;
+    }
+
+    public function run(DoctorContext $context): array
+    {
+        $anchor = $this->anchorReader->readLatestAnchor();
+        $currentSequence = $this->anchorService->capture()->sequence;
+
+        return [
+            $this->checkReadsLogged($context),
+            $this->checkRetention(),
+            $this->checkHashChain($currentSequence),
+            $this->checkExternalSink($context),
+            $this->checkAnchor($context, $anchor, $currentSequence),
+            $this->checkSinkFailures(),
+        ];
+    }
+
+    /**
+     * Are reads written to the audit log?
+     *
+     * Reads are the operation that matters most in an audit: a stolen credential
+     * is *read*, not written. With `auditReads` off, the trail records who
+     * created a secret and never who used it.
+     */
+    private function checkReadsLogged(DoctorContext $context): Finding
+    {
+        $id = 'audit.reads_logged';
+
+        if ($this->configuration->isAuditReadsEnabled()) {
+            return Finding::pass(
+                id: $id,
+                summary: 'Read access is written to the audit log.',
+                docsUrl: DocsLink::AUDIT_LOGGING,
+            );
+        }
+
+        $finding = Finding::warning(
+            id: $id,
+            summary: 'Read access is NOT written to the audit log (auditReads is disabled).',
+            risk: 'The trail records who created and rotated secrets but not who consumed them. '
+                . 'Credential misuse — the case audit logging exists for — leaves no record at all.',
+            remediation: 'Enable "auditReads", and pin it out of admin reach in '
+                . 'config/system/additional.php '
+                . '($GLOBALS[TYPO3_CONF_VARS][SYS][nrVault][auditReads] = true) so it cannot be '
+                . 'silenced from the backend Settings module.',
+            docsUrl: DocsLink::AUDIT_LOGGING,
+            details: ['auditReads' => false],
+        );
+
+        // Under the hardened profile an unattributable read is not hygiene, it is
+        // the profile failing to deliver the thing it exists for.
+        return $context->isHardened()
+            ? $finding->escalatedTo(FindingSeverity::Critical)
+            : $finding;
+    }
+
+    /**
+     * Will the trail still be there when someone comes to read it?
+     *
+     * `0` means "keep forever", which is the safest setting for an audit trail
+     * and therefore a pass — the finding only fires for a retention window too
+     * short to cover a review cycle.
+     */
+    private function checkRetention(): Finding
+    {
+        $id = 'audit.retention';
+        $days = $this->configuration->getAuditLogRetention();
+
+        if ($days === 0) {
+            return Finding::pass(
+                id: $id,
+                summary: 'Audit entries are retained indefinitely.',
+                docsUrl: DocsLink::AUDIT_LOGGING,
+                details: ['retentionDays' => 0],
+            );
+        }
+
+        if ($days < 0) {
+            return Finding::warning(
+                id: $id,
+                summary: \sprintf('Audit log retention is a negative value (%d days).', $days),
+                risk: 'The value is not a meaningful retention window; purge behaviour is undefined.',
+                remediation: \sprintf(
+                    'Set "auditLogRetention" to 0 (keep forever) or to at least %d days.',
+                    self::RETENTION_FLOOR_DAYS,
+                ),
+                docsUrl: DocsLink::AUDIT_LOGGING,
+                details: ['retentionDays' => $days],
+            );
+        }
+
+        if ($days < self::RETENTION_FLOOR_DAYS) {
+            return Finding::warning(
+                id: $id,
+                summary: \sprintf('Audit entries are kept for %d days.', $days),
+                risk: \sprintf(
+                    'Shorter than a %d-day review cycle, so a reviewer cannot see the previous '
+                    . 'cycle\'s access. It also shortens the window in which a slow-burn credential '
+                    . 'misuse is still reconstructable.',
+                    self::RETENTION_FLOOR_DAYS,
+                ),
+                remediation: \sprintf(
+                    'Raise "auditLogRetention" to at least %d, or to 0 to keep entries indefinitely. '
+                    . 'If a shorter window is a data-protection requirement, record that decision — the '
+                    . 'purge is legitimate but it does remove evidence.',
+                    self::RETENTION_FLOOR_DAYS,
+                ),
+                docsUrl: DocsLink::AUDIT_LOGGING,
+                details: ['retentionDays' => $days],
+            );
+        }
+
+        return Finding::pass(
+            id: $id,
+            summary: \sprintf('Audit entries are kept for %d days.', $days),
+            docsUrl: DocsLink::AUDIT_LOGGING,
+            details: ['retentionDays' => $days],
+        );
+    }
+
+    /**
+     * Does the newest slice of the hash chain still verify?
+     */
+    private function checkHashChain(int $currentSequence): Finding
+    {
+        $id = 'audit.hash_chain';
+
+        if ($currentSequence === 0) {
+            return Finding::pass(
+                id: $id,
+                summary: 'The audit log is empty; there is no hash chain to verify yet.',
+                docsUrl: DocsLink::AUDIT_HASH_CHAIN,
+                details: ['currentSequence' => 0],
+            );
+        }
+
+        $fromUid = max(1, $currentSequence - self::CHAIN_TAIL_SIZE + 1);
+        $result = $this->auditLogService->verifyHashChain($fromUid);
+
+        $details = [
+            'fromUid' => $fromUid,
+            'toUid' => $currentSequence,
+            'errorCount' => $result->getErrorCount(),
+            'missingUidCount' => $result->missingUidCount,
+        ];
+
+        if (!$result->isValid()) {
+            return Finding::critical(
+                id: $id,
+                summary: \sprintf(
+                    'Hash chain verification failed on %d of the last %d audit entries (uid %d..%d)%s.',
+                    $result->getErrorCount(),
+                    $currentSequence - $fromUid + 1,
+                    $fromUid,
+                    $currentSequence,
+                    $result->hasMissingUids()
+                        ? \sprintf('; %d uid(s) missing from the sequence', $result->missingUidCount)
+                        : '',
+                ),
+                risk: 'Stored audit rows no longer match their own HMACs, or rows were deleted from the '
+                    . 'sequence. Either way the trail currently proves nothing. A missing uid is the '
+                    . 'signature of a deletion whose successor row had its previous_hash patched — the '
+                    . 'one attack the per-row check alone cannot see.',
+                remediation: 'Run vendor/bin/typo3 vault:audit-verify for the full-range report and the '
+                    . 'reason codes (HASH_MISMATCH / UID_GAP / EPOCH_DOWNGRADE). Reconcile any gap '
+                    . 'against a documented purge before assuming it is benign. Do not re-seal the chain '
+                    . 'first — re-sealing launders the tampering into a valid chain.',
+                docsUrl: DocsLink::AUDIT_HASH_CHAIN,
+                details: $details,
+            );
+        }
+
+        return Finding::pass(
+            id: $id,
+            summary: \sprintf(
+                'The last %d audit entries (uid %d..%d) verify against the hash chain. Full-range '
+                . 'verification is vault:audit-verify.',
+                $currentSequence - $fromUid + 1,
+                $fromUid,
+                $currentSequence,
+            ),
+            docsUrl: DocsLink::AUDIT_HASH_CHAIN,
+            details: $details,
+        );
+    }
+
+    /**
+     * Does the audit trail exist anywhere outside the database it protects?
+     *
+     * The severity split mirrors {@see AuditIntegrityReason::NoExternalSink}: the
+     * standard profile treats sinks as opt-in, so a default installation is not
+     * flagged for having no SIEM. Only the hardened profile promises external
+     * evidence, and there the absence is the promise being broken.
+     */
+    private function checkExternalSink(DoctorContext $context): Finding
+    {
+        $id = 'audit.external_sink';
+        $enabled = $this->sinkRegistry->getEnabledSinkIdentifiers();
+
+        if ($enabled !== []) {
+            return Finding::pass(
+                id: $id,
+                summary: \sprintf('External audit sink(s) enabled: %s.', implode(', ', $enabled)),
+                docsUrl: DocsLink::AUDIT_SINKS,
+                details: ['sinks' => implode(',', $enabled)],
+            );
+        }
+
+        if (!$context->isHardened()) {
+            return Finding::pass(
+                id: $id,
+                summary: 'No external audit sink is enabled. Sinks are opt-in under the standard profile.',
+                docsUrl: DocsLink::AUDIT_SINKS,
+                details: ['sinks' => '', 'reasonCode' => AuditIntegrityReason::NoExternalSink->value],
+            );
+        }
+
+        return Finding::critical(
+            id: $id,
+            summary: 'The hardened profile requires an external audit sink, but none is enabled and usable.',
+            risk: 'The audit trail exists only in the database it is meant to protect. An attacker with '
+                . 'DELETE rights can truncate the table and let a fresh, internally consistent chain '
+                . 'build from uid 1 — nothing inside the database distinguishes that from a young '
+                . 'installation. No chain-tip anchor can be published either, so the reset stays '
+                . 'undetectable.',
+            remediation: 'Enable at least one of "auditSinkFileEnabled" (append-only NDJSON outside the '
+                . 'web root), "auditSinkSyslogEnabled" or "auditSinkWebhookEnabled", then schedule '
+                . 'vendor/bin/typo3 vault:audit-anchor.',
+            docsUrl: DocsLink::AUDIT_SINKS,
+            details: ['sinks' => '', 'reasonCode' => AuditIntegrityReason::NoExternalSink->value],
+        );
+    }
+
+    /**
+     * Is there external evidence of the chain, and is the chain still at least as
+     * long as that evidence says?
+     *
+     * Only the shrinkage half of the anchor comparison is done here — an integer
+     * comparison, cheap enough for a page load. The row-hash substitution check
+     * lives in {@see ChainTipAnchorServiceInterface::verify()}, which recomputes
+     * the full chain; the remediation text points there rather than duplicating
+     * its logic, so there is one implementation of the deep comparison.
+     */
+    private function checkAnchor(
+        DoctorContext $context,
+        ?ChainTipAnchor $anchor,
+        int $currentSequence,
+    ): Finding {
+        $id = 'audit.anchor';
+
+        if (!$anchor instanceof ChainTipAnchor) {
+            if (!$context->isHardened()) {
+                return Finding::pass(
+                    id: $id,
+                    summary: 'No chain-tip anchor has been published. Anchoring is opt-in under the '
+                        . 'standard profile.',
+                    docsUrl: DocsLink::AUDIT_SINK_SCHEDULING,
+                    details: ['anchorAvailable' => $this->anchorReader->isAvailable()],
+                );
+            }
+
+            return Finding::critical(
+                id: $id,
+                summary: 'No chain-tip anchor could be read, although the hardened profile requires one.',
+                risk: 'A full audit-table reset would be undetectable: there is no external record of '
+                    . 'how long the chain had grown or what its tip hashed to.',
+                remediation: 'Run vendor/bin/typo3 vault:audit-anchor once, then schedule the '
+                    . '"Vault Audit Chain Anchoring" task hourly. The interval is the blind window — an '
+                    . 'attacker can only hide entries written since the last anchor.',
+                docsUrl: DocsLink::AUDIT_SINK_SCHEDULING,
+                details: [
+                    'anchorAvailable' => $this->anchorReader->isAvailable(),
+                    'reasonCode' => AuditIntegrityReason::NoExternalSink->value,
+                ],
+            );
+        }
+
+        $details = [
+            'anchoredSequence' => $anchor->sequence,
+            'currentSequence' => $currentSequence,
+            'anchoredAt' => $anchor->timestamp,
+        ];
+
+        if ($currentSequence < $anchor->sequence) {
+            return Finding::critical(
+                id: $id,
+                summary: \sprintf(
+                    'The audit chain shrank: highest uid is %d but sequence %d was anchored on %s UTC.',
+                    $currentSequence,
+                    $anchor->sequence,
+                    gmdate('Y-m-d H:i:s', $anchor->timestamp),
+                ),
+                risk: 'An append-only chain cannot get shorter. The audit table was truncated or rows '
+                    . 'were deleted wholesale — the signature of a truncate-and-rebuild.',
+                remediation: 'Treat this as an incident. Run vendor/bin/typo3 vault:audit-verify for the '
+                    . 'TABLE_RESET report, and reconstruct the removed interval from the external sink '
+                    . 'stream, which the database reset did not touch.',
+                docsUrl: DocsLink::AUDIT_SINK_SCHEDULING,
+                details: $details + ['reasonCode' => AuditIntegrityReason::TableReset->value],
+            );
+        }
+
+        return Finding::pass(
+            id: $id,
+            summary: \sprintf(
+                'Chain-tip anchor present (sequence %d, anchored %s UTC); the chain has not shrunk. '
+                . 'Tip-hash comparison is vault:audit-verify.',
+                $anchor->sequence,
+                gmdate('Y-m-d H:i:s', $anchor->timestamp),
+            ),
+            docsUrl: DocsLink::AUDIT_SINK_SCHEDULING,
+            details: $details,
+        );
+    }
+
+    /**
+     * Did any sink refuse delivery in this process?
+     *
+     * Per-process by design (persisting the counter would mean writing to the
+     * storage a sink failure may indicate is broken), so a zero here means "not
+     * in this run", not "never". It still catches the common case: a wrong
+     * webhook URL or an unwritable log path fails on the very first dispatch.
+     */
+    private function checkSinkFailures(): Finding
+    {
+        $id = 'audit.sink_delivery';
+        $failures = $this->sinkRegistry->getFailureCountsBySink();
+        $total = $this->sinkRegistry->getFailureCount();
+
+        if ($total === 0) {
+            return Finding::pass(
+                id: $id,
+                summary: 'No audit sink delivery failures observed in this process.',
+                docsUrl: DocsLink::AUDIT_SINKS,
+                details: ['failureCount' => 0],
+            );
+        }
+
+        $perSink = [];
+        foreach ($failures as $sink => $count) {
+            $perSink[] = \sprintf('%s (%d)', $sink, $count);
+        }
+
+        return Finding::warning(
+            id: $id,
+            summary: \sprintf(
+                '%d audit sink delivery failure(s) in this process: %s.',
+                $total,
+                implode(', ', $perSink),
+            ),
+            risk: 'Audit evidence written during this process did not reach the external sink. The '
+                . 'database copy is intact, but the external witness — the part that survives a table '
+                . 'reset — has holes.',
+            remediation: 'Check the TYPO3 log for the per-sink reason (unreachable collector, full disk, '
+                . 'unwritable path), fix it, then re-anchor with vendor/bin/typo3 vault:audit-anchor.',
+            docsUrl: DocsLink::AUDIT_SINKS,
+            details: ['failureCount' => $total, 'failuresBySink' => implode(',', $perSink)],
+        );
+    }
+}

--- a/Classes/Service/Doctor/Check/BreakGlassCheck.php
+++ b/Classes/Service/Doctor/Check/BreakGlassCheck.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor\Check;
+
+use DateTimeImmutable;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Security\BreakGlassSession;
+use Netresearch\NrVault\Security\BreakGlassStateInterface;
+use Netresearch\NrVault\Service\Doctor\DocsLink;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
+
+/**
+ * Is an emergency-access window open right now?
+ *
+ * The backend modules already show a banner while a window is open, so this
+ * check exists for the surfaces the banner cannot reach: the CLI, a monitoring
+ * probe, and a CI deployment gate. A release that ships while an operator's
+ * bypass is live is a release nobody can attribute correctly afterwards.
+ *
+ * Warning rather than critical, on purpose. An open window is a deliberate,
+ * justified, time-boxed act, not a misconfiguration — and a critical finding
+ * would push operators to close the window in order to get a green gate during
+ * the very incident it was opened for. Warning states the fact and lets the
+ * human decide.
+ */
+final readonly class BreakGlassCheck implements ReadinessCheckInterface
+{
+    private const DATE_FORMAT = 'Y-m-d H:i';
+
+    public function __construct(
+        private BreakGlassStateInterface $breakGlassState,
+    ) {}
+
+    public function getId(): string
+    {
+        return 'breakglass';
+    }
+
+    public function appliesTo(SecurityProfile $profile): bool
+    {
+        return true;
+    }
+
+    public function run(DoctorContext $context): array
+    {
+        $id = 'breakglass.window_open';
+        $session = $this->breakGlassState->getActiveSession();
+
+        if (!$session instanceof BreakGlassSession) {
+            return [
+                Finding::pass(
+                    id: $id,
+                    summary: 'No break-glass window is open.',
+                    docsUrl: DocsLink::BREAK_GLASS,
+                ),
+            ];
+        }
+
+        $remainingMinutes = (int) ceil($session->remainingSeconds(new DateTimeImmutable()) / 60);
+
+        return [
+            Finding::warning(
+                id: $id,
+                summary: \sprintf(
+                    'A break-glass window is open: %s (uid %d) until %s (%d minute(s) left), reason: %s',
+                    $session->activatedByUsername,
+                    $session->activatedByUid,
+                    $session->expiresAt->format(self::DATE_FORMAT),
+                    $remainingMinutes,
+                    $session->reason,
+                ),
+                risk: 'While the window is open the admin override is fully restored: that operator '
+                    . 'holds every vault permission and read/write/delete on every secret, regardless of '
+                    . 'the hardened profile. Break-glass buys evidence and a time box, not restriction.',
+                remediation: \sprintf(
+                    'Close it as soon as the work is done: vendor/bin/typo3 vault:break-glass '
+                    . '--deactivate --reason "…". It lapses on its own at %s. Review the activation as an '
+                    . 'incident, not as routine maintenance.',
+                    $session->expiresAt->format(self::DATE_FORMAT),
+                ),
+                docsUrl: DocsLink::BREAK_GLASS,
+                details: [
+                    'activatedByUid' => $session->activatedByUid,
+                    'activatedByUsername' => $session->activatedByUsername,
+                    'reason' => $session->reason,
+                    'expiresAt' => $session->expiresAt->getTimestamp(),
+                    'remainingMinutes' => $remainingMinutes,
+                ],
+            ),
+        ];
+    }
+}

--- a/Classes/Service/Doctor/Check/CliAccessCheck.php
+++ b/Classes/Service/Doctor/Check/CliAccessCheck.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor\Check;
+
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\DocsLink;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
+
+/**
+ * Who can read secrets from a shell?
+ *
+ * `allowCliAccess` is the one switch that grants vault permissions to an actor
+ * with no backend user behind it. It exists because deployment scripts need to
+ * store credentials, but it is also the widest grant in the extension: a shell on
+ * the box becomes read access to every secret whose per-secret ACL admits the CLI
+ * actor.
+ *
+ * Off by default, so the finding here is about a deliberate opt-in that may have
+ * outlived the deployment step it was added for — and about the second, easier
+ * mistake: turning it on and leaving the group restriction empty.
+ */
+final readonly class CliAccessCheck implements ReadinessCheckInterface
+{
+    public function __construct(
+        private ExtensionConfigurationInterface $configuration,
+    ) {}
+
+    public function getId(): string
+    {
+        return 'cli';
+    }
+
+    public function appliesTo(SecurityProfile $profile): bool
+    {
+        return true;
+    }
+
+    public function run(DoctorContext $context): array
+    {
+        $allowed = $this->configuration->isCliAccessAllowed();
+
+        if (!$allowed) {
+            return [
+                Finding::pass(
+                    id: 'cli.access',
+                    summary: 'CLI access to secrets is disabled.',
+                    docsUrl: DocsLink::ACCESS_CONTROL,
+                    details: ['allowCliAccess' => false],
+                ),
+            ];
+        }
+
+        return [
+            $this->checkAccessEnabled($context),
+            $this->checkAccessGroups(),
+        ];
+    }
+
+    /**
+     * CLI access is on — is that acceptable for the target profile?
+     *
+     * A pass under the standard profile: a deployment pipeline that stores
+     * credentials needs this, and calling it a defect would make the check noise.
+     * A warning under hardened, where every read is supposed to be attributable
+     * to a named actor and a bare CLI actor is not.
+     */
+    private function checkAccessEnabled(DoctorContext $context): Finding
+    {
+        $id = 'cli.access';
+        $details = ['allowCliAccess' => true];
+
+        if (!$context->isHardened()) {
+            return Finding::pass(
+                id: $id,
+                summary: 'CLI access to secrets is enabled (required for deployment automation).',
+                docsUrl: DocsLink::ACCESS_CONTROL,
+                details: $details,
+            );
+        }
+
+        return Finding::warning(
+            id: $id,
+            summary: 'CLI access to secrets is enabled under the hardened profile.',
+            risk: 'Anyone with a shell on the host can read secrets without authenticating as a backend '
+                . 'user. The audit trail records the operation but attributes it to the CLI actor, so it '
+                . 'cannot name the human responsible.',
+            remediation: 'Prefer the technical-actor API (TechnicalActorContext::runAs()) so headless '
+                . 'reads are attributed to a named backend user, then disable "allowCliAccess". If the '
+                . 'switch must stay on, restrict "cliAccessGroups" to the smallest possible group set.',
+            docsUrl: DocsLink::ACCESS_CONTROL,
+            details: $details,
+        );
+    }
+
+    /**
+     * Is the CLI grant scoped to specific groups?
+     */
+    private function checkAccessGroups(): Finding
+    {
+        $id = 'cli.access_groups';
+        // Drop 0 entries: getCliAccessGroups() maps unparseable values to 0, and
+        // group uid 0 does not exist — counting them would report a scoped grant
+        // where the configuration actually holds junk.
+        $groups = array_values(array_filter(
+            $this->configuration->getCliAccessGroups(),
+            static fn (int $groupUid): bool => $groupUid > 0,
+        ));
+
+        if ($groups === []) {
+            return Finding::warning(
+                id: $id,
+                summary: 'CLI access is enabled but "cliAccessGroups" is empty, so the grant is unscoped.',
+                risk: 'The CLI actor is not narrowed to any backend group, so its reach is whatever the '
+                    . 'per-secret ACLs happen to allow the CLI context — in practice every secret that is '
+                    . 'not owner-restricted. There is no group boundary left to review.',
+                remediation: 'List the specific backend group UIDs the deployment identity belongs to in '
+                    . '"cliAccessGroups", so an unrelated secret cannot be read from a shell.',
+                docsUrl: DocsLink::ACCESS_CONTROL,
+                details: ['cliAccessGroupCount' => 0],
+            );
+        }
+
+        return Finding::pass(
+            id: $id,
+            summary: \sprintf('CLI access is scoped to %d backend group(s).', \count($groups)),
+            docsUrl: DocsLink::ACCESS_CONTROL,
+            details: ['cliAccessGroupCount' => \count($groups)],
+        );
+    }
+}

--- a/Classes/Service/Doctor/Check/EnvironmentCheck.php
+++ b/Classes/Service/Doctor/Check/EnvironmentCheck.php
@@ -1,0 +1,155 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor\Check;
+
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\DocsLink;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
+use TYPO3\CMS\Core\Core\Environment;
+
+/**
+ * The TYPO3 installation around the vault.
+ *
+ * Two controls only, and that is the point. The vault sits inside a TYPO3
+ * installation whose own settings can undo its protection — a revealed secret
+ * travelling over plain HTTP is exposed regardless of how well it was encrypted
+ * at rest — but a doctor that guesses at the host environment produces findings
+ * an operator cannot act on and learns to ignore.
+ *
+ * So this check reads exactly two values that are unambiguous and locally
+ * knowable: the application context and `[BE][lockSSL]`. Notably absent:
+ *
+ *  - a separate "secure cookie" control. TYPO3 derives the backend cookie's
+ *    `secure` flag from `lockSSL`; there is no independent setting to read, so a
+ *    second finding would report the same fact twice.
+ *  - anything requiring an outbound request (real TLS termination, HSTS headers,
+ *    reverse-proxy behaviour). Those are worth checking — by something that can
+ *    actually see the edge, not by a CLI process behind it.
+ */
+final readonly class EnvironmentCheck implements ReadinessCheckInterface
+{
+    public function getId(): string
+    {
+        return 'environment';
+    }
+
+    public function appliesTo(SecurityProfile $profile): bool
+    {
+        return true;
+    }
+
+    public function run(DoctorContext $context): array
+    {
+        return [
+            $this->checkApplicationContext($context),
+            $this->checkBackendLockSsl(),
+        ];
+    }
+
+    /**
+     * Is the installation running in a Production context?
+     *
+     * Only a finding under the hardened profile, where it is a genuine
+     * contradiction: a Development context enables verbose error output and
+     * relaxes framework-level protections, so claiming a fail-closed audit-ready
+     * posture from it is claiming something the environment does not support.
+     * Under the standard profile a Development context is the normal state of a
+     * developer machine and reporting it would be noise.
+     */
+    private function checkApplicationContext(DoctorContext $context): Finding
+    {
+        $id = 'environment.production_context';
+        $applicationContext = (string) Environment::getContext();
+        $isProduction = Environment::getContext()->isProduction();
+        $details = ['applicationContext' => $applicationContext];
+
+        if ($isProduction || !$context->isHardened()) {
+            return Finding::pass(
+                id: $id,
+                summary: \sprintf('Application context is "%s".', $applicationContext),
+                details: $details,
+            );
+        }
+
+        return Finding::warning(
+            id: $id,
+            summary: \sprintf(
+                'The hardened profile is active but the application context is "%s", not Production.',
+                $applicationContext,
+            ),
+            risk: 'Non-production contexts show detailed errors and stack traces to the browser and relax '
+                . 'framework protections. A stack trace from the crypto layer can name the master-key '
+                . 'path; a hardened deployment is supposed to give an attacker nothing.',
+            remediation: 'Set TYPO3_CONTEXT=Production on the production host. If this run is on a '
+                . 'staging or developer machine, this finding is expected there and only the production '
+                . 'run needs to pass.',
+            docsUrl: DocsLink::DEPLOYMENT_GATE,
+            details: $details,
+        );
+    }
+
+    /**
+     * Is the backend restricted to HTTPS?
+     *
+     * Profile-independent: the reveal endpoint returns plaintext secrets to a
+     * browser, so an unencrypted backend session leaks them on the wire whatever
+     * profile is configured.
+     */
+    private function checkBackendLockSsl(): Finding
+    {
+        $id = 'environment.backend_lock_ssl';
+
+        if ($this->isBackendSslLocked()) {
+            return Finding::pass(
+                id: $id,
+                summary: 'The TYPO3 backend is restricted to HTTPS ([BE][lockSSL] is set).',
+                details: ['lockSSL' => true],
+            );
+        }
+
+        return Finding::warning(
+            id: $id,
+            summary: 'The TYPO3 backend is not restricted to HTTPS ([BE][lockSSL] is not set).',
+            risk: 'The reveal endpoint sends secret plaintext to the browser and the backend session '
+                . 'cookie is not marked secure. On an unencrypted connection both are readable on the '
+                . 'wire, which defeats the encryption at rest entirely.',
+            remediation: 'Set $GLOBALS[TYPO3_CONF_VARS][BE][lockSSL] = true in '
+                . 'config/system/settings.php once TLS terminates in front of the backend.',
+            docsUrl: DocsLink::DEPLOYMENT_GATE,
+            details: ['lockSSL' => false],
+        );
+    }
+
+    /**
+     * Is `$TYPO3_CONF_VARS[BE][lockSSL]` set?
+     *
+     * Read from `$GLOBALS` rather than injected because there is no service-shaped
+     * accessor for core settings, and mirrors
+     * {@see \Netresearch\NrVault\Configuration\ExtensionConfiguration} — an absent
+     * or unexpectedly-shaped section reads as "not configured", which is the
+     * direction that produces the finding rather than hiding it.
+     */
+    private function isBackendSslLocked(): bool
+    {
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        if (!\is_array($confVars)) {
+            return false;
+        }
+
+        $backend = $confVars['BE'] ?? null;
+        if (!\is_array($backend)) {
+            return false;
+        }
+
+        return (bool) ($backend['lockSSL'] ?? false);
+    }
+}

--- a/Classes/Service/Doctor/Check/MasterKeyProviderCheck.php
+++ b/Classes/Service/Doctor/Check/MasterKeyProviderCheck.php
@@ -1,0 +1,355 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor\Check;
+
+use Netresearch\NrVault\Configuration\ExtensionConfiguration;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface;
+use Netresearch\NrVault\Exception\ConfigurationException;
+use Netresearch\NrVault\Service\Doctor\DocsLink;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
+use Netresearch\NrVault\Service\VaultHealthServiceInterface;
+
+/**
+ * The master key: is one configured, permitted, reachable, and protected on disk?
+ *
+ * This is the check whose failure means the vault is not a vault. Everything
+ * else degrades gracefully; a master key that cannot be read makes every stored
+ * secret unrecoverable, and a master key the web server group can read makes the
+ * envelope encryption decorative.
+ *
+ * The liveness probe is delegated to {@see VaultHealthServiceInterface} rather
+ * than re-implemented, so the CLI gate and the module's health banner cannot
+ * disagree about whether encryption works — and so this check inherits that
+ * service's rule of never letting a raw exception message (which can carry the
+ * key file path) reach the caller.
+ *
+ * For the same reason no finding here carries the key path. Only the octal file
+ * mode travels in `details`: the JSON report is written to CI logs, and a log
+ * line naming the master-key location is a gift to anyone reading build output.
+ */
+final readonly class MasterKeyProviderCheck implements ReadinessCheckInterface
+{
+    /**
+     * The provider that derives the master key from TYPO3's own encryption key.
+     *
+     * Also the extension's zero-config default, which is why "the provider is
+     * `typo3`" and "no provider was chosen" are the same observation.
+     */
+    private const PROVIDER_TYPO3 = 'typo3';
+
+    private const PROVIDER_FILE = 'file';
+
+    public function __construct(
+        private ExtensionConfigurationInterface $configuration,
+        private MasterKeyProviderFactoryInterface $providerFactory,
+        private VaultHealthServiceInterface $healthService,
+    ) {}
+
+    public function getId(): string
+    {
+        return 'provider';
+    }
+
+    public function appliesTo(SecurityProfile $profile): bool
+    {
+        return true;
+    }
+
+    public function run(DoctorContext $context): array
+    {
+        $configured = $this->configuration->getMasterKeyProvider();
+
+        $findings = [
+            $this->checkConfigured($context, $configured),
+            $this->checkKnown($configured),
+            ...$this->checkLiveness($configured),
+        ];
+
+        if ($configured === self::PROVIDER_FILE) {
+            $findings[] = $this->checkKeyFilePermissions();
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Is a provider chosen, and is that provider permitted under the target
+     * profile?
+     *
+     * One control rather than two because the failing case is the same one: the
+     * TYPO3 encryption key is both the unconfigured default and the value the
+     * hardened profile forbids. Splitting them would report the identical
+     * observation twice.
+     */
+    private function checkConfigured(DoctorContext $context, string $configured): Finding
+    {
+        $id = 'provider.configured';
+
+        if (trim($configured) === '') {
+            return Finding::critical(
+                id: $id,
+                summary: 'No master-key provider is configured.',
+                risk: 'The vault cannot derive a master key, so no secret can be stored or read.',
+                remediation: 'Set the "masterKeyProvider" extension setting to file or env, then run '
+                    . 'vendor/bin/typo3 vault:init.',
+                docsUrl: DocsLink::MASTER_KEY_PROVIDERS,
+                details: ['provider' => ''],
+            );
+        }
+
+        if ($configured !== self::PROVIDER_TYPO3) {
+            return Finding::pass(
+                id: $id,
+                summary: \sprintf('Master-key provider "%s" is explicitly configured.', $configured),
+                docsUrl: DocsLink::MASTER_KEY_PROVIDERS,
+                details: ['provider' => $configured],
+            );
+        }
+
+        // The TYPO3 provider is in use — the extension default, i.e. also the
+        // state of an installation where nobody made a choice.
+        if ($context->isHardened()) {
+            return Finding::critical(
+                id: $id,
+                summary: 'The hardened profile forbids the "typo3" master-key provider, but it is in use.',
+                risk: 'Vault secrets share their key with $GLOBALS[TYPO3_CONF_VARS][SYS][encryptionKey], '
+                    . 'which lives in a file every deployment copies and which other extensions also read. '
+                    . 'One leaked configuration file loses every secret in the vault.',
+                remediation: 'Configure an external provider ("file" or "env") and re-encrypt with '
+                    . 'vendor/bin/typo3 vault:rotate-master-key. The provider factory refuses to boot the '
+                    . 'hardened profile on "typo3", so this must be fixed before the vault will run at all.',
+                docsUrl: DocsLink::MASTER_KEY_PROVIDERS,
+                details: ['provider' => $configured, 'profile' => $context->profile->value],
+            );
+        }
+
+        return Finding::warning(
+            id: $id,
+            summary: 'The master key is derived from the TYPO3 encryption key (zero-configuration default).',
+            risk: 'The vault shares its key with the rest of the installation: anyone who can read '
+                . 'the system configuration can decrypt every secret, and rotating the TYPO3 '
+                . 'encryption key silently makes the vault unreadable.',
+            remediation: 'For anything holding third-party credentials, move to the "file" or "env" '
+                . 'provider and re-encrypt with vendor/bin/typo3 vault:rotate-master-key.',
+            docsUrl: DocsLink::MASTER_KEY_PROVIDERS,
+            details: ['provider' => $configured],
+        );
+    }
+
+    /**
+     * Can the factory actually build the configured provider?
+     *
+     * Deliberately generic: the finding names whatever identifier is configured
+     * without a hard-coded list of valid ones, so a provider shipped by a later
+     * release (or by a consuming extension) that is configured on an installation
+     * which does not have it reports as "unknown here" rather than as a passing
+     * control.
+     */
+    private function checkKnown(string $configured): Finding
+    {
+        $id = 'provider.known';
+
+        try {
+            $this->providerFactory->create();
+        } catch (ConfigurationException $e) {
+            return Finding::critical(
+                id: $id,
+                summary: \sprintf('The configured master-key provider "%s" cannot be built.', $configured),
+                risk: 'Every vault operation fails at the crypto boundary. The message is: ' . $e->getMessage(),
+                remediation: 'Correct the "masterKeyProvider" extension setting, or install the extension '
+                    . 'that supplies this provider.',
+                docsUrl: DocsLink::MASTER_KEY_PROVIDERS,
+                details: ['provider' => $configured],
+            );
+        }
+
+        return Finding::pass(
+            id: $id,
+            summary: \sprintf('Master-key provider "%s" resolves.', $configured),
+            docsUrl: DocsLink::MASTER_KEY_PROVIDERS,
+            details: ['provider' => $configured],
+        );
+    }
+
+    /**
+     * Is a key present, and does it actually decrypt?
+     *
+     * Two controls from one probe: `provider.available` answers "is there a key
+     * source at all", `provider.master_key_readable` answers "can we read a
+     * non-empty key out of it". They fail independently — a present but truncated
+     * key file passes the first and fails the second.
+     *
+     * @return list<Finding>
+     */
+    private function checkLiveness(string $configured): array
+    {
+        $status = $this->healthService->checkHealth();
+        $resolved = $status->masterKeyProvider;
+
+        if (!$status->masterKeyAvailable) {
+            $available = Finding::critical(
+                id: 'provider.available',
+                summary: 'No master-key provider is available at runtime.',
+                risk: 'Secrets cannot be read. Existing ciphertext stays in the database but is '
+                    . 'unusable until the key source is restored.',
+                remediation: 'Run vendor/bin/typo3 vault:init to verify the configuration, then check '
+                    . 'the TYPO3 log — the provider records why it is unavailable there (the reason can '
+                    . 'name the key path, so it is logged rather than shown here).',
+                docsUrl: DocsLink::MASTER_KEY_PROVIDERS,
+                details: ['configuredProvider' => $configured, 'resolvedProvider' => $resolved],
+            );
+        } elseif ($resolved !== '' && $resolved !== $configured) {
+            // Standard-profile auto-detection found a usable key somewhere other
+            // than the configured source. The vault works, but it is not working
+            // the way the configuration says it does — and a later hardening
+            // switch turns that into an outage, because the hardened factory does
+            // not auto-detect.
+            $available = Finding::warning(
+                id: 'provider.available',
+                summary: \sprintf(
+                    'The configured provider is "%s" but the runtime resolved "%s" by auto-detection.',
+                    $configured,
+                    $resolved,
+                ),
+                risk: 'Secrets are protected by a different key source than the configuration states, '
+                    . 'so key rotation and backup procedures written against the configuration will miss '
+                    . 'the key actually in use. Switching to the hardened profile removes auto-detection '
+                    . 'and turns this into an immediate outage.',
+                remediation: \sprintf(
+                    'Either make "%s" usable, or set "masterKeyProvider" to "%s" to match reality.',
+                    $configured,
+                    $resolved,
+                ),
+                docsUrl: DocsLink::MASTER_KEY_PROVIDERS,
+                details: ['configuredProvider' => $configured, 'resolvedProvider' => $resolved],
+            );
+        } else {
+            $available = Finding::pass(
+                id: 'provider.available',
+                summary: \sprintf('Master-key provider "%s" is available.', $resolved),
+                docsUrl: DocsLink::MASTER_KEY_PROVIDERS,
+                details: ['resolvedProvider' => $resolved],
+            );
+        }
+
+        $readable = $status->encryptionWorking
+            ? Finding::pass(
+                id: 'provider.master_key_readable',
+                summary: 'The master key was read and envelope encryption is operational.',
+                docsUrl: DocsLink::MASTER_KEY_PROVIDERS,
+            )
+            : Finding::critical(
+                id: 'provider.master_key_readable',
+                summary: 'The master key could not be read.',
+                risk: 'Every store, retrieve and rotate operation fails. Secrets already in the '
+                    . 'database cannot be decrypted while this persists.',
+                remediation: 'Check the key source exists, is readable by the web server / CLI user, and '
+                    . 'holds a 32-byte key (raw or base64). The provider logs the specific reason via '
+                    . 'PSR-3; it is not repeated here because it can contain the key path.',
+                docsUrl: DocsLink::MASTER_KEY_PROVIDERS,
+                details: ['resolvedProvider' => $resolved],
+            );
+
+        return [$available, $readable];
+    }
+
+    /**
+     * Is the key file readable by anyone other than its owner?
+     *
+     * File-provider only. The resolution mirrors
+     * {@see \Netresearch\NrVault\Crypto\FileMasterKeyProvider}: the configured
+     * source when it is a real path, otherwise the auto-generated development
+     * path the provider falls back to.
+     */
+    private function checkKeyFilePermissions(): Finding
+    {
+        $id = 'provider.key_permissions';
+        $path = $this->resolveKeyFilePath();
+
+        if ($path === null) {
+            return Finding::warning(
+                id: $id,
+                summary: 'The master-key file permissions could not be inspected because no key file exists '
+                    . 'at the configured or fallback path.',
+                risk: 'A key file that is not there cannot be protected, and the file provider will fail '
+                    . 'on the next read.',
+                remediation: 'Set "masterKeySource" to the absolute path of the key file, or generate one '
+                    . 'with vendor/bin/typo3 vault:init.',
+                docsUrl: DocsLink::MASTER_KEY_FILE,
+            );
+        }
+
+        clearstatcache(true, $path);
+        $perms = fileperms($path);
+
+        if ($perms === false) {
+            return Finding::warning(
+                id: $id,
+                summary: 'The master-key file exists but its permissions could not be read.',
+                risk: 'The file may be group- or world-readable without this check noticing.',
+                remediation: 'Inspect the file mode manually; it must be 0400 or 0600 and owned by the '
+                    . 'user the web server and CLI run as.',
+                docsUrl: DocsLink::MASTER_KEY_FILE,
+            );
+        }
+
+        $mode = $perms & 0o777;
+        $octal = \sprintf('0%o', $mode);
+
+        // Group or other holding read, write or execute. Read is the one that
+        // loses the secrets; write and execute are included because a mode that
+        // loose is never intentional.
+        if (($mode & 0o077) !== 0) {
+            return Finding::critical(
+                id: $id,
+                summary: \sprintf('The master-key file is accessible beyond its owner (mode %s).', $octal),
+                risk: 'Any local account in the file\'s group — on shared hosting, every other site on '
+                    . 'the box — can read the key and decrypt every secret in the vault. Envelope '
+                    . 'encryption provides no protection once the master key is readable.',
+                remediation: 'chmod 0400 the key file and chown it to the user the web server and CLI '
+                    . 'run as. If the key was ever group-readable, treat it as compromised: generate a '
+                    . 'new one and run vendor/bin/typo3 vault:rotate-master-key.',
+                docsUrl: DocsLink::MASTER_KEY_FILE,
+                details: ['mode' => $octal],
+            );
+        }
+
+        return Finding::pass(
+            id: $id,
+            summary: \sprintf('The master-key file is owner-only (mode %s).', $octal),
+            docsUrl: DocsLink::MASTER_KEY_FILE,
+            details: ['mode' => $octal],
+        );
+    }
+
+    /**
+     * The key file the file provider would actually read, or null when neither
+     * candidate exists.
+     */
+    private function resolveKeyFilePath(): ?string
+    {
+        $source = trim($this->configuration->getMasterKeySource());
+        if (
+            $source !== ''
+            && $source !== ExtensionConfiguration::DEFAULT_MASTER_KEY_SOURCE
+            && is_file($source)
+        ) {
+            return $source;
+        }
+
+        $autoPath = $this->configuration->getAutoKeyPath();
+
+        return is_file($autoPath) ? $autoPath : null;
+    }
+}

--- a/Classes/Service/Doctor/Check/SecretHygieneCheck.php
+++ b/Classes/Service/Doctor/Check/SecretHygieneCheck.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor\Check;
+
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Domain\Dto\StaleSecret;
+use Netresearch\NrVault\Domain\StalenessRule;
+use Netresearch\NrVault\Service\Analytics\VaultAnalyticsServiceInterface;
+use Netresearch\NrVault\Service\Doctor\DocsLink;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
+
+/**
+ * Is the stored inventory itself in good order?
+ *
+ * The other checks ask whether the vault is configured correctly. This one asks
+ * whether what is *in* it should still be there. Every secret is a liability for
+ * as long as it exists: an expired credential nobody removed, a token nothing has
+ * read in months, a password never rotated since the person who set it left.
+ * Reducing the inventory is the cheapest security work available, and it is the
+ * work nobody does unless something counts it.
+ *
+ * The counts come from {@see VaultAnalyticsServiceInterface}, the same source the
+ * Analytics module renders, so the CLI gate and the module cannot disagree about
+ * how many secrets are stale. No identifier is included in any finding — a
+ * secret identifier names a credential and the JSON report travels into CI logs.
+ * The Analytics module is where an operator sees which ones.
+ */
+final readonly class SecretHygieneCheck implements ReadinessCheckInterface
+{
+    /**
+     * Analysis window for the read-activity split, in days.
+     *
+     * Matched to the longest staleness threshold that exists by default
+     * (`staleNeverRotatedDays`, 180) so a secret is not called unread merely
+     * because the window was shorter than its usage interval.
+     */
+    private const WINDOW_DAYS = 180;
+
+    public function __construct(
+        private VaultAnalyticsServiceInterface $analytics,
+        private ExtensionConfigurationInterface $configuration,
+    ) {}
+
+    public function getId(): string
+    {
+        return 'secrets';
+    }
+
+    public function appliesTo(SecurityProfile $profile): bool
+    {
+        return true;
+    }
+
+    public function run(DoctorContext $context): array
+    {
+        $stats = $this->analytics->getUsageStats(self::WINDOW_DAYS);
+        $candidates = $this->analytics->getRedactionCandidates(self::WINDOW_DAYS);
+
+        return [
+            $this->checkExpired($stats->expired),
+            $this->checkNeverRotated($stats->neverRotated),
+            $this->checkDead($this->countByRule($candidates, StalenessRule::Dead)),
+        ];
+    }
+
+    private function checkExpired(int $expired): Finding
+    {
+        $id = 'secrets.expired';
+
+        if ($expired === 0) {
+            return Finding::pass(
+                id: $id,
+                summary: 'No expired secrets are stored.',
+                details: ['expiredCount' => 0],
+            );
+        }
+
+        return Finding::warning(
+            id: $id,
+            summary: \sprintf('%d stored secret(s) are past their expiry date.', $expired),
+            risk: 'An expired secret still decrypts, so the credential remains recoverable from a '
+                . 'database dump long after it stopped being needed. Consumers that still reference it '
+                . 'also fail at an unpredictable moment rather than at the expiry date.',
+            remediation: 'Review them in the vault Analytics module and either rotate them with '
+                . 'vendor/bin/typo3 vault:rotate, or remove them with vendor/bin/typo3 vault:delete.',
+            docsUrl: DocsLink::COMMANDS,
+            details: ['expiredCount' => $expired],
+        );
+    }
+
+    private function checkNeverRotated(int $neverRotated): Finding
+    {
+        $id = 'secrets.never_rotated';
+        $threshold = $this->configuration->getStaleNeverRotatedDays();
+
+        if ($neverRotated === 0) {
+            return Finding::pass(
+                id: $id,
+                summary: \sprintf('Every stored secret was rotated within the last %d days.', $threshold),
+                details: ['neverRotatedCount' => 0, 'thresholdDays' => $threshold],
+            );
+        }
+
+        return Finding::warning(
+            id: $id,
+            summary: \sprintf(
+                '%d stored secret(s) have not been rotated in %d days or more.',
+                $neverRotated,
+                $threshold,
+            ),
+            risk: 'The longer a credential lives, the more places it has been copied to and the more '
+                . 'former staff have seen it. An unrotated secret means a leak from any point in its '
+                . 'history is still live today.',
+            remediation: 'Rotate them with vendor/bin/typo3 vault:rotate. Rotate on personnel changes as '
+                . 'well as on a schedule — a departure is what makes an old credential dangerous.',
+            docsUrl: DocsLink::COMMANDS,
+            details: ['neverRotatedCount' => $neverRotated, 'thresholdDays' => $threshold],
+        );
+    }
+
+    private function checkDead(int $dead): Finding
+    {
+        $id = 'secrets.dead';
+
+        if ($dead === 0) {
+            return Finding::pass(
+                id: $id,
+                summary: 'No stored secret looks unused.',
+                details: ['deadCount' => 0],
+            );
+        }
+
+        return Finding::warning(
+            id: $id,
+            summary: \sprintf('%d stored secret(s) show no read activity and look unused.', $dead),
+            risk: 'A credential nothing reads is pure liability: it is still decryptable, still in every '
+                . 'backup, and nobody would notice if it were used. It also inflates the blast radius of '
+                . 'a master-key compromise for no operational benefit.',
+            remediation: 'Confirm in the vault Analytics module that nothing consumes them, then delete '
+                . 'them with vendor/bin/typo3 vault:delete. Revoke the credential at the issuing system '
+                . 'too — removing the vault copy does not invalidate the credential.',
+            docsUrl: DocsLink::COMMANDS,
+            details: ['deadCount' => $dead],
+        );
+    }
+
+    /**
+     * @param list<StaleSecret> $candidates
+     */
+    private function countByRule(array $candidates, StalenessRule $rule): int
+    {
+        $count = 0;
+        foreach ($candidates as $candidate) {
+            if (\in_array($rule, $candidate->rules, true)) {
+                ++$count;
+            }
+        }
+
+        return $count;
+    }
+}

--- a/Classes/Service/Doctor/Check/SecurityProfileCheck.php
+++ b/Classes/Service/Doctor/Check/SecurityProfileCheck.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor\Check;
+
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Exception\ConfigurationException;
+use Netresearch\NrVault\Service\Doctor\DocsLink;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
+
+/**
+ * Is the profile a real profile, and do the toggles around it agree with it?
+ *
+ * A profile is a single coherent policy, not a bag of switches, which makes the
+ * *mismatch* between a switch and the profile a finding in its own right. Both
+ * directions mislead an operator, in opposite ways:
+ *
+ *  - `disableAdminOverride` set while the profile is `standard` reads like the
+ *    override is gone. It is not: the flag is inert outside the hardened profile,
+ *    so every admin still bypasses every gate while the configuration screen says
+ *    otherwise. A control believed to be on is worse than one known to be off.
+ *  - the `hardened` profile *without* `disableAdminOverride` is a genuine
+ *    hardened deployment that kept its widest bypass. Defensible — the flag is a
+ *    lockout risk, so it stays opt-in — but not something to discover during an
+ *    audit.
+ */
+final readonly class SecurityProfileCheck implements ReadinessCheckInterface
+{
+    public function __construct(
+        private ExtensionConfigurationInterface $configuration,
+    ) {}
+
+    public function getId(): string
+    {
+        return 'profile';
+    }
+
+    public function appliesTo(SecurityProfile $profile): bool
+    {
+        return true;
+    }
+
+    public function run(DoctorContext $context): array
+    {
+        return [
+            $this->checkProfileValue(),
+            $this->checkAdminOverrideConsistency($context),
+        ];
+    }
+
+    /**
+     * Is the configured profile string one the extension knows?
+     *
+     * `getSecurityProfile()` throws on an unknown value rather than degrading to
+     * standard, so this check exists to turn that fail-closed exception into a
+     * readable finding. It is the one control that must be evaluated even though
+     * the doctor service already needed the profile to build the context — the
+     * service falls back to standard silently so the rest of the report stays
+     * readable, and this is where the operator is told that happened.
+     */
+    private function checkProfileValue(): Finding
+    {
+        $id = 'profile.valid';
+
+        try {
+            $profile = $this->configuration->getSecurityProfile();
+        } catch (ConfigurationException $e) {
+            return Finding::critical(
+                id: $id,
+                summary: 'The configured security profile is not a valid profile.',
+                risk: 'Every code path that resolves the profile throws, which takes down secret '
+                    . 'retrieval, the backend modules and the audit verifier. The extension refuses to '
+                    . 'guess a profile rather than silently running a weaker policy than intended — so '
+                    . 'this is an outage, not a degradation. Reported message: ' . $e->getMessage(),
+                remediation: 'Set the "securityProfile" extension setting to exactly "standard" or '
+                    . '"hardened".',
+                docsUrl: DocsLink::SECURITY_PROFILES,
+            );
+        }
+
+        return Finding::pass(
+            id: $id,
+            summary: \sprintf('Security profile "%s" is in force.', $profile->value),
+            docsUrl: DocsLink::SECURITY_PROFILES,
+            details: ['profile' => $profile->value],
+        );
+    }
+
+    /**
+     * Does the admin-override flag mean what the profile makes it mean?
+     */
+    private function checkAdminOverrideConsistency(DoctorContext $context): Finding
+    {
+        $id = 'profile.admin_override';
+        $disabled = $this->configuration->isAdminOverrideDisabled();
+        $details = [
+            'disableAdminOverride' => $disabled,
+            'profile' => $context->profile->value,
+        ];
+
+        if ($disabled && !$context->isHardened()) {
+            return Finding::warning(
+                id: $id,
+                summary: 'disableAdminOverride is set, but it has no effect outside the hardened profile.',
+                risk: 'The configuration reads as though the admin bypass were removed while every '
+                    . 'administrator still holds every vault permission and read/write/delete on every '
+                    . 'secret. An operator relying on this flag believes in a control that is not there.',
+                remediation: 'Either switch "securityProfile" to "hardened" so the flag takes effect, or '
+                    . 'clear "disableAdminOverride" so the configuration stops implying a control it does '
+                    . 'not provide.',
+                docsUrl: DocsLink::ADMIN_OVERRIDE,
+                details: $details,
+            );
+        }
+
+        if (!$disabled && $context->isHardened()) {
+            return Finding::warning(
+                id: $id,
+                summary: 'The hardened profile is active but the admin override is still in place.',
+                risk: 'Any administrator or system maintainer bypasses every operation permission and '
+                    . 'every per-secret ACL. The granular permission model is advisory for them, so a '
+                    . 'single compromised admin account reads the whole vault.',
+                remediation: 'Pin disableAdminOverride in config/system/additional.php '
+                    . '($GLOBALS[TYPO3_CONF_VARS][SYS][nrVault][disableAdminOverride] = true) so it '
+                    . 'cannot be undone from the backend, and grant yourself the vault permissions you '
+                    . 'need through a group first. Keep vault:break-glass available for lockout recovery.',
+                docsUrl: DocsLink::ADMIN_OVERRIDE,
+                details: $details,
+            );
+        }
+
+        return Finding::pass(
+            id: $id,
+            summary: $disabled
+                ? 'The admin override is disabled and the hardened profile makes that effective.'
+                : 'The admin override is active, consistent with the standard profile.',
+            docsUrl: DocsLink::ADMIN_OVERRIDE,
+            details: $details,
+        );
+    }
+}

--- a/Classes/Service/Doctor/Check/Typo3VersionRange.php
+++ b/Classes/Service/Doctor/Check/Typo3VersionRange.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor\Check;
+
+use Stringable;
+
+/**
+ * An `ext_emconf.php` dependency range, e.g. `13.4.0-14.99.99`.
+ *
+ * Extracted from {@see VersionCheck} because parsing an operator-editable string
+ * is the part with edge cases (missing upper bound, reversed bounds, junk), and a
+ * diagnostic that silently mis-parses its own constraint would report a
+ * compatible installation as broken. Kept deliberately dumb: `version_compare()`
+ * over two bounds, no composer semantics — the authoritative resolution is
+ * composer's, and duplicating it here would only create a second answer.
+ */
+final readonly class Typo3VersionRange implements Stringable
+{
+    private function __construct(
+        public string $minimum,
+        public string $maximum,
+    ) {}
+
+    public function __toString(): string
+    {
+        return $this->minimum . '-' . $this->maximum;
+    }
+
+    /**
+     * Parse an `ext_emconf.php` constraint, or null when it is not a usable range.
+     *
+     * Null rather than a permissive fallback: "we could not read the constraint"
+     * and "every version is allowed" are different statements, and only the
+     * caller knows which finding to raise.
+     */
+    public static function fromConstraint(string $constraint): ?self
+    {
+        $parts = explode('-', trim($constraint));
+        if (\count($parts) !== 2) {
+            return null;
+        }
+
+        $minimum = trim($parts[0]);
+        $maximum = trim($parts[1]);
+
+        if ($minimum === '' || $maximum === '') {
+            return null;
+        }
+
+        if (version_compare($minimum, $maximum, '>')) {
+            return null;
+        }
+
+        return new self(minimum: $minimum, maximum: $maximum);
+    }
+
+    /**
+     * Is `$version` inside the range (inclusive on both bounds)?
+     */
+    public function contains(string $version): bool
+    {
+        $version = trim($version);
+        if ($version === '') {
+            return false;
+        }
+
+        return version_compare($version, $this->minimum, '>=')
+            && version_compare($version, $this->maximum, '<=');
+    }
+}

--- a/Classes/Service/Doctor/Check/VersionCheck.php
+++ b/Classes/Service/Doctor/Check/VersionCheck.php
@@ -1,0 +1,218 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor\Check;
+
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
+use Throwable;
+use TYPO3\CMS\Core\Information\Typo3Version;
+use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
+
+/**
+ * Which versions are actually running?
+ *
+ * Basic sanity, and the report's provenance line. Two things a reader of a
+ * `vault:doctor` report from three months ago needs: which extension version
+ * produced it, and whether it was running on a core it declares support for.
+ *
+ * Deliberately not a compatibility resolver. Composer already refused to install
+ * an unsupported combination, so the only way to reach a version mismatch here is
+ * a hand-assembled deployment — rare, but exactly the situation where every other
+ * control's result becomes unreliable, so it is worth naming.
+ */
+final readonly class VersionCheck implements ReadinessCheckInterface
+{
+    private const EXTENSION_KEY = 'nr_vault';
+
+    public function __construct(
+        private Typo3Version $typo3Version,
+    ) {}
+
+    public function getId(): string
+    {
+        return 'version';
+    }
+
+    public function appliesTo(SecurityProfile $profile): bool
+    {
+        return true;
+    }
+
+    public function run(DoctorContext $context): array
+    {
+        $emConf = $this->readEmConf();
+        $extensionVersion = \is_string($emConf['version'] ?? null) ? $emConf['version'] : '';
+
+        return [
+            $this->checkExtensionVersion($extensionVersion),
+            $this->checkTypo3Supported($emConf, $extensionVersion),
+        ];
+    }
+
+    private function checkExtensionVersion(string $extensionVersion): Finding
+    {
+        $id = 'version.extension';
+
+        if ($extensionVersion === '') {
+            return Finding::warning(
+                id: $id,
+                summary: 'The extension version could not be read from ext_emconf.php.',
+                risk: 'A readiness report that cannot state which version produced it is not evidence: '
+                    . 'a reviewer cannot tell whether the controls it lists are the ones that release '
+                    . 'actually implements.',
+                remediation: 'Restore ext_emconf.php from the release artefact — an installation missing '
+                    . 'it is incomplete in other ways too.',
+            );
+        }
+
+        return Finding::pass(
+            id: $id,
+            summary: \sprintf('nr_vault %s is installed.', $extensionVersion),
+            details: ['extensionVersion' => $extensionVersion],
+        );
+    }
+
+    /**
+     * Does the running core fall inside the range the extension declares?
+     *
+     * @param array<mixed> $emConf
+     */
+    private function checkTypo3Supported(array $emConf, string $extensionVersion): Finding
+    {
+        $id = 'version.typo3_supported';
+        $running = $this->typo3Version->getVersion();
+        $constraint = $this->extractTypo3Constraint($emConf);
+
+        if ($constraint === '') {
+            return Finding::warning(
+                id: $id,
+                summary: \sprintf(
+                    'TYPO3 %s is running, but the extension declares no TYPO3 version constraint.',
+                    $running,
+                ),
+                risk: 'Nothing states which cores this build was tested against, so an incompatibility '
+                    . 'would surface as a runtime error in the crypto or audit path rather than at '
+                    . 'install time.',
+                remediation: 'Restore the constraints block in ext_emconf.php from the release artefact.',
+                details: ['typo3Version' => $running],
+            );
+        }
+
+        $range = Typo3VersionRange::fromConstraint($constraint);
+
+        if (!$range instanceof Typo3VersionRange) {
+            return Finding::warning(
+                id: $id,
+                summary: \sprintf(
+                    'The declared TYPO3 constraint "%s" is not a parseable version range.',
+                    $constraint,
+                ),
+                risk: 'Compatibility cannot be confirmed from the extension metadata.',
+                remediation: 'Express the constraint as "<min>-<max>", e.g. 13.4.0-14.99.99.',
+                details: ['typo3Version' => $running, 'constraint' => $constraint],
+            );
+        }
+
+        $details = [
+            'typo3Version' => $running,
+            'constraint' => (string) $range,
+            'extensionVersion' => $extensionVersion,
+        ];
+
+        if (!$range->contains($running)) {
+            return Finding::warning(
+                id: $id,
+                summary: \sprintf(
+                    'TYPO3 %s is outside the range nr_vault declares support for (%s).',
+                    $running,
+                    (string) $range,
+                ),
+                risk: 'The extension is running on an untested core. Crypto and audit code paths depend '
+                    . 'on core APIs that change between major versions, so a silent behaviour change '
+                    . 'there is a correctness risk in exactly the code that must not be wrong.',
+                remediation: 'Upgrade nr_vault to a release that supports this core, or run the core '
+                    . 'version this release declares. Let composer resolve it rather than installing by '
+                    . 'hand.',
+                details: $details,
+            );
+        }
+
+        return Finding::pass(
+            id: $id,
+            summary: \sprintf('TYPO3 %s is within the supported range (%s).', $running, (string) $range),
+            details: $details,
+        );
+    }
+
+    /**
+     * @param array<mixed> $emConf
+     */
+    private function extractTypo3Constraint(array $emConf): string
+    {
+        $constraints = $emConf['constraints'] ?? null;
+        if (!\is_array($constraints)) {
+            return '';
+        }
+
+        $depends = $constraints['depends'] ?? null;
+        if (!\is_array($depends)) {
+            return '';
+        }
+
+        $typo3 = $depends['typo3'] ?? null;
+
+        return \is_string($typo3) ? $typo3 : '';
+    }
+
+    /**
+     * Read this extension's own `ext_emconf.php`.
+     *
+     * Included in an isolated closure scope rather than read with a parser: the
+     * file is a PHP array literal by TYPO3 convention, and `include` is how the
+     * core itself reads it.
+     *
+     * Every failure — no package manager (which is the case in a unit-test
+     * process), missing file, unexpected contents — degrades to an empty array, so
+     * the findings above report the problem instead of an exception taking the
+     * whole readiness run into `check.crashed`. Version metadata is the one area
+     * where being unable to look is genuinely only worth a warning.
+     *
+     * `array<mixed>` rather than `array<string, mixed>` on purpose: the contents
+     * come from an `include`, so nothing here can prove the key type. Every read
+     * above narrows the value it needs.
+     *
+     * @return array<mixed>
+     */
+    private function readEmConf(): array
+    {
+        try {
+            $path = ExtensionManagementUtility::extPath(self::EXTENSION_KEY) . 'ext_emconf.php';
+        } catch (Throwable) {
+            return [];
+        }
+
+        if (!is_file($path) || !is_readable($path)) {
+            return [];
+        }
+
+        $emConf = (static function (string $file, string $extensionKey): mixed {
+            $_EXTKEY = $extensionKey;
+            /** @var array<string, mixed> $EM_CONF */
+            $EM_CONF = [];
+            include $file;
+
+            return $EM_CONF[$_EXTKEY] ?? null;
+        })($path, self::EXTENSION_KEY);
+
+        return \is_array($emConf) ? $emConf : [];
+    }
+}

--- a/Classes/Service/Doctor/Check/VersionCheck.php
+++ b/Classes/Service/Doctor/Check/VersionCheck.php
@@ -208,7 +208,12 @@ final readonly class VersionCheck implements ReadinessCheckInterface
             $_EXTKEY = $extensionKey;
             /** @var array<string, mixed> $EM_CONF */
             $EM_CONF = [];
-            include $file;
+            // NOSONAR php:S2003 — must be `include`, not `include_once`: this
+            // reads a data file (ext_emconf.php sets $EM_CONF) into the closure
+            // scope, and include_once would return true without re-populating
+            // $EM_CONF on any second call in the same process, yielding an empty
+            // (wrong) version result.
+            include $file; // NOSONAR
 
             return $EM_CONF[$_EXTKEY] ?? null;
         })($path, self::EXTENSION_KEY);

--- a/Classes/Service/Doctor/DocsLink.php
+++ b/Classes/Service/Doctor/DocsLink.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor;
+
+/**
+ * Deep links from a {@see Finding} into the rendered documentation.
+ *
+ * Centralised as constants rather than inlined per check so a moved section
+ * breaks in one place, and so `grep DocsLink Classes/` lists every documentation
+ * anchor the diagnostics promise to keep alive. Each constant corresponds to an
+ * explicit `.. _label:` target in `Documentation/`; do not point one at a
+ * generated heading anchor, which changes whenever the heading text does.
+ */
+final class DocsLink
+{
+    public const BASE = 'https://docs.typo3.org/p/netresearch/nr-vault/main/en-us/';
+
+    public const MASTER_KEY_PROVIDERS = self::BASE . 'Configuration/Index.html#configuration-master-key-providers';
+
+    public const MASTER_KEY_FILE = self::BASE . 'Security/Index.html#security-file-storage';
+
+    public const SECURITY_PROFILES = self::BASE . 'Configuration/Index.html#configuration-extension';
+
+    public const ADMIN_OVERRIDE = self::BASE . 'Security/Index.html#security-disable-admin-override';
+
+    public const BREAK_GLASS = self::BASE . 'Security/Index.html#security-break-glass';
+
+    public const AUDIT_LOGGING = self::BASE . 'Security/Index.html#security-audit-logging';
+
+    public const AUDIT_HASH_CHAIN = self::BASE . 'Security/Index.html#security-hash-chain';
+
+    public const AUDIT_SINKS = self::BASE . 'Configuration/Index.html#configuration-audit-sinks';
+
+    public const AUDIT_SINK_SCHEDULING = self::BASE . 'Configuration/Index.html#configuration-audit-sink-scheduling';
+
+    public const ACCESS_CONTROL = self::BASE . 'Configuration/Index.html#configuration-access-control';
+
+    public const DEPLOYMENT_GATE = self::BASE . 'Security/Index.html#security-deployment-gate';
+
+    public const COMMANDS = self::BASE . 'Developer/Commands.html#developer-commands';
+}

--- a/Classes/Service/Doctor/DoctorContext.php
+++ b/Classes/Service/Doctor/DoctorContext.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor;
+
+use Netresearch\NrVault\Configuration\SecurityProfile;
+
+/**
+ * The profile a readiness run is judged against.
+ *
+ * Two profiles, not one, because the useful question before a hardening
+ * migration is "would this configuration pass as hardened?" — answerable only by
+ * evaluating the live configuration against a target profile it does not
+ * currently claim. `vault:doctor --profile=hardened` therefore changes what the
+ * checks *require*, never what the vault *does*: no configuration is written and
+ * no enforcement path is affected.
+ *
+ * `$configuredProfile` is retained alongside so output can state which profile
+ * is actually in force — a report that only showed the target would let an
+ * operator read a passing `--profile=hardened` dry run as proof that hardening
+ * is already live.
+ */
+final readonly class DoctorContext
+{
+    public function __construct(
+        /** The profile the checks assert against. */
+        public SecurityProfile $profile,
+        /** The profile actually configured in the extension configuration. */
+        public SecurityProfile $configuredProfile,
+    ) {}
+
+    /**
+     * Judge the configured profile against itself — the default for a live
+     * readiness report and for the backend status surface.
+     */
+    public static function forConfiguredProfile(SecurityProfile $profile): self
+    {
+        return new self(profile: $profile, configuredProfile: $profile);
+    }
+
+    /**
+     * Is the run asserting against a profile other than the configured one?
+     */
+    public function isProfileOverridden(): bool
+    {
+        return $this->profile !== $this->configuredProfile;
+    }
+
+    /**
+     * Does the run assert the hardened policy?
+     */
+    public function isHardened(): bool
+    {
+        return $this->profile->isHardened();
+    }
+}

--- a/Classes/Service/Doctor/DoctorReport.php
+++ b/Classes/Service/Doctor/DoctorReport.php
@@ -1,0 +1,157 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor;
+
+/**
+ * Result of one `vault:doctor` run: every evaluated control plus the verdict.
+ *
+ * ## Exit-code aggregation
+ *
+ * The single rule, applied here rather than in the command so the backend
+ * surface and any future consumer cannot disagree with the CLI:
+ *
+ *   - `2` — at least one {@see FindingSeverity::Critical} finding;
+ *   - `1` — otherwise, at least one {@see FindingSeverity::Warning};
+ *   - `0` — only passes (this includes an empty report, which the doctor service
+ *     never produces because every applicable check reports its passes too).
+ *
+ * Worst-severity-wins rather than a score: a gate must not be able to average a
+ * critical finding away against a long list of passes.
+ */
+final readonly class DoctorReport
+{
+    /**
+     * @param list<Finding> $findings Every evaluated control, passing ones included
+     */
+    public function __construct(
+        public DoctorContext $context,
+        public array $findings,
+    ) {}
+
+    /**
+     * The verdict: the highest severity present.
+     */
+    public function highestSeverity(): FindingSeverity
+    {
+        $highest = FindingSeverity::Pass;
+        foreach ($this->findings as $finding) {
+            if ($finding->severity->rank() > $highest->rank()) {
+                $highest = $finding->severity;
+            }
+        }
+
+        return $highest;
+    }
+
+    /**
+     * Process exit code per the aggregation rule in the class docblock.
+     */
+    public function exitCode(): int
+    {
+        return match ($this->highestSeverity()) {
+            FindingSeverity::Critical => 2,
+            FindingSeverity::Warning => 1,
+            FindingSeverity::Pass => 0,
+        };
+    }
+
+    /**
+     * Is the configuration audit-ready — no finding above Pass?
+     */
+    public function isAuditReady(): bool
+    {
+        return $this->highestSeverity() === FindingSeverity::Pass;
+    }
+
+    /**
+     * @return list<Finding>
+     */
+    public function findingsOfSeverity(FindingSeverity $severity): array
+    {
+        return array_values(array_filter(
+            $this->findings,
+            static fn (Finding $finding): bool => $finding->severity === $severity,
+        ));
+    }
+
+    /**
+     * Every finding that is not a pass, criticals first.
+     *
+     * The ordering is the point: an operator scanning a long report must hit the
+     * blocking findings before the advisory ones.
+     *
+     * @return list<Finding>
+     */
+    public function problems(): array
+    {
+        return [
+            ...$this->findingsOfSeverity(FindingSeverity::Critical),
+            ...$this->findingsOfSeverity(FindingSeverity::Warning),
+        ];
+    }
+
+    /**
+     * Number of controls evaluated.
+     */
+    public function totalControls(): int
+    {
+        return \count($this->findings);
+    }
+
+    /**
+     * Number of controls satisfied.
+     */
+    public function passedControls(): int
+    {
+        return \count($this->findingsOfSeverity(FindingSeverity::Pass));
+    }
+
+    /**
+     * @return array{
+     *     profile: string,
+     *     configuredProfile: string,
+     *     profileOverridden: bool,
+     *     auditReady: bool,
+     *     highestSeverity: string,
+     *     exitCode: int,
+     *     summary: array{total: int, pass: int, warning: int, critical: int},
+     *     findings: list<array{
+     *         id: string,
+     *         severity: string,
+     *         summary: string,
+     *         risk: string,
+     *         remediation: string,
+     *         docsUrl: string,
+     *         details: array<string, bool|int|string>,
+     *     }>,
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'profile' => $this->context->profile->value,
+            'configuredProfile' => $this->context->configuredProfile->value,
+            'profileOverridden' => $this->context->isProfileOverridden(),
+            'auditReady' => $this->isAuditReady(),
+            'highestSeverity' => $this->highestSeverity()->value,
+            'exitCode' => $this->exitCode(),
+            'summary' => [
+                'total' => $this->totalControls(),
+                'pass' => $this->passedControls(),
+                'warning' => \count($this->findingsOfSeverity(FindingSeverity::Warning)),
+                'critical' => \count($this->findingsOfSeverity(FindingSeverity::Critical)),
+            ],
+            'findings' => array_map(
+                static fn (Finding $finding): array => $finding->toArray(),
+                $this->findings,
+            ),
+        ];
+    }
+}

--- a/Classes/Service/Doctor/Finding.php
+++ b/Classes/Service/Doctor/Finding.php
@@ -1,0 +1,174 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor;
+
+/**
+ * One evaluated readiness control.
+ *
+ * ## Why four text fields instead of one message
+ *
+ * A deployment gate that only says "audit.external_sink: critical" tells the
+ * operator nothing they can act on at 23:50 on a release evening. The three
+ * prose fields answer the three questions that actually come up, and keeping
+ * them separate means the CLI, the backend module and a CI log all show the
+ * same answer instead of each inventing its own phrasing:
+ *
+ *  - `summary` — what was observed;
+ *  - `risk` — what an attacker or auditor gets out of it (empty for Pass);
+ *  - `remediation` — the concrete next action, ideally a command (empty for Pass).
+ *
+ * ## Identifier scheme
+ *
+ * `<area>.<control>`, lower snake within a segment: `provider.key_permissions`,
+ * `audit.external_sink`, `breakglass.window_open`. Dotted rather than numbered
+ * (`NRVAULT-DOC-001`) so an id survives inserting a control in the middle and
+ * still reads as a sentence in a monitoring rule.
+ *
+ * **The ids are external API.** They appear in `--format=json`, in CI gate
+ * allow-lists and in monitoring rules; renaming one silently changes what a
+ * downstream gate is asserting. Add a new id rather than repurposing an old one.
+ *
+ * `details` carries machine-readable specifics (counts, reason codes, octal file
+ * modes). It is deliberately scalar-only and must never carry key material, a
+ * master-key path, or a secret value — the JSON form travels into CI logs.
+ */
+final readonly class Finding
+{
+    /**
+     * @param string $id Stable dotted control id, e.g. `audit.external_sink`
+     * @param string $summary What was observed, one sentence
+     * @param string $risk What the finding costs the operator ('' for Pass)
+     * @param string $remediation Concrete next action ('' for Pass)
+     * @param string $docsUrl Deep link into the rendered documentation ('' when none applies)
+     * @param array<string, bool|int|string> $details Machine-readable specifics — never secret material
+     */
+    public function __construct(
+        public string $id,
+        public FindingSeverity $severity,
+        public string $summary,
+        public string $risk = '',
+        public string $remediation = '',
+        public string $docsUrl = '',
+        public array $details = [],
+    ) {}
+
+    /**
+     * @param array<string, bool|int|string> $details
+     */
+    public static function pass(string $id, string $summary, string $docsUrl = '', array $details = []): self
+    {
+        return new self(
+            id: $id,
+            severity: FindingSeverity::Pass,
+            summary: $summary,
+            docsUrl: $docsUrl,
+            details: $details,
+        );
+    }
+
+    /**
+     * @param array<string, bool|int|string> $details
+     */
+    public static function warning(
+        string $id,
+        string $summary,
+        string $risk,
+        string $remediation,
+        string $docsUrl = '',
+        array $details = [],
+    ): self {
+        return new self(
+            id: $id,
+            severity: FindingSeverity::Warning,
+            summary: $summary,
+            risk: $risk,
+            remediation: $remediation,
+            docsUrl: $docsUrl,
+            details: $details,
+        );
+    }
+
+    /**
+     * @param array<string, bool|int|string> $details
+     */
+    public static function critical(
+        string $id,
+        string $summary,
+        string $risk,
+        string $remediation,
+        string $docsUrl = '',
+        array $details = [],
+    ): self {
+        return new self(
+            id: $id,
+            severity: FindingSeverity::Critical,
+            summary: $summary,
+            risk: $risk,
+            remediation: $remediation,
+            docsUrl: $docsUrl,
+            details: $details,
+        );
+    }
+
+    /**
+     * Escalate a warning to critical, keeping every text field.
+     *
+     * Several controls are the same observation at two severities depending on
+     * the target profile (an unlogged read is hygiene under `standard` and a
+     * broken promise under `hardened`). Building the finding once and raising it
+     * keeps the wording identical between profiles, which is what makes a
+     * `--profile=hardened` dry run comparable to the live report.
+     */
+    public function escalatedTo(FindingSeverity $severity): self
+    {
+        if ($severity === $this->severity) {
+            return $this;
+        }
+
+        return new self(
+            id: $this->id,
+            severity: $severity,
+            summary: $this->summary,
+            risk: $this->risk,
+            remediation: $this->remediation,
+            docsUrl: $this->docsUrl,
+            details: $this->details,
+        );
+    }
+
+    public function isPass(): bool
+    {
+        return $this->severity === FindingSeverity::Pass;
+    }
+
+    /**
+     * @return array{
+     *     id: string,
+     *     severity: string,
+     *     summary: string,
+     *     risk: string,
+     *     remediation: string,
+     *     docsUrl: string,
+     *     details: array<string, bool|int|string>,
+     * }
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'severity' => $this->severity->value,
+            'summary' => $this->summary,
+            'risk' => $this->risk,
+            'remediation' => $this->remediation,
+            'docsUrl' => $this->docsUrl,
+            'details' => $this->details,
+        ];
+    }
+}

--- a/Classes/Service/Doctor/FindingSeverity.php
+++ b/Classes/Service/Doctor/FindingSeverity.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor;
+
+/**
+ * Severity of a single readiness {@see Finding}.
+ *
+ * Three levels, not five: the only decision this feeds is the `vault:doctor`
+ * exit code, and a deployment gate has exactly three answers — go, go with a
+ * note, stop. Backing values are part of the JSON contract.
+ */
+enum FindingSeverity: string
+{
+    /**
+     * The control is satisfied. Reported rather than omitted, so the JSON
+     * output is the full control list and "N of M passed" needs no second
+     * source of truth.
+     */
+    case Pass = 'pass';
+
+    /**
+     * The control is not satisfied, but the vault still protects secrets.
+     * Audit-relevant weakness or operational hygiene — worth fixing before an
+     * audit, not worth blocking a deployment over.
+     */
+    case Warning = 'warning';
+
+    /**
+     * The control is not satisfied in a way that breaks the profile's own
+     * promise: secrets unreadable, master key exposed, audit trail unprovable.
+     * A hardened deployment must not go live in this state.
+     */
+    case Critical = 'critical';
+
+    /**
+     * Ordering weight for aggregation — higher wins.
+     *
+     * Used by {@see DoctorReport} to reduce a finding list to one verdict; the
+     * numbers are internal and deliberately not the exit codes (Pass exits 0,
+     * but so may a report with no findings at all).
+     */
+    public function rank(): int
+    {
+        return match ($this) {
+            self::Pass => 0,
+            self::Warning => 1,
+            self::Critical => 2,
+        };
+    }
+
+    /**
+     * Bootstrap contextual class for the backend badge.
+     */
+    public function bootstrapContext(): string
+    {
+        return match ($this) {
+            self::Pass => 'success',
+            self::Warning => 'warning',
+            self::Critical => 'danger',
+        };
+    }
+}

--- a/Classes/Service/Doctor/ReadinessCheckInterface.php
+++ b/Classes/Service/Doctor/ReadinessCheckInterface.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor;
+
+use Netresearch\NrVault\Configuration\SecurityProfile;
+
+/**
+ * One area of the vault's deployment readiness.
+ *
+ * Implementations are discovered through the `nr_vault.readiness_check` tag
+ * (applied automatically by the `_instanceof` block in `Services.yaml`) and
+ * injected into {@see VaultDoctorService} as an iterator, so a consuming
+ * extension adds its own control by implementing this interface — no edit to the
+ * doctor service, and no way for a check to be silently forgotten.
+ *
+ * Two contract rules matter:
+ *
+ *  1. **Read-only.** A check runs on a production system during a deployment
+ *     gate and on every render of the backend status surface. It must not write
+ *     configuration, secrets, audit rows or files.
+ *  2. **Report, don't throw.** A check SHOULD contain its own expected failures
+ *     and report them as {@see Finding}s. Unexpected throwables are contained by
+ *     {@see VaultDoctorService} and surface as a `check.crashed` critical
+ *     finding — that safety net exists so one broken check cannot blank the
+ *     report, not as the normal error path.
+ */
+interface ReadinessCheckInterface
+{
+    /**
+     * Stable dotted identifier of the area this check covers, e.g. `audit`.
+     *
+     * Used for crash attribution and for ordering the report. The `<area>`
+     * segment of every {@see Finding} id this check emits SHOULD match it, so an
+     * operator reading `audit.external_sink` knows which check to look at.
+     */
+    public function getId(): string;
+
+    /**
+     * Does this check have anything to assert for the target profile?
+     *
+     * Profile-independent checks return `true` for both and vary only the
+     * severity they report. Returning `false` removes the check from the run
+     * entirely — including from the "N of M controls passed" denominator, which
+     * is why it is a declaration and not something a check decides inside
+     * {@see self::run()}.
+     */
+    public function appliesTo(SecurityProfile $profile): bool;
+
+    /**
+     * Evaluate the controls in this area.
+     *
+     * Returns one {@see Finding} per control — including passing ones, so the
+     * report is a full control list rather than a defect list.
+     *
+     * @return list<Finding>
+     */
+    public function run(DoctorContext $context): array;
+}

--- a/Classes/Service/Doctor/VaultDoctorService.php
+++ b/Classes/Service/Doctor/VaultDoctorService.php
@@ -1,0 +1,120 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor;
+
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Psr\Log\LoggerInterface;
+use Throwable;
+use Traversable;
+
+/**
+ * Orchestrates the readiness checks behind `vault:doctor` and the backend
+ * security status panel.
+ *
+ * ## Crash containment
+ *
+ * Every check runs inside its own `try`/`catch`. A check that throws is reported
+ * as a `check.crashed` critical finding naming the failing check, and the run
+ * continues. The reasoning is the same one that makes a fail-closed provider
+ * factory the right default: a diagnostic tool whose output degrades to "no
+ * findings" when part of it breaks is worse than no diagnostic tool, because an
+ * operator reads the silence as a pass. A crashed check is therefore louder than
+ * a failing one, never quieter.
+ *
+ * The exception message is included, and this is deliberate: `vault:doctor` is
+ * reachable only from the CLI and from a `vault.configure`-gated backend panel,
+ * and a crash with no message is unactionable. Checks must still not put key
+ * material or key paths into their own findings (see {@see Finding}).
+ */
+final readonly class VaultDoctorService implements VaultDoctorServiceInterface
+{
+    /**
+     * @param Traversable<ReadinessCheckInterface> $checks Tagged
+     *                                                     `nr_vault.readiness_check` services, injected as an iterator
+     */
+    public function __construct(
+        private Traversable $checks,
+        private ExtensionConfigurationInterface $configuration,
+        private LoggerInterface $logger,
+    ) {}
+
+    public function run(?SecurityProfile $targetProfile = null): DoctorReport
+    {
+        $configuredProfile = $this->resolveConfiguredProfile();
+        $context = new DoctorContext(
+            profile: $targetProfile ?? $configuredProfile,
+            configuredProfile: $configuredProfile,
+        );
+
+        $findings = [];
+        foreach ($this->checks as $check) {
+            if (!$check->appliesTo($context->profile)) {
+                continue;
+            }
+
+            foreach ($this->runContained($check, $context) as $finding) {
+                $findings[] = $finding;
+            }
+        }
+
+        return new DoctorReport(context: $context, findings: $findings);
+    }
+
+    /**
+     * @return list<Finding>
+     */
+    private function runContained(ReadinessCheckInterface $check, DoctorContext $context): array
+    {
+        try {
+            return $check->run($context);
+        } catch (Throwable $e) {
+            $this->logger->error('nr-vault readiness check crashed.', [
+                'check' => $check->getId(),
+                'exception' => $e->getMessage(),
+            ]);
+
+            return [
+                Finding::critical(
+                    id: 'check.crashed',
+                    summary: \sprintf(
+                        'Readiness check "%s" could not complete: %s',
+                        $check->getId(),
+                        $e->getMessage(),
+                    ),
+                    risk: 'The controls in this area were not evaluated. Treat them as unknown, '
+                        . 'not as satisfied — an unevaluated control provides no assurance.',
+                    remediation: 'Check the TYPO3 log for the full stack trace, then re-run '
+                        . 'vendor/bin/typo3 vault:doctor.',
+                    details: ['check' => $check->getId()],
+                ),
+            ];
+        }
+    }
+
+    /**
+     * The configured profile, or Standard when the configured value is not a
+     * valid profile.
+     *
+     * An unknown profile string is a critical finding raised by
+     * {@see Check\SecurityProfileCheck}; it must not also decide what the rest
+     * of the run asserts. Falling back to Standard keeps the remaining output
+     * readable and never lets a typo silently *raise* the bar in a way that
+     * buries the real problem under hardened-only findings.
+     */
+    private function resolveConfiguredProfile(): SecurityProfile
+    {
+        try {
+            return $this->configuration->getSecurityProfile();
+        } catch (Throwable) {
+            return SecurityProfile::Standard;
+        }
+    }
+}

--- a/Classes/Service/Doctor/VaultDoctorServiceInterface.php
+++ b/Classes/Service/Doctor/VaultDoctorServiceInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor;
+
+use Netresearch\NrVault\Configuration\SecurityProfile;
+
+/**
+ * Runs every applicable readiness check and aggregates one verdict.
+ *
+ * The single entry point behind both `vault:doctor` and the backend security
+ * status panel, so a deployment gate and the module can never disagree about
+ * whether the vault is audit-ready.
+ */
+interface VaultDoctorServiceInterface
+{
+    /**
+     * Evaluate readiness against a target profile.
+     *
+     * @param SecurityProfile|null $targetProfile Profile to assert against; null
+     *                                            uses the configured profile
+     *                                            ("is this deployment ready for
+     *                                            what it claims to be?")
+     */
+    public function run(?SecurityProfile $targetProfile = null): DoctorReport;
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -11,6 +11,11 @@ services:
   _instanceof:
     Netresearch\NrVault\Audit\Sink\AuditSinkInterface:
       tags: ['nr_vault.audit_sink']
+    # Same discovery contract for the vault:doctor readiness checks: implement
+    # the interface and the doctor service receives it, with no edit here and no
+    # way for a check to be silently left out of the report.
+    Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface:
+      tags: ['nr_vault.readiness_check']
 
   Netresearch\NrVault\:
     resource: '../Classes/*'
@@ -132,6 +137,9 @@ services:
   Netresearch\NrVault\Service\Analytics\VaultAnalyticsServiceInterface:
     alias: Netresearch\NrVault\Service\Analytics\VaultAnalyticsService
 
+  Netresearch\NrVault\Service\Doctor\VaultDoctorServiceInterface:
+    alias: Netresearch\NrVault\Service\Doctor\VaultDoctorService
+
   # ----- Factory-resolved services ----------------------------------------
   # Factories cannot be discovered by autowire and must be declared explicitly.
 
@@ -143,6 +151,12 @@ services:
   Netresearch\NrVault\Audit\Sink\AuditSinkRegistry:
     arguments:
       $sinks: !tagged_iterator nr_vault.audit_sink
+
+  # ----- Readiness checks (vault:doctor) ----------------------------------
+
+  Netresearch\NrVault\Service\Doctor\VaultDoctorService:
+    arguments:
+      $checks: !tagged_iterator nr_vault.readiness_check
 
   # The webhook sink deliberately uses a SHORT-timeout client built by
   # SecureHttpClientFactory rather than the ambient PSR-18 client: audit fan-out

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -919,3 +919,263 @@ exits ``0`` — a closed window is a successful answer, not a failure:
    While a window is open, administrators hold **every** vault permission and
    full access to **every** secret. Close it as soon as the work is done
    rather than waiting for the expiry.
+
+.. _command-doctor:
+
+vault:doctor
+============
+
+Evaluate every deployment-readiness control and report each one with the risk it
+carries and the command that fixes it.
+
+Designed as the last step of a deployment pipeline: the exit code is the
+contract, so the command can gate a release without anything parsing its prose.
+See :ref:`security-deployment-gate` for how to wire it in.
+
+.. code-block:: bash
+   :caption: Command syntax
+
+   vendor/bin/typo3 vault:doctor [options]
+
+.. _command-doctor-options:
+
+Options
+-------
+
+--profile, -p =PROFILE
+   Security profile to check against: ``standard`` or ``hardened``. Defaults to
+   the configured profile.
+
+   **This never changes any configuration.** ``--profile=hardened`` on a standard
+   installation answers "would this pass if we hardened it?", so a hardening
+   migration can be planned from the real finding list instead of by flipping the
+   switch on production and seeing what breaks. The report states both the profile
+   it checked and the profile actually in force.
+
+--format, -f =FORMAT
+   Output format: ``text`` (default) or ``json``. The JSON form carries every
+   control — passing ones included — under stable ids.
+
+.. _command-doctor-exit-codes:
+
+Exit codes
+----------
+
+The verdict is the **worst severity present**, never an average: a long list of
+passing controls can never offset a critical finding.
+
+0
+   Every control passed. The configuration is audit-ready for the checked profile.
+
+1
+   Warnings only. Deployable; fix before an audit.
+
+2
+   At least one critical finding — or the profile value was unusable, or the run
+   could not complete at all. A gate that cannot run never reports success.
+
+.. _command-doctor-controls:
+
+Control catalogue
+-----------------
+
+Control ids are **stable API**: they appear in ``--format=json``, in CI gate
+allow-lists and in monitoring rules. A new control gets a new id rather than
+reusing an old one.
+
+Severities below are given as ``standard`` / ``hardened`` where they differ.
+
+.. rst-class:: dl-parameters
+
+provider.configured
+   A master-key provider is chosen and permitted by the profile. ``typo3`` (the
+   zero-configuration default) is *warning* / *critical* — the hardened profile
+   forbids it, and its factory refuses to boot. An empty value is critical in
+   both.
+
+provider.known
+   The configured provider identifier resolves to something this installation can
+   build. Critical when it does not — a provider from a later release, or from an
+   extension that is not installed here.
+
+provider.available
+   A key source is reachable at runtime. Critical when none is. *Warning* when
+   standard-profile auto-detection resolved a different provider than the one
+   configured: the vault works, but not the way the configuration says, and
+   hardening removes the fallback.
+
+provider.master_key_readable
+   A non-empty key was actually read and envelope encryption is operational.
+   Critical otherwise.
+
+provider.key_permissions
+   File provider only. Critical when the key file is readable, writable or
+   executable beyond its owner. Only the octal mode is reported, never the path.
+
+profile.valid
+   The configured ``securityProfile`` is a known profile. Critical otherwise —
+   the extension refuses to guess, so an unknown value is an outage.
+
+profile.admin_override
+   ``disableAdminOverride`` agrees with the profile. Warning in both mismatch
+   directions: the flag set under ``standard`` (where it is inert, so the
+   configuration implies a control that does not exist), and ``hardened`` without
+   it (a hardened deployment that kept its widest bypass).
+
+breakglass.window_open
+   Warning while a :ref:`break-glass window <security-break-glass>` is open,
+   naming who opened it, why, and when it closes. Warning rather than critical on
+   purpose: an open window is a justified deliberate act, and a red gate would
+   push operators to close it mid-incident just to deploy.
+
+audit.reads_logged
+   ``auditReads`` is enabled. *Warning* / *critical* — a stolen credential is
+   *read*, not written, so an unlogged read defeats what the hardened profile
+   exists for.
+
+audit.retention
+   ``auditLogRetention`` is 0 (keep forever) or at least 365 days. Warning for a
+   shorter window, which cannot cover the previous review cycle.
+
+audit.hash_chain
+   The newest 1000 audit entries verify against the hash chain. Critical on any
+   hash error or uid gap. **Bounded on purpose** — a full-table HMAC
+   recomputation does not belong on a page load — so a pass means "the recent
+   tail verifies", never "the chain is intact". :ref:`command-audit-verify` is
+   the authoritative full-range verifier and belongs on a schedule.
+
+audit.external_sink
+   At least one external audit sink is enabled. *Pass* / *critical*: sinks are
+   documented as opt-in under ``standard``, and flagging a default installation
+   for having no SIEM would train operators to ignore the hardened finding.
+   Carries ``details.reasonCode = NO_EXTERNAL_SINK``, the same code
+   ``vault:audit-verify`` uses.
+
+audit.anchor
+   A chain-tip anchor exists and the chain has not shrunk below it. Missing
+   anchor is *pass* / *critical*. A chain shorter than the anchored sequence is
+   critical in both (``TABLE_RESET``) — an append-only chain cannot get shorter.
+   Only the shrinkage comparison is done here; the tip-hash comparison is
+   :ref:`command-audit-verify`.
+
+audit.sink_delivery
+   No sink refused delivery in this process. Warning with the per-sink counts
+   otherwise. Per-process by design, so zero means "not in this run".
+
+cli.access
+   ``allowCliAccess``. Pass when off. When on: *pass* / *warning* — deployment
+   automation legitimately needs it, but under ``hardened`` a bare CLI actor
+   cannot be attributed to a human.
+
+cli.access_groups
+   Emitted only when CLI access is on. Warning when ``cliAccessGroups`` is empty,
+   leaving the grant unscoped with no group boundary left to review.
+
+secrets.expired
+   No stored secret is past its expiry. Warning with the count otherwise: an
+   expired secret still decrypts, so the credential stays recoverable from a
+   database dump.
+
+secrets.never_rotated
+   No secret has gone unrotated beyond ``staleNeverRotatedDays``. Warning with
+   the count otherwise.
+
+secrets.dead
+   No stored secret shows zero read activity. Warning with the count otherwise.
+   No identifier appears in any of these three findings — an identifier names a
+   credential and the JSON report travels into CI logs. Use the Analytics module
+   to see which secrets.
+
+environment.production_context
+   ``Environment::getContext()`` is Production. *Pass* / *warning* — a
+   Development context is the normal state of a developer machine, and only a
+   hardened deployment contradicts itself by running in one.
+
+environment.backend_lock_ssl
+   ``[BE][lockSSL]`` is set. Warning otherwise, in both profiles: the reveal
+   endpoint returns secret plaintext to a browser.
+
+version.extension
+   The extension version was read from ``ext_emconf.php``. Warning otherwise — a
+   report that cannot state which version produced it is not evidence.
+
+version.typo3_supported
+   The running core is inside the range the extension declares. Warning
+   otherwise.
+
+check.crashed
+   Not a control but a containment result: emitted as **critical** when a check
+   throws, naming the failing check in ``details.check``. A diagnostic whose
+   output degrades to "no findings" when part of it breaks is worse than none,
+   because the silence reads as a pass — so a crashed check is louder than a
+   failing one.
+
+.. _command-doctor-json:
+
+JSON output
+-----------
+
+.. code-block:: json
+   :caption: vault:doctor --format=json (abridged)
+
+   {
+     "profile": "hardened",
+     "configuredProfile": "standard",
+     "profileOverridden": true,
+     "auditReady": false,
+     "highestSeverity": "critical",
+     "exitCode": 2,
+     "summary": { "total": 22, "pass": 19, "warning": 2, "critical": 1 },
+     "findings": [
+       {
+         "id": "provider.configured",
+         "severity": "pass",
+         "summary": "Master-key provider \"file\" is explicitly configured.",
+         "risk": "",
+         "remediation": "",
+         "docsUrl": "https://docs.typo3.org/p/netresearch/nr-vault/main/en-us/Configuration/Index.html#configuration-master-key-providers",
+         "details": { "provider": "file" }
+       },
+       {
+         "id": "audit.external_sink",
+         "severity": "critical",
+         "summary": "The hardened profile requires an external audit sink, but none is enabled and usable.",
+         "risk": "The audit trail exists only in the database it is meant to protect. …",
+         "remediation": "Enable at least one of \"auditSinkFileEnabled\", \"auditSinkSyslogEnabled\" or \"auditSinkWebhookEnabled\", then schedule the anchoring command. …",
+         "docsUrl": "https://docs.typo3.org/p/netresearch/nr-vault/main/en-us/Configuration/Index.html#configuration-audit-sinks",
+         "details": { "sinks": "", "reasonCode": "NO_EXTERNAL_SINK" }
+       }
+     ]
+   }
+
+Field notes for anything parsing this:
+
+*  ``findings`` lists **every** evaluated control, passing ones included, so
+   ``summary.pass`` / ``summary.total`` needs no second source of truth.
+*  ``severity`` is one of ``pass``, ``warning``, ``critical``.
+*  ``risk`` and ``remediation`` are empty strings for passing controls, never
+   absent.
+*  ``docsUrl`` may be an empty string.
+*  ``details`` holds scalars only, and never key material, a master-key path or a
+   secret identifier.
+*  ``exitCode`` duplicates the process exit code, for wrappers that swallow it.
+*  On a rejected ``--profile`` value or a run that could not start, the payload is
+   ``{"error": "…", "exitCode": 2}`` instead — check for ``error`` before reading
+   ``findings``.
+
+.. _command-doctor-example:
+
+Example
+-------
+
+.. code-block:: bash
+   :caption: vault:doctor examples
+
+   # Is this deployment ready for the profile it claims?
+   vendor/bin/typo3 vault:doctor
+
+   # Would it pass as hardened? Changes nothing.
+   vendor/bin/typo3 vault:doctor --profile=hardened
+
+   # Machine-readable, for a CI gate or a monitoring probe
+   vendor/bin/typo3 vault:doctor --format=json

--- a/Documentation/Security/Index.rst
+++ b/Documentation/Security/Index.rst
@@ -487,6 +487,91 @@ Threat-model notes:
    unless required, minimal group membership, and monitor its
    ``access_denied`` events.
 
+.. _security-deployment-gate:
+
+Deployment gate
+===============
+
+Every control described on this page is checkable from a shell.
+:ref:`command-doctor` evaluates them all and reduces the result to a process exit
+code, which makes it usable as the last step of a deployment pipeline rather than
+as a document somebody is supposed to have read.
+
+.. code-block:: bash
+   :caption: Deployment gate — refuse the release on any critical finding
+
+   vendor/bin/typo3 vault:doctor --profile=hardened
+
+Exit-code contract
+------------------
+
+======  ==========================================================
+Code    Meaning
+======  ==========================================================
+``0``   Every control passed — audit-ready for the checked profile.
+``1``   Warnings only. Deployable; fix before an audit.
+``2``   At least one critical finding, an unusable ``--profile``
+        value, or the run could not complete.
+======  ==========================================================
+
+The verdict is the **worst severity present**, never an average, so a long list
+of passing controls cannot offset one critical finding. And ``2`` covers "could
+not check" as well as "checked and found a problem" — a gate that cannot run must
+never be readable as a gate that found nothing.
+
+Two ways to wire it, and they answer different questions:
+
+.. code-block:: bash
+   :caption: Fail the pipeline only on critical findings
+
+   vendor/bin/typo3 vault:doctor
+   test $? -le 1
+
+.. code-block:: bash
+   :caption: Require a fully clean report
+
+   vendor/bin/typo3 vault:doctor
+
+The stricter form is the one to aim for. Accepting exit ``1`` indefinitely means
+a warning nobody ever removes, which is the state in which a *new* warning goes
+unnoticed.
+
+Checking a profile you have not adopted yet
+-------------------------------------------
+
+``--profile=hardened`` evaluates the live configuration against the hardened
+policy **without changing anything**. That is how to plan the migration described
+in :ref:`security-disable-admin-override` — from the actual finding list, rather
+than by switching the profile on production and finding out which service stops
+booting.
+
+The report always states both the profile it checked and the profile in force, so
+a passing dry run cannot be mistaken for hardening already being live.
+
+What the gate does not cover
+----------------------------
+
+``vault:doctor`` bounds its own cost so it can run in a pipeline and on a backend
+page load. Two limits matter, and both are stated in the findings themselves:
+
+*  the hash-chain pass covers the newest 1000 audit entries, not the whole chain;
+*  the anchor comparison detects a chain that has *shrunk*, not one whose
+   anchored row now hashes differently.
+
+:ref:`command-audit-verify` does both in full and is the authoritative integrity
+verifier. Schedule it — the gate is a pre-flight check, not a substitute for
+continuous verification.
+
+Backend surface
+---------------
+
+The vault Overview module shows the same controls: the active profile, an
+"N of M controls passed" ratio, and the open findings with their risk and
+remediation. The detailed finding list requires the ``vault.configure``
+permission — it names this installation's concrete weak points and the files to
+edit. Everyone else sees the profile badge and the ratio, which is enough to
+escalate.
+
 .. _security-best-practices:
 
 Security best practices

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -23,6 +23,16 @@ Access the vault through the TYPO3 backend:
 
    The vault overview displays key metrics and provides quick-start code examples
 
+The overview also carries a **Security Readiness** panel: the active security
+profile, an "N of M controls passed" ratio, and the open findings with the risk
+each one carries and the command that fixes it. The detailed finding list requires
+the ``vault.configure`` permission, because it names this installation's concrete
+weak points; everyone else sees the profile badge and the ratio.
+
+The panel and :ref:`command-doctor` evaluate the same controls, so the module and
+a CI gate cannot disagree. Use the command for anything scheduled or automated —
+see :ref:`security-deployment-gate`.
+
 .. _usage-creating-secrets:
 
 Creating secrets

--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -465,8 +465,45 @@
       <trans-unit id="overview.cli.break_glass">
         <source>Open, close or inspect a time-boxed break-glass window</source>
       </trans-unit>
+      <trans-unit id="overview.cli.doctor">
+        <source>Check the configuration for deployment and audit readiness</source>
+      </trans-unit>
       <trans-unit id="overview.cli.help_hint">
         <source>Run bin/typo3 vault:&lt;command&gt; --help for detailed usage.</source>
+      </trans-unit>
+      <!-- Security readiness panel (vault:doctor) -->
+      <trans-unit id="overview.security.status.title">
+        <source>Security Readiness</source>
+      </trans-unit>
+      <trans-unit id="overview.security.status.profile.standard">
+        <source>Standard profile</source>
+      </trans-unit>
+      <trans-unit id="overview.security.status.profile.hardened">
+        <source>Hardened profile</source>
+      </trans-unit>
+      <trans-unit id="overview.security.status.controlsPassed">
+        <source>%1$s of %2$s controls passed</source>
+      </trans-unit>
+      <trans-unit id="overview.security.status.auditReady">
+        <source>Every readiness control passed. This configuration is audit-ready for the active security profile.</source>
+      </trans-unit>
+      <trans-unit id="overview.security.status.risk">
+        <source>Risk:</source>
+      </trans-unit>
+      <trans-unit id="overview.security.status.fix">
+        <source>Fix:</source>
+      </trans-unit>
+      <trans-unit id="overview.security.status.docs">
+        <source>Read the documentation for this control</source>
+      </trans-unit>
+      <trans-unit id="overview.security.status.cliHint">
+        <source>The same report, with machine-readable output and an exit code for a deployment gate:</source>
+      </trans-unit>
+      <trans-unit id="overview.security.status.restricted">
+        <source>%1$s critical and %2$s advisory readiness finding(s) are open. Details are restricted to users who may configure the vault — ask a vault administrator to review them.</source>
+      </trans-unit>
+      <trans-unit id="overview.security.status.unavailable">
+        <source>The readiness controls could not be evaluated. Treat their result as unknown, not as passed, and run the command-line report for the reason:</source>
       </trans-unit>
       <trans-unit id="overview.security.title">
         <source>Security Features</source>

--- a/Resources/Private/Partials/SecurityStatus.html
+++ b/Resources/Private/Partials/SecurityStatus.html
@@ -1,0 +1,107 @@
+<html xmlns:f="http://typo3.org/ns/TYPO3/CMS/Fluid/ViewHelpers"
+      xmlns:core="http://typo3.org/ns/TYPO3/CMS/Core/ViewHelpers"
+      data-namespace-typo3-fluid="true">
+
+<!--
+    Security readiness panel — the backend face of `vault:doctor`.
+
+    Expects `securityStatus` as shaped by
+    Classes/Controller/SecurityStatusProvider::forView(): every key is always
+    present, including when the run failed (`available: false`), so no branch
+    here can render a blank box where a warning belongs.
+
+    Two audiences in one partial: the profile badge and the pass ratio are for
+    anyone who can open the module; `securityStatus.detailed` is true only for
+    actors holding `vault.configure`, and gates the finding list that names this
+    installation's concrete weak points. The gate is decided in the provider —
+    do NOT add a permission check here, and do not render `findings` outside the
+    `detailed` branch.
+-->
+<div class="mb-4" data-testid="vault-security-status">
+    <h2>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.title')}</h2>
+
+    <f:if condition="{securityStatus.available}">
+        <f:then>
+            <p class="mb-3">
+                <span class="badge bg-secondary" data-testid="vault-security-profile">
+                    <core:icon identifier="actions-shield" size="small" />
+                    <!--
+                        Two explicit branches rather than a translation key built by
+                        string interpolation: an interpolated key silently falls back
+                        to printing the key itself when the profile value is anything
+                        unexpected, which puts a raw LLL path on the landing page.
+                    -->
+                    <f:if condition="{securityStatus.profile} == 'hardened'">
+                        <f:then>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.profile.hardened')}</f:then>
+                        <f:else>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.profile.standard')}</f:else>
+                    </f:if>
+                </span>
+                <span class="badge bg-{securityStatus.context}" data-testid="vault-security-ratio">
+                    {f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.controlsPassed', arguments: {0: securityStatus.passed, 1: securityStatus.total})}
+                </span>
+            </p>
+
+            <f:if condition="{securityStatus.auditReady}">
+                <f:then>
+                    <div class="alert alert-success" role="alert" data-testid="vault-security-ready">
+                        <core:icon identifier="actions-check" size="small" />
+                        {f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.auditReady')}
+                    </div>
+                </f:then>
+                <f:else>
+                    <f:if condition="{securityStatus.detailed}">
+                        <f:then>
+                            <f:for each="{securityStatus.findings}" as="finding">
+                                <div class="alert alert-{finding.context}" role="alert" data-testid="vault-security-finding">
+                                    <h3 class="alert-heading h5">
+                                        <core:icon identifier="actions-exclamation-triangle" size="small" />
+                                        <code>{finding.id}</code>
+                                    </h3>
+                                    <p class="mb-2">{finding.summary}</p>
+                                    <f:if condition="{finding.risk}">
+                                        <p class="mb-2 small">
+                                            <strong>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.risk')}</strong>
+                                            {finding.risk}
+                                        </p>
+                                    </f:if>
+                                    <f:if condition="{finding.remediation}">
+                                        <p class="mb-2 small">
+                                            <strong>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.fix')}</strong>
+                                            {finding.remediation}
+                                        </p>
+                                    </f:if>
+                                    <f:if condition="{finding.docsUrl}">
+                                        <p class="mb-0 small">
+                                            <a href="{finding.docsUrl}" target="_blank" rel="noopener" class="text-decoration-underline">
+                                                {f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.docs')}
+                                            </a>
+                                        </p>
+                                    </f:if>
+                                </div>
+                            </f:for>
+                            <p class="text-body-secondary small mb-0">
+                                {f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.cliHint')}
+                                <code>vendor/bin/typo3 vault:doctor</code>
+                            </p>
+                        </f:then>
+                        <f:else>
+                            <div class="alert alert-warning" role="alert" data-testid="vault-security-restricted">
+                                <core:icon identifier="actions-exclamation-triangle" size="small" />
+                                {f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.restricted', arguments: {0: securityStatus.criticalCount, 1: securityStatus.warningCount})}
+                            </div>
+                        </f:else>
+                    </f:if>
+                </f:else>
+            </f:if>
+        </f:then>
+        <f:else>
+            <div class="alert alert-warning" role="alert" data-testid="vault-security-unavailable">
+                <core:icon identifier="actions-exclamation-triangle" size="small" />
+                {f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.unavailable')}
+                <code>vendor/bin/typo3 vault:doctor</code>
+            </div>
+        </f:else>
+    </f:if>
+</div>
+
+</html>

--- a/Resources/Private/Templates/Overview/Index.html
+++ b/Resources/Private/Templates/Overview/Index.html
@@ -51,6 +51,9 @@
         </div>
     </f:if>
 
+    <!-- Security readiness (vault:doctor) -->
+    <f:render partial="SecurityStatus" arguments="{securityStatus: securityStatus}" />
+
     <!-- Statistics Cards -->
     <div class="card-container mb-4" role="group" aria-label="{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.stats.total_secrets')}" data-testid="vault-stats">
         <div class="card card-size-fixed-small" data-testid="stat-card-total">
@@ -274,6 +277,7 @@ lib.mapsKey.stdWrap.cache.disable = 1</code></pre>
                 <tr><td><code>vault:rotate-master-key</code></td><td>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.cli.rotate_master_key')}</td></tr>
                 <tr><td><code>vault:cleanup-orphans</code></td><td>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.cli.cleanup_orphans')}</td></tr>
                 <tr><td><code>vault:break-glass</code></td><td>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.cli.break_glass')}</td></tr>
+                <tr><td><code>vault:doctor</code></td><td>{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.cli.doctor')}</td></tr>
             </tbody>
         </table>
         <small class="text-muted">{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.cli.help_hint')}</small>

--- a/Tests/Functional/Command/VaultDoctorCommandTest.php
+++ b/Tests/Functional/Command/VaultDoctorCommandTest.php
@@ -1,0 +1,295 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Command;
+
+use Netresearch\NrVault\Command\VaultDoctorCommand;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * End-to-end `vault:doctor` runs through the real DI container.
+ *
+ * What only a functional run can prove, and the reason this file exists on top of
+ * the unit tests:
+ *
+ *  - every readiness check is actually discovered through the
+ *    `nr_vault.readiness_check` tag. A check that autowiring silently drops would
+ *    make the gate green by omission, and no unit test can catch that;
+ *  - the checks work against a real database, a real chain-tip anchor reader and
+ *    the real extension configuration;
+ *  - the exit-code contract holds end to end.
+ *
+ * The base class configures the FILE master-key provider with a 0600 key, which
+ * is the deployment shape the hardened profile expects.
+ */
+#[CoversClass(VaultDoctorCommand::class)]
+final class VaultDoctorCommandTest extends AbstractVaultFunctionalTestCase
+{
+    protected ?string $backendUserFixture = __DIR__ . '/../Fixtures/Users/be_users.csv';
+
+    /** @var array<string, mixed> */
+    protected array $extensionConfiguration = [
+        'masterKeyProvider' => 'file',
+    ];
+
+    /**
+     * Hardened profile, file provider, and no external audit sink: the gate must
+     * refuse the deployment and name the control, because the audit trail would
+     * exist only in the database it is meant to protect.
+     */
+    #[Test]
+    public function hardenedWithoutAnExternalSinkExitsTwoAndNamesTheSinkControl(): void
+    {
+        $this->configure(['securityProfile' => 'hardened']);
+
+        $tester = new CommandTester($this->get(VaultDoctorCommand::class));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(2, $exitCode, $tester->getDisplay());
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('audit.external_sink', $display);
+        self::assertStringContainsString('NOT audit-ready', $display);
+    }
+
+    /**
+     * The same run in JSON, which is the form a CI gate consumes: the machine-
+     * readable finding must carry the stable id and the NO_EXTERNAL_SINK reason
+     * code that `vault:audit-verify` uses for the same condition.
+     */
+    #[Test]
+    public function hardenedWithoutAnExternalSinkReportsNoExternalSinkInJson(): void
+    {
+        $this->configure(['securityProfile' => 'hardened']);
+
+        $tester = new CommandTester($this->get(VaultDoctorCommand::class));
+        $exitCode = $tester->execute(['--format' => 'json']);
+
+        self::assertSame(2, $exitCode);
+
+        $payload = $this->decode($tester->getDisplay());
+
+        self::assertSame('hardened', $payload['profile']);
+        self::assertFalse($payload['auditReady']);
+        self::assertSame(2, $payload['exitCode']);
+        self::assertGreaterThan(0, $this->summary($payload)['critical']);
+
+        $sinkFinding = $this->findingById($payload, 'audit.external_sink');
+        self::assertSame('critical', $sinkFinding['severity']);
+        self::assertIsArray($sinkFinding['details']);
+        self::assertSame('NO_EXTERNAL_SINK', $sinkFinding['details']['reasonCode']);
+
+        // The file provider with a 0600 key is the shape hardened expects, so the
+        // master-key controls must NOT be among the criticals.
+        self::assertSame('pass', $this->findingById($payload, 'provider.configured')['severity']);
+        self::assertSame('pass', $this->findingById($payload, 'provider.key_permissions')['severity']);
+    }
+
+    /**
+     * Every check must be reachable through the DI tag. Asserting the concrete id
+     * list rather than a count makes a silently-dropped check a named failure
+     * instead of an off-by-one nobody investigates.
+     */
+    #[Test]
+    public function everyReadinessCheckIsDiscoveredThroughTheServiceTag(): void
+    {
+        $this->configure(['securityProfile' => 'standard']);
+
+        $tester = new CommandTester($this->get(VaultDoctorCommand::class));
+        $tester->execute(['--format' => 'json']);
+
+        $ids = array_column($this->findings($this->decode($tester->getDisplay())), 'id');
+
+        foreach ([
+            'provider.configured',
+            'provider.known',
+            'provider.available',
+            'provider.master_key_readable',
+            'provider.key_permissions',
+            'profile.valid',
+            'profile.admin_override',
+            'breakglass.window_open',
+            'audit.reads_logged',
+            'audit.retention',
+            'audit.hash_chain',
+            'audit.external_sink',
+            'audit.anchor',
+            'audit.sink_delivery',
+            'cli.access',
+            'secrets.expired',
+            'secrets.never_rotated',
+            'secrets.dead',
+            'environment.production_context',
+            'environment.backend_lock_ssl',
+            'version.extension',
+            'version.typo3_supported',
+        ] as $expected) {
+            self::assertContains($expected, $ids, 'missing readiness control: ' . $expected);
+        }
+
+        self::assertNotContains('check.crashed', $ids, $tester->getDisplay());
+    }
+
+    /**
+     * A default standard-profile installation must not be red. It carries the
+     * documented warnings of a test instance — no backend TLS lock, a non-Production
+     * application context is tolerated under standard — but nothing critical, or
+     * the gate would be useless as a signal.
+     */
+    #[Test]
+    public function aDefaultStandardInstallationHasNoCriticalFindings(): void
+    {
+        $this->configure(['securityProfile' => 'standard']);
+
+        $tester = new CommandTester($this->get(VaultDoctorCommand::class));
+        $exitCode = $tester->execute(['--format' => 'json']);
+
+        $payload = $this->decode($tester->getDisplay());
+        $criticals = array_filter(
+            $this->findings($payload),
+            static fn (array $finding): bool => $finding['severity'] === 'critical',
+        );
+
+        self::assertSame(
+            0,
+            $this->summary($payload)['critical'],
+            'unexpected criticals: ' . json_encode(
+                array_column($criticals, 'summary', 'id'),
+                JSON_THROW_ON_ERROR,
+            ),
+        );
+        self::assertLessThanOrEqual(1, $exitCode);
+    }
+
+    /**
+     * `--profile=hardened` must judge a standard installation by the hardened
+     * policy while reporting that the configuration is unchanged. This is the dry
+     * run that lets a hardening migration be planned from real findings instead of
+     * by flipping the switch on production.
+     */
+    #[Test]
+    public function theProfileOverrideJudgesHardenedWithoutChangingTheConfiguration(): void
+    {
+        $this->configure(['securityProfile' => 'standard']);
+
+        $tester = new CommandTester($this->get(VaultDoctorCommand::class));
+        $exitCode = $tester->execute(['--profile' => 'hardened', '--format' => 'json']);
+
+        self::assertSame(2, $exitCode);
+
+        $payload = $this->decode($tester->getDisplay());
+        self::assertSame('hardened', $payload['profile']);
+        self::assertSame('standard', $payload['configuredProfile']);
+        self::assertTrue($payload['profileOverridden']);
+
+        // The live profile is untouched by the dry run.
+        self::assertSame(
+            'standard',
+            $this->get(ExtensionConfigurationInterface::class)->getSecurityProfile()->value,
+        );
+    }
+
+    #[Test]
+    public function anUnknownProfileOptionIsRejected(): void
+    {
+        $this->configure(['securityProfile' => 'standard']);
+
+        $tester = new CommandTester($this->get(VaultDoctorCommand::class));
+
+        self::assertSame(2, $tester->execute(['--profile' => 'paranoid']));
+        self::assertStringContainsString('paranoid', $tester->getDisplay());
+    }
+
+    /**
+     * Decode a `--format=json` report body.
+     *
+     * @return array<string, mixed>
+     */
+    private function decode(string $json): array
+    {
+        $payload = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+
+        /** @var array<string, mixed> $payload */
+        return $payload;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, int>
+     */
+    private function summary(array $payload): array
+    {
+        $summary = $payload['summary'] ?? null;
+        self::assertIsArray($summary);
+
+        /** @var array<string, int> $summary */
+        return $summary;
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function findings(array $payload): array
+    {
+        $findings = $payload['findings'] ?? null;
+        self::assertIsArray($findings);
+
+        /** @var list<array<string, mixed>> $findings */
+        return array_values($findings);
+    }
+
+    /**
+     * @param array<string, mixed> $payload
+     *
+     * @return array<string, mixed>
+     */
+    private function findingById(array $payload, string $id): array
+    {
+        foreach ($this->findings($payload) as $finding) {
+            if (($finding['id'] ?? null) === $id) {
+                return $finding;
+            }
+        }
+
+        self::fail('No finding "' . $id . '" in the report');
+    }
+
+    /**
+     * Merge extra keys into the live extension configuration.
+     *
+     * Called from the test body, before the first `$this->get()` in that test: the
+     * `ExtensionConfiguration` wrapper is a singleton that snapshots the array in
+     * its constructor, so a value written after the container has resolved it would
+     * not be observed.
+     *
+     * @param array<string, mixed> $configuration
+     */
+    private function configure(array $configuration): void
+    {
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        self::assertIsArray($confVars);
+
+        $extensions = $confVars['EXTENSIONS'] ?? null;
+        self::assertIsArray($extensions);
+
+        $existing = $extensions['nr_vault'] ?? null;
+        $extensions['nr_vault'] = array_merge(\is_array($existing) ? $existing : [], $configuration);
+
+        $confVars['EXTENSIONS'] = $extensions;
+        $GLOBALS['TYPO3_CONF_VARS'] = $confVars;
+    }
+}

--- a/Tests/Functional/View/SecurityStatusPartialTest.php
+++ b/Tests/Functional/View/SecurityStatusPartialTest.php
@@ -1,0 +1,253 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\View;
+
+use Netresearch\NrVault\Controller\SecurityStatusProvider;
+use TYPO3\CMS\Core\Localization\LanguageServiceFactory;
+use TYPO3\CMS\Core\View\ViewFactoryData;
+use TYPO3\CMS\Core\View\ViewFactoryInterface;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * Renders `Partials/SecurityStatus.html` on its own.
+ *
+ * `OverviewControllerTest` deliberately stops at the DI graph — the full module
+ * render needs a routing context that does not belong in a functional test — and
+ * the Playwright suite only runs against a live DDEV instance. That leaves a Fluid
+ * parse error or a wrong variable path in this partial able to reach a release
+ * while every PHP test stays green, and the symptom would be an exception on the
+ * module's landing page.
+ *
+ * Rendering the partial in isolation closes that gap cheaply. It asserts the
+ * permission gate too, from the view side: the finding text must not appear in the
+ * markup when {@see SecurityStatusProvider} withheld it.
+ */
+final class SecurityStatusPartialTest extends FunctionalTestCase
+{
+    /** @var array<non-empty-string> */
+    protected array $testExtensionsToLoad = [
+        'netresearch/nr-vault',
+    ];
+
+    /** @var array<non-empty-string> */
+    protected array $coreExtensionsToLoad = [
+        'backend',
+        'fluid',
+    ];
+
+    public function testRendersTheProfileBadgeAndPassRatio(): void
+    {
+        $html = $this->render([
+            'available' => true,
+            'profile' => 'hardened',
+            'auditReady' => false,
+            'severity' => 'warning',
+            'context' => 'warning',
+            'passed' => 19,
+            'total' => 22,
+            'criticalCount' => 0,
+            'warningCount' => 3,
+            'detailed' => false,
+            'findings' => [],
+        ]);
+
+        self::assertStringContainsString('vault-security-status', $html);
+        self::assertStringContainsString('Hardened profile', $html);
+        self::assertStringContainsString('19 of 22 controls passed', $html);
+        self::assertStringContainsString('badge bg-warning', $html);
+    }
+
+    public function testRendersTheStandardProfileLabelForAnyNonHardenedValue(): void
+    {
+        $html = $this->render($this->view(profile: 'standard'));
+
+        self::assertStringContainsString('Standard profile', $html);
+        self::assertStringNotContainsString('LLL:EXT:nr_vault', $html);
+    }
+
+    public function testACleanReportRendersTheAuditReadyCallout(): void
+    {
+        $html = $this->render($this->view(auditReady: true, context: 'success'));
+
+        self::assertStringContainsString('vault-security-ready', $html);
+        self::assertStringContainsString('audit-ready', $html);
+        self::assertStringNotContainsString('vault-security-finding', $html);
+    }
+
+    public function testFindingsAreRenderedWithRiskRemediationAndDocsLink(): void
+    {
+        $html = $this->render($this->view(
+            auditReady: false,
+            context: 'danger',
+            detailed: true,
+            criticalCount: 1,
+            findings: [
+                [
+                    'id' => 'audit.external_sink',
+                    'severity' => 'critical',
+                    'context' => 'danger',
+                    'summary' => 'No external audit sink is enabled.',
+                    'risk' => 'The audit trail exists only in the database it protects.',
+                    'remediation' => 'Enable auditSinkFileEnabled.',
+                    'docsUrl' => 'https://example.org/docs/sinks',
+                ],
+            ],
+        ));
+
+        self::assertStringContainsString('vault-security-finding', $html);
+        self::assertStringContainsString('alert-danger', $html);
+        self::assertStringContainsString('audit.external_sink', $html);
+        self::assertStringContainsString('No external audit sink is enabled.', $html);
+        self::assertStringContainsString('The audit trail exists only in the database it protects.', $html);
+        self::assertStringContainsString('Enable auditSinkFileEnabled.', $html);
+        self::assertStringContainsString('https://example.org/docs/sinks', $html);
+        self::assertStringContainsString('vault:doctor', $html);
+    }
+
+    /**
+     * The permission gate seen from the view: with `detailed => false` the markup
+     * must carry the counts and nothing that names the weakness.
+     */
+    public function testWithheldFindingsRenderTheRestrictedNoticeInstead(): void
+    {
+        $html = $this->render($this->view(
+            auditReady: false,
+            context: 'danger',
+            detailed: false,
+            criticalCount: 2,
+            warningCount: 1,
+            // Populated on purpose: the provider empties this list, and the template
+            // must not render it even if a future caller forgets to.
+            findings: [
+                [
+                    'id' => 'audit.external_sink',
+                    'severity' => 'critical',
+                    'context' => 'danger',
+                    'summary' => 'No external audit sink is enabled.',
+                    'risk' => 'leaked risk text',
+                    'remediation' => 'leaked remediation text',
+                    'docsUrl' => 'https://example.org/docs/sinks',
+                ],
+            ],
+        ));
+
+        self::assertStringContainsString('vault-security-restricted', $html);
+        self::assertStringNotContainsString('vault-security-finding', $html);
+        self::assertStringNotContainsString('leaked risk text', $html);
+        self::assertStringNotContainsString('leaked remediation text', $html);
+        self::assertStringContainsString('2 critical and 1 advisory', $html);
+    }
+
+    public function testAnUnavailableRunRendersAWarningRatherThanABlankPanel(): void
+    {
+        $html = $this->render([
+            'available' => false,
+            'profile' => '',
+            'auditReady' => false,
+            'severity' => '',
+            'context' => 'warning',
+            'passed' => 0,
+            'total' => 0,
+            'criticalCount' => 0,
+            'warningCount' => 0,
+            'detailed' => false,
+            'findings' => [],
+        ]);
+
+        self::assertStringContainsString('vault-security-unavailable', $html);
+        self::assertStringContainsString('could not be evaluated', $html);
+        self::assertStringContainsString('vault:doctor', $html);
+        self::assertStringNotContainsString('controls passed', $html);
+    }
+
+    /**
+     * Secret plaintext never reaches this panel, but finding text is
+     * operator-supplied prose that must still be escaped like any other value.
+     */
+    public function testFindingTextIsHtmlEscaped(): void
+    {
+        $html = $this->render($this->view(
+            auditReady: false,
+            context: 'danger',
+            detailed: true,
+            criticalCount: 1,
+            findings: [
+                [
+                    'id' => 'audit.external_sink',
+                    'severity' => 'critical',
+                    'context' => 'danger',
+                    'summary' => '<script>alert(1)</script>',
+                    'risk' => '',
+                    'remediation' => '',
+                    'docsUrl' => '',
+                ],
+            ],
+        ));
+
+        self::assertStringNotContainsString('<script>alert(1)</script>', $html);
+        self::assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    /**
+     * A complete view shape with per-test overrides, mirroring
+     * {@see SecurityStatusProvider::forView()}.
+     *
+     * @param list<array<string, string>> $findings
+     *
+     * @return array<string, mixed>
+     */
+    private function view(
+        string $profile = 'hardened',
+        bool $auditReady = false,
+        string $context = 'warning',
+        bool $detailed = false,
+        int $criticalCount = 0,
+        int $warningCount = 0,
+        array $findings = [],
+    ): array {
+        return [
+            'available' => true,
+            'profile' => $profile,
+            'auditReady' => $auditReady,
+            'severity' => $auditReady ? 'pass' : 'warning',
+            'context' => $context,
+            'passed' => 19,
+            'total' => 22,
+            'criticalCount' => $criticalCount,
+            'warningCount' => $warningCount,
+            'detailed' => $detailed,
+            'findings' => $findings,
+        ];
+    }
+
+    /**
+     * Render the partial through the public view factory.
+     *
+     * The Partials directory is handed over as the TEMPLATE root path: a partial and
+     * a template are the same file format, and `ViewInterface::render()` is the only
+     * public entry point (`renderPartial()` lives on an `@internal` Fluid class).
+     * Rendering it as a template exercises the identical parse-and-render path the
+     * module takes.
+     *
+     * @param array<string, mixed> $securityStatus
+     */
+    private function render(array $securityStatus): string
+    {
+        // The LanguageService that f:translate resolves through: a view-only
+        // functional test gets no backend user, so nothing sets it up.
+        $GLOBALS['LANG'] = $this->get(LanguageServiceFactory::class)->createFromUserPreferences(null);
+
+        $view = $this->get(ViewFactoryInterface::class)->create(new ViewFactoryData(
+            templateRootPaths: ['EXT:nr_vault/Resources/Private/Partials/'],
+        ));
+
+        return $view->assign('securityStatus', $securityStatus)->render('SecurityStatus');
+    }
+}

--- a/Tests/Unit/Audit/Sink/JsonFileAuditSinkTest.php
+++ b/Tests/Unit/Audit/Sink/JsonFileAuditSinkTest.php
@@ -453,6 +453,7 @@ final class JsonFileAuditSinkTest extends TestCase
             $sandbox . '/public-was-removed',
             $sandbox . '/var',
             $sandbox . '/config',
+            'Testing',
         );
 
         self::assertFalse($this->createSubject()->isEnabled());

--- a/Tests/Unit/Command/VaultDoctorCommandTest.php
+++ b/Tests/Unit/Command/VaultDoctorCommandTest.php
@@ -1,0 +1,307 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Command;
+
+use Netresearch\NrVault\Command\VaultDoctorCommand;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\DoctorReport;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\VaultDoctorServiceInterface;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * The exit code is the contract, so it carries most of the assertions here: this
+ * command is meant to be the last step of a deployment pipeline, where nothing
+ * reads the prose.
+ */
+#[CoversClass(VaultDoctorCommand::class)]
+final class VaultDoctorCommandTest extends TestCase
+{
+    #[Test]
+    public function aCleanReportExitsZero(): void
+    {
+        $tester = $this->tester($this->report([Finding::pass('a.ok', 'all good')]));
+
+        self::assertSame(0, $tester->execute([]));
+        self::assertStringContainsString('audit-ready', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function warningsOnlyExitOne(): void
+    {
+        $tester = $this->tester($this->report([
+            Finding::pass('a.ok', 'all good'),
+            Finding::warning('a.warn', 'CLI access is on', 'shell reads secrets', 'disable allowCliAccess'),
+        ]));
+
+        self::assertSame(1, $tester->execute([]));
+
+        $display = $tester->getDisplay();
+        self::assertStringContainsString('a.warn', $display);
+        self::assertStringContainsString('1 warning(s)', $display);
+    }
+
+    #[Test]
+    public function anyCriticalExitsTwo(): void
+    {
+        $tester = $this->tester($this->report([
+            Finding::pass('a.ok', 'all good'),
+            Finding::critical('audit.external_sink', 'no sink', 'no evidence', 'enable a sink'),
+        ]));
+
+        self::assertSame(2, $tester->execute([]));
+        self::assertStringContainsString('NOT audit-ready', $tester->getDisplay());
+    }
+
+    /**
+     * Remediation text is a shell command an operator copies, so it must reach the
+     * output verbatim rather than being wrapped into a table cell.
+     */
+    #[Test]
+    public function theTextReportCarriesTheRiskRemediationAndDocsLink(): void
+    {
+        $tester = $this->tester($this->report([
+            Finding::critical(
+                id: 'audit.external_sink',
+                summary: 'no external audit sink',
+                risk: 'the trail exists only in the database it protects',
+                remediation: 'enable auditSinkFileEnabled, then run vendor/bin/typo3 vault:audit-anchor',
+                docsUrl: 'https://example.org/docs/sinks',
+            ),
+        ]));
+
+        $tester->execute([]);
+        $display = $tester->getDisplay();
+
+        self::assertStringContainsString('the trail exists only in the database it protects', $display);
+        self::assertStringContainsString('vault:audit-anchor', $display);
+        self::assertStringContainsString('https://example.org/docs/sinks', $display);
+    }
+
+    /**
+     * The JSON contract: stable ids, the summary block a gate reads, and the exit
+     * code inside the payload so a wrapper that swallows the process code can
+     * still act on it.
+     */
+    #[Test]
+    public function jsonOutputIsStableAndMachineReadable(): void
+    {
+        $tester = $this->tester($this->report(
+            [
+                Finding::pass('provider.configured', 'file provider configured'),
+                Finding::critical(
+                    id: 'audit.external_sink',
+                    summary: 'no sink',
+                    risk: 'no evidence',
+                    remediation: 'enable a sink',
+                    docsUrl: 'https://example.org/docs',
+                    details: ['reasonCode' => 'NO_EXTERNAL_SINK'],
+                ),
+            ],
+            profile: SecurityProfile::Hardened,
+        ));
+
+        self::assertSame(2, $tester->execute(['--format' => 'json']));
+
+        $payload = $this->decode($tester->getDisplay());
+
+        self::assertSame('hardened', $payload['profile']);
+        self::assertSame(2, $payload['exitCode']);
+        self::assertFalse($payload['auditReady']);
+        self::assertSame(['total' => 2, 'pass' => 1, 'warning' => 0, 'critical' => 1], $payload['summary']);
+
+        $findings = $payload['findings'];
+        self::assertIsArray($findings);
+        self::assertSame(['provider.configured', 'audit.external_sink'], array_column($findings, 'id'));
+
+        $sinkFinding = $findings[1];
+        self::assertIsArray($sinkFinding);
+        self::assertIsArray($sinkFinding['details']);
+        self::assertSame('NO_EXTERNAL_SINK', $sinkFinding['details']['reasonCode']);
+    }
+
+    #[Test]
+    public function jsonOutputOfACleanReportStillExitsZero(): void
+    {
+        $tester = $this->tester($this->report([Finding::pass('a.ok', 'all good')]));
+
+        self::assertSame(0, $tester->execute(['--format' => 'json']));
+
+        $payload = $this->decode($tester->getDisplay());
+        self::assertTrue($payload['auditReady']);
+        self::assertSame(0, $payload['exitCode']);
+    }
+
+    #[Test]
+    public function theProfileOptionSelectsTheTargetProfile(): void
+    {
+        $doctor = $this->createMock(VaultDoctorServiceInterface::class);
+        $doctor->expects(self::once())
+            ->method('run')
+            ->with(SecurityProfile::Hardened)
+            ->willReturn($this->report([Finding::pass('a.ok', 'ok')]));
+
+        $tester = new CommandTester(new VaultDoctorCommand($doctor));
+
+        self::assertSame(0, $tester->execute(['--profile' => 'hardened']));
+    }
+
+    #[Test]
+    public function withoutTheProfileOptionTheConfiguredProfileIsUsed(): void
+    {
+        $doctor = $this->createMock(VaultDoctorServiceInterface::class);
+        $doctor->expects(self::once())
+            ->method('run')
+            ->with(null)
+            ->willReturn($this->report([Finding::pass('a.ok', 'ok')]));
+
+        $tester = new CommandTester(new VaultDoctorCommand($doctor));
+        $tester->execute([]);
+    }
+
+    /**
+     * A dry run against another profile must state which profile is actually
+     * configured, or a passing `--profile=hardened` reads as proof that hardening
+     * is already live.
+     */
+    #[Test]
+    public function anOverriddenProfileIsMarkedAsNotChangingConfiguration(): void
+    {
+        $tester = $this->tester(new DoctorReport(
+            context: new DoctorContext(
+                profile: SecurityProfile::Hardened,
+                configuredProfile: SecurityProfile::Standard,
+            ),
+            findings: [Finding::pass('a.ok', 'ok')],
+        ));
+
+        $tester->execute([]);
+        $display = $tester->getDisplay();
+
+        self::assertStringContainsString('hardened', $display);
+        self::assertStringContainsString('NOT changed', $display);
+    }
+
+    /**
+     * An unusable `--profile` value must not be readable as "checked and fine",
+     * so it lands on the same non-zero code as a critical finding.
+     */
+    #[Test]
+    public function anUnknownProfileValueIsRejectedWithoutRunningAnyCheck(): void
+    {
+        $doctor = $this->createMock(VaultDoctorServiceInterface::class);
+        $doctor->expects(self::never())->method('run');
+
+        $tester = new CommandTester(new VaultDoctorCommand($doctor));
+        // INVALID is 2, the same code a critical finding produces: a gate handed
+        // an unusable profile value must not be readable as "checked and fine".
+        self::assertSame(Command::INVALID, $tester->execute(['--profile' => 'paranoid']));
+        self::assertStringContainsString('paranoid', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function anUnknownProfileValueIsAlsoReportedInJson(): void
+    {
+        $doctor = self::createStub(VaultDoctorServiceInterface::class);
+        $tester = new CommandTester(new VaultDoctorCommand($doctor));
+
+        self::assertSame(2, $tester->execute(['--profile' => 'paranoid', '--format' => 'json']));
+
+        $payload = $this->decode($tester->getDisplay());
+        self::assertSame(2, $payload['exitCode']);
+        self::assertIsString($payload['error']);
+        self::assertStringContainsString('paranoid', $payload['error']);
+    }
+
+    /**
+     * A gate that cannot run must never look like a gate that found nothing —
+     * the same stance vault:audit-verify takes.
+     */
+    #[Test]
+    public function aDoctorThatCannotRunExitsTwo(): void
+    {
+        $doctor = self::createStub(VaultDoctorServiceInterface::class);
+        $doctor->method('run')->willThrowException(new RuntimeException('container is broken'));
+
+        $tester = new CommandTester(new VaultDoctorCommand($doctor));
+
+        self::assertSame(2, $tester->execute([]));
+        self::assertStringContainsString('container is broken', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function aDoctorThatCannotRunReportsTheFailureInJsonToo(): void
+    {
+        $doctor = self::createStub(VaultDoctorServiceInterface::class);
+        $doctor->method('run')->willThrowException(new RuntimeException('container is broken'));
+
+        $tester = new CommandTester(new VaultDoctorCommand($doctor));
+
+        self::assertSame(2, $tester->execute(['--format' => 'json']));
+
+        $payload = $this->decode($tester->getDisplay());
+        self::assertSame(2, $payload['exitCode']);
+        self::assertIsString($payload['error']);
+        self::assertStringContainsString('container is broken', $payload['error']);
+    }
+
+    #[Test]
+    public function theControlRatioIsReported(): void
+    {
+        $tester = $this->tester($this->report([
+            Finding::pass('a.one', 'ok'),
+            Finding::pass('a.two', 'ok'),
+            Finding::warning('a.three', 'meh', 'risk', 'fix'),
+        ]));
+
+        $tester->execute([]);
+
+        self::assertStringContainsString('2 of 3', $tester->getDisplay());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decode(string $json): array
+    {
+        $payload = json_decode($json, true, 512, JSON_THROW_ON_ERROR);
+        self::assertIsArray($payload);
+
+        /** @var array<string, mixed> $payload */
+        return $payload;
+    }
+
+    private function tester(DoctorReport $report): CommandTester
+    {
+        $doctor = self::createStub(VaultDoctorServiceInterface::class);
+        $doctor->method('run')->willReturn($report);
+
+        return new CommandTester(new VaultDoctorCommand($doctor));
+    }
+
+    /**
+     * @param list<Finding> $findings
+     */
+    private function report(
+        array $findings,
+        SecurityProfile $profile = SecurityProfile::Standard,
+    ): DoctorReport {
+        return new DoctorReport(
+            context: DoctorContext::forConfiguredProfile($profile),
+            findings: $findings,
+        );
+    }
+}

--- a/Tests/Unit/Controller/SecurityStatusProviderTest.php
+++ b/Tests/Unit/Controller/SecurityStatusProviderTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Controller;
+
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Controller\SecurityStatusProvider;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\DoctorReport;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\VaultDoctorServiceInterface;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+
+#[CoversClass(SecurityStatusProvider::class)]
+final class SecurityStatusProviderTest extends TestCase
+{
+    #[Test]
+    public function exposesTheProfileBadgeAndPassRatio(): void
+    {
+        $view = $this->provider(
+            $this->report([
+                Finding::pass('a.one', 'ok'),
+                Finding::pass('a.two', 'ok'),
+                Finding::warning('a.three', 'meh', 'risk', 'fix'),
+            ], SecurityProfile::Hardened),
+            granted: true,
+        )->forView();
+
+        self::assertTrue($view['available']);
+        self::assertSame('hardened', $view['profile']);
+        self::assertSame(2, $view['passed']);
+        self::assertSame(3, $view['total']);
+        self::assertFalse($view['auditReady']);
+        self::assertSame('warning', $view['severity']);
+        self::assertSame('warning', $view['context']);
+        self::assertSame(0, $view['criticalCount']);
+        self::assertSame(1, $view['warningCount']);
+    }
+
+    /**
+     * The gate this class exists for: the finding list names the installation's
+     * concrete weak points and the file to edit, so it belongs to the permission
+     * that already governs vault configuration.
+     */
+    #[Test]
+    public function findingDetailIsWithheldWithoutTheVaultConfigurePermission(): void
+    {
+        $view = $this->provider(
+            $this->report([
+                Finding::pass('a.one', 'ok'),
+                Finding::critical('audit.external_sink', 'no sink', 'no evidence', 'enable a sink'),
+            ]),
+            granted: false,
+        )->forView();
+
+        self::assertFalse($view['detailed']);
+        self::assertSame([], $view['findings']);
+
+        // The counts stay visible: knowing THAT something is open is enough to
+        // escalate, and hiding it would leave the panel silently reassuring.
+        self::assertSame(1, $view['criticalCount']);
+        self::assertSame(1, $view['passed']);
+        self::assertSame(2, $view['total']);
+        self::assertFalse($view['auditReady']);
+    }
+
+    #[Test]
+    public function findingDetailIsShownWithTheVaultConfigurePermission(): void
+    {
+        $view = $this->provider(
+            $this->report([
+                Finding::pass('a.one', 'ok'),
+                Finding::critical(
+                    id: 'audit.external_sink',
+                    summary: 'no sink',
+                    risk: 'no external evidence',
+                    remediation: 'enable auditSinkFileEnabled',
+                    docsUrl: 'https://example.org/docs',
+                ),
+                Finding::warning('cli.access', 'cli on', 'shell reads secrets', 'disable it'),
+            ]),
+            granted: true,
+        )->forView();
+
+        self::assertTrue($view['detailed']);
+        self::assertSame(
+            ['audit.external_sink', 'cli.access'],
+            array_column($view['findings'], 'id'),
+        );
+
+        $first = $view['findings'][0];
+        self::assertSame('critical', $first['severity']);
+        self::assertSame('danger', $first['context']);
+        self::assertSame('no external evidence', $first['risk']);
+        self::assertSame('enable auditSinkFileEnabled', $first['remediation']);
+        self::assertSame('https://example.org/docs', $first['docsUrl']);
+    }
+
+    #[Test]
+    public function thePermissionCheckedIsVaultConfigure(): void
+    {
+        $accessControl = $this->createMock(AccessControlServiceInterface::class);
+        $accessControl->expects(self::once())
+            ->method('isGranted')
+            ->with(VaultPermission::VaultConfigure)
+            ->willReturn(true);
+
+        $doctor = self::createStub(VaultDoctorServiceInterface::class);
+        $doctor->method('run')->willReturn($this->report([Finding::pass('a.one', 'ok')]));
+
+        (new SecurityStatusProvider($doctor, $accessControl))->forView();
+    }
+
+    #[Test]
+    public function aCleanReportIsReportedAsAuditReady(): void
+    {
+        $view = $this->provider($this->report([Finding::pass('a.one', 'ok')]), granted: true)->forView();
+
+        self::assertTrue($view['auditReady']);
+        self::assertSame('success', $view['context']);
+        self::assertSame([], $view['findings']);
+    }
+
+    /**
+     * "We could not check" must not render as "there is nothing to report" — the
+     * panel returns a complete shape flagged unavailable so the partial shows a
+     * warning rather than a blank box.
+     */
+    #[Test]
+    public function aDoctorThatCannotRunYieldsAnUnavailableShapeWithEveryKeyPresent(): void
+    {
+        $doctor = self::createStub(VaultDoctorServiceInterface::class);
+        $doctor->method('run')->willThrowException(new RuntimeException('container is broken'));
+
+        $accessControl = self::createStub(AccessControlServiceInterface::class);
+        $accessControl->method('isGranted')->willReturn(true);
+
+        $view = (new SecurityStatusProvider($doctor, $accessControl))->forView();
+
+        self::assertFalse($view['available']);
+        self::assertFalse($view['auditReady']);
+        self::assertFalse($view['detailed']);
+        self::assertSame('warning', $view['context']);
+        self::assertSame(
+            [
+                'available', 'profile', 'auditReady', 'severity', 'context',
+                'passed', 'total', 'criticalCount', 'warningCount', 'detailed', 'findings',
+            ],
+            array_keys($view),
+        );
+    }
+
+    private function provider(DoctorReport $report, bool $granted): SecurityStatusProvider
+    {
+        $doctor = self::createStub(VaultDoctorServiceInterface::class);
+        $doctor->method('run')->willReturn($report);
+
+        $accessControl = self::createStub(AccessControlServiceInterface::class);
+        $accessControl->method('isGranted')->willReturn($granted);
+
+        return new SecurityStatusProvider($doctor, $accessControl);
+    }
+
+    /**
+     * @param list<Finding> $findings
+     */
+    private function report(
+        array $findings,
+        SecurityProfile $profile = SecurityProfile::Standard,
+    ): DoctorReport {
+        return new DoctorReport(
+            context: DoctorContext::forConfiguredProfile($profile),
+            findings: $findings,
+        );
+    }
+}

--- a/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
@@ -1,0 +1,370 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
+
+use Netresearch\NrVault\Audit\Anchor\AnchorReaderInterface;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\HashChainVerificationResult;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\Check\AuditCheck;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\DoctorFindingTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(AuditCheck::class)]
+final class AuditCheckTest extends TestCase
+{
+    use DoctorFindingTrait;
+
+    /**
+     * Highest audit uid used by the default fixture chain.
+     *
+     * Deliberately above the 1000-entry window so the default fixture exercises
+     * the bounded tail rather than accidentally covering the whole chain.
+     */
+    private const CHAIN_TIP = 2500;
+
+    #[Test]
+    public function appliesToBothProfiles(): void
+    {
+        $check = $this->check();
+
+        self::assertTrue($check->appliesTo(SecurityProfile::Standard));
+        self::assertTrue($check->appliesTo(SecurityProfile::Hardened));
+    }
+
+    #[Test]
+    public function aFullyConfiguredHardenedAuditTrailPassesEveryControl(): void
+    {
+        $findings = $this->check(
+            sinks: ['file', 'syslog'],
+            anchor: new ChainTipAnchor(
+                sequence: self::CHAIN_TIP - 20,
+                chainTip: 'tip',
+                timestamp: 1_700_000_000,
+                hmacEpoch: 3,
+            ),
+        )->run($this->doctorContext(SecurityProfile::Hardened));
+
+        self::assertSame(
+            [
+                'audit.reads_logged',
+                'audit.retention',
+                'audit.hash_chain',
+                'audit.external_sink',
+                'audit.anchor',
+                'audit.sink_delivery',
+            ],
+            $this->findingIds($findings),
+        );
+        foreach ($findings as $finding) {
+            self::assertTrue($finding->isPass(), $finding->id . ': ' . $finding->summary);
+        }
+    }
+
+    /**
+     * Reads are the operation an audit trail exists for — a stolen credential is
+     * read, not written. Hygiene under standard, a broken promise under hardened.
+     */
+    #[Test]
+    public function disabledReadLoggingIsAWarningUnderStandardAndCriticalUnderHardened(): void
+    {
+        $standard = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(auditReads: false)->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.reads_logged',
+        );
+
+        $hardened = $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $this->check(auditReads: false)->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.reads_logged',
+        );
+
+        // Escalation must keep the wording so a --profile=hardened dry run is
+        // directly comparable to the live standard-profile report.
+        self::assertSame($standard->summary, $hardened->summary);
+        self::assertSame($standard->risk, $hardened->risk);
+        self::assertSame($standard->remediation, $hardened->remediation);
+    }
+
+    /**
+     * 0 means "keep forever", which is the safest setting for an audit trail and
+     * therefore a pass — not a missing value to complain about.
+     */
+    #[Test]
+    #[DataProvider('retentionProvider')]
+    public function retentionIsJudgedAgainstAnAnnualReviewCycle(int $days, FindingSeverity $expected): void
+    {
+        $findings = $this->check(retention: $days)->run($this->doctorContext(SecurityProfile::Standard));
+
+        $finding = $this->assertFindingSeverity($expected, $findings, 'audit.retention');
+        self::assertSame($days, $finding->details['retentionDays']);
+    }
+
+    /**
+     * @return iterable<string, array{int, FindingSeverity}>
+     */
+    public static function retentionProvider(): iterable
+    {
+        yield 'forever' => [0, FindingSeverity::Pass];
+        yield 'exactly one year' => [365, FindingSeverity::Pass];
+        yield 'more than a year' => [730, FindingSeverity::Pass];
+        yield 'under a year' => [90, FindingSeverity::Warning];
+        yield 'one day short' => [364, FindingSeverity::Warning];
+        yield 'negative' => [-1, FindingSeverity::Warning];
+    }
+
+    #[Test]
+    public function anEmptyChainHasNothingToVerifyAndPasses(): void
+    {
+        $findings = $this->check(chainTip: 0)->run($this->doctorContext(SecurityProfile::Standard));
+
+        $finding = $this->findingById($findings, 'audit.hash_chain');
+        self::assertTrue($finding->isPass());
+        self::assertSame(0, $finding->details['currentSequence']);
+    }
+
+    /**
+     * The pass is bounded to the newest 1000 entries, so a passing finding must
+     * say so and name the authoritative full-range verifier. A gate that silently
+     * implied full coverage would be worse than one admitting its scope.
+     */
+    #[Test]
+    public function theChainPassIsBoundedToTheNewestThousandEntries(): void
+    {
+        $auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $auditLogService->expects(self::once())
+            ->method('verifyHashChain')
+            ->with(self::CHAIN_TIP - 999)
+            ->willReturn(HashChainVerificationResult::valid());
+
+        $finding = $this->findingById(
+            $this->check(auditLogService: $auditLogService)
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.hash_chain',
+        );
+
+        self::assertSame(self::CHAIN_TIP - 999, $finding->details['fromUid']);
+        self::assertSame(self::CHAIN_TIP, $finding->details['toUid']);
+        self::assertStringContainsString('vault:audit-verify', $finding->summary);
+    }
+
+    #[Test]
+    public function aShortChainIsVerifiedFromUidOne(): void
+    {
+        $auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $auditLogService->expects(self::once())
+            ->method('verifyHashChain')
+            ->with(1)
+            ->willReturn(HashChainVerificationResult::valid());
+
+        $this->check(chainTip: 12, auditLogService: $auditLogService)
+            ->run($this->doctorContext(SecurityProfile::Standard));
+    }
+
+    #[Test]
+    public function aFailingChainIsCritical(): void
+    {
+        $findings = $this->check(
+            chainResult: HashChainVerificationResult::invalid([17 => 'hash mismatch']),
+        )->run($this->doctorContext(SecurityProfile::Standard));
+
+        $finding = $this->assertFindingSeverity(FindingSeverity::Critical, $findings, 'audit.hash_chain');
+        self::assertSame(1, $finding->details['errorCount']);
+        self::assertStringContainsString('vault:audit-verify', $finding->remediation);
+    }
+
+    /**
+     * A uid gap is already an error in the verifier's own verdict, so it lands as
+     * critical here too — consistent with `vault:audit-verify`, which treats
+     * UID_GAP as tamper evidence until a documented purge accounts for it.
+     */
+    #[Test]
+    public function aUidGapIsCriticalAndTheGapSizeIsReported(): void
+    {
+        $findings = $this->check(
+            chainResult: HashChainVerificationResult::invalid(
+                errors: [20 => 'Audit log uid gap detected: missing uids 18..19'],
+                missingUids: [18, 19],
+            ),
+        )->run($this->doctorContext(SecurityProfile::Standard));
+
+        $finding = $this->assertFindingSeverity(FindingSeverity::Critical, $findings, 'audit.hash_chain');
+        self::assertSame(2, $finding->details['missingUidCount']);
+        self::assertStringContainsString('2 uid(s) missing', $finding->summary);
+    }
+
+    /**
+     * The hardened profile's NO_EXTERNAL_SINK invariant: an audit trail that lives
+     * only in the database it protects has no tamper evidence at all.
+     */
+    #[Test]
+    public function noExternalSinkIsCriticalUnderHardened(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $this->check(sinks: [])->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.external_sink',
+        );
+
+        self::assertSame('NO_EXTERNAL_SINK', $finding->details['reasonCode']);
+    }
+
+    /**
+     * Under the standard profile sinks are documented as opt-in, so flagging a
+     * default installation for having no SIEM would be noise — and noise is what
+     * trains an operator to ignore the hardened finding when it matters.
+     */
+    #[Test]
+    public function noExternalSinkPassesUnderTheStandardProfile(): void
+    {
+        $finding = $this->findingById(
+            $this->check(sinks: [])->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.external_sink',
+        );
+
+        self::assertTrue($finding->isPass());
+        self::assertSame('NO_EXTERNAL_SINK', $finding->details['reasonCode']);
+    }
+
+    #[Test]
+    public function aMissingAnchorIsCriticalUnderHardenedAndPassesUnderStandard(): void
+    {
+        $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $this->check(sinks: ['file'], withoutAnchor: true)
+                ->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.anchor',
+        );
+
+        self::assertTrue($this->findingById(
+            $this->check(withoutAnchor: true)->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.anchor',
+        )->isPass());
+    }
+
+    /**
+     * The one anchor comparison cheap enough for a page load: an append-only chain
+     * cannot get shorter, so a current tip below the anchored sequence is the
+     * signature of a truncate-and-rebuild.
+     */
+    #[Test]
+    public function aChainShorterThanTheAnchoredSequenceIsCritical(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $this->check(
+                chainTip: 3,
+                sinks: ['file'],
+                anchor: new ChainTipAnchor(
+                    sequence: 900,
+                    chainTip: 'tip',
+                    timestamp: 1_700_000_000,
+                    hmacEpoch: 3,
+                ),
+            )->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.anchor',
+        );
+
+        self::assertSame('TABLE_RESET', $finding->details['reasonCode']);
+        self::assertSame(900, $finding->details['anchoredSequence']);
+        self::assertSame(3, $finding->details['currentSequence']);
+    }
+
+    #[Test]
+    public function sinkDeliveryFailuresAreAWarningNamingTheSink(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(sinks: ['webhook'], sinkFailures: ['webhook' => 3])
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.sink_delivery',
+        );
+
+        self::assertSame(3, $finding->details['failureCount']);
+        self::assertStringContainsString('webhook', $finding->summary);
+    }
+
+    /**
+     * A check wired with a healthy audit configuration, overridable per test.
+     *
+     * @param list<string> $sinks Enabled sink identifiers
+     * @param array<string, int> $sinkFailures Per-sink delivery failures
+     * @param ChainTipAnchor|null $anchor Anchor to compare against; null uses the
+     *                                    healthy default (ignored when
+     *                                    `$withoutAnchor` is true)
+     * @param bool $withoutAnchor No anchor could be read at all
+     */
+    private function check(
+        bool $auditReads = true,
+        int $retention = 365,
+        int $chainTip = self::CHAIN_TIP,
+        ?HashChainVerificationResult $chainResult = null,
+        array $sinks = ['file'],
+        array $sinkFailures = [],
+        ?ChainTipAnchor $anchor = null,
+        bool $withoutAnchor = false,
+        ?AuditLogServiceInterface $auditLogService = null,
+    ): AuditCheck {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('isAuditReadsEnabled')->willReturn($auditReads);
+        $configuration->method('getAuditLogRetention')->willReturn($retention);
+
+        if (!$auditLogService instanceof AuditLogServiceInterface) {
+            $stub = self::createStub(AuditLogServiceInterface::class);
+            $stub->method('verifyHashChain')
+                ->willReturn($chainResult ?? HashChainVerificationResult::valid());
+            $auditLogService = $stub;
+        }
+
+        $registry = self::createStub(AuditSinkRegistryInterface::class);
+        $registry->method('getEnabledSinkIdentifiers')->willReturn($sinks);
+        $registry->method('hasExternalAuditSink')->willReturn($sinks !== []);
+        $registry->method('getFailureCountsBySink')->willReturn($sinkFailures);
+        $registry->method('getFailureCount')->willReturn(array_sum($sinkFailures));
+
+        $anchorService = self::createStub(ChainTipAnchorServiceInterface::class);
+        $anchorService->method('capture')->willReturn(new ChainTipAnchor(
+            sequence: $chainTip,
+            chainTip: $chainTip > 0 ? 'current-tip' : '',
+            timestamp: 1_700_000_100,
+            hmacEpoch: 3,
+        ));
+
+        $resolvedAnchor = $withoutAnchor
+            ? null
+            : ($anchor ?? new ChainTipAnchor(
+                sequence: max(0, $chainTip - 20),
+                chainTip: 'anchored-tip',
+                timestamp: 1_700_000_000,
+                hmacEpoch: 3,
+            ));
+
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn($resolvedAnchor);
+        $anchorReader->method('isAvailable')->willReturn(!$withoutAnchor);
+
+        return new AuditCheck(
+            $configuration,
+            $auditLogService,
+            $registry,
+            $anchorService,
+            $anchorReader,
+        );
+    }
+}

--- a/Tests/Unit/Service/Doctor/Check/BreakGlassCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/BreakGlassCheckTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
+
+use DateTimeImmutable;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Security\BreakGlassSession;
+use Netresearch\NrVault\Security\BreakGlassStateInterface;
+use Netresearch\NrVault\Service\Doctor\Check\BreakGlassCheck;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\DoctorFindingTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(BreakGlassCheck::class)]
+final class BreakGlassCheckTest extends TestCase
+{
+    use DoctorFindingTrait;
+
+    #[Test]
+    public function appliesToBothProfiles(): void
+    {
+        $check = $this->check(null);
+
+        self::assertTrue($check->appliesTo(SecurityProfile::Standard));
+        self::assertTrue($check->appliesTo(SecurityProfile::Hardened));
+    }
+
+    #[Test]
+    public function noOpenWindowPasses(): void
+    {
+        $findings = $this->check(null)->run($this->doctorContext(SecurityProfile::Hardened));
+
+        self::assertSame(['breakglass.window_open'], $this->findingIds($findings));
+        self::assertTrue($findings[0]->isPass());
+    }
+
+    /**
+     * The reason an open window is reported at all: the backend banner cannot
+     * reach a CI gate or a monitoring probe, and a release shipped during someone
+     * else's bypass window is a release nobody can attribute afterwards.
+     *
+     * Warning, not critical — an open window is a justified deliberate act, and a
+     * red gate would push operators to close it mid-incident just to deploy.
+     */
+    #[Test]
+    public function anOpenWindowIsAWarningNamingWhoWhyAndUntilWhen(): void
+    {
+        $expiresAt = (new DateTimeImmutable())->setTimestamp(time() + 900);
+        $session = new BreakGlassSession(
+            activatedByUid: 7,
+            activatedByUsername: 'alice',
+            reason: 'INC-4711 rotate leaked key',
+            activatedAt: new DateTimeImmutable(),
+            expiresAt: $expiresAt,
+        );
+
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check($session)->run($this->doctorContext(SecurityProfile::Hardened)),
+            'breakglass.window_open',
+        );
+
+        self::assertStringContainsString('alice', $finding->summary);
+        self::assertStringContainsString('INC-4711 rotate leaked key', $finding->summary);
+        self::assertStringContainsString($expiresAt->format('Y-m-d H:i'), $finding->summary);
+        self::assertSame(7, $finding->details['activatedByUid']);
+        self::assertSame('alice', $finding->details['activatedByUsername']);
+        self::assertSame($expiresAt->getTimestamp(), $finding->details['expiresAt']);
+    }
+
+    /**
+     * Round the remaining time UP: reporting "0 minutes left" while the bypass is
+     * still live understates the exposure being warned about.
+     */
+    #[Test]
+    public function theRemainingMinutesAreRoundedUp(): void
+    {
+        $session = new BreakGlassSession(
+            activatedByUid: 1,
+            activatedByUsername: 'bob',
+            reason: 'incident',
+            activatedAt: new DateTimeImmutable(),
+            expiresAt: (new DateTimeImmutable())->setTimestamp(time() + 61),
+        );
+
+        $finding = $this->findingById(
+            $this->check($session)->run($this->doctorContext(SecurityProfile::Standard)),
+            'breakglass.window_open',
+        );
+
+        self::assertSame(2, $finding->details['remainingMinutes']);
+    }
+
+    private function check(?BreakGlassSession $session): BreakGlassCheck
+    {
+        $state = self::createStub(BreakGlassStateInterface::class);
+        $state->method('getActiveSession')->willReturn($session);
+        $state->method('isActive')->willReturn($session instanceof BreakGlassSession);
+
+        return new BreakGlassCheck($state);
+    }
+}

--- a/Tests/Unit/Service/Doctor/Check/CliAccessCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/CliAccessCheckTest.php
@@ -1,0 +1,125 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
+
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\Check\CliAccessCheck;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\DoctorFindingTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(CliAccessCheck::class)]
+final class CliAccessCheckTest extends TestCase
+{
+    use DoctorFindingTrait;
+
+    #[Test]
+    public function appliesToBothProfiles(): void
+    {
+        $check = $this->check(false);
+
+        self::assertTrue($check->appliesTo(SecurityProfile::Standard));
+        self::assertTrue($check->appliesTo(SecurityProfile::Hardened));
+    }
+
+    /**
+     * Off is the default and the safe state — and there is then no group scope to
+     * assess, so only one control is emitted rather than a vacuous pass.
+     */
+    #[Test]
+    public function disabledCliAccessEmitsOnlyThePassingAccessControl(): void
+    {
+        $findings = $this->check(false)->run($this->doctorContext(SecurityProfile::Hardened));
+
+        self::assertSame(['cli.access'], $this->findingIds($findings));
+        self::assertTrue($findings[0]->isPass());
+    }
+
+    /**
+     * A deployment pipeline that stores credentials needs this switch, so calling
+     * it a defect under the standard profile would be noise.
+     */
+    #[Test]
+    public function enabledCliAccessPassesUnderTheStandardProfile(): void
+    {
+        $finding = $this->findingById(
+            $this->check(true, [42])->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.access',
+        );
+
+        self::assertTrue($finding->isPass());
+    }
+
+    #[Test]
+    public function enabledCliAccessIsAWarningUnderTheHardenedProfile(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(true, [42])->run($this->doctorContext(SecurityProfile::Hardened)),
+            'cli.access',
+        );
+
+        self::assertStringContainsString('TechnicalActorContext', $finding->remediation);
+    }
+
+    #[Test]
+    public function anEmptyGroupListWhileCliAccessIsOnIsAWarning(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(true, [])->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.access_groups',
+        );
+
+        self::assertSame(0, $finding->details['cliAccessGroupCount']);
+    }
+
+    /**
+     * `getCliAccessGroups()` maps unparseable configuration values to 0, and group
+     * uid 0 does not exist — counting those would report a scoped grant where the
+     * configuration actually holds junk.
+     */
+    #[Test]
+    public function groupUidZeroDoesNotCountAsAScopedGrant(): void
+    {
+        $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(true, [0, 0])->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.access_groups',
+        );
+    }
+
+    #[Test]
+    public function aScopedGroupListPasses(): void
+    {
+        $finding = $this->findingById(
+            $this->check(true, [3, 7])->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.access_groups',
+        );
+
+        self::assertTrue($finding->isPass());
+        self::assertSame(2, $finding->details['cliAccessGroupCount']);
+    }
+
+    /**
+     * @param list<int> $groups
+     */
+    private function check(bool $allowed, array $groups = []): CliAccessCheck
+    {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('isCliAccessAllowed')->willReturn($allowed);
+        $configuration->method('getCliAccessGroups')->willReturn($groups);
+
+        return new CliAccessCheck($configuration);
+    }
+}

--- a/Tests/Unit/Service/Doctor/Check/EnvironmentCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/EnvironmentCheckTest.php
@@ -1,0 +1,160 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
+
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\Check\EnvironmentCheck;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\DoctorFindingTrait;
+use Netresearch\NrVault\Tests\Unit\Traits\EnvironmentSandboxTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(EnvironmentCheck::class)]
+final class EnvironmentCheckTest extends TestCase
+{
+    use DoctorFindingTrait;
+    use EnvironmentSandboxTrait;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Environment is a static singleton the unit bootstrap leaves
+        // uninitialised, and getContext() throws until something initialises it.
+        $this->setUpEnvironmentSandbox('Testing');
+
+        // The check reads $TYPO3_CONF_VARS[BE] directly; backupGlobals is on for
+        // the unit suite, so a per-test value cannot leak into a sibling.
+        $GLOBALS['TYPO3_CONF_VARS']['BE'] = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $this->tearDownEnvironmentSandbox();
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function appliesToBothProfiles(): void
+    {
+        $check = new EnvironmentCheck();
+
+        self::assertTrue($check->appliesTo(SecurityProfile::Standard));
+        self::assertTrue($check->appliesTo(SecurityProfile::Hardened));
+    }
+
+    /**
+     * Exactly two controls, and no more: everything else worth knowing about the
+     * host (real TLS termination, HSTS, proxy behaviour) needs a view of the edge
+     * that a CLI process behind it does not have, and a guessed finding is one an
+     * operator learns to ignore.
+     */
+    #[Test]
+    public function emitsOnlyTheTwoControlsItCanCheckReliably(): void
+    {
+        $findings = (new EnvironmentCheck())->run($this->doctorContext(SecurityProfile::Standard));
+
+        self::assertSame(
+            ['environment.production_context', 'environment.backend_lock_ssl'],
+            $this->findingIds($findings),
+        );
+    }
+
+    /**
+     * A non-production context is the normal state of a developer machine, so
+     * reporting it outside the hardened profile would be noise.
+     */
+    #[Test]
+    public function aNonProductionContextPassesUnderTheStandardProfile(): void
+    {
+        $finding = $this->findingById(
+            (new EnvironmentCheck())->run($this->doctorContext(SecurityProfile::Standard)),
+            'environment.production_context',
+        );
+
+        self::assertTrue($finding->isPass());
+        self::assertSame('Testing', $finding->details['applicationContext']);
+    }
+
+    #[Test]
+    public function aNonProductionContextIsAWarningUnderTheHardenedProfile(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            (new EnvironmentCheck())->run($this->doctorContext(SecurityProfile::Hardened)),
+            'environment.production_context',
+        );
+
+        self::assertStringContainsString('TYPO3_CONTEXT=Production', $finding->remediation);
+        self::assertSame('Testing', $finding->details['applicationContext']);
+    }
+
+    #[Test]
+    public function aProductionContextPassesUnderTheHardenedProfile(): void
+    {
+        $this->setEnvironmentApplicationContext('Production');
+
+        $finding = $this->findingById(
+            (new EnvironmentCheck())->run($this->doctorContext(SecurityProfile::Hardened)),
+            'environment.production_context',
+        );
+
+        self::assertTrue($finding->isPass());
+        self::assertSame('Production', $finding->details['applicationContext']);
+    }
+
+    /**
+     * Profile-independent: the reveal endpoint returns secret plaintext to a
+     * browser, so an unencrypted backend session leaks it whatever profile is set.
+     */
+    #[Test]
+    public function anUnsetLockSslIsAWarningUnderEitherProfile(): void
+    {
+        foreach ([SecurityProfile::Standard, SecurityProfile::Hardened] as $profile) {
+            $this->assertFindingSeverity(
+                FindingSeverity::Warning,
+                (new EnvironmentCheck())->run($this->doctorContext($profile)),
+                'environment.backend_lock_ssl',
+            );
+        }
+    }
+
+    #[Test]
+    public function anEnabledLockSslPasses(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['BE']['lockSSL'] = true;
+
+        $finding = $this->findingById(
+            (new EnvironmentCheck())->run($this->doctorContext(SecurityProfile::Hardened)),
+            'environment.backend_lock_ssl',
+        );
+
+        self::assertTrue($finding->isPass());
+    }
+
+    /**
+     * A missing or unexpectedly-shaped configuration section must read as "not
+     * configured" — the direction that produces the finding rather than hiding it.
+     */
+    #[Test]
+    public function anAbsentBackendConfigurationSectionReadsAsNotConfigured(): void
+    {
+        unset($GLOBALS['TYPO3_CONF_VARS']);
+
+        $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            (new EnvironmentCheck())->run($this->doctorContext(SecurityProfile::Standard)),
+            'environment.backend_lock_ssl',
+        );
+    }
+}

--- a/Tests/Unit/Service/Doctor/Check/MasterKeyProviderCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/MasterKeyProviderCheckTest.php
@@ -1,0 +1,339 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
+
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface;
+use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
+use Netresearch\NrVault\Exception\ConfigurationException;
+use Netresearch\NrVault\Service\Doctor\Check\MasterKeyProviderCheck;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Service\VaultHealthServiceInterface;
+use Netresearch\NrVault\Service\VaultHealthStatus;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\DoctorFindingTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(MasterKeyProviderCheck::class)]
+final class MasterKeyProviderCheckTest extends TestCase
+{
+    use DoctorFindingTrait;
+
+    /**
+     * Key files created by this test, removed in tearDown.
+     *
+     * Not `$testFilesToDelete`: the testing framework's cleanup only accepts
+     * paths under the TYPO3 var path, which no unit test has.
+     *
+     * @var list<string>
+     */
+    private array $keyFiles = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->keyFiles as $path) {
+            if (is_file($path)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
+                unlink($path);
+            }
+        }
+        $this->keyFiles = [];
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function appliesToBothProfiles(): void
+    {
+        $check = $this->check('file');
+
+        self::assertTrue($check->appliesTo(SecurityProfile::Standard));
+        self::assertTrue($check->appliesTo(SecurityProfile::Hardened));
+    }
+
+    #[Test]
+    public function anExplicitExternalProviderWithAWorkingKeyPassesEveryControl(): void
+    {
+        // 'env' rather than 'file' so no key-file permission control is emitted:
+        // this asserts the clean baseline, not the filesystem branch.
+        $findings = $this->check('env')->run($this->doctorContext(SecurityProfile::Hardened));
+
+        foreach ($findings as $finding) {
+            self::assertTrue(
+                $finding->isPass(),
+                \sprintf('%s should pass: %s', $finding->id, $finding->summary),
+            );
+        }
+        self::assertSame(
+            ['provider.configured', 'provider.known', 'provider.available', 'provider.master_key_readable'],
+            $this->findingIds($findings),
+        );
+    }
+
+    /**
+     * The core hardened invariant: the TYPO3 encryption key must not protect
+     * vault secrets, because the vault would then share its fate with every
+     * other consumer of that key.
+     */
+    #[Test]
+    public function theTypo3ProviderIsCriticalUnderTheHardenedProfile(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $this->check('typo3')->run($this->doctorContext(SecurityProfile::Hardened)),
+            'provider.configured',
+        );
+
+        self::assertStringContainsString('hardened', $finding->summary);
+        self::assertStringContainsString('encryptionKey', $finding->risk);
+    }
+
+    /**
+     * Under the standard profile the same provider is the documented
+     * zero-configuration default — a warning about shared fate, not a defect.
+     */
+    #[Test]
+    public function theTypo3ProviderIsOnlyAWarningUnderTheStandardProfile(): void
+    {
+        $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check('typo3')->run($this->doctorContext(SecurityProfile::Standard)),
+            'provider.configured',
+        );
+    }
+
+    #[Test]
+    public function anEmptyProviderIsCritical(): void
+    {
+        $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $this->check('')->run($this->doctorContext(SecurityProfile::Standard)),
+            'provider.configured',
+        );
+    }
+
+    /**
+     * A provider identifier this installation cannot build — a value from a later
+     * release, or from an extension that is not installed here — must be named
+     * rather than passed over. The check keeps no allow-list of its own, so the
+     * factory stays the single authority on what resolves.
+     */
+    #[Test]
+    public function anUnknownButConfiguredProviderIsCritical(): void
+    {
+        $factory = self::createStub(MasterKeyProviderFactoryInterface::class);
+        $factory->method('create')
+            ->willThrowException(ConfigurationException::invalidProvider('transit'));
+
+        $check = new MasterKeyProviderCheck(
+            $this->configuration('transit'),
+            $factory,
+            $this->healthService(true, true, 'transit'),
+        );
+
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $check->run($this->doctorContext(SecurityProfile::Standard)),
+            'provider.known',
+        );
+
+        self::assertStringContainsString('transit', $finding->summary);
+    }
+
+    #[Test]
+    public function anUnavailableProviderIsCritical(): void
+    {
+        $check = new MasterKeyProviderCheck(
+            $this->configuration('file'),
+            $this->providerFactory(),
+            $this->healthService(false, false, 'file'),
+        );
+
+        $findings = $check->run($this->doctorContext(SecurityProfile::Standard));
+
+        $this->assertFindingSeverity(FindingSeverity::Critical, $findings, 'provider.available');
+        $this->assertFindingSeverity(FindingSeverity::Critical, $findings, 'provider.master_key_readable');
+    }
+
+    /**
+     * A present-but-unreadable key (truncated file, wrong length) fails the second
+     * control while passing the first — the two must not collapse into one.
+     */
+    #[Test]
+    public function aPresentButUnreadableKeyFailsOnlyTheReadabilityControl(): void
+    {
+        $check = new MasterKeyProviderCheck(
+            $this->configuration('env'),
+            $this->providerFactory(),
+            $this->healthService(true, false, 'env'),
+        );
+
+        $findings = $check->run($this->doctorContext(SecurityProfile::Standard));
+
+        self::assertTrue($this->findingById($findings, 'provider.available')->isPass());
+        $this->assertFindingSeverity(FindingSeverity::Critical, $findings, 'provider.master_key_readable');
+    }
+
+    /**
+     * Auto-detection silently running on a different key source than the
+     * configuration names is the failure mode that only surfaces later, when the
+     * hardened profile removes the fallback and the vault stops booting.
+     */
+    #[Test]
+    public function aResolvedProviderDifferentFromTheConfiguredOneIsAWarning(): void
+    {
+        $check = new MasterKeyProviderCheck(
+            $this->configuration('file'),
+            $this->providerFactory(),
+            $this->healthService(true, true, 'typo3'),
+        );
+
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $check->run($this->doctorContext(SecurityProfile::Standard)),
+            'provider.available',
+        );
+
+        self::assertSame('file', $finding->details['configuredProvider']);
+        self::assertSame('typo3', $finding->details['resolvedProvider']);
+    }
+
+    #[Test]
+    public function noKeyFilePermissionControlIsEmittedForNonFileProviders(): void
+    {
+        $ids = $this->findingIds($this->check('env')->run($this->doctorContext(SecurityProfile::Standard)));
+
+        self::assertNotContains('provider.key_permissions', $ids);
+    }
+
+    #[Test]
+    #[DataProvider('groupReadableModeProvider')]
+    public function aKeyFileReadableBeyondItsOwnerIsCritical(int $mode): void
+    {
+        $path = $this->createKeyFile($mode);
+
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $this->check('file', $path)->run($this->doctorContext(SecurityProfile::Standard)),
+            'provider.key_permissions',
+        );
+
+        self::assertSame(\sprintf('0%o', $mode), $finding->details['mode']);
+        // The path must never reach the finding — the JSON report goes into CI logs.
+        self::assertStringNotContainsString($path, $finding->summary . $finding->risk . $finding->remediation);
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function groupReadableModeProvider(): iterable
+    {
+        yield 'group readable' => [0o440];
+        yield 'world readable' => [0o444];
+        yield 'group writable' => [0o460];
+        yield 'world writable' => [0o406];
+    }
+
+    #[Test]
+    #[DataProvider('ownerOnlyModeProvider')]
+    public function anOwnerOnlyKeyFilePasses(int $mode): void
+    {
+        $finding = $this->findingById(
+            $this->check('file', $this->createKeyFile($mode))
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'provider.key_permissions',
+        );
+
+        self::assertTrue($finding->isPass(), $finding->summary);
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function ownerOnlyModeProvider(): iterable
+    {
+        yield 'read only' => [0o400];
+        yield 'read write' => [0o600];
+    }
+
+    #[Test]
+    public function aMissingKeyFileIsAWarningRatherThanACrash(): void
+    {
+        $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check('file', '/nonexistent/nr-vault-test/master.key')
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'provider.key_permissions',
+        );
+    }
+
+    private function check(string $provider, string $keySource = 'NR_VAULT_MASTER_KEY'): MasterKeyProviderCheck
+    {
+        return new MasterKeyProviderCheck(
+            $this->configuration($provider, $keySource),
+            $this->providerFactory(),
+            $this->healthService(true, true, $provider),
+        );
+    }
+
+    private function configuration(
+        string $provider,
+        string $keySource = 'NR_VAULT_MASTER_KEY',
+    ): ExtensionConfigurationInterface {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('getMasterKeyProvider')->willReturn($provider);
+        $configuration->method('getMasterKeySource')->willReturn($keySource);
+        // A path that cannot exist, so the auto-key fallback never picks up a real
+        // file from the test host.
+        $configuration->method('getAutoKeyPath')->willReturn('/nonexistent/nr-vault-test/auto.key');
+
+        return $configuration;
+    }
+
+    private function providerFactory(): MasterKeyProviderFactoryInterface
+    {
+        $factory = self::createStub(MasterKeyProviderFactoryInterface::class);
+        $factory->method('create')->willReturn(self::createStub(MasterKeyProviderInterface::class));
+
+        return $factory;
+    }
+
+    private function healthService(
+        bool $available,
+        bool $working,
+        string $resolvedProvider,
+    ): VaultHealthServiceInterface {
+        $service = self::createStub(VaultHealthServiceInterface::class);
+        $service->method('checkHealth')->willReturn(new VaultHealthStatus(
+            masterKeyAvailable: $available,
+            masterKeyProvider: $resolvedProvider,
+            encryptionWorking: $working,
+            hasIssues: !$available || !$working,
+        ));
+
+        return $service;
+    }
+
+    /**
+     * A throwaway key file with an exact mode, removed on tearDown.
+     */
+    private function createKeyFile(int $mode): string
+    {
+        $path = sys_get_temp_dir() . '/nr-vault-doctor-' . bin2hex(random_bytes(8)) . '.key';
+        file_put_contents($path, base64_encode(random_bytes(32)));
+        chmod($path, $mode);
+        $this->keyFiles[] = $path;
+
+        return $path;
+    }
+}

--- a/Tests/Unit/Service/Doctor/Check/SecretHygieneCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/SecretHygieneCheckTest.php
@@ -1,0 +1,168 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
+
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Domain\Dto\StaleSecret;
+use Netresearch\NrVault\Domain\Dto\VaultUsageStats;
+use Netresearch\NrVault\Domain\StalenessRule;
+use Netresearch\NrVault\Service\Analytics\VaultAnalyticsServiceInterface;
+use Netresearch\NrVault\Service\Doctor\Check\SecretHygieneCheck;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\DoctorFindingTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(SecretHygieneCheck::class)]
+final class SecretHygieneCheckTest extends TestCase
+{
+    use DoctorFindingTrait;
+
+    #[Test]
+    public function appliesToBothProfiles(): void
+    {
+        $check = $this->check();
+
+        self::assertTrue($check->appliesTo(SecurityProfile::Standard));
+        self::assertTrue($check->appliesTo(SecurityProfile::Hardened));
+    }
+
+    #[Test]
+    public function acleanInventoryPassesEveryControl(): void
+    {
+        $findings = $this->check()->run($this->doctorContext(SecurityProfile::Hardened));
+
+        self::assertSame(
+            ['secrets.expired', 'secrets.never_rotated', 'secrets.dead'],
+            $this->findingIds($findings),
+        );
+        foreach ($findings as $finding) {
+            self::assertTrue($finding->isPass(), $finding->id . ': ' . $finding->summary);
+        }
+    }
+
+    #[Test]
+    public function expiredSecretsAreAWarningWithTheCount(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(expired: 4)->run($this->doctorContext(SecurityProfile::Standard)),
+            'secrets.expired',
+        );
+
+        self::assertSame(4, $finding->details['expiredCount']);
+        self::assertStringContainsString('4 stored secret(s)', $finding->summary);
+    }
+
+    #[Test]
+    public function neverRotatedSecretsAreAWarningNamingTheThreshold(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(neverRotated: 2, neverRotatedDays: 90)
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'secrets.never_rotated',
+        );
+
+        self::assertSame(90, $finding->details['thresholdDays']);
+        self::assertStringContainsString('90 days', $finding->summary);
+    }
+
+    /**
+     * Only the `dead` staleness rule counts here. The other rules already have
+     * their own controls (`expired`) or describe usage patterns rather than
+     * removable inventory, and folding them together would double-report the same
+     * secret under two findings.
+     */
+    #[Test]
+    public function onlyDeadCandidatesCountTowardsTheDeadControl(): void
+    {
+        $findings = $this->check(candidates: [
+            $this->staleSecret([StalenessRule::Dead]),
+            $this->staleSecret([StalenessRule::Dead, StalenessRule::NeverRotated]),
+            $this->staleSecret([StalenessRule::AutomationStale]),
+            $this->staleSecret([StalenessRule::Expired]),
+        ])->run($this->doctorContext(SecurityProfile::Standard));
+
+        $finding = $this->assertFindingSeverity(FindingSeverity::Warning, $findings, 'secrets.dead');
+        self::assertSame(2, $finding->details['deadCount']);
+    }
+
+    /**
+     * No secret identifier may reach a finding: an identifier names a credential
+     * and the JSON report travels into CI logs.
+     */
+    #[Test]
+    public function noSecretIdentifierLeaksIntoAnyFinding(): void
+    {
+        $findings = $this->check(
+            expired: 1,
+            neverRotated: 1,
+            candidates: [$this->staleSecret([StalenessRule::Dead], 'stripe_live_api_key')],
+        )->run($this->doctorContext(SecurityProfile::Standard));
+
+        foreach ($findings as $finding) {
+            $text = $finding->summary . $finding->risk . $finding->remediation
+                . implode(' ', array_map(static fn (bool|int|string $v): string => (string) $v, $finding->details));
+            self::assertStringNotContainsString('stripe_live_api_key', $text, $finding->id);
+        }
+    }
+
+    /**
+     * @param list<StaleSecret> $candidates
+     */
+    private function check(
+        int $expired = 0,
+        int $neverRotated = 0,
+        int $neverRotatedDays = 180,
+        array $candidates = [],
+    ): SecretHygieneCheck {
+        $analytics = self::createStub(VaultAnalyticsServiceInterface::class);
+        $analytics->method('getUsageStats')->willReturn(new VaultUsageStats(
+            total: 10,
+            active: 10,
+            disabled: 0,
+            expired: $expired,
+            frontendAccessible: 0,
+            neverRotated: $neverRotated,
+            automatedReads: 100,
+            manualReveals: 5,
+            windowDays: 180,
+            byAdapter: [],
+            byContext: [],
+        ));
+        $analytics->method('getRedactionCandidates')->willReturn($candidates);
+
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('getStaleNeverRotatedDays')->willReturn($neverRotatedDays);
+
+        return new SecretHygieneCheck($analytics, $configuration);
+    }
+
+    /**
+     * @param list<StalenessRule> $rules
+     */
+    private function staleSecret(array $rules, string $identifier = 'some_secret'): StaleSecret
+    {
+        return new StaleSecret(
+            uid: 1,
+            identifier: $identifier,
+            context: 'default',
+            adapter: 'local',
+            lastReadAt: null,
+            automatedReads: 0,
+            manualReveals: 0,
+            ageDays: 400,
+            rules: $rules,
+        );
+    }
+}

--- a/Tests/Unit/Service/Doctor/Check/SecurityProfileCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/SecurityProfileCheckTest.php
@@ -1,0 +1,139 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
+
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Exception\ConfigurationException;
+use Netresearch\NrVault\Service\Doctor\Check\SecurityProfileCheck;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\DoctorFindingTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(SecurityProfileCheck::class)]
+final class SecurityProfileCheckTest extends TestCase
+{
+    use DoctorFindingTrait;
+
+    #[Test]
+    public function appliesToBothProfiles(): void
+    {
+        $check = $this->check(SecurityProfile::Standard, false);
+
+        self::assertTrue($check->appliesTo(SecurityProfile::Standard));
+        self::assertTrue($check->appliesTo(SecurityProfile::Hardened));
+    }
+
+    #[Test]
+    public function aValidProfileWithAConsistentOverrideFlagPassesEverything(): void
+    {
+        $findings = $this->check(SecurityProfile::Standard, false)
+            ->run($this->doctorContext(SecurityProfile::Standard));
+
+        self::assertSame(['profile.valid', 'profile.admin_override'], $this->findingIds($findings));
+        foreach ($findings as $finding) {
+            self::assertTrue($finding->isPass(), $finding->id . ': ' . $finding->summary);
+        }
+    }
+
+    /**
+     * `getSecurityProfile()` throws on an unknown value rather than degrading to
+     * standard. That fail-closed behaviour is right, and this check is what turns
+     * the resulting outage into a message an operator can act on.
+     */
+    #[Test]
+    public function anUnknownProfileStringIsCritical(): void
+    {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('getSecurityProfile')
+            ->willThrowException(ConfigurationException::invalidSecurityProfile('paranoid'));
+        $configuration->method('isAdminOverrideDisabled')->willReturn(false);
+
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            (new SecurityProfileCheck($configuration))->run($this->doctorContext(SecurityProfile::Standard)),
+            'profile.valid',
+        );
+
+        self::assertStringContainsString('paranoid', $finding->risk);
+    }
+
+    /**
+     * The dangerous mismatch: the flag is set, the configuration screen reads as
+     * though the admin bypass were gone, and every admin still holds everything.
+     */
+    #[Test]
+    public function disableAdminOverrideSetUnderTheStandardProfileIsAnInertFlagWarning(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(SecurityProfile::Standard, true)
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'profile.admin_override',
+        );
+
+        self::assertStringContainsString('no effect', $finding->summary);
+        self::assertTrue($finding->details['disableAdminOverride']);
+    }
+
+    #[Test]
+    public function theHardenedProfileWithoutTheFlagWarnsThatTheOverrideIsStillLive(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(SecurityProfile::Hardened, false)
+                ->run($this->doctorContext(SecurityProfile::Hardened)),
+            'profile.admin_override',
+        );
+
+        self::assertStringContainsString('still in place', $finding->summary);
+        self::assertStringContainsString('break-glass', $finding->remediation);
+    }
+
+    #[Test]
+    public function theHardenedProfileWithTheFlagPasses(): void
+    {
+        $finding = $this->findingById(
+            $this->check(SecurityProfile::Hardened, true)
+                ->run($this->doctorContext(SecurityProfile::Hardened)),
+            'profile.admin_override',
+        );
+
+        self::assertTrue($finding->isPass(), $finding->summary);
+    }
+
+    /**
+     * `--profile=hardened` on a standard installation must report the mismatch
+     * the operator would get AFTER switching, which is the point of the dry run:
+     * with the flag unset, hardening would leave the override live.
+     */
+    #[Test]
+    public function theTargetProfileDecidesTheOverrideVerdictNotTheConfiguredOne(): void
+    {
+        $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(SecurityProfile::Standard, false)->run(
+                $this->doctorContextTargeting(SecurityProfile::Hardened, SecurityProfile::Standard),
+            ),
+            'profile.admin_override',
+        );
+    }
+
+    private function check(SecurityProfile $profile, bool $overrideDisabled): SecurityProfileCheck
+    {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('getSecurityProfile')->willReturn($profile);
+        $configuration->method('isAdminOverrideDisabled')->willReturn($overrideDisabled);
+
+        return new SecurityProfileCheck($configuration);
+    }
+}

--- a/Tests/Unit/Service/Doctor/Check/Typo3VersionRangeTest.php
+++ b/Tests/Unit/Service/Doctor/Check/Typo3VersionRangeTest.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
+
+use Netresearch\NrVault\Service\Doctor\Check\Typo3VersionRange;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(Typo3VersionRange::class)]
+final class Typo3VersionRangeTest extends TestCase
+{
+    #[Test]
+    public function parsesTheExtensionsOwnConstraint(): void
+    {
+        $range = Typo3VersionRange::fromConstraint('13.4.0-14.99.99');
+
+        self::assertInstanceOf(Typo3VersionRange::class, $range);
+        self::assertSame('13.4.0', $range->minimum);
+        self::assertSame('14.99.99', $range->maximum);
+        self::assertSame('13.4.0-14.99.99', (string) $range);
+    }
+
+    #[Test]
+    public function toleratesSurroundingWhitespace(): void
+    {
+        $range = Typo3VersionRange::fromConstraint('  13.4.0 - 14.99.99  ');
+
+        self::assertInstanceOf(Typo3VersionRange::class, $range);
+        self::assertSame('13.4.0', $range->minimum);
+    }
+
+    /**
+     * Null rather than a permissive fallback: "we could not read the constraint"
+     * and "every version is allowed" are different statements, and only the caller
+     * knows which finding to raise.
+     */
+    #[Test]
+    #[DataProvider('unusableConstraintProvider')]
+    public function refusesToGuessAtAnUnusableConstraint(string $constraint): void
+    {
+        self::assertNull(Typo3VersionRange::fromConstraint($constraint));
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function unusableConstraintProvider(): iterable
+    {
+        yield 'empty' => [''];
+        yield 'single version' => ['13.4.0'];
+        yield 'composer caret syntax' => ['^13.4'];
+        yield 'three parts' => ['13.4.0-14.0.0-15.0.0'];
+        yield 'missing lower bound' => ['-14.99.99'];
+        yield 'missing upper bound' => ['13.4.0-'];
+        yield 'reversed bounds' => ['14.99.99-13.4.0'];
+    }
+
+    #[Test]
+    #[DataProvider('containmentProvider')]
+    public function boundsAreInclusive(string $version, bool $expected): void
+    {
+        $range = Typo3VersionRange::fromConstraint('13.4.0-14.99.99');
+
+        self::assertInstanceOf(Typo3VersionRange::class, $range);
+        self::assertSame($expected, $range->contains($version));
+    }
+
+    /**
+     * @return iterable<string, array{string, bool}>
+     */
+    public static function containmentProvider(): iterable
+    {
+        yield 'lower bound' => ['13.4.0', true];
+        yield 'upper bound' => ['14.99.99', true];
+        yield 'inside' => ['14.3.2', true];
+        yield 'below' => ['13.3.9', false];
+        yield 'above' => ['15.0.0', false];
+        yield 'empty version' => ['', false];
+    }
+}

--- a/Tests/Unit/Service/Doctor/Check/VersionCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/VersionCheckTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
+
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\Check\VersionCheck;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\DoctorFindingTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Information\Typo3Version;
+
+/**
+ * A unit process has no package manager, so `ExtensionManagementUtility::extPath()`
+ * cannot resolve and `ext_emconf.php` is unreadable here. That is exactly the
+ * degraded path this test asserts: version metadata is the one area where being
+ * unable to look must warn rather than crash, because a `check.crashed` critical
+ * over unreadable provenance data would block a deployment for nothing.
+ *
+ * The happy path — real emconf, real core version, both controls passing — is
+ * covered by `Tests/Functional/Command/VaultDoctorCommandTest`, where a real
+ * bootstrap exists. The range comparison itself is covered exhaustively by
+ * {@see Typo3VersionRangeTest}.
+ */
+#[CoversClass(VersionCheck::class)]
+final class VersionCheckTest extends TestCase
+{
+    use DoctorFindingTrait;
+
+    #[Test]
+    public function appliesToBothProfiles(): void
+    {
+        $check = new VersionCheck(new Typo3Version());
+
+        self::assertTrue($check->appliesTo(SecurityProfile::Standard));
+        self::assertTrue($check->appliesTo(SecurityProfile::Hardened));
+    }
+
+    #[Test]
+    public function emitsBothVersionControls(): void
+    {
+        $findings = (new VersionCheck(new Typo3Version()))
+            ->run($this->doctorContext(SecurityProfile::Standard));
+
+        self::assertSame(
+            ['version.extension', 'version.typo3_supported'],
+            $this->findingIds($findings),
+        );
+    }
+
+    #[Test]
+    public function anUnreadableEmConfWarnsRatherThanCrashing(): void
+    {
+        $findings = (new VersionCheck(new Typo3Version()))
+            ->run($this->doctorContext(SecurityProfile::Hardened));
+
+        $this->assertFindingSeverity(FindingSeverity::Warning, $findings, 'version.extension');
+        $this->assertFindingSeverity(FindingSeverity::Warning, $findings, 'version.typo3_supported');
+    }
+
+    /**
+     * Even in the degraded path the running core version has to reach the report:
+     * it is the provenance line a reader of a three-month-old report needs.
+     */
+    #[Test]
+    public function theRunningCoreVersionIsReportedEvenWithoutEmConf(): void
+    {
+        $finding = $this->findingById(
+            (new VersionCheck(new Typo3Version()))->run($this->doctorContext(SecurityProfile::Standard)),
+            'version.typo3_supported',
+        );
+
+        self::assertSame((new Typo3Version())->getVersion(), $finding->details['typo3Version']);
+    }
+}

--- a/Tests/Unit/Service/Doctor/DoctorReportTest.php
+++ b/Tests/Unit/Service/Doctor/DoctorReportTest.php
@@ -1,0 +1,210 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service\Doctor;
+
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\DoctorReport;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+#[CoversClass(DoctorReport::class)]
+#[CoversClass(DoctorContext::class)]
+#[CoversClass(Finding::class)]
+final class DoctorReportTest extends TestCase
+{
+    /**
+     * The exit-code contract a CI gate is written against. Documented in
+     * Developer/Commands.rst; if this table changes, that document is wrong.
+     */
+    #[Test]
+    #[DataProvider('exitCodeProvider')]
+    public function exitCodeIsTheWorstSeverityPresent(FindingSeverity $worst, int $expected): void
+    {
+        $findings = [Finding::pass('a.ok', 'ok')];
+        if ($worst === FindingSeverity::Warning) {
+            $findings[] = Finding::warning('a.warn', 'meh', 'risk', 'fix');
+        }
+        if ($worst === FindingSeverity::Critical) {
+            $findings[] = Finding::warning('a.warn', 'meh', 'risk', 'fix');
+            $findings[] = Finding::critical('a.crit', 'broken', 'risk', 'fix');
+        }
+
+        $report = $this->report($findings);
+
+        self::assertSame($expected, $report->exitCode());
+        self::assertSame($worst, $report->highestSeverity());
+    }
+
+    /**
+     * @return iterable<string, array{FindingSeverity, int}>
+     */
+    public static function exitCodeProvider(): iterable
+    {
+        yield 'only passes' => [FindingSeverity::Pass, 0];
+        yield 'warnings' => [FindingSeverity::Warning, 1];
+        yield 'criticals' => [FindingSeverity::Critical, 2];
+    }
+
+    /**
+     * An empty report exits 0 by construction. The doctor service never produces
+     * one — every applicable check reports its passes too — but the aggregation
+     * must still be total rather than throwing on the edge.
+     */
+    #[Test]
+    public function anEmptyReportIsAuditReady(): void
+    {
+        $report = $this->report([]);
+
+        self::assertSame(0, $report->exitCode());
+        self::assertTrue($report->isAuditReady());
+        self::assertSame(0, $report->totalControls());
+    }
+
+    /**
+     * Criticals first: an operator scanning a long report must hit the blocking
+     * findings before the advisory ones, and passes must not pad the list.
+     */
+    #[Test]
+    public function problemsListCriticalsBeforeWarningsAndExcludePasses(): void
+    {
+        $report = $this->report([
+            Finding::warning('a.warn', 'meh', 'risk', 'fix'),
+            Finding::pass('a.ok', 'ok'),
+            Finding::critical('a.crit', 'broken', 'risk', 'fix'),
+            Finding::warning('b.warn', 'meh', 'risk', 'fix'),
+        ]);
+
+        self::assertSame(
+            ['a.crit', 'a.warn', 'b.warn'],
+            array_map(static fn (Finding $f): string => $f->id, $report->problems()),
+        );
+    }
+
+    #[Test]
+    public function countsSeparatePassesFromProblems(): void
+    {
+        $report = $this->report([
+            Finding::pass('a.ok', 'ok'),
+            Finding::pass('b.ok', 'ok'),
+            Finding::critical('a.crit', 'broken', 'risk', 'fix'),
+        ]);
+
+        self::assertSame(3, $report->totalControls());
+        self::assertSame(2, $report->passedControls());
+        self::assertFalse($report->isAuditReady());
+    }
+
+    /**
+     * The JSON shape is external API — CI gates and monitoring rules parse it.
+     */
+    #[Test]
+    public function theSerialisedFormCarriesTheContractFields(): void
+    {
+        $report = new DoctorReport(
+            context: new DoctorContext(
+                profile: SecurityProfile::Hardened,
+                configuredProfile: SecurityProfile::Standard,
+            ),
+            findings: [
+                Finding::pass('a.ok', 'fine'),
+                Finding::critical(
+                    id: 'audit.external_sink',
+                    summary: 'no sink',
+                    risk: 'no external evidence',
+                    remediation: 'enable a sink',
+                    docsUrl: 'https://example.org/docs',
+                    details: ['reasonCode' => 'NO_EXTERNAL_SINK'],
+                ),
+            ],
+        );
+
+        $payload = $report->toArray();
+
+        self::assertSame('hardened', $payload['profile']);
+        self::assertSame('standard', $payload['configuredProfile']);
+        self::assertTrue($payload['profileOverridden']);
+        self::assertFalse($payload['auditReady']);
+        self::assertSame('critical', $payload['highestSeverity']);
+        self::assertSame(2, $payload['exitCode']);
+        self::assertSame(['total' => 2, 'pass' => 1, 'warning' => 0, 'critical' => 1], $payload['summary']);
+
+        $sinkFinding = $payload['findings'][1];
+        self::assertSame('audit.external_sink', $sinkFinding['id']);
+        self::assertSame('critical', $sinkFinding['severity']);
+        self::assertSame('enable a sink', $sinkFinding['remediation']);
+        self::assertSame('https://example.org/docs', $sinkFinding['docsUrl']);
+        self::assertSame(['reasonCode' => 'NO_EXTERNAL_SINK'], $sinkFinding['details']);
+
+        // Passing controls stay in the payload so "N of M" needs no second source.
+        self::assertSame('a.ok', $payload['findings'][0]['id']);
+        self::assertSame('', $payload['findings'][0]['risk']);
+    }
+
+    /**
+     * Escalation keeps every text field, which is what makes a
+     * `--profile=hardened` dry run comparable to the live report.
+     */
+    #[Test]
+    public function escalatingAFindingPreservesItsWording(): void
+    {
+        $warning = Finding::warning(
+            id: 'audit.reads_logged',
+            summary: 'reads are not logged',
+            risk: 'no record of consumption',
+            remediation: 'enable auditReads',
+            docsUrl: 'https://example.org/docs',
+            details: ['auditReads' => false],
+        );
+
+        $critical = $warning->escalatedTo(FindingSeverity::Critical);
+
+        self::assertSame(FindingSeverity::Critical, $critical->severity);
+        self::assertSame($warning->id, $critical->id);
+        self::assertSame($warning->summary, $critical->summary);
+        self::assertSame($warning->risk, $critical->risk);
+        self::assertSame($warning->remediation, $critical->remediation);
+        self::assertSame($warning->docsUrl, $critical->docsUrl);
+        self::assertSame($warning->details, $critical->details);
+    }
+
+    #[Test]
+    public function escalatingToTheSameSeverityReturnsTheSameInstance(): void
+    {
+        $warning = Finding::warning('a.warn', 'meh', 'risk', 'fix');
+
+        self::assertSame($warning, $warning->escalatedTo(FindingSeverity::Warning));
+    }
+
+    #[Test]
+    public function aContextForTheConfiguredProfileIsNotOverridden(): void
+    {
+        $context = DoctorContext::forConfiguredProfile(SecurityProfile::Hardened);
+
+        self::assertFalse($context->isProfileOverridden());
+        self::assertTrue($context->isHardened());
+        self::assertSame(SecurityProfile::Hardened, $context->configuredProfile);
+    }
+
+    /**
+     * @param list<Finding> $findings
+     */
+    private function report(array $findings): DoctorReport
+    {
+        return new DoctorReport(
+            context: DoctorContext::forConfiguredProfile(SecurityProfile::Standard),
+            findings: $findings,
+        );
+    }
+}

--- a/Tests/Unit/Service/Doctor/VaultDoctorServiceTest.php
+++ b/Tests/Unit/Service/Doctor/VaultDoctorServiceTest.php
@@ -1,0 +1,227 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service\Doctor;
+
+use ArrayIterator;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Exception\ConfigurationException;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
+use Netresearch\NrVault\Service\Doctor\VaultDoctorService;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use RuntimeException;
+
+#[CoversClass(VaultDoctorService::class)]
+final class VaultDoctorServiceTest extends TestCase
+{
+    #[Test]
+    public function collectsFindingsFromEveryApplicableCheck(): void
+    {
+        $report = $this->service(
+            SecurityProfile::Standard,
+            $this->check('a', [Finding::pass('a.one', 'ok')]),
+            $this->check('b', [Finding::pass('b.one', 'ok'), Finding::pass('b.two', 'ok')]),
+        )->run();
+
+        self::assertSame(3, $report->totalControls());
+        self::assertSame(3, $report->passedControls());
+        self::assertSame(0, $report->exitCode());
+        self::assertTrue($report->isAuditReady());
+    }
+
+    /**
+     * A check that declares itself inapplicable must not be counted at all —
+     * neither as a pass nor in the denominator. Counting it as passed would
+     * inflate "N of M controls passed" with controls that were never evaluated.
+     */
+    #[Test]
+    public function skipsChecksThatDoNotApplyToTheTargetProfile(): void
+    {
+        $applicable = $this->check('a', [Finding::pass('a.one', 'ok')]);
+        $inapplicable = $this->check('b', [Finding::pass('b.one', 'ok')], appliesTo: false);
+
+        $report = $this->service(SecurityProfile::Standard, $applicable, $inapplicable)->run();
+
+        self::assertSame(1, $report->totalControls());
+        self::assertSame(['a.one'], array_column($report->toArray()['findings'], 'id'));
+    }
+
+    /**
+     * The load-bearing containment property: a crashing check must cost its own
+     * area, never the rest of the report — and it must be LOUDER than a failing
+     * check, because an operator reads silence as a pass.
+     */
+    #[Test]
+    public function aCrashingCheckBecomesACriticalFindingAndTheRunContinues(): void
+    {
+        $crashing = self::createStub(ReadinessCheckInterface::class);
+        $crashing->method('getId')->willReturn('exploding');
+        $crashing->method('appliesTo')->willReturn(true);
+        $crashing->method('run')->willThrowException(new RuntimeException('sink registry unreachable'));
+
+        $report = $this->service(
+            SecurityProfile::Standard,
+            $crashing,
+            $this->check('survivor', [Finding::pass('survivor.one', 'ok')]),
+        )->run();
+
+        self::assertSame(2, $report->totalControls());
+        self::assertSame(2, $report->exitCode());
+
+        $crash = $report->findingsOfSeverity(FindingSeverity::Critical)[0];
+        self::assertSame('check.crashed', $crash->id);
+        self::assertStringContainsString('exploding', $crash->summary);
+        self::assertStringContainsString('sink registry unreachable', $crash->summary);
+        self::assertSame('exploding', $crash->details['check']);
+
+        // The healthy check still reported.
+        self::assertCount(1, $report->findingsOfSeverity(FindingSeverity::Pass));
+    }
+
+    #[Test]
+    public function warningsOnlyAggregateToExitCodeOne(): void
+    {
+        $report = $this->service(
+            SecurityProfile::Standard,
+            $this->check('a', [
+                Finding::pass('a.one', 'ok'),
+                Finding::warning('a.two', 'meh', 'risk', 'fix'),
+            ]),
+        )->run();
+
+        self::assertSame(1, $report->exitCode());
+        self::assertSame(FindingSeverity::Warning, $report->highestSeverity());
+        self::assertFalse($report->isAuditReady());
+    }
+
+    /**
+     * Worst-severity-wins: a long list of passes must never average a critical
+     * finding away, or the gate becomes a scoreboard instead of a gate.
+     */
+    #[Test]
+    public function oneCriticalOutweighsAnyNumberOfPasses(): void
+    {
+        $findings = [Finding::critical('a.bad', 'broken', 'risk', 'fix')];
+        for ($i = 0; $i < 20; $i++) {
+            $findings[] = Finding::pass('a.ok' . $i, 'ok');
+        }
+
+        $report = $this->service(SecurityProfile::Standard, $this->check('a', $findings))->run();
+
+        self::assertSame(2, $report->exitCode());
+        self::assertSame(20, $report->passedControls());
+        self::assertSame(21, $report->totalControls());
+    }
+
+    #[Test]
+    public function withoutATargetProfileTheConfiguredProfileIsAsserted(): void
+    {
+        $report = $this->service(SecurityProfile::Hardened, $this->check('a', []))->run();
+
+        self::assertSame(SecurityProfile::Hardened, $report->context->profile);
+        self::assertFalse($report->context->isProfileOverridden());
+    }
+
+    /**
+     * `--profile=hardened` on a standard installation must change what is
+     * asserted while still reporting what is actually configured — otherwise a
+     * passing dry run reads as proof that hardening is already live.
+     */
+    #[Test]
+    public function anExplicitTargetProfileIsAssertedAndTheConfiguredOneIsRetained(): void
+    {
+        $report = $this->service(SecurityProfile::Standard, $this->check('a', []))
+            ->run(SecurityProfile::Hardened);
+
+        self::assertSame(SecurityProfile::Hardened, $report->context->profile);
+        self::assertSame(SecurityProfile::Standard, $report->context->configuredProfile);
+        self::assertTrue($report->context->isProfileOverridden());
+    }
+
+    /**
+     * An unknown profile string makes `getSecurityProfile()` throw. The run must
+     * still produce a report — the invalid value is itself reported by
+     * SecurityProfileCheck, and burying that under hardened-only findings would
+     * hide the actual problem.
+     */
+    #[Test]
+    public function anUnresolvableConfiguredProfileFallsBackToStandardWithoutCrashing(): void
+    {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('getSecurityProfile')
+            ->willThrowException(ConfigurationException::invalidSecurityProfile('paranoid'));
+
+        $service = new VaultDoctorService(
+            new ArrayIterator([$this->check('a', [Finding::pass('a.one', 'ok')])]),
+            $configuration,
+            new NullLogger(),
+        );
+
+        $report = $service->run();
+
+        self::assertSame(SecurityProfile::Standard, $report->context->profile);
+        self::assertSame(SecurityProfile::Standard, $report->context->configuredProfile);
+        self::assertSame(0, $report->exitCode());
+    }
+
+    /**
+     * Checks receive the target profile, not the configured one — that is what
+     * makes the `--profile` dry run meaningful.
+     */
+    #[Test]
+    public function checksAreAskedAboutTheTargetProfileNotTheConfiguredOne(): void
+    {
+        $check = $this->createMock(ReadinessCheckInterface::class);
+        $check->method('getId')->willReturn('a');
+        $check->expects(self::once())
+            ->method('appliesTo')
+            ->with(SecurityProfile::Hardened)
+            ->willReturn(true);
+        $check->method('run')->willReturnCallback(
+            static function (DoctorContext $context): array {
+                self::assertTrue($context->isHardened());
+                self::assertSame(SecurityProfile::Standard, $context->configuredProfile);
+
+                return [];
+            },
+        );
+
+        $this->service(SecurityProfile::Standard, $check)->run(SecurityProfile::Hardened);
+    }
+
+    private function service(
+        SecurityProfile $configuredProfile,
+        ReadinessCheckInterface ...$checks,
+    ): VaultDoctorService {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('getSecurityProfile')->willReturn($configuredProfile);
+
+        return new VaultDoctorService(new ArrayIterator($checks), $configuration, new NullLogger());
+    }
+
+    /**
+     * @param list<Finding> $findings
+     */
+    private function check(string $id, array $findings, bool $appliesTo = true): ReadinessCheckInterface
+    {
+        $check = self::createStub(ReadinessCheckInterface::class);
+        $check->method('getId')->willReturn($id);
+        $check->method('appliesTo')->willReturn($appliesTo);
+        $check->method('run')->willReturn($findings);
+
+        return $check;
+    }
+}

--- a/Tests/Unit/Traits/DoctorFindingTrait.php
+++ b/Tests/Unit/Traits/DoctorFindingTrait.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Traits;
+
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+
+/**
+ * Shared helpers for the `vault:doctor` readiness-check tests.
+ *
+ * Every check test needs the same three things — build a context, pull one
+ * finding out of the returned list by its stable id, and assert its severity —
+ * so they live here rather than being re-declared per test class (which is how a
+ * duplication gate ends up flagging eight near-identical private helpers).
+ */
+trait DoctorFindingTrait
+{
+    protected function doctorContext(SecurityProfile $profile): DoctorContext
+    {
+        return DoctorContext::forConfiguredProfile($profile);
+    }
+
+    /**
+     * A context asserting `$target` on an installation configured as
+     * `$configured` — the `vault:doctor --profile=…` dry run.
+     */
+    protected function doctorContextTargeting(
+        SecurityProfile $target,
+        SecurityProfile $configured,
+    ): DoctorContext {
+        return new DoctorContext(profile: $target, configuredProfile: $configured);
+    }
+
+    /**
+     * The finding with this id, failing the test when the check did not emit it.
+     *
+     * Failing rather than returning null is deliberate: a check that silently
+     * stops reporting a control is exactly the regression these tests exist to
+     * catch, and a null-safe lookup would let it pass as "no finding, no problem".
+     *
+     * @param list<Finding> $findings
+     */
+    protected function findingById(array $findings, string $id): Finding
+    {
+        foreach ($findings as $finding) {
+            if ($finding->id === $id) {
+                return $finding;
+            }
+        }
+
+        self::fail(\sprintf(
+            'No finding "%s" among [%s]',
+            $id,
+            implode(', ', $this->findingIds($findings)),
+        ));
+    }
+
+    /**
+     * @param list<Finding> $findings
+     *
+     * @return list<string>
+     */
+    protected function findingIds(array $findings): array
+    {
+        return array_map(static fn (Finding $finding): string => $finding->id, $findings);
+    }
+
+    /**
+     * @param list<Finding> $findings
+     */
+    protected function assertFindingSeverity(
+        FindingSeverity $expected,
+        array $findings,
+        string $id,
+    ): Finding {
+        $finding = $this->findingById($findings, $id);
+
+        self::assertSame(
+            $expected,
+            $finding->severity,
+            \sprintf('%s severity; summary was: %s', $id, $finding->summary),
+        );
+
+        // Anything above a pass has to tell the operator what it costs and what
+        // to do — a severity with no risk or remediation text is a dead end.
+        if ($expected !== FindingSeverity::Pass) {
+            self::assertNotSame('', $finding->risk, $id . ' must state the risk');
+            self::assertNotSame('', $finding->remediation, $id . ' must state a remediation');
+        }
+
+        return $finding;
+    }
+}

--- a/Tests/Unit/Traits/EnvironmentSandboxTrait.php
+++ b/Tests/Unit/Traits/EnvironmentSandboxTrait.php
@@ -26,6 +26,11 @@ use TYPO3\CMS\Core\Core\Environment;
  * cannot resolve a stream-wrapper URL, so a virtual filesystem would force the
  * production code to be loosened to suit the test.
  *
+ * It is also the only place allowed to call the `@internal`
+ * `Environment::initialize()` (see the scoped exemption in `phpstan.neon`), so
+ * anything a unit test needs from that singleton — including a specific
+ * application context — goes through here rather than into the test itself.
+ *
  * Usage: call `setUpEnvironmentSandbox()` from `setUp()` and
  * `tearDownEnvironmentSandbox()` from `tearDown()`.
  */
@@ -35,8 +40,12 @@ trait EnvironmentSandboxTrait
 
     /**
      * Create `<sandbox>/{public,var,config}` and point Environment at it.
+     *
+     * `$applicationContext` exists for the checks that branch on
+     * `Environment::getContext()->isProduction()`; the default keeps every other
+     * consumer on the context a test process should report.
      */
-    private function setUpEnvironmentSandbox(): void
+    private function setUpEnvironmentSandbox(string $applicationContext = 'Testing'): void
     {
         $this->environmentSandbox = sys_get_temp_dir() . '/nr-vault-env-' . bin2hex(random_bytes(6));
 
@@ -49,6 +58,24 @@ trait EnvironmentSandboxTrait
             $this->environmentSandbox . '/public',
             $this->environmentSandbox . '/var',
             $this->environmentSandbox . '/config',
+            $applicationContext,
+        );
+    }
+
+    /**
+     * Switch the application context of an existing sandbox.
+     *
+     * For tests that need to observe both sides of an `isProduction()` branch
+     * without standing up a second sandbox directory.
+     */
+    private function setEnvironmentApplicationContext(string $applicationContext): void
+    {
+        $this->initializeEnvironment(
+            $this->environmentSandbox,
+            $this->environmentSandbox . '/public',
+            $this->environmentSandbox . '/var',
+            $this->environmentSandbox . '/config',
+            $applicationContext,
         );
     }
 
@@ -64,7 +91,7 @@ trait EnvironmentSandboxTrait
         $this->environmentSandbox = '';
 
         $fallback = sys_get_temp_dir();
-        $this->initializeEnvironment($fallback, $fallback, $fallback, $fallback);
+        $this->initializeEnvironment($fallback, $fallback, $fallback, $fallback, 'Testing');
     }
 
     /**
@@ -80,9 +107,10 @@ trait EnvironmentSandboxTrait
         string $publicPath,
         string $varPath,
         string $configPath,
+        string $applicationContext,
     ): void {
         Environment::initialize(
-            new ApplicationContext('Testing'),
+            new ApplicationContext($applicationContext),
             true,
             true,
             $projectPath,


### PR DESCRIPTION
## Summary

P1 item (roadmap PR 6): `vault:doctor` — a single readiness check over the whole security posture, with exit codes an auditor or CI/CD pipeline can gate on, plus a backend security-status view. Stacked on the PR1–PR5 integration (needs the profile, permissions, break-glass and audit-sink features it inspects).

- **`Classes/Service/Doctor/`**: one class per check (provider explicitness/availability/key-file permissions, profile consistency, break-glass window, audit reads/retention/chain/external-sink/anchor, CLI exposure, secret expiry & rotation hygiene, production-context/HTTPS, version sanity). Each declares which profiles it applies to; `VaultDoctorService` contains a crashing check as a `check.crashed` critical finding rather than failing the run.
- Typed **`Finding`** (id, severity, summary, risk, remediation, docs link) → machine-readable, actionable.
- **`vault:doctor --profile=hardened --format=text|json`**, exit **0** (only passes / audit-ready), **1** (warnings), **2** (any critical). `--profile` overrides the target so an operator can ask "would this pass as hardened?" without changing config — a deployment gate.
- Backend overview: profile badge + "N/M controls passed" for any vault user; detailed findings with remediation + doc links gated behind `vault.configure`.

## Test plan
- `composer ci` exit 0, Rector clean, full functional suite green locally (232 tests, sqlite). Unit tests per check (pass/fail/profile-applicability), service crash-containment + exit-code aggregation, command JSON stability + exit-code scenarios, functional test: hardened + file provider + no external sink → exit 2.
- Live `vault:doctor` needs a configured DB (not available in the bare worktree); exercised via the functional suite instead.

## Dependencies & merge order

Diamond dependency: needs both #241 (break-glass) and #240 (audit sinks), which both build on #237. Diff is shown against `feature/break-glass`; the audit-sink commits appear as already-merged context. **Merge after** #236–#241. This is the branch the PR8 docs (#243) describe as `vault:doctor`; the two can land together.

Roadmap: PR 6 of 10.
