### PR TITLE
ci: sync with netresearch/.github templates/typo3-extension

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,6 +22,20 @@ jobs:
       contents: read
       security-events: write
 
+  gitleaks:
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
+    permissions:
+      contents: read
+      security-events: write
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+  zizmor:
+    uses: netresearch/.github/.github/workflows/zizmor.yml@main
+    permissions:
+      contents: read
+      security-events: write
+
   fuzz:
     uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,13 @@ on:
 permissions:
   contents: read
 
-# Per-extension test matrix (intentional-drift). Security/quality jobs are in checks.yml.
+# This workflow runs the extension's own test matrix and is the ONE per-extension
+# CI value: its `with:` block (php-versions, typo3-versions, matrix-exclude,
+# run-functional-tests, db settings, remove-dev-deps, coverage, …) differs per
+# extension. It is therefore listed under intentional-drift in
+# .github/template.yaml — customise it freely here. The security/quality jobs
+# with elevated permissions are drift-enforced in checks.yml; do not duplicate
+# them here.
 jobs:
   ci:
     uses: netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main
@@ -19,10 +25,8 @@ jobs:
       contents: read
     with:
       php-versions: '["8.2","8.3","8.4","8.5"]'
-      typo3-versions: '["^13.4","^14.3"]'
-      run-functional-tests: true
-      upload-coverage: true
-      coverage-tool: 'xdebug'
-      php-extensions: 'intl, mbstring, xml, sodium, json'
+      typo3-versions: '["^12.4","^13.4","^14.3"]'
+      # TYPO3 12.4 supports PHP <= 8.4 (drop the 8.5 x ^12.4 combo).
+      matrix-exclude: '[{"php":"8.5","typo3":"^12.4"}]'
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
 
 permissions: {}
 
+# The `with:` block (archive-prefix / package-name / extension-key) is
+# per-extension, so this file is listed under intentional-drift in
+# .github/template.yaml — set this repo's real values here.
 jobs:
   release:
     uses: netresearch/typo3-ci-workflows/.github/workflows/release-typo3-extension.yml@main
@@ -15,8 +18,8 @@ jobs:
       id-token: write
       attestations: write
     with:
-      archive-prefix: 'nr-vault'
-      package-name: 'netresearch/nr-vault'
-      extension-key: 'nr_vault'
+      archive-prefix: my-extension
+      package-name: netresearch/my-extension
+      extension-key: my_extension
     secrets:
       TYPO3_TER_ACCESS_TOKEN: ${{ secrets.TYPO3_TER_ACCESS_TOKEN }}


### PR DESCRIPTION
Auto-opened by sync-template.sh. Brings this repo back into alignment with the canonical `typo3-extension` template in `netresearch/.github`.

To keep any diverging files, add their paths to `.github/template.yaml`'s `intentional-drift:` list before merging — otherwise the next sync run will revert them.