### PR TITLE
Narrow the CLI actor to an explicit operation allowlist

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -1549,7 +1549,7 @@ parameters:
 		-
 			rawMessage: 'Call to an undefined method PHPUnit\Framework\MockObject\InvocationStubber::with().'
 			identifier: method.notFound
-			count: 38
+			count: 39
 			path: ../Tests/Unit/Configuration/ExtensionConfigurationTest.php
 
 		-
@@ -1567,7 +1567,7 @@ parameters:
 		-
 			rawMessage: 'Cannot call method willReturn() on mixed.'
 			identifier: method.nonObject
-			count: 38
+			count: 39
 			path: ../Tests/Unit/Configuration/ExtensionConfigurationTest.php
 
 		-

--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -1549,7 +1549,7 @@ parameters:
 		-
 			rawMessage: 'Call to an undefined method PHPUnit\Framework\MockObject\InvocationStubber::with().'
 			identifier: method.notFound
-			count: 39
+			count: 40
 			path: ../Tests/Unit/Configuration/ExtensionConfigurationTest.php
 
 		-
@@ -1567,7 +1567,7 @@ parameters:
 		-
 			rawMessage: 'Cannot call method willReturn() on mixed.'
 			identifier: method.nonObject
-			count: 39
+			count: 40
 			path: ../Tests/Unit/Configuration/ExtensionConfigurationTest.php
 
 		-

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -35,6 +35,14 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
 
     public const DEFAULT_ALLOW_CLI_ACCESS = false;
 
+    /**
+     * Operation permissions the unattributed CLI actor may hold when
+     * `allowCliAccess` is on. High-risk operations (secret.reveal,
+     * secret.delete, audit.export, master_key.rotate, vault.configure) are
+     * deliberately absent — they must be opted into explicitly.
+     */
+    public const DEFAULT_CLI_ALLOWED_OPERATIONS = 'secret.use,secret.create,secret.rotate';
+
     public const DEFAULT_AUDIT_READS = true;
 
     public const DEFAULT_DISABLE_ADMIN_OVERRIDE = false;
@@ -195,6 +203,28 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
         }
 
         return [];
+    }
+
+    /**
+     * The operation permissions the unattributed CLI actor may hold when
+     * `allowCliAccess` is on (see DEFAULT_CLI_ALLOWED_OPERATIONS for the
+     * default and its rationale). Entries are trimmed; unknown values are
+     * kept as-is here — `vault:doctor` reports them, and the grant lookup
+     * compares against real permission values so junk simply never matches.
+     *
+     * @return list<string>
+     */
+    public function getCliAllowedOperations(): array
+    {
+        $raw = $this->configuration['cliAllowedOperations'] ?? self::DEFAULT_CLI_ALLOWED_OPERATIONS;
+        if (!\is_string($raw)) {
+            $raw = self::DEFAULT_CLI_ALLOWED_OPERATIONS;
+        }
+
+        return array_values(array_filter(array_map(
+            static fn (string $value): string => trim($value),
+            explode(',', $raw),
+        ), static fn (string $value): bool => $value !== ''));
     }
 
     /**

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -222,7 +222,7 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
         }
 
         return array_values(array_filter(array_map(
-            static fn (string $value): string => trim($value),
+            trim(...),
             explode(',', $raw),
         ), static fn (string $value): bool => $value !== ''));
     }

--- a/Classes/Configuration/ExtensionConfigurationInterface.php
+++ b/Classes/Configuration/ExtensionConfigurationInterface.php
@@ -61,6 +61,15 @@ interface ExtensionConfigurationInterface
     public function getCliAccessGroups(): array;
 
     /**
+     * Operation permissions the unattributed CLI actor may hold when
+     * `allowCliAccess` is on. High-risk operations are excluded by default
+     * and must be opted into explicitly.
+     *
+     * @return list<string>
+     */
+    public function getCliAllowedOperations(): array;
+
+    /**
      * Check if read operations should be written to the audit log.
      */
     public function isAuditReadsEnabled(): bool;

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -143,11 +143,12 @@ final class AccessControlService implements AccessControlServiceInterface
         // UNAUTHENTICATED CommandLineUserAuthentication in $GLOBALS['BE_USER']
         // (CommandApplication::run() never logs the `_cli_` user in), so there
         // is no user record and no group that could carry a custom permission
-        // option. The vault's own CLI trust switch decides instead — the same
-        // authority hasCliAccess() uses for the per-secret tiers, and off by
-        // default (ExtensionConfiguration::DEFAULT_ALLOW_CLI_ACCESS).
+        // option. The vault's own CLI trust switch decides instead — narrowed
+        // to the cliAllowedOperations allowlist, because "anyone with a shell"
+        // must not implicitly hold reveal/delete/audit-export/master-key
+        // powers just because deployment automation needs store/rotate.
         if ($this->isUnauthenticatedCommandLineUser($backendUser)) {
-            return $this->configuration->isCliAccessAllowed();
+            return $this->cliOperationGranted($permission);
         }
 
         if ($backendUser instanceof BackendUserAuthentication) {
@@ -167,7 +168,7 @@ final class AccessControlService implements AccessControlServiceInterface
         // No backend user at all but a real CLI context (no BE_USER global
         // was ever created): same trusted-operator rule as above.
         if ($this->isRealCliContext()) {
-            return $this->configuration->isCliAccessAllowed();
+            return $this->cliOperationGranted($permission);
         }
 
         // No actor we can attribute an operation to: fail closed.
@@ -341,6 +342,18 @@ final class AccessControlService implements AccessControlServiceInterface
         }
 
         return array_values(array_intersect($groupIds, $existing));
+    }
+
+    /**
+     * The unattributed CLI actor's operation grant: the CLI trust switch AND
+     * the cliAllowedOperations allowlist must both hold. The per-secret tiers
+     * (hasCliAccess) stay governed by allowCliAccess/cliAccessGroups alone —
+     * this narrows only the OPERATION dimension.
+     */
+    private function cliOperationGranted(VaultPermission $permission): bool
+    {
+        return $this->configuration->isCliAccessAllowed()
+            && \in_array($permission->value, $this->configuration->getCliAllowedOperations(), true);
     }
 
     /**

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -165,14 +165,10 @@ final class AccessControlService implements AccessControlServiceInterface
             return $this->hasCustomPermissionOption($backendUser, $permission);
         }
 
-        // No backend user at all but a real CLI context (no BE_USER global
-        // was ever created): same trusted-operator rule as above.
-        if ($this->isRealCliContext()) {
-            return $this->cliOperationGranted($permission);
-        }
-
-        // No actor we can attribute an operation to: fail closed.
-        return false;
+        // No backend user at all: grant only in a real CLI context (no
+        // BE_USER global was ever created — same trusted-operator rule as
+        // above). Any other unattributable actor fails closed.
+        return $this->isRealCliContext() && $this->cliOperationGranted($permission);
     }
 
     public function isCurrentActorAdmin(): bool

--- a/Classes/Service/Doctor/Check/CliAccessCheck.php
+++ b/Classes/Service/Doctor/Check/CliAccessCheck.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrVault\Service\Doctor\Check;
 
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\Doctor\DocsLink;
 use Netresearch\NrVault\Service\Doctor\DoctorContext;
 use Netresearch\NrVault\Service\Doctor\Finding;
@@ -63,6 +64,7 @@ final readonly class CliAccessCheck implements ReadinessCheckInterface
         return [
             $this->checkAccessEnabled($context),
             $this->checkAccessGroups(),
+            $this->checkAllowedOperations(),
         ];
     }
 
@@ -71,8 +73,9 @@ final readonly class CliAccessCheck implements ReadinessCheckInterface
      *
      * A pass under the standard profile: a deployment pipeline that stores
      * credentials needs this, and calling it a defect would make the check noise.
-     * A warning under hardened, where every read is supposed to be attributable
-     * to a named actor and a bare CLI actor is not.
+     * A CRITICAL under hardened: that profile promises every operation is
+     * attributable to a named actor, and a bare CLI actor is by construction
+     * not — the promise is broken as long as the switch is on.
      */
     private function checkAccessEnabled(DoctorContext $context): Finding
     {
@@ -88,15 +91,79 @@ final readonly class CliAccessCheck implements ReadinessCheckInterface
             );
         }
 
+        return Finding::critical(
+            id: $id,
+            summary: 'Unattributed CLI access to secrets is enabled under the hardened profile.',
+            risk: 'Anyone with a shell on the host can use secrets without authenticating as a backend '
+                . 'user. The audit trail records the operation but attributes it to the anonymous CLI '
+                . 'actor, so it cannot name the human responsible — the hardened profile\'s '
+                . 'attributability promise does not hold while this switch is on.',
+            remediation: 'Use the technical-actor API (TechnicalActorContext::runAs()) so headless '
+                . 'operations are attributed to a named backend user, then disable "allowCliAccess". '
+                . 'While migrating, restrict "cliAccessGroups" and keep "cliAllowedOperations" minimal.',
+            docsUrl: DocsLink::ACCESS_CONTROL,
+            details: $details,
+        );
+    }
+
+    /**
+     * Which operations does the unattributed CLI actor actually hold?
+     *
+     * The allowlist defaults to store/rotate/use. Every high-risk operation
+     * present is called out; unknown tokens are reported too — a typo in the
+     * list silently revokes the grant the operator believes is configured.
+     */
+    private function checkAllowedOperations(): Finding
+    {
+        $id = 'cli.allowed_operations';
+        $operations = $this->configuration->getCliAllowedOperations();
+
+        $known = array_map(
+            static fn (VaultPermission $permission): string => $permission->value,
+            VaultPermission::cases(),
+        );
+        $highRisk = ['secret.reveal', 'secret.delete', 'audit.export', 'master_key.rotate', 'vault.configure'];
+
+        $unknown = array_values(array_diff($operations, $known));
+        $risky = array_values(array_intersect($operations, $highRisk));
+
+        $details = [
+            'cliAllowedOperations' => implode(',', $operations),
+            'highRisk' => implode(',', $risky),
+            'unknown' => implode(',', $unknown),
+        ];
+
+        if ($risky === [] && $unknown === []) {
+            return Finding::pass(
+                id: $id,
+                summary: \sprintf(
+                    'The CLI operation allowlist is scoped to %d low-risk operation(s): %s.',
+                    \count($operations),
+                    implode(', ', $operations),
+                ),
+                docsUrl: DocsLink::ACCESS_CONTROL,
+                details: $details,
+            );
+        }
+
+        $summaryParts = [];
+        if ($risky !== []) {
+            $summaryParts[] = \sprintf('grants high-risk operation(s) %s to the unattributed CLI actor', implode(', ', $risky));
+        }
+        if ($unknown !== []) {
+            $summaryParts[] = \sprintf('contains unknown value(s) %s', implode(', ', $unknown));
+        }
+
         return Finding::warning(
             id: $id,
-            summary: 'CLI access to secrets is enabled under the hardened profile.',
-            risk: 'Anyone with a shell on the host can read secrets without authenticating as a backend '
-                . 'user. The audit trail records the operation but attributes it to the CLI actor, so it '
-                . 'cannot name the human responsible.',
-            remediation: 'Prefer the technical-actor API (TechnicalActorContext::runAs()) so headless '
-                . 'reads are attributed to a named backend user, then disable "allowCliAccess". If the '
-                . 'switch must stay on, restrict "cliAccessGroups" to the smallest possible group set.',
+            summary: 'The "cliAllowedOperations" list ' . implode(' and ', $summaryParts) . '.',
+            risk: 'High-risk operations let anyone with a shell reveal plaintext, delete secrets, walk '
+                . 'off with the audit history or rewrite every key envelope — without a named actor in '
+                . 'the audit trail. Unknown values do nothing: the grant the operator believes is '
+                . 'configured is silently absent.',
+            remediation: 'Remove the high-risk operations from "cliAllowedOperations" (use a named '
+                . 'technical actor for those workflows) and fix any typo — valid values are the '
+                . 'tx_nrvault permission identifiers, e.g. secret.use, secret.create, secret.rotate.',
             docsUrl: DocsLink::ACCESS_CONTROL,
             details: $details,
         );

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -166,6 +166,24 @@ Configure nr-vault in :guilabel:`Admin Tools > Settings > Extension Configuratio
    Comma-separated list of backend user group UIDs that CLI can access.
    Empty means all secrets are accessible when CLI access is enabled.
 
+.. confval:: cliAllowedOperations
+   :name: ext-nrvault-cliAllowedOperations
+   :type: string
+   :Default: ``secret.use,secret.create,secret.rotate``
+
+   Operation permissions the unattributed CLI actor may hold while
+   :confval:`allowCliAccess <ext-nrvault-allowCliAccess>` is on.
+   The default covers deployment automation (store, rotate, consume).
+   High-risk operations — ``secret.reveal`` (:bash:`vault:retrieve`
+   printing plaintext), ``secret.delete``, ``audit.export``,
+   ``master_key.rotate`` (:bash:`vault:rotate-master-key`),
+   ``vault.configure`` — are **excluded by default** and must be added
+   explicitly where a workflow genuinely needs them. Prefer a named
+   technical actor (``TechnicalActorContext::runAs()``) over widening
+   this list: the audit trail then names the responsible identity.
+   Note that the scheduled orphan cleanup deletes secrets and therefore
+   needs ``secret.delete`` when it runs as the bare CLI actor.
+
 .. confval:: auditLogRetention
    :name: ext-nrvault-auditLogRetention
    :type: integer

--- a/Documentation/Security/Index.rst
+++ b/Documentation/Security/Index.rst
@@ -290,10 +290,16 @@ Notes on the model:
    non-admins. The same holds for the ``vault_reveal`` / ``vault_rotate``
    AJAX routes.
 -  **CLI**: a trusted CLI operator has no backend user record and thus no
-   group grants, so operation permissions follow the vault's
-   :ref:`allowCliAccess <configuration>` switch (**off by default**).
-   Enabling CLI access is therefore required for
-   ``vault:rotate-master-key`` and ``vault:retrieve``.
+   group grants. Operation permissions follow the vault's
+   :ref:`allowCliAccess <configuration>` switch (**off by default**),
+   narrowed to the ``cliAllowedOperations`` allowlist (default:
+   ``secret.use,secret.create,secret.rotate``). High-risk operations are
+   excluded by default: ``vault:retrieve`` (needs ``secret.reveal``),
+   ``vault:delete`` / the scheduled orphan cleanup (``secret.delete``),
+   ``vault:rotate-master-key`` (``master_key.rotate``) and the audit
+   export require adding the respective operation to the allowlist — or,
+   preferably, a named technical actor via
+   ``TechnicalActorContext::runAs()``.
 -  **Frontend requests never hold operation permissions**, regardless of
    any backend session the visitor carries — frontend visibility remains
    a property of the secret (``frontend_accessible``) alone.

--- a/Tests/Unit/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/Configuration/ExtensionConfigurationTest.php
@@ -182,6 +182,47 @@ final class ExtensionConfigurationTest extends TestCase
     }
 
     #[Test]
+    public function getCliAllowedOperationsReturnsSafeDefault(): void
+    {
+        $this->typo3Config->method('get')
+            ->with('nr_vault')
+            ->willReturn([]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame(
+            ['secret.use', 'secret.create', 'secret.rotate'],
+            $config->getCliAllowedOperations(),
+        );
+    }
+
+    #[Test]
+    public function getCliAllowedOperationsParsesAndTrimsConfiguredList(): void
+    {
+        $this->typo3Config->method('get')
+            ->with('nr_vault')
+            ->willReturn(['cliAllowedOperations' => ' secret.use , secret.delete ,, ']);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame(['secret.use', 'secret.delete'], $config->getCliAllowedOperations());
+    }
+
+    #[Test]
+    public function getCliAllowedOperationsCanBeEmptiedExplicitly(): void
+    {
+        // An operator may strip the CLI actor of every operation while
+        // keeping the per-secret CLI tiers (allowCliAccess) intact.
+        $this->typo3Config->method('get')
+            ->with('nr_vault')
+            ->willReturn(['cliAllowedOperations' => '']);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame([], $config->getCliAllowedOperations());
+    }
+
+    #[Test]
     public function isAuditReadsEnabledReturnsTrueByDefault(): void
     {
         $this->typo3Config->method('get')

--- a/Tests/Unit/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/Configuration/ExtensionConfigurationTest.php
@@ -209,6 +209,21 @@ final class ExtensionConfigurationTest extends TestCase
     }
 
     #[Test]
+    public function getCliAllowedOperationsFallsBackToTheDefaultOnANonStringValue(): void
+    {
+        $this->typo3Config->method('get')
+            ->with('nr_vault')
+            ->willReturn(['cliAllowedOperations' => ['not', 'a', 'string']]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame(
+            ['secret.use', 'secret.create', 'secret.rotate'],
+            $config->getCliAllowedOperations(),
+        );
+    }
+
+    #[Test]
     public function getCliAllowedOperationsCanBeEmptiedExplicitly(): void
     {
         // An operator may strip the CLI actor of every operation while

--- a/Tests/Unit/Security/AccessControlServiceIsGrantedTest.php
+++ b/Tests/Unit/Security/AccessControlServiceIsGrantedTest.php
@@ -182,12 +182,39 @@ final class AccessControlServiceIsGrantedTest extends TestCase
 
     #[Test]
     #[DataProvider('allPermissionsProvider')]
-    public function unauthenticatedCliOperatorIsGrantedWhenCliAccessIsOn(VaultPermission $permission): void
+    public function unauthenticatedCliOperatorIsGrantedOnlyAllowlistedOperationsWhenCliAccessIsOn(VaultPermission $permission): void
     {
+        // With CLI access on, the actor holds exactly the
+        // cliAllowedOperations allowlist — never reveal/delete/audit-export/
+        // master-key/configure implicitly.
         $this->configuration->method('isCliAccessAllowed')->willReturn(true);
+        $this->configuration->method('getCliAllowedOperations')->willReturn(
+            ['secret.use', 'secret.create', 'secret.rotate'],
+        );
         $this->setUnauthenticatedCommandLineUser();
 
-        self::assertTrue($this->subject->isGranted($permission));
+        $expected = \in_array(
+            $permission,
+            [VaultPermission::SecretUse, VaultPermission::SecretCreate, VaultPermission::SecretRotate],
+            true,
+        );
+
+        self::assertSame($expected, $this->subject->isGranted($permission));
+    }
+
+    #[Test]
+    public function unauthenticatedCliOperatorGainsAnExplicitlyAllowlistedHighRiskOperation(): void
+    {
+        // The exclusion is a default, not a hard rule: an operator who
+        // explicitly adds secret.reveal opts into it.
+        $this->configuration->method('isCliAccessAllowed')->willReturn(true);
+        $this->configuration->method('getCliAllowedOperations')->willReturn(
+            ['secret.use', 'secret.reveal'],
+        );
+        $this->setUnauthenticatedCommandLineUser();
+
+        self::assertTrue($this->subject->isGranted(VaultPermission::SecretReveal));
+        self::assertFalse($this->subject->isGranted(VaultPermission::SecretDelete));
     }
 
     /**

--- a/Tests/Unit/Service/Doctor/Check/CliAccessCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/CliAccessCheckTest.php
@@ -61,15 +61,56 @@ final class CliAccessCheckTest extends TestCase
     }
 
     #[Test]
-    public function enabledCliAccessIsAWarningUnderTheHardenedProfile(): void
+    public function enabledCliAccessIsCriticalUnderTheHardenedProfile(): void
     {
+        // The hardened profile promises attributability; an unattributed CLI
+        // actor breaks that promise, so this blocks (exit code 2), it does
+        // not merely warn.
         $finding = $this->assertFindingSeverity(
-            FindingSeverity::Warning,
+            FindingSeverity::Critical,
             $this->check(true, [42])->run($this->doctorContext(SecurityProfile::Hardened)),
             'cli.access',
         );
 
         self::assertStringContainsString('TechnicalActorContext', $finding->remediation);
+    }
+
+    #[Test]
+    public function theDefaultOperationAllowlistPasses(): void
+    {
+        $finding = $this->findingById(
+            $this->check(true, [42])->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.allowed_operations',
+        );
+
+        self::assertTrue($finding->isPass());
+    }
+
+    #[Test]
+    public function highRiskOperationsInTheAllowlistAreAWarning(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(true, [42], ['secret.use', 'secret.reveal', 'master_key.rotate'])
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.allowed_operations',
+        );
+
+        self::assertSame('secret.reveal,master_key.rotate', $finding->details['highRisk']);
+    }
+
+    #[Test]
+    public function unknownAllowlistValuesAreAWarning(): void
+    {
+        // A typo silently revokes the grant the operator believes exists.
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(true, [42], ['secret.use', 'secret.rotat'])
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.allowed_operations',
+        );
+
+        self::assertSame('secret.rotat', $finding->details['unknown']);
     }
 
     #[Test]
@@ -113,12 +154,17 @@ final class CliAccessCheckTest extends TestCase
 
     /**
      * @param list<int> $groups
+     * @param list<string> $operations
      */
-    private function check(bool $allowed, array $groups = []): CliAccessCheck
-    {
+    private function check(
+        bool $allowed,
+        array $groups = [],
+        array $operations = ['secret.use', 'secret.create', 'secret.rotate'],
+    ): CliAccessCheck {
         $configuration = self::createStub(ExtensionConfigurationInterface::class);
         $configuration->method('isCliAccessAllowed')->willReturn($allowed);
         $configuration->method('getCliAccessGroups')->willReturn($groups);
+        $configuration->method('getCliAllowedOperations')->willReturn($operations);
 
         return new CliAccessCheck($configuration);
     }

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -39,6 +39,9 @@ allowCliAccess = 0
 # cat=Security; type=string; label=CLI Access Groups: Comma-separated list of backend user group IDs allowed CLI access
 cliAccessGroups =
 
+# cat=Security; type=string; label=CLI Allowed Operations: Comma-separated operation permissions the unattributed CLI actor may hold when "allowCliAccess" is on. High-risk operations (secret.reveal, secret.delete, audit.export, master_key.rotate, vault.configure) are excluded by default - add them explicitly only where the deployment genuinely needs them, or prefer a named technical actor (TechnicalActorContext::runAs()).
+cliAllowedOperations = secret.use,secret.create,secret.rotate
+
 # cat=Security; type=int+; label=Audit Log Retention (days): Number of days to keep audit log entries (0 = forever)
 auditLogRetention = 365
 


### PR DESCRIPTION
## Finding (Medium): `allowCliAccess` grants every operation permission

For the unattributed CLI actor, `isGranted()` returned `isCliAccessAllowed()` regardless of the requested permission — with the switch on (as deployment automation requires), a shell on the host implicitly held `secret.reveal`, `secret.delete`, `audit.export`, `master_key.rotate` and `vault.configure`. `cliAccessGroups` narrowed only the per-secret tiers, never these global operation grants, and `vault:doctor` rated enabled CLI under the hardened profile as a mere warning.

## Fix

- **`cliAllowedOperations`** (default `secret.use,secret.create,secret.rotate`): both CLI branches of `isGranted()` now require the trust switch **and** the allowlist. Per-secret tiers (`allowCliAccess`/`cliAccessGroups`) unchanged.
- **Excluded by default** (explicit opt-in required): `secret.reveal` (`vault:retrieve`), `secret.delete` (`vault:delete`, scheduled orphan cleanup), `audit.export`, `master_key.rotate` (`vault:rotate-master-key`), `vault.configure`. Preferred alternative: a named technical actor via `TechnicalActorContext::runAs()` — grants come from its provisioned groups (#251) and the audit trail names a real identity.
- **`vault:doctor`**: unattributed CLI access under the hardened profile is now **Critical** (exit code 2 — the review's acceptance criterion), not a warning. New `cli.allowed_operations` check flags high-risk operations in the allowlist and unknown values (a typo silently revokes the grant the operator believes exists).

## Behavioural change

Installations with `allowCliAccess=1` whose CLI workflows reveal/delete/export/rotate-master-key must add the operation to `cliAllowedOperations` or move to a technical actor. Documented in the configuration reference and security chapter (including the orphan-cleanup note).

## Verification

- `composer ci` (cgl + phpstan + unit 2969 + fuzz 1612): green
- Full functional suite (257 tests): green, exit 0
- Unit: allowlist matrix over all 10 permissions, explicit high-risk opt-in, config parsing (default/trim/empty), doctor severity + allowlist checks

Part 4/5, stacked on #252. Next: active audit-sink verification (PR 5).
