### PR TITLE
Activate betterleaks and zizmor from the updated template

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,6 +22,20 @@ jobs:
       contents: read
       security-events: write
 
+  gitleaks:
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
+    permissions:
+      contents: read
+      security-events: write
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+  zizmor:
+    uses: netresearch/.github/.github/workflows/zizmor.yml@main
+    permissions:
+      contents: read
+      security-events: write
+
   fuzz:
     uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
     permissions:


### PR DESCRIPTION
Sync `checks.yml` with the updated `netresearch/.github` typo3-extension template ([#327](https://github.com/netresearch/.github/pull/327)): adds the **gitleaks** (secret scanning / betterleaks) and **zizmor** (GitHub Actions workflow SAST) jobs so both run on nr-vault now rather than at the next template sync. Also clears the template-drift the #327 change would otherwise flag.

Only `checks.yml` changes — the intentional-drift `ci.yml` / `release.yml` are untouched. Both scanners are report-only (SARIF → code scanning), minimal permissions (`contents: read` + `security-events: write`).