### PR TITLE
Enforce operation permissions centrally in VaultService

### DIFF
--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -14,6 +14,7 @@ use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Domain\Model\Secret;
 use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
@@ -301,10 +302,14 @@ final class SecretTcaHook
 
         $identifier = $secret->getIdentifier();
 
-        // Write-path authorization (CWE-862): only the owner, an admin or a
-        // system maintainer may delete a secret. A non-owner non-admin editor
-        // with generic table-modify rights must be stopped here.
-        if (!$this->accessControlService->canDelete($secret)) {
+        // Write-path authorization (CWE-862): the per-secret tier (owner /
+        // admin / system maintainer) AND the secret.delete operation
+        // permission must both hold. A non-owner non-admin editor with
+        // generic table-modify rights — or an owner lacking the delete
+        // grant — must be stopped here.
+        if (!$this->accessControlService->canDelete($secret)
+            || !$this->accessControlService->isGranted(VaultPermission::SecretDelete)
+        ) {
             $this->deniedDeletions[$uid] = true;
 
             try {
@@ -326,7 +331,7 @@ final class SecretTcaHook
                 2,
                 null,
                 1,
-                'Vault secret can only be deleted by its owner or an administrator',
+                'Vault secret deletion requires being its owner or an administrator AND holding the secret.delete permission',
             );
 
             return;
@@ -437,8 +442,14 @@ final class SecretTcaHook
         $storedOwner = is_numeric($original['owner_uid'] ?? null) ? (int) $original['owner_uid'] : 0;
         $actorUid = $this->accessControlService->getCurrentActorUid();
 
-        // The owner may freely manage their own secret's ACL.
-        if ($actorUid !== 0 && $actorUid === $storedOwner) {
+        // The owner may manage their own secret's ACL — but only while
+        // holding the secret.manage_policy operation permission (separation
+        // of duties: owning a secret and widening who may access it are
+        // different privileges). An owner without the grant falls through to
+        // the revert below, exactly like a non-owner.
+        if ($actorUid !== 0 && $actorUid === $storedOwner
+            && $this->accessControlService->isGranted(VaultPermission::SecretManagePolicy)
+        ) {
             return;
         }
 
@@ -489,7 +500,7 @@ final class SecretTcaHook
                 2,
                 null,
                 1,
-                'Vault secret ACL columns can only be changed by the secret owner or an administrator',
+                'Vault secret ACL columns can only be changed by an administrator or by the secret owner holding the secret.manage_policy permission',
             );
         }
     }

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -643,7 +643,10 @@ final class AccessControlService implements AccessControlServiceInterface
 
         foreach ($rows as $row) {
             $options = $row['custom_options'] ?? null;
-            if (!\is_string($options) || $options === '') {
+            if (!\is_string($options)) {
+                continue;
+            }
+            if ($options === '') {
                 continue;
             }
             if (GeneralUtility::inList($options, self::PERM_OPTION_GROUP . ':' . $permission->value)) {

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -579,16 +579,18 @@ final class AccessControlService implements AccessControlServiceInterface
      *
      * A technical actor is a snapshot of a real backend user, but it has no
      * live session and `runAs()` is explicitly NOT an authentication boundary
-     * (any code with DI access can open a scope). So a NON-admin technical
-     * actor gets no operation permissions at all — its power stays bounded by
-     * the per-secret `canRead`/`canWrite` tiers, which is what its group
-     * membership was actually provisioned for.
+     * (any code with DI access can open a scope). A NON-admin technical actor
+     * therefore holds exactly what its provisioned backend groups grant via
+     * the `tx_nrvault` custom permission options — the same carrier an
+     * interactive user's grants come from, resolved here directly from
+     * `be_groups` because a technical actor has no authenticated
+     * `BackendUserAuthentication` whose `groupData` could be consulted.
      *
-     * The one exception is `SecretUse`: headless consumption is the entire
-     * purpose of a technical actor, and gating it on a group-level custom
-     * permission option would break every existing `runAs()` caller while
-     * adding nothing — the per-secret tier already decides which secrets the
-     * actor may read.
+     * The one implicit grant is `SecretUse`: headless consumption is the
+     * entire purpose of a technical actor, and gating it on a group-level
+     * custom permission option would break every existing `runAs()` caller
+     * while adding nothing — the per-secret tier already decides which
+     * secrets the actor may read.
      */
     private function hasTechnicalActorGrant(TechnicalActor $actor, VaultPermission $permission): bool
     {
@@ -596,7 +598,60 @@ final class AccessControlService implements AccessControlServiceInterface
             return true;
         }
 
-        return $permission === VaultPermission::SecretUse;
+        if ($permission === VaultPermission::SecretUse) {
+            return true;
+        }
+
+        return $this->technicalActorGroupsGrant($actor, $permission);
+    }
+
+    /**
+     * Does any of the technical actor's (already subgroup-expanded) groups
+     * carry the `tx_nrvault:<permission>` custom permission option?
+     *
+     * Fail-closed: no ConnectionPool wired (bare unit-test construction) or
+     * no groups means no grant.
+     */
+    private function technicalActorGroupsGrant(TechnicalActor $actor, VaultPermission $permission): bool
+    {
+        if (!$this->connectionPool instanceof ConnectionPool) {
+            return false;
+        }
+
+        $groupIds = $this->filterExistingGroupIds($actor->groupIds);
+        if ($groupIds === []) {
+            return false;
+        }
+
+        try {
+            $queryBuilder = $this->connectionPool->getQueryBuilderForTable('be_groups');
+            $rows = $queryBuilder
+                ->select('custom_options')
+                ->from('be_groups')
+                ->where(
+                    $queryBuilder->expr()->in(
+                        'uid',
+                        $queryBuilder->createNamedParameter($groupIds, Connection::PARAM_INT_ARRAY),
+                    ),
+                )
+                ->executeQuery()
+                ->fetchAllAssociative();
+        } catch (Throwable) {
+            // Fail closed on any database error.
+            return false;
+        }
+
+        foreach ($rows as $row) {
+            $options = $row['custom_options'] ?? null;
+            if (!\is_string($options) || $options === '') {
+                continue;
+            }
+            if (GeneralUtility::inList($options, self::PERM_OPTION_GROUP . ':' . $permission->value)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -76,6 +76,19 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
 
             $this->assertWritePermission($identifier, $existing);
 
+            // Separation of duties: the per-secret ACL above answers "may this
+            // actor touch THIS secret", the operation permission answers "may
+            // this actor perform this KIND of operation at all". Both gates
+            // must pass at this business boundary — controller checks are UX,
+            // not the security boundary (a DataHandler request or programmatic
+            // caller never passes through them).
+            if ($existing instanceof Secret) {
+                $this->assertOperationGranted(VaultPermission::SecretRotate, $identifier, 'Update');
+                $this->assertPolicyChangeGranted($identifier, $options, $existing);
+            } else {
+                $this->assertOperationGranted(VaultPermission::SecretCreate, $identifier, 'Create');
+            }
+
             $encrypted = $this->encryptionService->encrypt($secret, $identifier);
             $secretEntity = $this->buildSecretEntity($identifier, $encrypted, $options, $existing);
 
@@ -181,6 +194,9 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             throw AccessDeniedException::forIdentifier($identifier, 'delete permission denied');
         }
 
+        // Separation of duties: per-secret ACL AND operation permission.
+        $this->assertOperationGranted(VaultPermission::SecretDelete, $identifier, 'Delete');
+
         $hashBefore = $secret->getValueChecksum();
 
         // Delete
@@ -229,6 +245,9 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
 
             throw AccessDeniedException::forIdentifier($identifier, 'rotate permission denied');
         }
+
+        // Separation of duties: per-secret ACL AND operation permission.
+        $this->assertOperationGranted(VaultPermission::SecretRotate, $identifier, 'Rotate');
 
         if ($newSecret === '') {
             throw ValidationException::emptySecret();
@@ -455,6 +474,75 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             $identifier,
             'missing ' . VaultPermission::SecretUse->value . ' permission',
         );
+    }
+
+    /**
+     * Assert an operation-level vault permission for the current actor, on
+     * top of the per-secret ACL tier the caller already verified.
+     *
+     * `isGranted()` resolves the actor-appropriate grant source: custom
+     * permission options for interactive backend users (admins pass via the
+     * central bypass seam), group-provisioned grants for technical actors,
+     * the CLI trust switch for unauthenticated CLI, and a hard deny for
+     * frontend requests — which never mutate the vault.
+     */
+    private function assertOperationGranted(
+        VaultPermission $permission,
+        string $identifier,
+        string $operation,
+    ): void {
+        if ($this->accessControlService->isGranted($permission)) {
+            return;
+        }
+
+        $this->auditLogService->log(
+            $identifier,
+            AuditAction::AccessDenied->value,
+            false,
+            $operation . ' denied: missing ' . $permission->value . ' permission',
+        );
+
+        throw AccessDeniedException::forIdentifier(
+            $identifier,
+            'missing ' . $permission->value . ' permission',
+        );
+    }
+
+    /**
+     * A `store()` over an existing secret that changes its access policy
+     * (owner, group tiers, frontend availability) additionally requires
+     * `secret.manage_policy` — widening who can read or write a secret is
+     * vault administration, not day-to-day secret handling.
+     *
+     * The comparison uses the EFFECTIVE values (after the owner /
+     * frontend-accessible coercions below): a submitted change that the
+     * coercion silently reverts for a non-admin backend user is not a policy
+     * change and must not start requiring an additional permission.
+     *
+     * @param array<string, mixed> $options
+     */
+    private function assertPolicyChangeGranted(string $identifier, array $options, Secret $existing): void
+    {
+        $optional = $this->collectOptionalFields($options);
+
+        $ownerChanges = $this->resolveOwnerUid($options, $existing) !== $existing->getOwnerUid();
+        $frontendChanges = $this->resolveFrontendAccessible($optional['frontendAccessible'], $existing)
+            !== $existing->isFrontendAccessible();
+
+        $groupsChange = false;
+        if (isset($options['groups'])) {
+            $submittedGroups = $optional['allowedGroups'];
+            $existingGroups = $existing->getAllowedGroups();
+            sort($submittedGroups);
+            sort($existingGroups);
+            $groupsChange = $submittedGroups !== $existingGroups;
+        }
+
+        if (!$ownerChanges && !$frontendChanges && !$groupsChange) {
+            return;
+        }
+
+        $this->assertOperationGranted(VaultPermission::SecretManagePolicy, $identifier, 'Policy change');
     }
 
     /**

--- a/Documentation/Auditor/ControlMapping.rst
+++ b/Documentation/Auditor/ControlMapping.rst
@@ -131,9 +131,17 @@ OWASP ASVS v4: chapter 2 (Authentication), chapter 4 (Access Control).*
         -   :ref:`adr-005-access-control`
 
     *   -   Server-side enforcement at every entry point
-        -   :php:`AjaxController` re-asserts method and permission; modules
-            registered ``access => 'user'`` with per-action checks
-        -   Route configuration plus controller code
+        -   Operation permissions are enforced centrally in
+            :php:`VaultService` (``store()`` requires ``secret.create`` /
+            ``secret.rotate`` and — for access-policy changes —
+            ``secret.manage_policy``; ``rotate()`` requires
+            ``secret.rotate``; ``delete()`` requires ``secret.delete``), so
+            DataHandler/FormEngine requests and programmatic callers face the
+            same gate as the module controllers. Controllers and
+            :php:`SecretTcaHook` re-assert the permissions as
+            defense-in-depth.
+        -   :php:`VaultService::assertOperationGranted()`; route
+            configuration plus controller code
 
     *   -   No privileged short-circuit in the grant lookup
         -   Grant evaluation deliberately avoids

--- a/Documentation/Security/Index.rst
+++ b/Documentation/Security/Index.rst
@@ -264,6 +264,21 @@ Notes on the model:
    read**, including FormEngine vault field widgets and FlexForm /
    TypoScript placeholder resolution. Grant it to the groups whose
    editors work with vault-backed fields.
+-  **Mutations are enforced centrally in the service, not only in the
+   module controllers.** ``VaultService::store()`` requires
+   ``secret.create`` (new identifier) or ``secret.rotate`` (existing
+   identifier, plus ``secret.manage_policy`` when the call also changes
+   owner, group tiers or frontend availability); ``rotate()`` requires
+   ``secret.rotate``; ``delete()`` requires ``secret.delete``. A direct
+   DataHandler/FormEngine request or a programmatic caller therefore
+   faces the same gates as the secrets module. Editors whose forms
+   write vault-backed TCA fields need ``secret.create`` /
+   ``secret.rotate`` in addition to ``secret.use``.
+-  **Technical actors** (``TechnicalActorContext::runAs()``) hold
+   ``secret.use`` implicitly — headless consumption is their purpose —
+   and every other operation permission only if one of their
+   provisioned backend groups grants it via the same
+   ``tx_nrvault:*`` custom permission options.
 -  **Admins and system maintainers hold every permission**
    unconditionally, and have full per-secret access to every secret.
    That override lives in a single seam

--- a/Tests/Functional/Hook/Fixtures/be_users_acl.csv
+++ b/Tests/Functional/Hook/Fixtures/be_users_acl.csv
@@ -1,4 +1,8 @@
-"be_users"
-,"uid","username","password","admin","disable","starttime","endtime"
-,1,"admin","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",1,0,0,0
-,2,"editor","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0
+"be_users",,,,,,,,
+,"uid","username","password","admin","disable","starttime","endtime","usergroup"
+,1,"admin","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",1,0,0,0,""
+,2,"editor","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0,""
+,3,"owner_with_delete","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0,"21"
+"be_groups",,,,,
+,"uid","pid","title","custom_options"
+,21,0,"vault-deleters","tx_nrvault:secret.delete"

--- a/Tests/Functional/Hook/Fixtures/be_users_field_permissions.csv
+++ b/Tests/Functional/Hook/Fixtures/be_users_field_permissions.csv
@@ -4,4 +4,4 @@
 page.vault.permissions.tx_test.secret_read_only.readOnly = 1","20"
 "be_groups",,,,
 ,"uid","pid","title","custom_options"
-,20,0,"vault-field-editors","tx_nrvault:secret.use"
+,20,0,"vault-field-editors","tx_nrvault:secret.use,tx_nrvault:secret.create,tx_nrvault:secret.rotate"

--- a/Tests/Functional/Hook/SecretTcaHookCreateAclTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookCreateAclTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Hook;
+
+use Netresearch\NrVault\Audit\AuditAction;
+use Netresearch\NrVault\Hook\SecretTcaHook;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * The review's acceptance scenario for the FormEngine create path: a backend
+ * user holding generic TABLE permissions on tx_nrvault_secret but NOT the
+ * secret.create operation permission must not be able to store a secret value
+ * through a direct DataHandler request — the secrets-module controller check
+ * is UX, the enforcement lives in VaultService::store() behind the hook.
+ *
+ * The hook contract is driven directly (like SecretTcaHookDeleteAclTest):
+ * core's own table-permission system would block the group-less editor before
+ * the vault gate runs and mask the result under test.
+ */
+#[CoversClass(SecretTcaHook::class)]
+final class SecretTcaHookCreateAclTest extends AbstractVaultFunctionalTestCase
+{
+    private const SECRET_TABLE = 'tx_nrvault_secret';
+
+    private const AUDIT_TABLE = 'tx_nrvault_audit_log';
+
+    /** Non-admin editor (uid 2), no vault operation permissions. */
+    private const EDITOR_UID = 2;
+
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_acl.csv';
+
+    protected ?int $backendUserUid = self::EDITOR_UID;
+
+    #[Test]
+    public function editorWithoutSecretCreatePermissionCannotStoreViaDataHandler(): void
+    {
+        $identifier = 'op_create_' . bin2hex(random_bytes(4));
+
+        $hook = $this->get(SecretTcaHook::class);
+        self::assertInstanceOf(SecretTcaHook::class, $hook);
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+
+        // Simulate the FormEngine create: preProcess captures the pending
+        // secret value, core writes the row, afterDatabaseOperations hands
+        // the value to VaultService::store() — which must deny.
+        $fieldArray = [
+            'pid' => 0,
+            'identifier' => $identifier,
+            'secret_input' => 'must-not-be-stored',
+        ];
+        $hook->processDatamap_preProcessFieldArray($fieldArray, self::SECRET_TABLE, 'NEW1', $dataHandler);
+
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::SECRET_TABLE);
+        $connection->insert(self::SECRET_TABLE, [
+            'pid' => 0,
+            'identifier' => $identifier,
+            'owner_uid' => self::EDITOR_UID,
+            'deleted' => 0,
+        ]);
+        $newUid = (int) $connection->lastInsertId();
+
+        $dataHandler->substNEWwithIDs['NEW1'] = $newUid;
+        $hook->processDatamap_afterDatabaseOperations('new', self::SECRET_TABLE, 'NEW1', $fieldArray, $dataHandler);
+
+        // No encrypted value may have been persisted for the record.
+        $row = $connection->select(
+            ['encrypted_value'],
+            self::SECRET_TABLE,
+            ['uid' => $newUid],
+        )->fetchAssociative();
+        self::assertIsArray($row);
+        $encryptedValue = $row['encrypted_value'] ?? '';
+        self::assertIsString($encryptedValue);
+        self::assertSame('', $encryptedValue, 'The denied create must not persist a secret value.');
+
+        // The denial is recorded in the audit trail.
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::AUDIT_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $denied = $queryBuilder
+            ->count('uid')
+            ->from(self::AUDIT_TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('secret_identifier', $queryBuilder->createNamedParameter($identifier)),
+                $queryBuilder->expr()->eq('action', $queryBuilder->createNamedParameter(AuditAction::AccessDenied->value)),
+                $queryBuilder->expr()->eq('success', $queryBuilder->createNamedParameter(0, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchOne();
+        self::assertSame(1, is_numeric($denied) ? (int) $denied : 0, 'The denied create must be audited as access_denied.');
+
+        // The DataHandler log carries the user-facing error.
+        /** @phpstan-ignore property.internal */
+        self::assertNotEmpty($dataHandler->errorLog, 'The denied create must surface in the DataHandler error log.');
+    }
+}

--- a/Tests/Functional/Hook/SecretTcaHookDeleteAclTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookDeleteAclTest.php
@@ -37,8 +37,11 @@ final class SecretTcaHookDeleteAclTest extends AbstractVaultFunctionalTestCase
     /** Admin backend user (uid 1 in the fixture). */
     private const ADMIN_UID = 1;
 
-    /** Non-admin editor (uid 2 in the fixture). */
+    /** Non-admin editor (uid 2 in the fixture), no operation permissions. */
     private const EDITOR_UID = 2;
+
+    /** Non-admin user (uid 3) whose group grants tx_nrvault:secret.delete. */
+    private const DELETER_UID = 3;
 
     protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_acl.csv';
 
@@ -77,14 +80,46 @@ final class SecretTcaHookDeleteAclTest extends AbstractVaultFunctionalTestCase
     }
 
     #[Test]
-    public function nonAdminOwnerDeleteIsAllowedByVaultGate(): void
+    public function ownerWithoutDeletePermissionIsBlocked(): void
     {
+        // Separation of duties: owning the secret satisfies the per-secret
+        // tier, but without the secret.delete operation permission the delete
+        // must still be cancelled.
         $this->setUpBackendUser(self::EDITOR_UID);
         [$uid, $identifier] = $this->seedSecret(self::EDITOR_UID);
 
         $commandIsProcessed = $this->runDeleteHook($uid);
 
-        self::assertFalse($commandIsProcessed, 'The owner must not be blocked by the vault delete gate.');
+        self::assertTrue(
+            $commandIsProcessed,
+            'An owner without the secret.delete permission must be blocked (commandIsProcessed=true).',
+        );
+        self::assertSame(
+            1,
+            $this->countAudit($identifier, AuditAction::AccessDenied->value, 0),
+            'A failed access_denied audit entry must be recorded for the denied delete.',
+        );
+        self::assertSame(
+            0,
+            $this->countAudit($identifier, AuditAction::Delete->value, 1),
+            'No successful delete audit entry may be written for a denied delete.',
+        );
+    }
+
+    #[Test]
+    public function ownerWithDeletePermissionIsAllowedByVaultGate(): void
+    {
+        // Both gates hold: per-secret tier (owner) AND the secret.delete
+        // operation permission via the group custom permission option.
+        $this->setUpBackendUser(self::DELETER_UID);
+        [$uid, $identifier] = $this->seedSecret(self::DELETER_UID);
+
+        $commandIsProcessed = $this->runDeleteHook($uid);
+
+        self::assertFalse(
+            $commandIsProcessed,
+            'An owner holding secret.delete must not be blocked by the vault delete gate.',
+        );
         self::assertSame(
             1,
             $this->countAudit($identifier, AuditAction::Delete->value, 1),

--- a/Tests/Functional/Service/Fixtures/cross_actor_users.csv
+++ b/Tests/Functional/Service/Fixtures/cross_actor_users.csv
@@ -1,4 +1,7 @@
 "be_users",,,,,,,,
 ,"uid","pid","tstamp","username","password","admin","disable","usergroup"
-,10,0,1700000000,"tech_owner","",0,0,""
+,10,0,1700000000,"tech_owner","",0,0,"7"
 ,13,0,1700000000,"tech_other","",0,0,""
+"be_groups",,,,,,
+,"uid","pid","tstamp","title","custom_options"
+,7,0,1700000000,"vault-writers","tx_nrvault:secret.create"

--- a/Tests/Unit/Security/AccessControlServiceIsGrantedTest.php
+++ b/Tests/Unit/Security/AccessControlServiceIsGrantedTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Security;
 
+use Doctrine\DBAL\Result;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Security\AccessControlService;
 use Netresearch\NrVault\Security\TechnicalActor;
@@ -19,7 +20,6 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
-use Doctrine\DBAL\Result;
 use PHPUnit\Framework\MockObject\MockObject;
 use RuntimeException;
 use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
@@ -206,55 +206,6 @@ final class AccessControlServiceIsGrantedTest extends TestCase
         }
     }
 
-    /**
-     * Install a backend user whose groups grant exactly the given permissions.
-     *
-     * Mirrors TYPO3 core storage: the grants live in the merged
-     * `groupData['custom_options']` list, so a grant is present or it is not —
-     * there is no per-user override.
-     *
-     * @param list<VaultPermission> $grantedOptions
-     */
-    private function setBackendUser(
-        bool $isAdmin,
-        array $grantedOptions = [],
-        bool $isSystemMaintainer = false,
-        int $disable = 0,
-    ): void {
-        $GLOBALS['BE_USER'] = $this->createMockBackendUser(
-            uid: 5,
-            isAdmin: $isAdmin,
-            disabled: $disable !== 0,
-            isSystemMaintainer: $isSystemMaintainer,
-            grantedPermissions: $grantedOptions,
-        );
-    }
-
-    /**
-     * Install the unauthenticated CommandLineUserAuthentication placeholder the
-     * TYPO3 CLI bootstrap puts into $GLOBALS['BE_USER'] (no user record).
-     */
-    private function setUnauthenticatedCommandLineUser(): void
-    {
-        $cliUser = $this->createMock(CommandLineUserAuthentication::class);
-        /** @phpstan-ignore property.internal */
-        $cliUser->user = ['uid' => 0];
-
-        $GLOBALS['BE_USER'] = $cliUser;
-    }
-
-    private function setFrontendRequest(): void
-    {
-        /** @phpstan-ignore classConstant.internal */
-        $frontendType = SystemEnvironmentBuilder::REQUESTTYPE_FE;
-
-        /** @phpstan-ignore new.internalClass, method.internalClass */
-        $request = new ServerRequest('https://example.com/');
-
-        /** @phpstan-ignore method.internalClass */
-        $GLOBALS['TYPO3_REQUEST'] = $request->withAttribute('applicationType', $frontendType);
-    }
-
     #[Test]
     public function technicalActorAlwaysHoldsSecretUse(): void
     {
@@ -341,10 +292,59 @@ final class AccessControlServiceIsGrantedTest extends TestCase
     }
 
     /**
+     * Install a backend user whose groups grant exactly the given permissions.
+     *
+     * Mirrors TYPO3 core storage: the grants live in the merged
+     * `groupData['custom_options']` list, so a grant is present or it is not —
+     * there is no per-user override.
+     *
+     * @param list<VaultPermission> $grantedOptions
+     */
+    private function setBackendUser(
+        bool $isAdmin,
+        array $grantedOptions = [],
+        bool $isSystemMaintainer = false,
+        int $disable = 0,
+    ): void {
+        $GLOBALS['BE_USER'] = $this->createMockBackendUser(
+            uid: 5,
+            isAdmin: $isAdmin,
+            disabled: $disable !== 0,
+            isSystemMaintainer: $isSystemMaintainer,
+            grantedPermissions: $grantedOptions,
+        );
+    }
+
+    /**
+     * Install the unauthenticated CommandLineUserAuthentication placeholder the
+     * TYPO3 CLI bootstrap puts into $GLOBALS['BE_USER'] (no user record).
+     */
+    private function setUnauthenticatedCommandLineUser(): void
+    {
+        $cliUser = $this->createMock(CommandLineUserAuthentication::class);
+        /** @phpstan-ignore property.internal */
+        $cliUser->user = ['uid' => 0];
+
+        $GLOBALS['BE_USER'] = $cliUser;
+    }
+
+    private function setFrontendRequest(): void
+    {
+        /** @phpstan-ignore classConstant.internal */
+        $frontendType = SystemEnvironmentBuilder::REQUESTTYPE_FE;
+
+        /** @phpstan-ignore new.internalClass, method.internalClass */
+        $request = new ServerRequest('https://example.com/');
+
+        /** @phpstan-ignore method.internalClass */
+        $GLOBALS['TYPO3_REQUEST'] = $request->withAttribute('applicationType', $frontendType);
+    }
+
+    /**
      * @param list<array{uid: int, custom_options: string}>|null $groupRows
-     *        be_groups rows the mocked pool returns; the same rows serve the
-     *        existing-uid filter (reads `uid`) and the custom-options grant
-     *        lookup (reads `custom_options`). null = no ConnectionPool.
+     *                                                                      be_groups rows the mocked pool returns; the same rows serve the
+     *                                                                      existing-uid filter (reads `uid`) and the custom-options grant
+     *                                                                      lookup (reads `custom_options`). null = no ConnectionPool.
      */
     private function createSubjectWithTechnicalActor(bool $admin, ?array $groupRows = null): AccessControlService
     {

--- a/Tests/Unit/Security/AccessControlServiceIsGrantedTest.php
+++ b/Tests/Unit/Security/AccessControlServiceIsGrantedTest.php
@@ -19,9 +19,15 @@ use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use Doctrine\DBAL\Result;
 use PHPUnit\Framework\MockObject\MockObject;
+use RuntimeException;
 use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\DefaultRestrictionContainer;
 use TYPO3\CMS\Core\Http\ServerRequest;
 
 /**
@@ -249,7 +255,98 @@ final class AccessControlServiceIsGrantedTest extends TestCase
         $GLOBALS['TYPO3_REQUEST'] = $request->withAttribute('applicationType', $frontendType);
     }
 
-    private function createSubjectWithTechnicalActor(bool $admin): AccessControlService
+    #[Test]
+    public function technicalActorAlwaysHoldsSecretUse(): void
+    {
+        // Headless consumption is the purpose of a technical actor; the
+        // implicit grant must not depend on any group or database state.
+        $subject = $this->createSubjectWithTechnicalActor(admin: false);
+
+        self::assertTrue($subject->isGranted(VaultPermission::SecretUse));
+    }
+
+    #[Test]
+    public function technicalActorGainsOperationsGrantedByItsGroups(): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(
+            admin: false,
+            groupRows: [['uid' => 5, 'custom_options' => 'tx_nrvault:secret.create,tx_nrvault:secret.rotate']],
+        );
+
+        self::assertTrue($subject->isGranted(VaultPermission::SecretCreate));
+        self::assertTrue($subject->isGranted(VaultPermission::SecretRotate));
+        self::assertFalse($subject->isGranted(VaultPermission::SecretDelete), 'not granted by the group');
+        self::assertFalse($subject->isGranted(VaultPermission::SecretReveal), 'never implicit');
+    }
+
+    #[Test]
+    public function technicalActorWithoutMatchingGroupOptionsIsDenied(): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(
+            admin: false,
+            groupRows: [['uid' => 5, 'custom_options' => '']],
+        );
+
+        self::assertFalse($subject->isGranted(VaultPermission::SecretCreate));
+    }
+
+    #[Test]
+    public function technicalActorGrantFailsClosedWithoutAConnectionPool(): void
+    {
+        // Bare construction (no pool): the group grants cannot be resolved,
+        // so everything except the implicit secret.use is denied.
+        $subject = $this->createSubjectWithTechnicalActor(admin: false);
+
+        self::assertFalse($subject->isGranted(VaultPermission::SecretCreate));
+        self::assertFalse($subject->isGranted(VaultPermission::MasterKeyRotate));
+    }
+
+    #[Test]
+    public function technicalActorGrantFailsClosedOnADatabaseError(): void
+    {
+        $context = $this->createMock(TechnicalActorContextInterface::class);
+        $context->method('getCurrentActor')->willReturn(new TechnicalActor(
+            uid: 10,
+            username: 'tech_indexer',
+            admin: false,
+            groupIds: [5],
+        ));
+
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool->method('getQueryBuilderForTable')
+            ->willThrowException(new RuntimeException('database gone'));
+
+        $subject = new AccessControlService($this->configuration, $connectionPool, $context);
+
+        self::assertFalse($subject->isGranted(VaultPermission::SecretCreate));
+        self::assertTrue($subject->isGranted(VaultPermission::SecretUse), 'implicit grant needs no DB');
+    }
+
+    #[Test]
+    public function technicalActorWithoutGroupsIsDeniedWithoutQuerying(): void
+    {
+        $context = $this->createMock(TechnicalActorContextInterface::class);
+        $context->method('getCurrentActor')->willReturn(new TechnicalActor(
+            uid: 10,
+            username: 'tech_loner',
+            admin: false,
+            groupIds: [],
+        ));
+
+        $connectionPool = $this->createMock(ConnectionPool::class);
+
+        $subject = new AccessControlService($this->configuration, $connectionPool, $context);
+
+        self::assertFalse($subject->isGranted(VaultPermission::SecretCreate));
+    }
+
+    /**
+     * @param list<array{uid: int, custom_options: string}>|null $groupRows
+     *        be_groups rows the mocked pool returns; the same rows serve the
+     *        existing-uid filter (reads `uid`) and the custom-options grant
+     *        lookup (reads `custom_options`). null = no ConnectionPool.
+     */
+    private function createSubjectWithTechnicalActor(bool $admin, ?array $groupRows = null): AccessControlService
     {
         $context = $this->createMock(TechnicalActorContextInterface::class);
         $context
@@ -261,6 +358,30 @@ final class AccessControlServiceIsGrantedTest extends TestCase
                 groupIds: [5],
             ));
 
-        return new AccessControlService($this->configuration, null, $context);
+        $connectionPool = null;
+        if ($groupRows !== null) {
+            $result = $this->createMock(Result::class);
+            $result->method('fetchAllAssociative')->willReturn($groupRows);
+
+            $expressionBuilder = $this->createMock(ExpressionBuilder::class);
+            $expressionBuilder->method('eq')->willReturn('deleted = 0');
+            $expressionBuilder->method('in')->willReturn('uid IN (:dcValue1)');
+
+            $queryBuilder = $this->createMock(QueryBuilder::class);
+            $queryBuilder->method('getRestrictions')->willReturn($this->createMock(DefaultRestrictionContainer::class));
+            $queryBuilder->method('select')->willReturnSelf();
+            $queryBuilder->method('from')->willReturnSelf();
+            $queryBuilder->method('where')->willReturnSelf();
+            $queryBuilder->method('expr')->willReturn($expressionBuilder);
+            $queryBuilder->method('createNamedParameter')->willReturn(':dcValue1');
+            $queryBuilder->method('executeQuery')->willReturn($result);
+
+            $connectionPool = $this->createMock(ConnectionPool::class);
+            $connectionPool
+                ->method('getQueryBuilderForTable')
+                ->willReturn($queryBuilder);
+        }
+
+        return new AccessControlService($this->configuration, $connectionPool, $context);
     }
 }

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -86,6 +86,13 @@ final class VaultServiceTest extends TestCase
             ->method('canCreate')
             ->willReturn(true);
 
+        // Default the operation permissions (secret.create/rotate/delete,
+        // secret.manage_policy) to granted; the denial-branch tests build
+        // their own access-control mock instead.
+        $this->accessControlService
+            ->method('isGranted')
+            ->willReturn(true);
+
         $this->subject = new VaultService(
             $this->adapter,
             $this->encryptionService,
@@ -212,12 +219,221 @@ final class VaultServiceTest extends TestCase
     }
 
     #[Test]
+    public function storeDeniesCreateWithoutSecretCreatePermission(): void
+    {
+        // Per-secret ACL passes (canCreate), but the actor lacks the
+        // secret.create operation permission: both gates must hold.
+        $noGrantAccess = $this->createMock(AccessControlServiceInterface::class);
+        $noGrantAccess->method('getCurrentActorUid')->willReturn(1);
+        $noGrantAccess->method('getCurrentActorType')->willReturn('backend');
+        $noGrantAccess->method('canCreate')->willReturn(true);
+        $noGrantAccess->method('isGranted')->willReturn(false);
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $noGrantAccess,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->adapter->method('retrieve')->willReturn(null);
+        $this->adapter->expects(self::never())->method('store');
+        $this->encryptionService->expects(self::never())->method('encrypt');
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('opGate', 'access_denied', false, 'Create denied: missing secret.create permission');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $subject->store('opGate', 'plaintext');
+    }
+
+    #[Test]
+    public function storeDeniesUpdateWithoutSecretRotatePermission(): void
+    {
+        $existing = $this->createSecretEntity('opGateUpdate', uid: 42);
+
+        $noGrantAccess = $this->createMock(AccessControlServiceInterface::class);
+        $noGrantAccess->method('getCurrentActorUid')->willReturn(1);
+        $noGrantAccess->method('getCurrentActorType')->willReturn('backend');
+        $noGrantAccess->method('canWrite')->willReturn(true);
+        $noGrantAccess->method('isGranted')->willReturn(false);
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $noGrantAccess,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->adapter->method('retrieve')->willReturn($existing);
+        $this->adapter->expects(self::never())->method('store');
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('opGateUpdate', 'access_denied', false, 'Update denied: missing secret.rotate permission');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $subject->store('opGateUpdate', 'new-value');
+    }
+
+    #[Test]
+    public function storeDeniesPolicyChangeWithoutManagePolicyPermission(): void
+    {
+        $existing = $this->createSecretEntity('opGatePolicy', uid: 42);
+
+        // secret.rotate is granted, secret.manage_policy is not: replacing
+        // the value is fine, widening the group ACL alongside it is not.
+        $rotateOnlyAccess = $this->createMock(AccessControlServiceInterface::class);
+        $rotateOnlyAccess->method('getCurrentActorUid')->willReturn(1);
+        $rotateOnlyAccess->method('getCurrentActorType')->willReturn('cli');
+        $rotateOnlyAccess->method('canWrite')->willReturn(true);
+        $rotateOnlyAccess->method('isGranted')->willReturnCallback(
+            static fn (VaultPermission $permission): bool => $permission === VaultPermission::SecretRotate,
+        );
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $rotateOnlyAccess,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->adapter->method('retrieve')->willReturn($existing);
+        $this->adapter->expects(self::never())->method('store');
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('opGatePolicy', 'access_denied', false, 'Policy change denied: missing secret.manage_policy permission');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $subject->store('opGatePolicy', 'new-value', ['groups' => [5, 6]]);
+    }
+
+    #[Test]
+    public function storeAllowsUpdateWithoutManagePolicyWhenPolicyIsUnchanged(): void
+    {
+        $existing = $this->createSecretEntity('opGateNoPolicy', uid: 42);
+
+        // Same grant profile as above — but no policy option changes, so
+        // secret.rotate alone must suffice for a plain value update.
+        $rotateOnlyAccess = $this->createMock(AccessControlServiceInterface::class);
+        $rotateOnlyAccess->method('getCurrentActorUid')->willReturn(1);
+        $rotateOnlyAccess->method('getCurrentActorType')->willReturn('cli');
+        $rotateOnlyAccess->method('canWrite')->willReturn(true);
+        $rotateOnlyAccess->method('isGranted')->willReturnCallback(
+            static fn (VaultPermission $permission): bool => $permission === VaultPermission::SecretRotate,
+        );
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $rotateOnlyAccess,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->encryptionService
+            ->method('encrypt')
+            ->willReturn(new EncryptedData('enc', 'dek', 'n1', 'n2', 'cs'));
+
+        $this->adapter->method('retrieve')->willReturn($existing);
+
+        $this->adapter
+            ->expects(self::once())
+            ->method('store')
+            ->willReturnArgument(0);
+
+        $subject->store('opGateNoPolicy', 'new-value');
+    }
+
+    #[Test]
+    public function rotateDeniesWithoutSecretRotatePermission(): void
+    {
+        $existing = $this->createSecretEntity('opGateRotate', uid: 42);
+
+        $noGrantAccess = $this->createMock(AccessControlServiceInterface::class);
+        $noGrantAccess->method('getCurrentActorUid')->willReturn(1);
+        $noGrantAccess->method('getCurrentActorType')->willReturn('backend');
+        $noGrantAccess->method('canWrite')->willReturn(true);
+        $noGrantAccess->method('isGranted')->willReturn(false);
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $noGrantAccess,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->adapter->method('retrieve')->willReturn($existing);
+        $this->adapter->expects(self::never())->method('store');
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('opGateRotate', 'access_denied', false, 'Rotate denied: missing secret.rotate permission');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $subject->rotate('opGateRotate', 'new-value');
+    }
+
+    #[Test]
+    public function deleteDeniesWithoutSecretDeletePermission(): void
+    {
+        $existing = $this->createSecretEntity('opGateDelete', uid: 42);
+
+        $noGrantAccess = $this->createMock(AccessControlServiceInterface::class);
+        $noGrantAccess->method('getCurrentActorUid')->willReturn(1);
+        $noGrantAccess->method('getCurrentActorType')->willReturn('backend');
+        $noGrantAccess->method('canDelete')->willReturn(true);
+        $noGrantAccess->method('isGranted')->willReturn(false);
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $noGrantAccess,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->adapter->method('retrieve')->willReturn($existing);
+        $this->adapter->expects(self::never())->method('delete');
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('opGateDelete', 'access_denied', false, 'Delete denied: missing secret.delete permission');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $subject->delete('opGateDelete');
+    }
+
+    #[Test]
     public function storeCoercesOwnerUidForNonAdminBackendActor(): void
     {
         $beActorAccess = $this->createMock(AccessControlServiceInterface::class);
         $beActorAccess->method('getCurrentActorUid')->willReturn(7);
         $beActorAccess->method('getCurrentActorType')->willReturn('backend');
         $beActorAccess->method('canCreate')->willReturn(true);
+        $beActorAccess->method('isGranted')->willReturn(true);
         $beActorAccess->method('isCurrentActorAdmin')->willReturn(false);
 
         $subject = new VaultService(
@@ -252,6 +468,7 @@ final class VaultServiceTest extends TestCase
         $beActorAccess->method('getCurrentActorUid')->willReturn(7);
         $beActorAccess->method('getCurrentActorType')->willReturn('backend');
         $beActorAccess->method('canCreate')->willReturn(true);
+        $beActorAccess->method('isGranted')->willReturn(true);
         $beActorAccess->method('isCurrentActorAdmin')->willReturn(false);
 
         $subject = new VaultService(
@@ -287,6 +504,7 @@ final class VaultServiceTest extends TestCase
         $adminAccess->method('getCurrentActorUid')->willReturn(1);
         $adminAccess->method('getCurrentActorType')->willReturn('backend');
         $adminAccess->method('canCreate')->willReturn(true);
+        $adminAccess->method('isGranted')->willReturn(true);
         $adminAccess->method('isCurrentActorAdmin')->willReturn(true);
 
         $subject = new VaultService(


### PR DESCRIPTION
## Finding (High): the operation permissions can be bypassed via central paths

The `VaultPermission` model and the auditor documentation state that operation permission **and** per-secret ACL must both hold. Only the module controllers checked the operation permissions (`createAction` → `secret.create`, AJAX rotate → `secret.rotate`, …). `VaultService::store()/rotate()/delete()` checked just the per-secret tiers (`canCreate`/`canWrite`/`canDelete`), and `tx_nrvault_secret` is a visible TCA table not limited to admins — so a backend user with generic table permissions could use a direct FormEngine/DataHandler request to create, rotate or delete secrets without ever facing `secret.create`/`secret.rotate`/`secret.delete`, and to change policy columns without `secret.manage_policy`.

## Fix — enforcement at the business boundary

**`VaultService`** (single enforcement point, audited denials):

| Operation | Required permission |
|---|---|
| `store()` — new identifier | `secret.create` |
| `store()` — existing identifier | `secret.rotate` (+ `secret.manage_policy` iff the call changes owner / group tiers / frontend availability, compared on the **effective** values after the existing coercions) |
| `rotate()` | `secret.rotate` |
| `delete()` | `secret.delete` |

**`SecretTcaHook`** (defense-in-depth for the two FormEngine paths that do not pass through the service): the delete command requires `canDelete()` **and** `secret.delete`; privileged ACL columns are changeable only by an admin or by the owner holding `secret.manage_policy`.

**Technical actors**: previously hard-coded to the implicit `secret.use` grant only — central enforcement would have made mutating `runAs()` workers impossible to authorize. They now resolve the other operation permissions from their provisioned backend groups' `tx_nrvault` custom permission options (read directly from `be_groups`; fail-closed). `secret.use` stays implicit.

**Unchanged**: CLI (`isGranted()` follows the same `allowCliAccess` switch the per-secret CLI tiers already used — narrowed separately in PR 4), admins (central bypass seam), frontend (never holds operation permissions).

Docs updated: `Auditor/ControlMapping.rst` ("server-side enforcement at every entry point" now names the central gate) and `Security/Index.rst` (central mutation enforcement + technical-actor grant model).

## Acceptance tests (from the review)

- Direct DataHandler create with table rights but without `secret.create` → denied, audited, no value persisted (`SecretTcaHookCreateAclTest`)
- Owner without `secret.delete`, direct FormEngine delete → cancelled, `access_denied` audited (`SecretTcaHookDeleteAclTest::ownerWithoutDeletePermissionIsBlocked`)
- Owner **with** `secret.delete` group grant → allowed (`ownerWithDeletePermissionIsAllowedByVaultGate`)
- Unit: denial + audit message for every new gate; `secret.rotate` alone suffices for a plain value update (policy-unchanged case)
- Technical-actor group-grant resolution exercised end-to-end via the cross-actor fixture (actor stores under a `secret.create` group grant)

## Verification

- `composer ci` (cgl + phpstan + unit 2960 + fuzz 1612): green
- Full functional suite (254 tests): green, exit 0

Part 2/5, stacked on #250. Next: audit atomicity for the FormEngine/DataHandler mutations (PR 3).
