### PR TITLE
Remove the plaintext secret cache from VaultService

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,7 +116,6 @@ VaultServiceInterface::delete(string $identifier, string $reason = ''): void
 VaultServiceInterface::rotate(string $identifier, string $newSecret, string $reason = ''): void
 VaultServiceInterface::list(?string $pattern = null): array
 VaultServiceInterface::getMetadata(string $identifier): SecretDetails
-VaultServiceInterface::clearCache(): void
 VaultServiceInterface::http(): VaultHttpClientInterface
 
 // Encryption — Classes/Crypto/EncryptionServiceInterface.php

--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -889,7 +889,7 @@ parameters:
 		-
 			rawMessage: 'You should use assertSame() instead of assertEquals(), because both values are scalars of the same type'
 			identifier: phpunit.assertEquals
-			count: 14
+			count: 13
 			path: ../Tests/Functional/Service/VaultServiceTest.php
 
 		-

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -35,8 +35,6 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
 
     public const DEFAULT_ALLOW_CLI_ACCESS = false;
 
-    public const DEFAULT_CACHE_ENABLED = true;
-
     public const DEFAULT_AUDIT_READS = true;
 
     public const DEFAULT_DISABLE_ADMIN_OVERRIDE = false;
@@ -197,14 +195,6 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
         }
 
         return [];
-    }
-
-    /**
-     * Check if request-scoped caching is enabled.
-     */
-    public function isCacheEnabled(): bool
-    {
-        return (bool) ($this->configuration['cacheEnabled'] ?? self::DEFAULT_CACHE_ENABLED);
     }
 
     /**

--- a/Classes/Configuration/ExtensionConfigurationInterface.php
+++ b/Classes/Configuration/ExtensionConfigurationInterface.php
@@ -61,11 +61,6 @@ interface ExtensionConfigurationInterface
     public function getCliAccessGroups(): array;
 
     /**
-     * Check if request-scoped caching is enabled.
-     */
-    public function isCacheEnabled(): bool;
-
-    /**
      * Check if read operations should be written to the audit log.
      */
     public function isAuditReadsEnabled(): bool;

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -48,17 +48,17 @@ use TYPO3\CMS\Core\SingletonInterface;
 /**
  * Main vault service implementation.
  */
-final class VaultService implements VaultServiceInterface, SingletonInterface
+final readonly class VaultService implements VaultServiceInterface, SingletonInterface
 {
     public function __construct(
-        private readonly VaultAdapterInterface $adapter,
-        private readonly EncryptionServiceInterface $encryptionService,
-        private readonly AccessControlServiceInterface $accessControlService,
-        private readonly AuditLogServiceInterface $auditLogService,
-        private readonly ExtensionConfigurationInterface $configuration,
-        private readonly VaultHttpClientFactoryInterface $httpClientFactory,
-        private readonly ?EventDispatcherInterface $eventDispatcher = null,
-        private readonly ?LoggerInterface $logger = null,
+        private VaultAdapterInterface $adapter,
+        private EncryptionServiceInterface $encryptionService,
+        private AccessControlServiceInterface $accessControlService,
+        private AuditLogServiceInterface $auditLogService,
+        private ExtensionConfigurationInterface $configuration,
+        private VaultHttpClientFactoryInterface $httpClientFactory,
+        private ?EventDispatcherInterface $eventDispatcher = null,
+        private ?LoggerInterface $logger = null,
     ) {}
 
     /**

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -50,9 +50,6 @@ use TYPO3\CMS\Core\SingletonInterface;
  */
 final class VaultService implements VaultServiceInterface, SingletonInterface
 {
-    /** @var array<string, string> Request-scoped cache */
-    private array $cache = [];
-
     public function __construct(
         private readonly VaultAdapterInterface $adapter,
         private readonly EncryptionServiceInterface $encryptionService,
@@ -63,11 +60,6 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
         private readonly ?EventDispatcherInterface $eventDispatcher = null,
         private readonly ?LoggerInterface $logger = null,
     ) {}
-
-    public function __destruct()
-    {
-        $this->clearCache();
-    }
 
     /**
      * @param array<string, mixed> $options
@@ -128,8 +120,6 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             }
 
             $this->dispatchStoreEvent($identifier, $secretEntity, !$existing instanceof Secret);
-
-            unset($this->cache[$identifier]);
         } finally {
             // Securely wipe the plaintext even if an exception occurred
             sodium_memzero($secret);
@@ -224,9 +214,6 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             $this->accessControlService->getCurrentActorUid(),
             $reason,
         ));
-
-        // Clear cache
-        unset($this->cache[$identifier]);
     }
 
     public function rotate(string $identifier, #[SensitiveParameter] string $newSecret, string $reason = ''): void
@@ -295,9 +282,6 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
                 $this->accessControlService->getCurrentActorUid(),
                 $reason,
             ));
-
-            // Clear cache
-            unset($this->cache[$identifier]);
         } finally {
             // Securely wipe the plaintext even if an exception occurred
             sodium_memzero($newSecret);
@@ -357,19 +341,6 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
     }
 
     /**
-     * Clear the request-scoped cache.
-     */
-    public function clearCache(): void
-    {
-        // Securely wipe cached values via reference to avoid copy-on-write
-        foreach ($this->cache as &$value) {
-            sodium_memzero($value);
-        }
-        unset($value);
-        $this->cache = [];
-    }
-
-    /**
      * The single read path shared by `retrieve()` and `retrieveForFrontend()`.
      *
      * `$enforceSecretUse` toggles ONLY the interactive-backend-user operation
@@ -382,11 +353,6 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
      */
     private function doRetrieve(string $identifier, bool $enforceSecretUse): ?string
     {
-        // Check request-scoped cache
-        if ($this->configuration->isCacheEnabled() && isset($this->cache[$identifier])) {
-            return $this->cache[$identifier];
-        }
-
         $secret = $this->adapter->retrieve($identifier);
         if (!$secret instanceof Secret) {
             return null;
@@ -444,11 +410,6 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             $this->accessControlService->getCurrentActorUid(),
             $secret->getContext(),
         ));
-
-        // Cache for this request
-        if ($this->configuration->isCacheEnabled()) {
-            $this->cache[$identifier] = $plaintext;
-        }
 
         return $plaintext;
     }
@@ -529,16 +490,12 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
                 ],
             );
 
-            unset($this->cache[$identifier]);
-
             throw new AuditWriteException(
                 $auditException->getMessage(),
                 $auditException->getCode(),
                 $revertFailure,
             );
         }
-
-        unset($this->cache[$identifier]);
 
         throw $auditException;
     }

--- a/Classes/Service/VaultServiceInterface.php
+++ b/Classes/Service/VaultServiceInterface.php
@@ -113,13 +113,6 @@ interface VaultServiceInterface
     public function getMetadata(string $identifier): SecretDetails;
 
     /**
-     * Clear the request-scoped cache of decrypted secrets.
-     *
-     * Securely wipes cached plaintext values from memory.
-     */
-    public function clearCache(): void;
-
-    /**
      * Get the Vault HTTP Client for making authenticated API calls.
      *
      * Returns a PSR-18 compatible client. Use withAuthentication() to configure

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -265,15 +265,6 @@ Configure nr-vault in :guilabel:`Admin Tools > Settings > Extension Configuratio
    Prefer XChaCha20-Poly1305 over AES-256-GCM. XChaCha20 is recommended
    when hardware AES acceleration is not available.
 
-.. confval:: cacheEnabled
-   :name: ext-nrvault-cacheEnabled
-   :type: boolean
-   :Default: true
-
-   Enable request-scoped caching of decrypted secrets. When enabled,
-   repeated retrievals of the same secret within a single request
-   return the cached value instead of decrypting again.
-
 .. _configuration-audit-sinks:
 
 External audit sinks

--- a/Documentation/Developer/Api.rst
+++ b/Documentation/Developer/Api.rst
@@ -90,11 +90,6 @@ The main service for interacting with the vault.
       :throws SecretNotFoundException: If secret doesn't exist.
       :throws AccessDeniedException: If user lacks permission.
 
-   .. php:method:: clearCache(): void
-
-      Clear the request-scoped cache of decrypted secrets, securely
-      wiping cached plaintext from memory.
-
    .. php:method:: http(): VaultHttpClientInterface
 
       Get an HTTP client that can inject secrets into requests.

--- a/Tests/Functional/Command/VaultRotateCommandTest.php
+++ b/Tests/Functional/Command/VaultRotateCommandTest.php
@@ -53,7 +53,6 @@ final class VaultRotateCommandTest extends AbstractVaultFunctionalTestCase
             self::assertSame(0, $exitCode, $tester->getDisplay());
 
             // Verify the secret was updated
-            $vaultService->clearCache();
             $retrieved = $vaultService->retrieve($identifier);
             self::assertSame('rotated-value', $retrieved);
         } finally {

--- a/Tests/Functional/Crypto/MasterKeyRotationAbortTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationAbortTest.php
@@ -281,7 +281,6 @@ final class MasterKeyRotationAbortTest extends AbstractVaultFunctionalTestCase
     {
         FileMasterKeyProvider::clearCachedKey();
         $vaultService = $this->get(VaultServiceInterface::class);
-        $vaultService->clearCache();
 
         foreach ($seeded as $identifier => $expected) {
             if ($identifier === $sabotaged) {

--- a/Tests/Functional/Crypto/MasterKeyRotationTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationTest.php
@@ -476,7 +476,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         file_put_contents($key1Path, sodium_crypto_secretbox_keygen());
 
         $this->runRotationCommand($commandTester, $key1Path);
-        $this->switchMasterKeyFile($key1Path, $vaultService);
+        $this->switchMasterKeyFile($key1Path);
 
         foreach ($secrets as $identifier => $expectedValue) {
             self::assertSame(
@@ -496,7 +496,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         file_put_contents($key2Path, sodium_crypto_secretbox_keygen());
 
         $this->runRotationCommand($commandTester, $key2Path);
-        $this->switchMasterKeyFile($key2Path, $vaultService);
+        $this->switchMasterKeyFile($key2Path);
 
         foreach ($secrets as $identifier => $expectedValue) {
             self::assertSame(
@@ -547,9 +547,9 @@ final class MasterKeyRotationTest extends FunctionalTestCase
 
     /**
      * Make the rotated key the configured one, as the operator does after
-     * the command: replace the key file and drop all caches.
+     * the command: replace the key file and drop the cached key.
      */
-    private function switchMasterKeyFile(string $newKeyPath, VaultServiceInterface $vaultService): void
+    private function switchMasterKeyFile(string $newKeyPath): void
     {
         self::assertIsString($this->masterKeyPath);
         copy($newKeyPath, $this->masterKeyPath);

--- a/Tests/Functional/Crypto/MasterKeyRotationTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationTest.php
@@ -149,7 +149,6 @@ final class MasterKeyRotationTest extends FunctionalTestCase
 
         // Clear cached keys so the provider re-reads from disk
         FileMasterKeyProvider::clearCachedKey();
-        $vaultService->clearCache();
 
         // Verify all secrets are still retrievable with the new key
         foreach ($secrets as $identifier => $expectedValue) {
@@ -208,7 +207,6 @@ final class MasterKeyRotationTest extends FunctionalTestCase
 
         // Clear caches and verify both secrets are still accessible with the original key
         FileMasterKeyProvider::clearCachedKey();
-        $vaultService->clearCache();
 
         $retrieved1 = $vaultService->retrieve($identifier1);
         self::assertSame('secret-1', $retrieved1, 'First secret must remain accessible after failed rotation');
@@ -291,7 +289,6 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         // Switch to new key and verify retrieval works
         copy($newKeyPath, $this->masterKeyPath);
         FileMasterKeyProvider::clearCachedKey();
-        $vaultService->clearCache();
 
         foreach ($identifiers as $i => $identifier) {
             $retrieved = $vaultService->retrieve($identifier);
@@ -414,7 +411,6 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         // with the original key. A mix (some under new, some under old) is
         // a failure of atomicity.
         FileMasterKeyProvider::clearCachedKey();
-        $vaultService->clearCache();
 
         foreach ($seeded as $identifier => $expectedValue) {
             $retrieved = $vaultService->retrieve($identifier);
@@ -558,7 +554,6 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         self::assertIsString($this->masterKeyPath);
         copy($newKeyPath, $this->masterKeyPath);
         FileMasterKeyProvider::clearCachedKey();
-        $vaultService->clearCache();
     }
 
     /**

--- a/Tests/Functional/Crypto/WrongMasterKeyRestoreTest.php
+++ b/Tests/Functional/Crypto/WrongMasterKeyRestoreTest.php
@@ -213,7 +213,6 @@ final class WrongMasterKeyRestoreTest extends AbstractVaultFunctionalTestCase
         chmod($this->masterKeyPath, 0o600);
 
         FileMasterKeyProvider::clearCachedKey();
-        $this->get(VaultServiceInterface::class)->clearCache();
     }
 
     /**

--- a/Tests/Functional/Hook/DataHandlerHookTest.php
+++ b/Tests/Functional/Hook/DataHandlerHookTest.php
@@ -109,7 +109,6 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
             $dataHandler = $this->createDataHandler();
             $hook->processDatamap_afterDatabaseOperations('update', 'tx_test', 99, $fieldArray, $dataHandler);
 
-            $vaultService->clearCache();
             $retrieved = $vaultService->retrieve($vaultIdentifier);
             self::assertSame($newValue, $retrieved, 'Vault must contain rotated secret value');
         } finally {
@@ -149,7 +148,6 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
 
             $hook->processDatamap_afterDatabaseOperations('update', 'tx_test', 99, $fieldArray, $this->createDataHandler());
 
-            $vaultService->clearCache();
             $retrieved = $vaultService->retrieve($vaultIdentifier);
             self::assertSame($originalValue, $retrieved, 'Vault secret must survive an untouched save (issue #223)');
         } finally {
@@ -229,7 +227,6 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
 
             $hook->processDatamap_afterDatabaseOperations('update', 'tx_test', 99, $fieldArray, $dataHandler);
 
-            $vaultService->clearCache();
             self::assertSame(
                 $originalValue,
                 $vaultService->retrieve($vaultIdentifier),
@@ -276,7 +273,6 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
 
             $hook->processDatamap_afterDatabaseOperations('update', 'tx_test', 99, $fieldArray, $dataHandler);
 
-            $vaultService->clearCache();
             self::assertSame(
                 $newValue,
                 $vaultService->retrieve($vaultIdentifier),
@@ -336,7 +332,6 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
         $hook->processCmdmap_preProcess('delete', 'tx_nrvault_hooktest2', $recordUid, null, $dataHandler, false);
 
         // Secret must be deleted
-        $vaultService->clearCache();
         $retrieved = $vaultService->retrieve($vaultIdentifier);
         self::assertNull($retrieved, 'Vault secret must be deleted when its record is deleted');
     }

--- a/Tests/Functional/Hook/FlexFormVaultHookTest.php
+++ b/Tests/Functional/Hook/FlexFormVaultHookTest.php
@@ -96,7 +96,6 @@ final class FlexFormVaultHookTest extends AbstractVaultFunctionalTestCase
             $dataHandler->substNEWwithIDs['NEW1'] = 4711;
             $hook->processDatamap_afterDatabaseOperations('new', 'tt_content', 'NEW1', $fieldArray, $dataHandler);
 
-            $vaultService->clearCache();
             self::assertSame(
                 $secretValue,
                 $vaultService->retrieve($vaultIdentifier),

--- a/Tests/Functional/Service/Fixtures/cross_actor_users.csv
+++ b/Tests/Functional/Service/Fixtures/cross_actor_users.csv
@@ -1,0 +1,4 @@
+"be_users",,,,,,,,
+,"uid","pid","tstamp","username","password","admin","disable","usergroup"
+,10,0,1700000000,"tech_owner","",0,0,""
+,13,0,1700000000,"tech_other","",0,0,""

--- a/Tests/Functional/Service/VaultServiceCrossActorTest.php
+++ b/Tests/Functional/Service/VaultServiceCrossActorTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Service;
+
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Exception\AccessDeniedException;
+use Netresearch\NrVault\Security\TechnicalActorContextInterface;
+use Netresearch\NrVault\Service\VaultService;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Throwable;
+
+/**
+ * Cross-actor isolation of the read path inside ONE long-running process.
+ *
+ * The scenario is a Symfony Messenger / Scheduler worker: the shared
+ * VaultService singleton serves several technical-actor scopes in sequence.
+ * A plaintext read performed for actor A must never leak to a later actor B —
+ * every retrieve() has to re-run the per-secret ACL, the expiry check and the
+ * audit trail against the CURRENT actor. (Regression test for the plaintext
+ * request cache that short-circuited all of these before any check ran.)
+ *
+ * Fixture: be_users 10 `tech_owner` and 13 `tech_other`, both enabled,
+ * root-level, without any group that could widen access.
+ */
+#[CoversClass(VaultService::class)]
+final class VaultServiceCrossActorTest extends AbstractVaultFunctionalTestCase
+{
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/cross_actor_users.csv';
+
+    /** No ambient backend user: headless-worker reality. */
+    protected ?int $backendUserUid = null;
+
+    #[Test]
+    public function actorWithoutPermissionIsDeniedAfterAnotherActorReadTheSecret(): void
+    {
+        $vault = $this->get(VaultServiceInterface::class);
+        $context = $this->get(TechnicalActorContextInterface::class);
+
+        // Actor A creates and reads its own secret: the plaintext passes
+        // through the shared service instance.
+        $context->runAs(10, static function () use ($vault): void {
+            $vault->store('cross_actor_owned', 'owner-only-value');
+            self::assertSame('owner-only-value', $vault->retrieve('cross_actor_owned'));
+        });
+
+        // Actor B follows in the SAME process on the SAME service instance.
+        // B is neither owner nor group member, so the read must be denied —
+        // never satisfied from anything actor A's read left behind.
+        // (Caught as Throwable and narrowed by assertion: PHPStan cannot see
+        // through runAs()'s callable indirection that retrieve() throws.)
+        $denied = null;
+
+        try {
+            $context->runAs(13, static fn (): ?string => $vault->retrieve('cross_actor_owned'));
+        } catch (Throwable $throwable) {
+            $denied = $throwable;
+        }
+
+        self::assertInstanceOf(
+            AccessDeniedException::class,
+            $denied,
+            'actor 13 must not read actor 10\'s secret',
+        );
+
+        // The denial is attributed to actor B in the audit trail.
+        $auditLog = $this->get(AuditLogServiceInterface::class);
+        $deniedEntries = array_values(array_filter(
+            $auditLog->query(),
+            static fn ($entry): bool => $entry->action === 'access_denied'
+                && $entry->secretIdentifier === 'cross_actor_owned',
+        ));
+
+        self::assertCount(1, $deniedEntries);
+        self::assertSame(13, $deniedEntries[0]->actorUid);
+    }
+
+    #[Test]
+    public function everyRetrieveWritesItsOwnReadAuditEntry(): void
+    {
+        $vault = $this->get(VaultServiceInterface::class);
+        $context = $this->get(TechnicalActorContextInterface::class);
+
+        $context->runAs(10, static function () use ($vault): void {
+            $vault->store('cross_actor_audited', 'audited-value');
+            $vault->retrieve('cross_actor_audited');
+            $vault->retrieve('cross_actor_audited');
+        });
+
+        // Two reads => two read audit entries. A plaintext cache would have
+        // collapsed the second read into a silent, unaudited hit.
+        $auditLog = $this->get(AuditLogServiceInterface::class);
+        $readEntries = array_values(array_filter(
+            $auditLog->query(),
+            static fn ($entry): bool => $entry->action === 'read'
+                && $entry->success
+                && $entry->secretIdentifier === 'cross_actor_audited',
+        ));
+
+        self::assertCount(2, $readEntries);
+    }
+}

--- a/Tests/Functional/Service/VaultServiceTest.php
+++ b/Tests/Functional/Service/VaultServiceTest.php
@@ -9,6 +9,9 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Functional\Service;
 
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Audit\AuditLogFilter;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Service\VaultService;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -238,11 +241,21 @@ final class VaultServiceTest extends FunctionalTestCase
         $subject = $this->getSubject();
         $subject->store($identifier, $secretValue);
 
-        // No plaintext cache exists: every retrieve() decrypts from the
-        // database, so repeated reads in one process stay consistent with
-        // the stored record.
+        // No plaintext cache exists: every retrieve() re-runs the full read
+        // path against the database.
         self::assertSame($secretValue, $subject->retrieve($identifier));
         self::assertSame($secretValue, $subject->retrieve($identifier));
+
+        // The distinguishing side effect: two reads produce two read audit
+        // entries. A cache would have collapsed the second read into a
+        // silent, unaudited hit (value equality alone cannot tell the two
+        // apart).
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $readEntries = array_filter(
+            $auditService->query(AuditLogFilter::forSecret($identifier)),
+            static fn (AuditLogEntry $entry): bool => $entry->action === 'read' && $entry->success,
+        );
+        self::assertCount(2, $readEntries, 'each retrieve() must write its own read audit entry');
     }
 
     private function getSubject(): VaultServiceInterface

--- a/Tests/Functional/Service/VaultServiceTest.php
+++ b/Tests/Functional/Service/VaultServiceTest.php
@@ -55,7 +55,6 @@ final class VaultServiceTest extends FunctionalTestCase
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_vault'] = [
             'masterKeySource' => $this->masterKeyPath,
             'autoKeyPath' => $this->masterKeyPath,
-            'enableCache' => false,
         ];
 
         // Import backend user for access control
@@ -231,22 +230,19 @@ final class VaultServiceTest extends FunctionalTestCase
     }
 
     #[Test]
-    public function clearCacheDoesNotAffectStoredSecrets(): void
+    public function repeatedRetrieveAlwaysDecryptsFromTheDatabase(): void
     {
-        $identifier = 'cache_test';
-        $secretValue = 'cache-test-value';
+        $identifier = 'no_cache_test';
+        $secretValue = 'no-cache-test-value';
 
         $subject = $this->getSubject();
         $subject->store($identifier, $secretValue);
 
-        // clearCache is implementation detail - only available on VaultService
-        if ($subject instanceof VaultService) {
-            $subject->clearCache();
-        }
-
-        // Should still be retrievable from database
-        $retrieved = $subject->retrieve($identifier);
-        self::assertEquals($secretValue, $retrieved);
+        // No plaintext cache exists: every retrieve() decrypts from the
+        // database, so repeated reads in one process stay consistent with
+        // the stored record.
+        self::assertSame($secretValue, $subject->retrieve($identifier));
+        self::assertSame($secretValue, $subject->retrieve($identifier));
     }
 
     private function getSubject(): VaultServiceInterface

--- a/Tests/Functional/Task/OrphanCleanupTaskTest.php
+++ b/Tests/Functional/Task/OrphanCleanupTaskTest.php
@@ -93,7 +93,6 @@ final class OrphanCleanupTaskTest extends AbstractVaultFunctionalTestCase
         self::assertTrue($result, $result ? 'ok' : 'Task execution failed');
 
         // The orphan should be deleted
-        $vaultService->clearCache();
         $retrieved = $vaultService->retrieve($identifier);
         self::assertNull($retrieved, 'Orphaned secret must be deleted after cleanup task runs');
     }
@@ -114,7 +113,6 @@ final class OrphanCleanupTaskTest extends AbstractVaultFunctionalTestCase
         $task->execute();
 
         // Non-TCA secrets must not be deleted
-        $vaultService->clearCache();
         $retrieved = $vaultService->retrieve($identifier);
         self::assertSame('nonorphan_value', $retrieved, 'Non-orphaned secrets must not be deleted');
 
@@ -146,7 +144,6 @@ final class OrphanCleanupTaskTest extends AbstractVaultFunctionalTestCase
         $task->execute();
 
         // Secret must still exist (within retention period)
-        $vaultService->clearCache();
         $retrieved = $vaultService->retrieve($identifier);
         self::assertSame(
             'freshorphan_value',

--- a/Tests/Unit/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/Configuration/ExtensionConfigurationTest.php
@@ -182,30 +182,6 @@ final class ExtensionConfigurationTest extends TestCase
     }
 
     #[Test]
-    public function isCacheEnabledReturnsTrueByDefault(): void
-    {
-        $this->typo3Config->method('get')
-            ->with('nr_vault')
-            ->willReturn([]);
-
-        $config = new ExtensionConfiguration($this->typo3Config);
-
-        self::assertTrue($config->isCacheEnabled());
-    }
-
-    #[Test]
-    public function isCacheEnabledReturnsFalseWhenDisabled(): void
-    {
-        $this->typo3Config->method('get')
-            ->with('nr_vault')
-            ->willReturn(['cacheEnabled' => false]);
-
-        $config = new ExtensionConfiguration($this->typo3Config);
-
-        self::assertFalse($config->isCacheEnabled());
-    }
-
-    #[Test]
     public function isAuditReadsEnabledReturnsTrueByDefault(): void
     {
         $this->typo3Config->method('get')

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -86,10 +86,6 @@ final class VaultServiceTest extends TestCase
             ->method('canCreate')
             ->willReturn(true);
 
-        $this->configuration
-            ->method('isCacheEnabled')
-            ->willReturn(false);
-
         $this->subject = new VaultService(
             $this->adapter,
             $this->encryptionService,
@@ -812,14 +808,6 @@ final class VaultServiceTest extends TestCase
     }
 
     #[Test]
-    public function clearCacheClearsInternalCache(): void
-    {
-        // This test verifies clearCache doesn't throw
-        $this->subject->clearCache();
-        $this->expectNotToPerformAssertions();
-    }
-
-    #[Test]
     public function storeWithAllOptions(): void
     {
         $identifier = 'fullOptions';
@@ -954,22 +942,42 @@ final class VaultServiceTest extends TestCase
     }
 
     #[Test]
-    public function retrieveWithCacheEnabled(): void
+    public function retrieveNeverCachesPlaintextAcrossCalls(): void
     {
-        // Create service with cache enabled
-        $this->configuration = $this->createMock(ExtensionConfigurationInterface::class);
-        $this->configuration->method('isCacheEnabled')->willReturn(true);
+        // Security invariant: there is NO plaintext cache. Every retrieve()
+        // must re-load the record, re-run the ACL decision and re-decrypt —
+        // a cached plaintext handed to a later caller would bypass
+        // authorization, expiry and the audit trail (cross-actor leak in
+        // long-running worker processes).
+        $secret = $this->createSecretEntity('uncached');
 
-        $subject = new VaultService(
-            $this->adapter,
-            $this->encryptionService,
-            $this->accessControlService,
-            $this->auditLogService,
-            $this->configuration,
-            $this->httpClientFactory,
-        );
+        $this->adapter
+            ->expects(self::exactly(2))
+            ->method('retrieve')
+            ->willReturn($secret);
 
-        $secret = $this->createSecretEntity('cached');
+        $this->accessControlService
+            ->expects(self::exactly(2))
+            ->method('canRead')
+            ->willReturn(true);
+
+        $this->encryptionService
+            ->expects(self::exactly(2))
+            ->method('decrypt')
+            ->willReturn('plain-value');
+
+        self::assertSame('plain-value', $this->subject->retrieve('uncached'));
+        self::assertSame('plain-value', $this->subject->retrieve('uncached'));
+    }
+
+    #[Test]
+    public function retrieveDeniesSecondCallWhenAclRevokedBetweenReads(): void
+    {
+        // The cross-actor regression: actor A reads the secret, then the ACL
+        // decision changes (e.g. a technical-actor switch in the same
+        // process). The second retrieve() must be denied — never served from
+        // a previous caller's plaintext.
+        $secret = $this->createSecretEntity('switched');
 
         $this->adapter
             ->method('retrieve')
@@ -977,20 +985,23 @@ final class VaultServiceTest extends TestCase
 
         $this->accessControlService
             ->method('canRead')
-            ->willReturn(true);
+            ->willReturnOnConsecutiveCalls(true, false);
 
         $this->encryptionService
-            ->expects(self::once()) // Only once due to caching
+            ->expects(self::once())
             ->method('decrypt')
-            ->willReturn('cached-value');
+            ->willReturn('plain-value');
 
-        // First call - should decrypt
-        $result1 = $subject->retrieve('cached');
-        // Second call - should use cache
-        $result2 = $subject->retrieve('cached');
+        self::assertSame('plain-value', $this->subject->retrieve('switched'));
 
-        self::assertSame('cached-value', $result1);
-        self::assertSame('cached-value', $result2);
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('switched', 'access_denied', false, 'Read access denied');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $this->subject->retrieve('switched');
     }
 
     #[Test]
@@ -1049,51 +1060,6 @@ final class VaultServiceTest extends TestCase
         $this->expectException(AccessDeniedException::class);
 
         $this->subject->rotate('protected', 'newValue');
-    }
-
-    #[Test]
-    public function clearCacheWipesSecureMemory(): void
-    {
-        // Enable cache for this test
-        $this->configuration = $this->createMock(ExtensionConfigurationInterface::class);
-        $this->configuration->method('isCacheEnabled')->willReturn(true);
-
-        $subject = new VaultService(
-            $this->adapter,
-            $this->encryptionService,
-            $this->accessControlService,
-            $this->auditLogService,
-            $this->configuration,
-            $this->httpClientFactory,
-        );
-
-        $secret = $this->createSecretEntity('cached');
-
-        $this->adapter
-            ->method('retrieve')
-            ->willReturn($secret);
-
-        $this->accessControlService
-            ->method('canRead')
-            ->willReturn(true);
-
-        $this->encryptionService
-            ->method('decrypt')
-            ->willReturn('secret-value');
-
-        // First retrieve to populate cache
-        $subject->retrieve('cached');
-
-        // Clear cache should not throw
-        $subject->clearCache();
-
-        // Verify by retrieving again - should call decrypt again
-        $this->encryptionService
-            ->expects(self::once())
-            ->method('decrypt')
-            ->willReturn('secret-value');
-
-        $subject->retrieve('cached');
     }
 
     #[Test]

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -81,13 +81,6 @@ auditSinkWebhookEnabled = 0
 # cat=Audit Sinks; type=string; label=Webhook URL: https:// endpoint receiving the JSON payloads. Outbound calls go through the hardened HTTP client, so a collector on a private/RFC1918 address must be allow-listed literally in $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'] (a filesystem-bound setting, deliberately out of reach of the backend Settings module).
 auditSinkWebhookUrl =
 
-##################
-### PERFORMANCE ###
-##################
-
-# cat=Performance; type=boolean; label=Enable Cache: Enable request-scoped caching of decrypted secrets
-cacheEnabled = 1
-
 ########################
 ### HASHICORP VAULT ###
 ########################


### PR DESCRIPTION
## Finding (High): plaintext cache bypasses authorization and audit

`VaultService` held a request-scoped plaintext cache that was consulted **before** every control on the read path: before the record load, the per-secret ACL (`canRead()`), the interactive `secret.use` gate, the expiry check and the read audit entry.

`VaultService` is a shared singleton. In a long-running worker process (Symfony Messenger, Scheduler) the concrete failure is:

1. Technical actor A reads secret X → plaintext lands in the cache.
2. The `TechnicalActorContext::runAs()` scope switches to actor B.
3. Actor B retrieves the same identifier → the cache returns the plaintext directly — **no authorization, no `secret.use`, no expiry check, no read audit**.

The cache key carried neither actor nor context nor permission state, and the cache was only reliably emptied in the destructor.

## Fix

The cache is removed entirely — not keyed by actor. The saved work was a single-row SELECT plus one decrypt; for a vault that never justifies weakening the authorization/audit invariants, and an actor-keyed cache would stay error-prone (permission state changes, break-glass windows, expiry mid-request).

- `VaultService`: cache property, destructor wipe, read short-circuit and per-mutation invalidation removed. Every `retrieve()` re-runs ACL, `secret.use`, expiry, decryption, read statistics and the audit trail.
- **Breaking:** `VaultServiceInterface::clearCache()` removed (nothing left to clear).
- Extension setting `cacheEnabled`, `ExtensionConfiguration(Interface)::isCacheEnabled()`, the `ext_conf_template.txt` entry and the documentation for both removed.
- Functional tests drop their `clearCache()` workarounds that only existed to defeat the cache between assertions.

## Regression coverage

- Unit: two `retrieve()` calls load/authorize/decrypt twice; an ACL decision flipping between two reads denies the second read (`retrieveDeniesSecondCallWhenAclRevokedBetweenReads`).
- Functional `VaultServiceCrossActorTest`: two technical-actor scopes in one process — actor B without permission is denied after actor A read the secret, the denial is audited and attributed to B; two successful reads produce two read audit entries (a cache would have collapsed the second into an unaudited hit).

## Verification

- `composer ci` (cgl + phpstan + unit 2954 + fuzz 1612): green
- Full functional suite (`typo3DatabaseDriver=pdo_sqlite`, 252 tests): green, exit 0
- Rector dry-run fails identically on unmodified `main` in this environment (phar stub resolution under PHP 8.5) — relying on the CI rector gate.

Part 1/5 of the follow-up hardening round; next: central operation-permission enforcement in `VaultService` (stacked on this branch).
