### PR TITLE
Stop claiming automated secret scanning that does not run

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,7 +177,7 @@ vault:seed-demo            # Seed demo secrets + audit history (development only
 - Rotating / regenerating cryptographic keys in fixtures.
 
 ### Never Do
-- Commit secrets, credentials, or real master keys (test fixtures only — allowlisted in `.gitleaks.toml`).
+- Commit secrets, credentials, or real master keys (test fixtures only — synthetic values, reviewed by hand; `.gitleaks.toml` is present but not enforced by any CI job).
 - Commit `composer.lock` (extension, not application).
 - Push directly to `main` — open a PR.
 - Merge a PR before all review threads are resolved.

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -84,7 +84,7 @@ Tests/
 - Functional fixtures: `Tests/.../Fixtures/*.csv`, loaded via `$this->importCSVDataSet()`.
 
 ## Security
-- **Never commit real secrets** — fixtures use clearly synthetic values. `.gitleaks.toml` allowlists only a narrow set of specific paths (see the `[allowlist] paths` list) for known synthetic tokens; new files are scanned by default.
+- **Never commit real secrets** — fixtures use clearly synthetic values. `.gitleaks.toml` exists at the repository root, but **no CI job runs gitleaks** (or any other secret scanner), so there is no automated scanning: treat every fixture as unscanned and review it by hand before committing.
 - **Master keys in tests** are generated per-test (`sodium_crypto_secretbox_keygen()`), never hard-coded.
 - **Do not** test against production vault backends.
 - **Audit logs** in tests must still verify HMAC chain integrity when the code path produces entries.


### PR DESCRIPTION
## Summary

Both `AGENTS.md` files implied `.gitleaks.toml` scans commits — `Tests/AGENTS.md` stated outright "new files are scanned by default". Verified against the reusable workflows and this repo's `.github/`: **no CI job runs gitleaks or any other secret scanner**; the file sits at the repository root unexecuted (Opengrep, the one SAST job, runs `--config auto` registry rules, not gitleaks).

In a secrets-management extension this false claim is load-bearing on **behaviour**, not just credibility: an agent adding fixtures may relax its own care trusting a scan that never happens. The fix states the truth — no automated scanning, review fixtures by hand.

Two-line accuracy correction, no behaviour/CI change. Surfaced during the security-hardening review (the same false-control-claim class as two auditor-doc rows already corrected in the docs PR).

## Related decision (separate, not in this PR)

Whether to **add** real scanning (wire `semgrep.yml` additively via `--config auto --config semgrep.yml`, and add a gitleaks job) or **delete** the inert `semgrep.yml` + `.gitleaks.toml` is a CI-config decision left to the maintainer. This PR only stops the docs from asserting a control that isn't enforced — true under either outcome.

## Test plan

Documentation-only (AGENTS.md + their CLAUDE.md/GEMINI.md symlinks). No code or CI change.