### PR TITLE
ci: add zizmor config exempting first-party reusables

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -27,8 +27,6 @@ jobs:
     permissions:
       contents: read
       security-events: write
-    secrets:
-      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
 
   zizmor:
     uses: netresearch/.github/.github/workflows/zizmor.yml@main

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -22,6 +22,20 @@ jobs:
       contents: read
       security-events: write
 
+  gitleaks:
+    uses: netresearch/.github/.github/workflows/gitleaks.yml@main
+    permissions:
+      contents: read
+      security-events: write
+    secrets:
+      GITLEAKS_LICENSE: ${{ secrets.GITLEAKS_LICENSE }}
+
+  zizmor:
+    uses: netresearch/.github/.github/workflows/zizmor.yml@main
+    permissions:
+      contents: read
+      security-events: write
+
   fuzz:
     uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
     permissions:

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,13 @@
+# zizmor (https://zizmor.sh) configuration
+#
+# Tunes zizmor to Netresearch conventions so the audit reports only
+# actionable findings. Third-party actions remain hash-pin enforced.
+rules:
+  unpinned-uses:
+    config:
+      policies:
+        # First-party reusable workflows track @main by policy and are
+        # never SHA-pinned, so fixes propagate to all consumers.
+        "netresearch/*": ref-pin
+        # Everything else must be pinned to a full commit SHA.
+        "*": hash-pin

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -7,6 +7,8 @@ paths = [
     '''Tests/Unit/Service/SecretDetectionServiceTest\.php''',
     '''Tests/Unit/Crypto/EnvironmentMasterKeyProviderTest\.php''',
     '''Tests/Fuzz/.*\.php''',
+    '''Tests/Unit/Secret/SecretRedactorTest\.php''',
+    '''Tests/Unit/Command/VaultMigrateFieldCommandTest\.php''',
     '''docs/implementation-plan\.md''',
     '''\.php-cs-fixer\.cache''',
     '''\.ddev/docker-compose\..*\.yaml''',


### PR DESCRIPTION
Adds `.github/zizmor.yml`, byte-identical to the shared template config in
netresearch/.github#329.

zizmor's default `unpinned-uses` policy is blanket hash-pin, so it flags every
`netresearch/*` reusable referenced `@main`. First-party reusables track `@main`
by policy so fixes propagate to all consumers without a SHA bump, so they are
exempted to `ref-pin` here.

Third-party actions remain hash-pin enforced — the audit is not disabled.

This repo is a template consumer (`.github/template.yaml`), and the shared
templates now ship this file, so it is required to keep the template drift check
green.
