### PR TITLE
Make FormEngine mutations audit-atomic and metadata-preserving

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -1219,7 +1219,7 @@ parameters:
 		-
 			rawMessage: 'Cannot call method method() on PHPUnit\Framework\MockObject\MockObject|null.'
 			identifier: method.nonObject
-			count: 160
+			count: 161
 			path: ../Tests/Unit/Audit/AuditLogServiceTest.php
 
 		-

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -19,6 +19,7 @@ use InvalidArgumentException;
 use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
+use Netresearch\NrVault\Exception\AuditWriteException;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Log\LoggerInterface;
@@ -120,7 +121,16 @@ final readonly class AuditLogService implements AuditLogServiceInterface
         } catch (Throwable $e) {
             $this->rollbackAuditLock($connection, $isSQLite);
 
-            throw $e;
+            // Single failure contract: log() either persisted the entry or
+            // throws AuditWriteException — the type the SEC-3 compensating
+            // rollbacks (VaultService, SecretTcaHook) key on. Without this
+            // wrap, a genuine write failure (broken schema, connection loss)
+            // would bypass the compensation that a lock timeout triggers.
+            if ($e instanceof AuditWriteException) {
+                throw $e;
+            }
+
+            throw AuditWriteException::writeFailed($e);
         } finally {
             $this->releaseAuditLock($connection, $isSQLite);
         }

--- a/Classes/Exception/AuditWriteException.php
+++ b/Classes/Exception/AuditWriteException.php
@@ -9,6 +9,8 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Exception;
 
+use Throwable;
+
 /**
  * Thrown when an audit-log write cannot proceed safely.
  *
@@ -16,12 +18,29 @@ namespace Netresearch\NrVault\Exception;
  * audit-chain writer — `AuditLogService::log()` (runtime) and the migration
  * sites (`AuditHmacMigrationWizard`, `VaultAuditMigrateCommand`) — when the
  * advisory lock that serialises hash-chain writers cannot be acquired
- * (`GET_LOCK` returned 0 = timeout, or NULL = database error). Migration
- * callers may catch this and translate to a context-specific exception if
- * they need a distinct type.
+ * (`GET_LOCK` returned 0 = timeout, or NULL = database error), and by
+ * `AuditLogService::log()` for any other failure of the chain write itself
+ * (via {@see self::writeFailed()}). `log()` therefore has a single failure
+ * contract: it either persisted the entry or threw this exception —
+ * which is what the SEC-3 compensating rollbacks in `VaultService` key on.
+ * Migration callers may catch this and translate to a context-specific
+ * exception if they need a distinct type.
  */
 final class AuditWriteException extends VaultException
 {
+    /**
+     * The audit-chain write itself failed (INSERT/UPDATE error, broken
+     * schema, connection loss mid-transaction, …).
+     */
+    public static function writeFailed(Throwable $cause): self
+    {
+        return new self(
+            'Audit-log write failed: ' . $cause->getMessage(),
+            1754038801,
+            $cause,
+        );
+    }
+
     /**
      * @param mixed $rawResult The value returned by `SELECT GET_LOCK(...)` —
      *                         normally 1/0/NULL but driver-dependent

--- a/Classes/Hook/DataHandlerHook.php
+++ b/Classes/Hook/DataHandlerHook.php
@@ -45,6 +45,18 @@ final class DataHandlerHook
     /** @var array<string, list<string>> Per-table cache of vault field names */
     private array $vaultFieldCache = [];
 
+    /**
+     * Record deletes (keyed by table) whose vault-secret cleanup failed in
+     * processCmdmap_preProcess() and that must therefore be cancelled in
+     * processCmdmap(): deleting the record while its secret survives would
+     * orphan the secret AND hide the failed (possibly denied) vault delete
+     * behind an apparently successful record removal. Entries are consumed
+     * when the cancel is applied.
+     *
+     * @var array<string, array<int, true>>
+     */
+    private array $deniedDeletions = [];
+
     public function __construct(
         private readonly ConnectionPool $connectionPool,
         private readonly VaultServiceInterface $vaultService,
@@ -252,6 +264,12 @@ final class DataHandlerHook
                     'operation' => 'delete',
                 ]);
 
+                // Fail closed: if the secret cannot be deleted (denied, audit
+                // write failed, vault error), the record delete is cancelled
+                // in processCmdmap() — otherwise the record removal would
+                // orphan the secret and mask the failure.
+                $this->deniedDeletions[$table][(int) $id] = true;
+
                 /** @phpstan-ignore method.internal */
                 $dataHandler->log(
                     $table,
@@ -259,9 +277,36 @@ final class DataHandlerHook
                     3,
                     null,
                     1,
-                    'Vault error during delete for field "' . $fieldName . '": ' . $userMessage,
+                    'Vault error during delete for field "' . $fieldName . '": ' . $userMessage
+                    . ' The record was preserved.',
                 );
             }
+        }
+    }
+
+    /**
+     * Cancels a record delete whose vault-secret cleanup failed in
+     * processCmdmap_preProcess(). Setting $commandIsProcessed = true makes
+     * core skip its own deleteAction() (DataHandler runs this hook before the
+     * command switch), so the record survives together with its secret.
+     */
+    public function processCmdmap(// NOSONAR: TYPO3 DataHandler hook method name (fixed API contract)
+        string $command,
+        string $table,
+        string|int $id,
+        mixed $value,
+        bool &$commandIsProcessed,
+        DataHandler $dataHandler,
+        mixed $pasteUpdate,
+    ): void {
+        if ($command !== 'delete') {
+            return;
+        }
+
+        $uid = is_numeric($id) ? (int) $id : 0;
+        if (($this->deniedDeletions[$table][$uid] ?? false) === true) {
+            unset($this->deniedDeletions[$table][$uid]);
+            $commandIsProcessed = true;
         }
     }
 

--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -173,7 +173,7 @@ final class SecretTcaHook
         // submits, for the compensating rollback should the metadata-update
         // audit write fail in afterDatabaseOperations (SEC-3 atomicity).
         if (!str_starts_with((string) $id, 'NEW') && $fieldArray !== []) {
-            $columns = array_filter(array_keys($fieldArray), is_string(...));
+            $columns = $this->submittedColumns($fieldArray);
             if ($columns !== []) {
                 $original = BackendUtility::getRecord(self::TABLE, (int) $id, implode(',', $columns));
                 if ($original !== null) {
@@ -290,7 +290,7 @@ final class SecretTcaHook
             return;
         }
 
-        $changedColumns = array_values(array_filter(array_keys($fieldArray), is_string(...)));
+        $changedColumns = $this->submittedColumns($fieldArray);
         if ($changedColumns === []) {
             return;
         }
@@ -416,7 +416,7 @@ final class SecretTcaHook
                 AuditAction::Create->value,
                 true,
                 null,
-                'FormEngine create: ' . implode(', ', array_filter(array_keys($fieldArray), is_string(...))),
+                'FormEngine create: ' . implode(', ', $this->submittedColumns($fieldArray)),
             );
         } catch (Throwable $e) {
             $reverted = $this->revertRow($uid, null);
@@ -474,6 +474,27 @@ final class SecretTcaHook
                 . ($reverted ? 'reverted (no mutation may persist without an audit entry).' : 'NOT revertible; manual reconciliation required.'),
             );
         }
+    }
+
+    /**
+     * The string column names a datamap submits. An explicit loop rather
+     * than array_filter with a first-class callable: every PHPStan version
+     * in the CI matrix narrows this form to list<string>.
+     *
+     * @param array<string, mixed> $fieldArray
+     *
+     * @return list<string>
+     */
+    private function submittedColumns(array $fieldArray): array
+    {
+        $columns = [];
+        foreach (array_keys($fieldArray) as $column) {
+            if (\is_string($column)) {
+                $columns[] = $column;
+            }
+        }
+
+        return $columns;
     }
 
     /**

--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -13,11 +13,13 @@ use Netresearch\NrVault\Audit\AuditAction;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Domain\Model\Secret;
 use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
+use Netresearch\NrVault\Exception\AccessDeniedException;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 
 /**
@@ -67,20 +69,41 @@ final class SecretTcaHook
     private array $pendingSecrets = [];
 
     /**
-     * Record UIDs whose delete command failed the vault ACL in
-     * processCmdmap_preProcess(), to be cancelled in processCmdmap(). Entries
-     * are consumed (unset) when the cancel is applied so a DI-shared hook
-     * instance cannot leak a stale denial across DataHandler runs.
+     * Record UIDs whose delete command was fully handled in
+     * processCmdmap_preProcess() — either performed through
+     * VaultService::delete() (ACL, operation permission and compensated audit
+     * included) or refused. Both outcomes must make core skip its own
+     * deleteAction in processCmdmap(). Entries are consumed (unset) when the
+     * cancel is applied so a DI-shared hook instance cannot leak a stale
+     * entry across DataHandler runs.
      *
      * @var array<int, true>
      */
-    private array $deniedDeletions = [];
+    private array $handledDeletions = [];
+
+    /**
+     * Original values of the real columns a datamap UPDATE submits, captured
+     * in processDatamap_preProcessFieldArray() keyed by record id. Used by
+     * the compensating rollback when the metadata-update audit write fails:
+     * the mutation and its audit entry are all-or-nothing (SEC-3), mirroring
+     * VaultService::compensateAuditFailure().
+     *
+     * @var array<string, array<string, mixed>>
+     */
+    private array $originalMetadata = [];
 
     public function __construct(
         private readonly VaultServiceInterface $vaultService,
         private readonly AuditLogServiceInterface $auditService,
         private readonly AccessControlServiceInterface $accessControlService,
         private readonly SecretRepositoryInterface $secretRepository,
+        /**
+         * Needed for the compensating rollback of a metadata change whose
+         * audit write failed. Optional so pre-existing unit-test
+         * constructions keep working; without it the rollback degrades to
+         * logging the inconsistency in the DataHandler log.
+         */
+        private readonly ?ConnectionPool $connectionPool = null,
     ) {}
 
     /**
@@ -145,6 +168,22 @@ final class SecretTcaHook
 
         // Always remove secret_input from fieldArray - it's not a real database column
         unset($fieldArray['secret_input']);
+
+        // Capture the pre-change values of the real columns this UPDATE
+        // submits, for the compensating rollback should the metadata-update
+        // audit write fail in afterDatabaseOperations (SEC-3 atomicity).
+        if (!str_starts_with((string) $id, 'NEW') && $fieldArray !== []) {
+            $columns = array_filter(array_keys($fieldArray), is_string(...));
+            if ($columns !== []) {
+                $original = BackendUtility::getRecord(self::TABLE, (int) $id, implode(',', $columns));
+                if ($original !== null) {
+                    $this->originalMetadata[(string) $id] = array_intersect_key(
+                        $original,
+                        array_flip($columns),
+                    );
+                }
+            }
+        }
     }
 
     /**
@@ -210,7 +249,7 @@ final class SecretTcaHook
                         $secretStored = true;
                     } else {
                         // Existing record - rotate the secret
-                        $this->vaultService->rotate($identifier, $secretValue);
+                        $this->vaultService->rotate($identifier, $secretValue, 'FormEngine edit');
                         $secretStored = true;
                     }
                 } catch (Throwable $e) {
@@ -232,41 +271,31 @@ final class SecretTcaHook
             }
         }
 
-        // Determine what changed for audit context
-        $changedFields = array_keys($fieldArray);
-        if ($secretStored) {
-            $changedFields[] = 'secret_input';
-        }
+        // Audit strategy: value mutations (the store()/rotate() above) are
+        // audited by VaultService itself, with a compensating rollback when
+        // the audit write fails — the hook must not add a second (or worse, a
+        // premature "success") entry for them. The hook stays responsible for
+        // what the service never sees: the creation of a value-less record
+        // and metadata-only column changes. Both are all-or-nothing here as
+        // well (SEC-3): if the audit write fails, the database change is
+        // reverted so no mutation persists without a tamper-evident record.
+        $originalMetadata = $this->originalMetadata[$originalId] ?? null;
+        unset($this->originalMetadata[$originalId]);
 
-        try {
-            // Determine action type
-            $action = AuditAction::MetadataUpdate->value;
-            if ($status === 'new') {
-                $action = AuditAction::Create->value;
-            } elseif ($secretStored) {
-                $action = AuditAction::Rotate->value;
+        if ($status === 'new') {
+            if (!$secretStored) {
+                $this->auditRecordCreationOrCompensate($identifier, $uid, $fieldArray, $dataHandler);
             }
 
-            // Log the operation
-            $this->auditService->log(
-                $identifier,
-                $action,
-                true,
-                null,
-                'FormEngine edit: ' . implode(', ', $changedFields),
-            );
-        } catch (Throwable $e) {
-            // Don't fail the save if audit logging fails
-            /** @phpstan-ignore method.internal */
-            $dataHandler->log(
-                self::TABLE,
-                $uid,
-                2,
-                null,
-                1,
-                'Audit logging failed: ' . $e->getMessage(),
-            );
+            return;
         }
+
+        $changedColumns = array_values(array_filter(array_keys($fieldArray), is_string(...)));
+        if ($changedColumns === []) {
+            return;
+        }
+
+        $this->auditMetadataUpdateOrCompensate($identifier, $uid, $changedColumns, $originalMetadata, $dataHandler);
     }
 
     /**
@@ -300,30 +329,19 @@ final class SecretTcaHook
             return;
         }
 
-        $identifier = $secret->getIdentifier();
+        // The delete is performed THROUGH the service, so the per-secret tier
+        // (owner / admin / system maintainer, CWE-862), the secret.delete
+        // operation permission, the audit entry and its compensating rollback
+        // (SEC-3: no delete may persist without an audit record) all apply
+        // exactly as on the programmatic path. Core's own deleteAction is
+        // skipped in processCmdmap() in every outcome: on success the service
+        // already soft-deleted the record, on refusal it must survive.
+        $this->handledDeletions[$uid] = true;
 
-        // Write-path authorization (CWE-862): the per-secret tier (owner /
-        // admin / system maintainer) AND the secret.delete operation
-        // permission must both hold. A non-owner non-admin editor with
-        // generic table-modify rights — or an owner lacking the delete
-        // grant — must be stopped here.
-        if (!$this->accessControlService->canDelete($secret)
-            || !$this->accessControlService->isGranted(VaultPermission::SecretDelete)
-        ) {
-            $this->deniedDeletions[$uid] = true;
-
-            try {
-                $this->auditService->log(
-                    $identifier,
-                    AuditAction::AccessDenied->value,
-                    false,
-                    'Delete access denied',
-                    'FormEngine delete denied',
-                );
-            } catch (Throwable) {
-                // A failed audit write must not mask the denial.
-            }
-
+        try {
+            $this->vaultService->delete($secret->getIdentifier(), 'Deleted via FormEngine');
+        } catch (AccessDeniedException) {
+            // The service audited the denial (access_denied entry).
             /** @phpstan-ignore method.internal */
             $dataHandler?->log(
                 self::TABLE,
@@ -333,33 +351,29 @@ final class SecretTcaHook
                 1,
                 'Vault secret deletion requires being its owner or an administrator AND holding the secret.delete permission',
             );
-
-            return;
-        }
-
-        // Authorized delete: record the audit entry now, while the identifier
-        // is still resolvable (core removes the row afterwards).
-        try {
-            $this->auditService->log(
-                $identifier,
-                AuditAction::Delete->value,
-                true,
+        } catch (Throwable $e) {
+            // Audit-write failure (the service reverted the delete) or any
+            // other vault error: the record is preserved.
+            /** @phpstan-ignore method.internal */
+            $dataHandler?->log(
+                self::TABLE,
+                $uid,
+                2,
                 null,
-                'Deleted via FormEngine',
+                1,
+                'Vault delete failed: ' . $e->getMessage() . ' — the record was preserved.',
             );
-        } catch (Throwable) {
-            // Don't fail the delete if audit logging fails
         }
     }
 
     /**
-     * Cancels a delete command that failed the vault ACL in
-     * processCmdmap_preProcess(). Setting $commandIsProcessed = true makes core
-     * skip its own deleteAction() (DataHandler runs this hook before the
-     * command switch), so the record is preserved.
+     * Makes core skip its own deleteAction() for every delete command the
+     * hook handled in processCmdmap_preProcess() — a successful service
+     * delete already soft-deleted the record, a refused one must leave it
+     * untouched. (DataHandler runs this hook before the command switch.)
      *
-     * The denial flag is consumed so a DI-shared hook instance cannot leak a
-     * stale denial into a later DataHandler run (same discipline as
+     * The flag is consumed so a DI-shared hook instance cannot leak a stale
+     * entry into a later DataHandler run (same discipline as
      * $pendingSecrets).
      */
     public function processCmdmap(// NOSONAR: TYPO3 DataHandler hook method name (fixed API contract)
@@ -376,9 +390,119 @@ final class SecretTcaHook
         }
 
         $uid = is_numeric($id) ? (int) $id : 0;
-        if (($this->deniedDeletions[$uid] ?? false) === true) {
-            unset($this->deniedDeletions[$uid]);
+        if (($this->handledDeletions[$uid] ?? false) === true) {
+            unset($this->handledDeletions[$uid]);
             $commandIsProcessed = true;
+        }
+    }
+
+    /**
+     * Audit the FormEngine creation of a record that carries no secret value
+     * (a value-bearing create is audited by VaultService::store()). If the
+     * audit write fails, the just-created row is removed again — a record
+     * must not exist without its audit entry.
+     *
+     * @param array<string, mixed> $fieldArray
+     */
+    private function auditRecordCreationOrCompensate(
+        string $identifier,
+        int $uid,
+        array $fieldArray,
+        DataHandler $dataHandler,
+    ): void {
+        try {
+            $this->auditService->log(
+                $identifier,
+                AuditAction::Create->value,
+                true,
+                null,
+                'FormEngine create: ' . implode(', ', array_filter(array_keys($fieldArray), is_string(...))),
+            );
+        } catch (Throwable $e) {
+            $reverted = $this->revertRow($uid, null);
+
+            /** @phpstan-ignore method.internal */
+            $dataHandler->log(
+                self::TABLE,
+                $uid,
+                1,
+                null,
+                1,
+                'Vault audit logging failed: ' . $e->getMessage() . ' — the record creation was '
+                . ($reverted ? 'reverted (no mutation may persist without an audit entry).' : 'NOT revertible; manual reconciliation required.'),
+            );
+        }
+    }
+
+    /**
+     * Audit a metadata-only column change. If the audit write fails, the
+     * captured pre-change values are written back (scalar columns; MM
+     * relation rows are owned by DataHandler and only their count column is
+     * restored) so the change does not persist unaudited.
+     *
+     * @param list<string> $changedColumns
+     * @param array<string, mixed>|null $originalMetadata
+     */
+    private function auditMetadataUpdateOrCompensate(
+        string $identifier,
+        int $uid,
+        array $changedColumns,
+        ?array $originalMetadata,
+        DataHandler $dataHandler,
+    ): void {
+        try {
+            $this->auditService->log(
+                $identifier,
+                AuditAction::MetadataUpdate->value,
+                true,
+                null,
+                'FormEngine edit: ' . implode(', ', $changedColumns),
+            );
+        } catch (Throwable $e) {
+            $reverted = $originalMetadata !== null
+                && $originalMetadata !== []
+                && $this->revertRow($uid, $originalMetadata);
+
+            /** @phpstan-ignore method.internal */
+            $dataHandler->log(
+                self::TABLE,
+                $uid,
+                2,
+                null,
+                1,
+                'Vault audit logging failed: ' . $e->getMessage() . ' — the metadata change was '
+                . ($reverted ? 'reverted (no mutation may persist without an audit entry).' : 'NOT revertible; manual reconciliation required.'),
+            );
+        }
+    }
+
+    /**
+     * Write the compensating revert: `null` removes the just-created row,
+     * a value map restores the captured pre-change column values.
+     *
+     * @param array<string, mixed>|null $originalValues
+     */
+    private function revertRow(int $uid, ?array $originalValues): bool
+    {
+        if ($uid <= 0 || !$this->connectionPool instanceof ConnectionPool) {
+            return false;
+        }
+
+        try {
+            $connection = $this->connectionPool->getConnectionForTable(self::TABLE);
+            if ($originalValues === null) {
+                $connection->delete(self::TABLE, ['uid' => $uid]);
+
+                return true;
+            }
+            if ($originalValues === []) {
+                return false;
+            }
+            $connection->update(self::TABLE, $originalValues, ['uid' => $uid]);
+
+            return true;
+        } catch (Throwable) {
+            return false;
         }
     }
 

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -76,17 +76,28 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
 
             $this->assertWritePermission($identifier, $existing);
 
+            // A record that exists but carries no encrypted value is a
+            // creation in progress, not a rotation target: the FormEngine
+            // path inserts the tx_nrvault_secret row first (DataHandler) and
+            // hands the value to store() afterwards. Classify by the VALUE,
+            // so that path faces secret.create — like the module controller —
+            // and is audited as the creation it is.
+            $isCreation = !$existing instanceof Secret
+                || ($existing->getEncryptedValue() ?? '') === '';
+
             // Separation of duties: the per-secret ACL above answers "may this
             // actor touch THIS secret", the operation permission answers "may
             // this actor perform this KIND of operation at all". Both gates
             // must pass at this business boundary — controller checks are UX,
             // not the security boundary (a DataHandler request or programmatic
             // caller never passes through them).
-            if ($existing instanceof Secret) {
-                $this->assertOperationGranted(VaultPermission::SecretRotate, $identifier, 'Update');
-                $this->assertPolicyChangeGranted($identifier, $options, $existing);
-            } else {
+            if ($isCreation) {
                 $this->assertOperationGranted(VaultPermission::SecretCreate, $identifier, 'Create');
+            } else {
+                $this->assertOperationGranted(VaultPermission::SecretRotate, $identifier, 'Update');
+            }
+            if ($existing instanceof Secret && !$isCreation) {
+                $this->assertPolicyChangeGranted($identifier, $options, $existing);
             }
 
             $encrypted = $this->encryptionService->encrypt($secret, $identifier);
@@ -109,7 +120,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             try {
                 $this->auditLogService->log(
                     $identifier,
-                    $existing instanceof Secret ? AuditAction::Update->value : AuditAction::Create->value,
+                    $isCreation ? AuditAction::Create->value : AuditAction::Update->value,
                     true,
                     null,
                     null,
@@ -132,7 +143,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
                 );
             }
 
-            $this->dispatchStoreEvent($identifier, $secretEntity, !$existing instanceof Secret);
+            $this->dispatchStoreEvent($identifier, $secretEntity, $isCreation);
         } finally {
             // Securely wipe the plaintext even if an exception occurred
             sodium_memzero($secret);
@@ -523,7 +534,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
      */
     private function assertPolicyChangeGranted(string $identifier, array $options, Secret $existing): void
     {
-        $optional = $this->collectOptionalFields($options);
+        $optional = $this->collectOptionalFields($options, $existing);
 
         $ownerChanges = $this->resolveOwnerUid($options, $existing) !== $existing->getOwnerUid();
         $frontendChanges = $this->resolveFrontendAccessible($optional['frontendAccessible'], $existing)
@@ -617,7 +628,16 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
      * Assemble the `Secret` aggregate from the encryption output + options.
      *
      * `$existing === null` → create path (new entity, new crdate/cruserId).
-     * `$existing !== null` → update path (preserve uid/crdate/version).
+     * `$existing !== null` → update path (preserve uid/crdate/version — and
+     * every metadata field the caller did NOT explicitly submit). The
+     * preserve semantics matter twice over: the FormEngine path persists the
+     * metadata columns via DataHandler BEFORE handing the value to store(),
+     * so replace-with-defaults would wipe what the editor just entered; and
+     * a programmatic `store('id', $value)` on an existing secret must not
+     * silently reset description, ACL group tiers, write_groups, expiry or
+     * frontend availability — those are policy fields whose CHANGE is gated
+     * by secret.manage_policy, so an accidental reset is a policy change
+     * without its permission.
      *
      * @param array<string, mixed> $options
      */
@@ -627,7 +647,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
         array $options,
         ?Secret $existing,
     ): Secret {
-        $optional = $this->collectOptionalFields($options);
+        $optional = $this->collectOptionalFields($options, $existing);
 
         return new Secret(
             identifier: $identifier,
@@ -643,6 +663,7 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
             valueChecksum: $encrypted->valueChecksum,
             ownerUid: $this->resolveOwnerUid($options, $existing),
             allowedGroups: $optional['allowedGroups'],
+            writeGroups: $existing instanceof Secret ? $existing->getWriteGroups() : [],
             context: $optional['context'],
             frontendAccessible: $this->resolveFrontendAccessible($optional['frontendAccessible'], $existing),
             version: $existing instanceof Secret ? $existing->getVersion() : 1,
@@ -708,10 +729,10 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
 
     /**
      * Collect the value-type-flexible options from the `store($options)`
-     * array into a typed bundle. Each option is defensively coerced to
-     * its expected type; options not supplied get the Secret-default
-     * value (matching the previous mutator-based behaviour where unset
-     * options left the constructed entity at its default).
+     * array into a typed bundle. Each option is defensively coerced to its
+     * expected type. An option NOT supplied keeps the existing secret's
+     * value on update (preserve semantics — see buildSecretEntity()) and
+     * gets the Secret-default value on create.
      *
      * @param array<string, mixed> $options
      *
@@ -725,21 +746,33 @@ final class VaultService implements VaultServiceInterface, SingletonInterface
      *     metadata: array<string, mixed>,
      * }
      */
-    private function collectOptionalFields(array $options): array
+    private function collectOptionalFields(array $options, ?Secret $existing): array
     {
-        $metadata = [];
+        $metadata = $existing?->getMetadata() ?? [];
         if (isset($options['metadata'])) {
             /** @var array<string, mixed> $metadata */
             $metadata = (array) $options['metadata'];
         }
 
         return [
-            'scopePid' => (isset($options['scopePid']) && is_numeric($options['scopePid'])) ? (int) $options['scopePid'] : 0,
-            'description' => isset($options['description']) ? $this->coerceToString($options['description']) : '',
-            'allowedGroups' => isset($options['groups']) ? $this->coerceGroupList($options['groups']) : [],
-            'context' => isset($options['context']) ? $this->coerceToString($options['context']) : '',
-            'frontendAccessible' => isset($options['frontendAccessible']) && (bool) $options['frontendAccessible'],
-            'expiresAt' => isset($options['expiresAt']) ? $this->coerceTimestamp($options['expiresAt']) : 0,
+            'scopePid' => (isset($options['scopePid']) && is_numeric($options['scopePid']))
+                ? (int) $options['scopePid']
+                : ($existing?->getScopePid() ?? 0),
+            'description' => isset($options['description'])
+                ? $this->coerceToString($options['description'])
+                : ($existing?->getDescription() ?? ''),
+            'allowedGroups' => isset($options['groups'])
+                ? $this->coerceGroupList($options['groups'])
+                : array_values($existing?->getAllowedGroups() ?? []),
+            'context' => isset($options['context'])
+                ? $this->coerceToString($options['context'])
+                : ($existing?->getContext() ?? ''),
+            'frontendAccessible' => isset($options['frontendAccessible'])
+                ? (bool) $options['frontendAccessible']
+                : ($existing instanceof Secret && $existing->isFrontendAccessible()),
+            'expiresAt' => isset($options['expiresAt'])
+                ? $this->coerceTimestamp($options['expiresAt'])
+                : ($existing?->getExpiresAt() ?? 0),
             'metadata' => $metadata,
         ];
     }

--- a/Documentation/Auditor/ControlMapping.rst
+++ b/Documentation/Auditor/ControlMapping.rst
@@ -203,9 +203,16 @@ and Logging).*
 
     *   -   Log entry precedes the effect where order matters
         -   Break-glass audits **before** granting; delete/store compensate a
-            failed audit write by rolling the data change back
+            failed audit write by rolling the data change back. The
+            FormEngine/DataHandler paths share this contract: the
+            ``tx_nrvault_secret`` delete command runs through
+            :php:`VaultService::delete()`, and a metadata change (or
+            value-less record creation) whose audit write fails is reverted
+            by :php:`SecretTcaHook` — no mutation persists without its audit
+            entry.
         -   :php:`BreakGlassService::activate()`,
-            :php:`VaultService::delete()`
+            :php:`VaultService::delete()`,
+            :php:`SecretTcaHook`
 
     *   -   Complete attribution
         -   ``actor_uid``, ``actor_type``, ``actor_username``,

--- a/Tests/Functional/Hook/DataHandlerHookTest.php
+++ b/Tests/Functional/Hook/DataHandlerHookTest.php
@@ -334,6 +334,62 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
         // Secret must be deleted
         $retrieved = $vaultService->retrieve($vaultIdentifier);
         self::assertNull($retrieved, 'Vault secret must be deleted when its record is deleted');
+
+        // The successful cleanup must NOT cancel the record delete.
+        $commandIsProcessed = false;
+        $hook->processCmdmap('delete', 'tx_nrvault_hooktest2', $recordUid, null, $commandIsProcessed, $dataHandler, false);
+        self::assertFalse($commandIsProcessed, 'A successful vault cleanup must let core delete the record.');
+    }
+
+    #[Test]
+    public function recordDeleteIsCancelledWhenVaultDeleteFails(): void
+    {
+        $this->skipIfNotSqlite();
+
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $connectionPool = $this->get(ConnectionPool::class);
+        $hook = $this->createHookWithVaultFields('tx_nrvault_hooktest3', ['api_key']);
+
+        $connection = $connectionPool->getConnectionForTable('tx_nrvault_hooktest3');
+        $connection->executeStatement(
+            'CREATE TABLE IF NOT EXISTS tx_nrvault_hooktest3 (
+                uid INTEGER PRIMARY KEY AUTOINCREMENT,
+                pid INTEGER DEFAULT 0,
+                api_key VARCHAR(255) DEFAULT \'\'
+            )',
+        );
+
+        $vaultIdentifier = $this->generateUuidV7();
+        $vaultService->store($vaultIdentifier, 'cancel-test-secret');
+
+        $connection->insert('tx_nrvault_hooktest3', [
+            'pid' => 0,
+            'api_key' => $vaultIdentifier,
+        ]);
+        $recordUid = (int) $connection->lastInsertId();
+
+        // Break the audit chain for real: the vault delete's audit write
+        // fails, VaultService compensates (the secret survives), and the
+        // hook must cancel the record delete — deleting the record while its
+        // secret survives would orphan the secret and mask the failure.
+        $connectionPool
+            ->getConnectionForTable('tx_nrvault_audit_log')
+            ->executeStatement('DROP TABLE tx_nrvault_audit_log');
+
+        $dataHandler = $this->createDataHandler();
+        $hook->processCmdmap_preProcess('delete', 'tx_nrvault_hooktest3', $recordUid, null, $dataHandler, false);
+
+        $commandIsProcessed = false;
+        $hook->processCmdmap('delete', 'tx_nrvault_hooktest3', $recordUid, null, $commandIsProcessed, $dataHandler, false);
+
+        self::assertTrue(
+            $commandIsProcessed,
+            'A failed vault delete must cancel the record delete (fail closed).',
+        );
+        self::assertTrue(
+            $vaultService->exists($vaultIdentifier),
+            'The secret must survive its failed (compensated) delete.',
+        );
     }
 
     /**

--- a/Tests/Functional/Hook/SecretTcaHookAuditAtomicityTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookAuditAtomicityTest.php
@@ -1,0 +1,171 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Hook;
+
+use Netresearch\NrVault\Hook\SecretTcaHook;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * SEC-3 all-or-nothing on the FormEngine/DataHandler paths: a mutation and
+ * its tamper-evident audit entry must stand or fall together. The audit
+ * write is broken for real (the audit table is dropped mid-test), then the
+ * review's acceptance scenarios are exercised end-to-end:
+ *
+ * - "AuditLogService throws on the metadata update => the database change
+ *   is not kept" — SecretTcaHook's compensating rollback restores the
+ *   captured pre-change values.
+ * - "AuditLogService throws on the FormEngine delete => the secret
+ *   survives" — the delete runs through VaultService::delete(), whose
+ *   compensation re-stores the record (deleted=0).
+ */
+#[CoversClass(SecretTcaHook::class)]
+final class SecretTcaHookAuditAtomicityTest extends AbstractVaultFunctionalTestCase
+{
+    private const SECRET_TABLE = 'tx_nrvault_secret';
+
+    private const AUDIT_TABLE = 'tx_nrvault_audit_log';
+
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users.csv';
+
+    #[Test]
+    public function metadataChangeIsRevertedWhenAuditWriteFails(): void
+    {
+        $identifier = 'atomic_meta_' . bin2hex(random_bytes(4));
+        $recordUid = $this->createRecord($identifier, 'Original description');
+
+        $this->breakAuditWrites();
+
+        $updateHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $updateHandler->start(
+            [
+                self::SECRET_TABLE => [
+                    $recordUid => [
+                        'description' => 'Changed description',
+                    ],
+                ],
+            ],
+            [],
+        );
+        $updateHandler->process_datamap();
+
+        // The mutation must not survive its failed audit entry.
+        self::assertSame(
+            'Original description',
+            $this->readColumn($recordUid, 'description'),
+            'The metadata change must be reverted when its audit write fails.',
+        );
+
+        /** @phpstan-ignore property.internal */
+        $errorLog = $updateHandler->errorLog;
+        self::assertNotEmpty(
+            $errorLog,
+            'The reverted save must surface in the DataHandler error log.',
+        );
+    }
+
+    #[Test]
+    public function formEngineDeleteIsRevertedWhenAuditWriteFails(): void
+    {
+        $identifier = 'atomic_del_' . bin2hex(random_bytes(4));
+        $recordUid = $this->createRecord($identifier, 'To be deleted');
+
+        $this->breakAuditWrites();
+
+        $deleteHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $deleteHandler->start(
+            [],
+            [
+                self::SECRET_TABLE => [
+                    $recordUid => [
+                        'delete' => 1,
+                    ],
+                ],
+            ],
+        );
+        $deleteHandler->process_cmdmap();
+
+        // VaultService::delete() compensated the failed audit write by
+        // re-storing the record, and the hook cancelled core's deleteAction.
+        self::assertSame(
+            0,
+            (int) $this->readColumn($recordUid, 'deleted'),
+            'The secret must survive a delete whose audit write failed.',
+        );
+        self::assertNotSame(
+            '',
+            $this->readColumn($recordUid, 'encrypted_value'),
+            'The encrypted value must remain intact after the reverted delete.',
+        );
+    }
+
+    /**
+     * Create a value-bearing secret record through the real DataHandler
+     * (audit still healthy at this point).
+     */
+    private function createRecord(string $identifier, string $description): int
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start(
+            [
+                self::SECRET_TABLE => [
+                    'NEW1' => [
+                        'pid' => 0,
+                        'identifier' => $identifier,
+                        'description' => $description,
+                        'secret_input' => 'atomicity-test-value',
+                    ],
+                ],
+            ],
+            [],
+        );
+        $dataHandler->process_datamap();
+
+        $recordUid = $dataHandler->substNEWwithIDs['NEW1'] ?? 0;
+        self::assertIsNumeric($recordUid);
+        self::assertGreaterThan(0, (int) $recordUid);
+
+        /** @phpstan-ignore property.internal */
+        $errorLog = $dataHandler->errorLog;
+        self::assertEmpty($errorLog, 'Seeding must succeed: ' . implode(', ', $errorLog));
+
+        return (int) $recordUid;
+    }
+
+    /**
+     * Make every subsequent audit-chain write fail for real: drop the audit
+     * table. AuditLogService::log() wraps the resulting driver exception in
+     * AuditWriteException — the type the compensations key on.
+     */
+    private function breakAuditWrites(): void
+    {
+        $this->getConnectionPool()
+            ->getConnectionForTable(self::AUDIT_TABLE)
+            ->executeStatement('DROP TABLE ' . self::AUDIT_TABLE);
+    }
+
+    private function readColumn(int $uid, string $column): string
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::SECRET_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $value = $queryBuilder
+            ->select($column)
+            ->from(self::SECRET_TABLE)
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)))
+            ->executeQuery()
+            ->fetchOne();
+
+        return \is_scalar($value) ? (string) $value : '';
+    }
+}

--- a/Tests/Functional/Hook/SecretTcaHookAuditAtomicityTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookAuditAtomicityTest.php
@@ -136,9 +136,12 @@ final class SecretTcaHookAuditAtomicityTest extends AbstractVaultFunctionalTestC
         self::assertIsNumeric($recordUid);
         self::assertGreaterThan(0, (int) $recordUid);
 
+        // assertSame([], ...) prints the offending entries itself on failure
+        // (and sidesteps the v13 core stub typing errorLog as plain `array`,
+        // which rejects implode()).
         /** @phpstan-ignore property.internal */
         $errorLog = $dataHandler->errorLog;
-        self::assertEmpty($errorLog, 'Seeding must succeed: ' . implode(', ', $errorLog));
+        self::assertSame([], $errorLog, 'Seeding must succeed without DataHandler errors.');
 
         return (int) $recordUid;
     }

--- a/Tests/Functional/Hook/SecretTcaHookDeleteAclTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookDeleteAclTest.php
@@ -110,16 +110,20 @@ final class SecretTcaHookDeleteAclTest extends AbstractVaultFunctionalTestCase
     public function ownerWithDeletePermissionIsAllowedByVaultGate(): void
     {
         // Both gates hold: per-secret tier (owner) AND the secret.delete
-        // operation permission via the group custom permission option.
+        // operation permission via the group custom permission option. The
+        // delete runs THROUGH VaultService (audit with compensating
+        // rollback), so the hook marks the command processed and core's own
+        // deleteAction is skipped.
         $this->setUpBackendUser(self::DELETER_UID);
         [$uid, $identifier] = $this->seedSecret(self::DELETER_UID);
 
         $commandIsProcessed = $this->runDeleteHook($uid);
 
-        self::assertFalse(
+        self::assertTrue(
             $commandIsProcessed,
-            'An owner holding secret.delete must not be blocked by the vault delete gate.',
+            'The service-performed delete must mark the command processed (core skips deleteAction).',
         );
+        self::assertSame(1, $this->readDeletedFlag($uid), 'The record must be soft-deleted by the service.');
         self::assertSame(
             1,
             $this->countAudit($identifier, AuditAction::Delete->value, 1),
@@ -135,7 +139,11 @@ final class SecretTcaHookDeleteAclTest extends AbstractVaultFunctionalTestCase
 
         $commandIsProcessed = $this->runDeleteHook($uid);
 
-        self::assertFalse($commandIsProcessed, 'An admin must not be blocked by the vault delete gate.');
+        self::assertTrue(
+            $commandIsProcessed,
+            'The service-performed delete must mark the command processed (core skips deleteAction).',
+        );
+        self::assertSame(1, $this->readDeletedFlag($uid), 'The record must be soft-deleted by the service.');
         self::assertSame(
             1,
             $this->countAudit($identifier, AuditAction::Delete->value, 1),
@@ -181,6 +189,20 @@ final class SecretTcaHookDeleteAclTest extends AbstractVaultFunctionalTestCase
         ]);
 
         return [(int) $connection->lastInsertId(), $identifier];
+    }
+
+    private function readDeletedFlag(int $uid): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::SECRET_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $deleted = $queryBuilder
+            ->select('deleted')
+            ->from(self::SECRET_TABLE)
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)))
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($deleted) ? (int) $deleted : -1;
     }
 
     private function countAudit(string $identifier, string $action, int $success): int

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -753,9 +753,10 @@ final class AuditLogServiceTest extends TestCase
     {
         $this->setupDatabaseMocks();
 
+        $cause = new RuntimeException('Insert failed');
         $this->connection
             ->method('insert')
-            ->willThrowException(new RuntimeException('Insert failed'));
+            ->willThrowException($cause);
 
         $this->connection
             ->expects(self::once())
@@ -765,10 +766,37 @@ final class AuditLogServiceTest extends TestCase
             ->expects(self::never())
             ->method('commit');
 
-        $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Insert failed');
+        // Single failure contract: any chain-write failure surfaces as
+        // AuditWriteException — the type the SEC-3 compensating rollbacks in
+        // VaultService and SecretTcaHook key on — with the driver error
+        // chained as previous.
+        try {
+            $this->getSubject()->log('test_secret', 'create', true);
+            self::fail('log() must throw on a failed insert');
+        } catch (AuditWriteException $e) {
+            self::assertStringContainsString('Insert failed', $e->getMessage());
+            self::assertSame($cause, $e->getPrevious());
+        }
+    }
 
-        $this->getSubject()->log('test_secret', 'create', true);
+    #[Test]
+    public function logDoesNotDoubleWrapAnAuditWriteException(): void
+    {
+        // A lock-acquisition failure is already an AuditWriteException; the
+        // wrap in log() must rethrow it as-is instead of nesting it.
+        $this->setupDatabaseMocks();
+
+        $original = AuditWriteException::lockAcquisitionFailed(0);
+        $this->connection
+            ->method('insert')
+            ->willThrowException($original);
+
+        try {
+            $this->getSubject()->log('test_secret', 'create', true);
+            self::fail('log() must rethrow the AuditWriteException');
+        } catch (AuditWriteException $e) {
+            self::assertSame($original, $e);
+        }
     }
 
     #[Test]

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -427,6 +427,110 @@ final class VaultServiceTest extends TestCase
     }
 
     #[Test]
+    public function storeUpdatePreservesUnsubmittedMetadata(): void
+    {
+        // Preserve semantics: a value update without options must not reset
+        // description, ACL tiers, context, expiry or frontend availability —
+        // those are policy fields whose CHANGE is gated by
+        // secret.manage_policy, so an accidental reset would be a policy
+        // change without its permission.
+        $existing = new Secret(
+            identifier: 'preserve',
+            uid: 42,
+            scopePid: 7,
+            description: 'Keep me',
+            encryptedValue: 'encrypted',
+            encryptedDek: 'dek',
+            dekNonce: 'n1',
+            valueNonce: 'n2',
+            valueChecksum: 'cs',
+            ownerUid: 1,
+            allowedGroups: [5, 6],
+            writeGroups: [6],
+            context: 'prod',
+            frontendAccessible: true,
+            version: 3,
+            expiresAt: 2000000000,
+            metadata: ['team' => 'ops'],
+        );
+
+        $this->encryptionService
+            ->method('encrypt')
+            ->willReturn(new EncryptedData('enc2', 'dek2', 'n3', 'n4', 'cs2'));
+
+        $this->adapter->method('retrieve')->willReturn($existing);
+        $this->accessControlService->method('canWrite')->willReturn(true);
+
+        $this->adapter
+            ->expects(self::once())
+            ->method('store')
+            ->with(self::callback(static fn (Secret $s): bool => $s->getDescription() === 'Keep me'
+                && $s->getScopePid() === 7
+                && $s->getAllowedGroups() === [5, 6]
+                && $s->getWriteGroups() === [6]
+                && $s->getContext() === 'prod'
+                && $s->isFrontendAccessible() === true
+                && $s->getExpiresAt() === 2000000000
+                && $s->getMetadata() === ['team' => 'ops']))
+            ->willReturnArgument(0);
+
+        $this->subject->store('preserve', 'new-value');
+    }
+
+    #[Test]
+    public function storeOnValueLessExistingRecordIsACreation(): void
+    {
+        // The FormEngine path: DataHandler inserts the tx_nrvault_secret row
+        // (metadata only), then hands the value to store(). A record without
+        // an encrypted value is a creation in progress — it must face
+        // secret.create (not secret.rotate), be audited as create, and keep
+        // the metadata the row already carries.
+        $existing = new Secret(
+            identifier: 'formCreate',
+            uid: 42,
+            description: 'Entered in the form',
+            ownerUid: 1,
+        );
+
+        $createOnlyAccess = $this->createMock(AccessControlServiceInterface::class);
+        $createOnlyAccess->method('getCurrentActorUid')->willReturn(1);
+        $createOnlyAccess->method('getCurrentActorType')->willReturn('cli');
+        $createOnlyAccess->method('canWrite')->willReturn(true);
+        $createOnlyAccess->method('isGranted')->willReturnCallback(
+            static fn (VaultPermission $permission): bool => $permission === VaultPermission::SecretCreate,
+        );
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $createOnlyAccess,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->encryptionService
+            ->method('encrypt')
+            ->willReturn(new EncryptedData('enc', 'dek', 'n1', 'n2', 'cs'));
+
+        $this->adapter->method('retrieve')->willReturn($existing);
+
+        $this->adapter
+            ->expects(self::once())
+            ->method('store')
+            ->with(self::callback(static fn (Secret $s): bool => $s->getUid() === 42
+                && $s->getDescription() === 'Entered in the form'))
+            ->willReturnArgument(0);
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('formCreate', 'create', true);
+
+        $subject->store('formCreate', 'first-value');
+    }
+
+    #[Test]
     public function storeCoercesOwnerUidForNonAdminBackendActor(): void
     {
         $beActorAccess = $this->createMock(AccessControlServiceInterface::class);

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -469,7 +469,7 @@ final class VaultServiceTest extends TestCase
                 && $s->getAllowedGroups() === [5, 6]
                 && $s->getWriteGroups() === [6]
                 && $s->getContext() === 'prod'
-                && $s->isFrontendAccessible() === true
+                && $s->isFrontendAccessible()
                 && $s->getExpiresAt() === 2000000000
                 && $s->getMetadata() === ['team' => 'ops']))
             ->willReturnArgument(0);


### PR DESCRIPTION
## Finding (High for audit purposes): FormEngine mutations are fail-open on audit errors

`SecretTcaHook` wrote the delete success audit **before** core deleted the record and swallowed a failing audit write entirely (`catch (Throwable) {}`); a metadata update kept the database change when its audit write failed ("don't fail the save"); and the auditor docs' claims ("every mutation is logged", "delete/store compensate a failed audit write") did not hold for the DataHandler path.

## Fixes

**Honest failure contract first:** `AuditLogService::log()` now wraps *any* chain-write failure in `AuditWriteException` — previously only the advisory-lock timeout was wrapped, so a genuine INSERT failure (broken schema, connection loss) bypassed every compensating rollback that catches this type. Without this, the review's acceptance tests were unsatisfiable.

- **Delete via the service:** the `tx_nrvault_secret` delete command runs through `VaultService::delete()` (per-secret tier + `secret.delete` + audited + compensated). Core's `deleteAction` is skipped in every outcome — success (service already soft-deleted) and refusal/audit failure (record must survive).
- **Metadata changes are compensated:** `SecretTcaHook` audits only what the service never sees (value-less record creations, metadata-only column changes) and reverts the captured pre-change values when the audit write fails. No more duplicate/false Create/Rotate entries next to the service's own audit.
- **`DataHandlerHook` (vault fields on foreign tables):** a failed vault delete now **cancels** the record delete instead of proceeding and orphaning the secret behind an apparently successful removal.

## Two correctness bugs surfaced by the new atomicity tests (fixed in `VaultService::store()`)

1. **Update replaced unsubmitted options with defaults** — wiping description, context, `allowed_groups`, `write_groups`, expiry, scope and frontend availability that FormEngine's DataHandler had just persisted; a plain programmatic `store('id', $value)` silently reset policy fields whose *change* is gated by `secret.manage_policy`. Updates now preserve unsubmitted fields.
2. **FormEngine create was classified as an update** (row exists before `store()` is called) — gated by `secret.rotate` and audited as `update`. Creation is now classified by the **value**: a record without an encrypted value is a creation in progress → `secret.create` (matching the module controller) and audited as `create`.

Docs: `Auditor/ControlMapping.rst` "log entry precedes the effect" row now names the FormEngine/DataHandler compensation.

## Acceptance tests (from the review)

The audit chain is broken for real (audit table dropped mid-test):

- Metadata update → the database change is **reverted**, DataHandler error log filled (`SecretTcaHookAuditAtomicityTest::metadataChangeIsRevertedWhenAuditWriteFails`)
- FormEngine delete → the secret **survives** (`deleted=0`, envelope intact) (`formEngineDeleteIsRevertedWhenAuditWriteFails`)
- Foreign-table record delete with failing vault delete → record delete **cancelled**, secret survives (`DataHandlerHookTest::recordDeleteIsCancelledWhenVaultDeleteFails`)
- Service-performed FormEngine deletes mark the command processed + soft-delete the record (`SecretTcaHookDeleteAclTest`)
- Unit: preserve semantics (`storeUpdatePreservesUnsubmittedMetadata`), value-less-record create classification (`storeOnValueLessExistingRecordIsACreation`)

## Verification

- `composer ci` (cgl + phpstan + unit 2962 + fuzz 1612): green
- Full functional suite (257 tests): green, exit 0

Part 3/5, stacked on #251. Next: CLI operation allowlist (PR 4).
