### PR TITLE
Verify audit sinks actively and persist per-sink delivery state

### DIFF
--- a/Classes/Audit/Sink/AuditSinkRegistry.php
+++ b/Classes/Audit/Sink/AuditSinkRegistry.php
@@ -63,6 +63,12 @@ final class AuditSinkRegistry implements AuditSinkRegistryInterface
         private readonly iterable $sinks,
         private readonly LoggerInterface $logger,
         private readonly EventDispatcherInterface $eventDispatcher,
+        /**
+         * Persisted per-sink delivery health. Optional so pre-existing test
+         * constructions keep working; without it only the in-process
+         * counters exist (and `vault:doctor` reports the evidence gap).
+         */
+        private readonly ?SinkDeliveryStateRepositoryInterface $deliveryState = null,
     ) {}
 
     public function dispatch(AuditLogEntry $entry, string $chainTip): int
@@ -161,6 +167,7 @@ final class AuditSinkRegistry implements AuditSinkRegistryInterface
             try {
                 $publish($sink);
                 ++$accepted;
+                $this->deliveryState?->recordSuccess($sink->getIdentifier());
             } catch (Throwable $e) {
                 $this->recordFailure($sink->getIdentifier(), $recordKind, $e, $logContext);
             }
@@ -197,6 +204,7 @@ final class AuditSinkRegistry implements AuditSinkRegistryInterface
     {
         ++$this->failureCount;
         $this->failuresBySink[$sinkIdentifier] = ($this->failuresBySink[$sinkIdentifier] ?? 0) + 1;
+        $this->deliveryState?->recordFailure($sinkIdentifier, $e->getMessage());
 
         $this->logger->error(
             'nr-vault audit sink delivery failed; the database chain entry is unaffected.',

--- a/Classes/Audit/Sink/SinkDeliveryState.php
+++ b/Classes/Audit/Sink/SinkDeliveryState.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Sink;
+
+/**
+ * Persisted delivery health of one external audit sink.
+ *
+ * A per-process failure counter answers "did anything fail since this PHP
+ * process started" — which for a freshly started `vault:doctor` is always
+ * "no". This state is persisted (sys_registry) so the readiness surface can
+ * answer the question that matters for external evidence: WHEN did this sink
+ * last demonstrably accept a record, and has it been failing since.
+ */
+final readonly class SinkDeliveryState
+{
+    public function __construct(
+        public string $sinkIdentifier,
+        /** Unix timestamp of the last accepted record, 0 = never observed. */
+        public int $lastSuccessAt = 0,
+        /** Unix timestamp of the last failed delivery, 0 = none recorded. */
+        public int $lastFailureAt = 0,
+        /** Failures since the last success (0 while the sink is healthy). */
+        public int $consecutiveFailures = 0,
+        /** Failures over the whole recorded lifetime. */
+        public int $totalFailures = 0,
+        /** Last failure's exception message (truncated, never secret material). */
+        public string $lastError = '',
+    ) {}
+
+    public function hasEverSucceeded(): bool
+    {
+        return $this->lastSuccessAt > 0;
+    }
+
+    public function isFailing(): bool
+    {
+        return $this->consecutiveFailures > 0;
+    }
+
+    /**
+     * @return array{sinkIdentifier: string, lastSuccessAt: int, lastFailureAt: int, consecutiveFailures: int, totalFailures: int, lastError: string}
+     */
+    public function toArray(): array
+    {
+        return [
+            'sinkIdentifier' => $this->sinkIdentifier,
+            'lastSuccessAt' => $this->lastSuccessAt,
+            'lastFailureAt' => $this->lastFailureAt,
+            'consecutiveFailures' => $this->consecutiveFailures,
+            'totalFailures' => $this->totalFailures,
+            'lastError' => $this->lastError,
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    public static function fromArray(string $sinkIdentifier, array $row): self
+    {
+        return new self(
+            sinkIdentifier: $sinkIdentifier,
+            lastSuccessAt: is_numeric($row['lastSuccessAt'] ?? null) ? (int) $row['lastSuccessAt'] : 0,
+            lastFailureAt: is_numeric($row['lastFailureAt'] ?? null) ? (int) $row['lastFailureAt'] : 0,
+            consecutiveFailures: is_numeric($row['consecutiveFailures'] ?? null) ? (int) $row['consecutiveFailures'] : 0,
+            totalFailures: is_numeric($row['totalFailures'] ?? null) ? (int) $row['totalFailures'] : 0,
+            lastError: \is_string($row['lastError'] ?? null) ? $row['lastError'] : '',
+        );
+    }
+}

--- a/Classes/Audit/Sink/SinkDeliveryStateRepository.php
+++ b/Classes/Audit/Sink/SinkDeliveryStateRepository.php
@@ -1,0 +1,134 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Sink;
+
+use Psr\Log\LoggerInterface;
+use Throwable;
+use TYPO3\CMS\Core\Registry;
+
+/**
+ * sys_registry-backed {@see SinkDeliveryStateRepositoryInterface}.
+ *
+ * sys_registry rather than a bespoke table: the state is a handful of scalars
+ * per sink, survives process restarts and deployments, and needs no schema of
+ * its own. It deliberately lives in the SAME database as the audit chain — it
+ * is operational health telemetry, not tamper-evident evidence; the evidence
+ * is what the sinks carry OUT of the database.
+ *
+ * Success writes are throttled (one registry UPDATE per sink per
+ * SUCCESS_WRITE_INTERVAL seconds) so an audit-heavy installation does not pay
+ * a bookkeeping write per audit entry; a success after observed failures is
+ * always persisted immediately so a recovery is visible. Failure writes are
+ * never throttled.
+ */
+final class SinkDeliveryStateRepository implements SinkDeliveryStateRepositoryInterface
+{
+    private const REGISTRY_NAMESPACE = 'tx_nrvault';
+
+    private const REGISTRY_KEY_PREFIX = 'sink_delivery_';
+
+    private const SUCCESS_WRITE_INTERVAL = 60;
+
+    private const ERROR_MESSAGE_MAX_LENGTH = 500;
+
+    /** @var array<string, int> In-process timestamp of the last persisted success per sink. */
+    private array $lastPersistedSuccess = [];
+
+    public function __construct(
+        private readonly Registry $registry,
+        private readonly LoggerInterface $logger,
+    ) {}
+
+    public function recordSuccess(string $sinkIdentifier): void
+    {
+        $now = time();
+        $lastPersisted = $this->lastPersistedSuccess[$sinkIdentifier] ?? 0;
+
+        try {
+            $state = $this->getState($sinkIdentifier);
+
+            // Throttle: skip the write while healthy and recently persisted.
+            if (!$state->isFailing() && ($now - $lastPersisted) < self::SUCCESS_WRITE_INTERVAL && $state->hasEverSucceeded()) {
+                return;
+            }
+
+            $this->persist(new SinkDeliveryState(
+                sinkIdentifier: $sinkIdentifier,
+                lastSuccessAt: $now,
+                lastFailureAt: $state->lastFailureAt,
+                consecutiveFailures: 0,
+                totalFailures: $state->totalFailures,
+                lastError: '',
+            ));
+            $this->lastPersistedSuccess[$sinkIdentifier] = $now;
+        } catch (Throwable $e) {
+            $this->logFailedBookkeeping($sinkIdentifier, $e);
+        }
+    }
+
+    public function recordFailure(string $sinkIdentifier, string $errorMessage): void
+    {
+        try {
+            $state = $this->getState($sinkIdentifier);
+
+            $this->persist(new SinkDeliveryState(
+                sinkIdentifier: $sinkIdentifier,
+                lastSuccessAt: $state->lastSuccessAt,
+                lastFailureAt: time(),
+                consecutiveFailures: $state->consecutiveFailures + 1,
+                totalFailures: $state->totalFailures + 1,
+                lastError: mb_substr($errorMessage, 0, self::ERROR_MESSAGE_MAX_LENGTH),
+            ));
+        } catch (Throwable $e) {
+            $this->logFailedBookkeeping($sinkIdentifier, $e);
+        }
+    }
+
+    public function getState(string $sinkIdentifier): SinkDeliveryState
+    {
+        try {
+            $row = $this->registry->get(
+                self::REGISTRY_NAMESPACE,
+                self::REGISTRY_KEY_PREFIX . $sinkIdentifier,
+            );
+        } catch (Throwable $e) {
+            $this->logFailedBookkeeping($sinkIdentifier, $e);
+            $row = null;
+        }
+
+        if (!\is_array($row)) {
+            return new SinkDeliveryState(sinkIdentifier: $sinkIdentifier);
+        }
+
+        // Keep only string keys: sys_registry stores what persist() wrote,
+        // but the value is unserialized data and typed defensively.
+        $stringKeyed = array_filter($row, is_string(...), ARRAY_FILTER_USE_KEY);
+
+        return SinkDeliveryState::fromArray($sinkIdentifier, $stringKeyed);
+    }
+
+    private function persist(SinkDeliveryState $state): void
+    {
+        $this->registry->set(
+            self::REGISTRY_NAMESPACE,
+            self::REGISTRY_KEY_PREFIX . $state->sinkIdentifier,
+            $state->toArray(),
+        );
+    }
+
+    private function logFailedBookkeeping(string $sinkIdentifier, Throwable $e): void
+    {
+        // Fail-safe: bookkeeping must never fail the audited operation.
+        $this->logger->warning(
+            'nr-vault could not read/write the persisted sink delivery state.',
+            ['sink' => $sinkIdentifier, 'error' => $e->getMessage()],
+        );
+    }
+}

--- a/Classes/Audit/Sink/SinkDeliveryStateRepositoryInterface.php
+++ b/Classes/Audit/Sink/SinkDeliveryStateRepositoryInterface.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Audit\Sink;
+
+/**
+ * Persistence for {@see SinkDeliveryState}.
+ *
+ * Implementations MUST be fail-safe on write: delivery bookkeeping must never
+ * fail (or slow down) the audited operation it accompanies. A write error is
+ * logged and swallowed.
+ */
+interface SinkDeliveryStateRepositoryInterface
+{
+    /**
+     * Record an accepted delivery. Implementations may throttle the write
+     * (an audit-heavy install would otherwise pay one registry UPDATE per
+     * audit entry), but MUST persist immediately when the sink was failing —
+     * the recovery must be visible.
+     */
+    public function recordSuccess(string $sinkIdentifier): void;
+
+    /**
+     * Record a failed delivery. Always persisted.
+     */
+    public function recordFailure(string $sinkIdentifier, string $errorMessage): void;
+
+    public function getState(string $sinkIdentifier): SinkDeliveryState;
+}

--- a/Classes/Command/VaultDoctorCommand.php
+++ b/Classes/Command/VaultDoctorCommand.php
@@ -79,6 +79,14 @@ final class VaultDoctorCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'Output format: text (default) or json',
                 'text',
+            )
+            ->addOption(
+                'active-probes',
+                null,
+                InputOption::VALUE_NONE,
+                'Additionally push the current chain-tip anchor through every enabled audit sink '
+                . 'to verify end-to-end delivery (webhook: the collector must answer 2xx). '
+                . 'Talks to external systems; not run by the passive checks or the status panel.',
             );
     }
 
@@ -102,7 +110,7 @@ final class VaultDoctorCommand extends Command
         }
 
         try {
-            $report = $this->doctor->run($targetProfile);
+            $report = $this->doctor->run($targetProfile, (bool) $input->getOption('active-probes'));
         } catch (Throwable $e) {
             // A gate that cannot run must never look like a gate that found
             // nothing — same stance as vault:audit-verify.

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -90,6 +90,12 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
 
     public const DEFAULT_AUDIT_SINK_WEBHOOK_ENABLED = false;
 
+    /**
+     * Hours after which the last successful external delivery of an enabled
+     * sink counts as stale for `vault:doctor` (hardened: critical).
+     */
+    public const DEFAULT_AUDIT_SINK_STALE_DELIVERY_HOURS = 24;
+
     public const DEFAULT_AUDIT_SINK_WEBHOOK_URL = '';
 
     public const DEFAULT_STALE_NEVER_READ_DAYS = 30;
@@ -377,6 +383,16 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
     public function isAuditSinkWebhookEnabled(): bool
     {
         return (bool) ($this->configuration['auditSinkWebhookEnabled'] ?? self::DEFAULT_AUDIT_SINK_WEBHOOK_ENABLED);
+    }
+
+    public function getAuditSinkStaleDeliveryHours(): int
+    {
+        $value = $this->configuration['auditSinkStaleDeliveryHours'] ?? null;
+        if (!is_numeric($value) || (int) $value < 1) {
+            return self::DEFAULT_AUDIT_SINK_STALE_DELIVERY_HOURS;
+        }
+
+        return (int) $value;
     }
 
     /**

--- a/Classes/Configuration/ExtensionConfigurationInterface.php
+++ b/Classes/Configuration/ExtensionConfigurationInterface.php
@@ -165,6 +165,12 @@ interface ExtensionConfigurationInterface
     public function getAuditSinkWebhookUrl(): string;
 
     /**
+     * Hours after which the last successful external delivery of an enabled
+     * sink counts as stale for the readiness surface (minimum 1).
+     */
+    public function getAuditSinkStaleDeliveryHours(): int;
+
+    /**
      * Days after creation with zero reads before a secret is "dead".
      */
     public function getStaleNeverReadDays(): int;

--- a/Classes/Service/Doctor/Check/AuditCheck.php
+++ b/Classes/Service/Doctor/Check/AuditCheck.php
@@ -15,6 +15,8 @@ use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
 use Netresearch\NrVault\Audit\AuditIntegrityReason;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Audit\Sink\SinkDeliveryState;
+use Netresearch\NrVault\Audit\Sink\SinkDeliveryStateRepositoryInterface;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Configuration\SecurityProfile;
 use Netresearch\NrVault\Service\Doctor\DocsLink;
@@ -63,6 +65,12 @@ final readonly class AuditCheck implements ReadinessCheckInterface
         private AuditSinkRegistryInterface $sinkRegistry,
         private ChainTipAnchorServiceInterface $anchorService,
         private AnchorReaderInterface $anchorReader,
+        /**
+         * Persisted per-sink delivery health. Optional so pre-existing test
+         * constructions keep working; absent means the persisted-state
+         * findings are simply not emitted.
+         */
+        private ?SinkDeliveryStateRepositoryInterface $deliveryState = null,
     ) {}
 
     public function getId(): string
@@ -87,7 +95,124 @@ final readonly class AuditCheck implements ReadinessCheckInterface
             $this->checkExternalSink($context),
             $this->checkAnchor($context, $anchor, $currentSequence),
             $this->checkSinkFailures(),
+            ...$this->checkPersistedDeliveryState($context),
         ];
+    }
+
+    /**
+     * Has each enabled sink demonstrably accepted a record recently?
+     *
+     * The per-process counter below answers "did anything fail since this PHP
+     * process started" — for a freshly started `vault:doctor` that is always
+     * "no failures", which let a collector that has been unreachable for days
+     * pass the gate. This check reads the PERSISTED delivery state
+     * (sys_registry, written fail-safe by the sink registry) instead.
+     *
+     * @return list<Finding>
+     */
+    private function checkPersistedDeliveryState(DoctorContext $context): array
+    {
+        if (!$this->deliveryState instanceof SinkDeliveryStateRepositoryInterface) {
+            return [];
+        }
+
+        $findings = [];
+        $staleAfterSeconds = $this->configuration->getAuditSinkStaleDeliveryHours() * 3600;
+
+        foreach ($this->sinkRegistry->getEnabledSinkIdentifiers() as $sinkIdentifier) {
+            $findings[] = $this->deliveryFindingForSink(
+                $context,
+                $this->deliveryState->getState($sinkIdentifier),
+                $staleAfterSeconds,
+            );
+        }
+
+        return $findings;
+    }
+
+    private function deliveryFindingForSink(
+        DoctorContext $context,
+        SinkDeliveryState $state,
+        int $staleAfterSeconds,
+    ): Finding {
+        $id = 'audit.sink_state.' . $state->sinkIdentifier;
+        $details = $state->toArray();
+
+        if ($state->isFailing()) {
+            $summary = \sprintf(
+                'Audit sink "%s" is failing: %d consecutive failure(s), last error: %s',
+                $state->sinkIdentifier,
+                $state->consecutiveFailures,
+                $state->lastError !== '' ? $state->lastError : '(not recorded)',
+            );
+            $risk = 'Audit evidence is not reaching this external sink. The database copy is intact, '
+                . 'but the external witness — the part that survives a table reset — has holes, and '
+                . 'under the hardened profile the external-evidence promise is currently broken.';
+            $remediation = 'Fix the sink (unreachable collector, full disk, unwritable path — see '
+                . 'lastError), verify with vendor/bin/typo3 vault:doctor --active-probes, then '
+                . 're-anchor with vendor/bin/typo3 vault:audit-anchor.';
+
+            return $context->isHardened()
+                ? Finding::critical(id: $id, summary: $summary, risk: $risk, remediation: $remediation, docsUrl: DocsLink::AUDIT_SINKS, details: $details)
+                : Finding::warning(id: $id, summary: $summary, risk: $risk, remediation: $remediation, docsUrl: DocsLink::AUDIT_SINKS, details: $details);
+        }
+
+        if (!$state->hasEverSucceeded()) {
+            $summary = \sprintf(
+                'Audit sink "%s" is enabled but no successful delivery has been recorded yet.',
+                $state->sinkIdentifier,
+            );
+
+            if (!$context->isHardened()) {
+                return Finding::pass(
+                    id: $id,
+                    summary: $summary . ' Delivery state builds up as audit events flow.',
+                    docsUrl: DocsLink::AUDIT_SINKS,
+                    details: $details,
+                );
+            }
+
+            return Finding::warning(
+                id: $id,
+                summary: $summary,
+                risk: 'The sink is configured but has never demonstrably accepted a record — external '
+                    . 'evidence is assumed, not proven.',
+                remediation: 'Run vendor/bin/typo3 vault:doctor --active-probes to push a chain-tip '
+                    . 'anchor through every enabled sink and confirm end-to-end delivery.',
+                docsUrl: DocsLink::AUDIT_SINKS,
+                details: $details,
+            );
+        }
+
+        $age = max(0, time() - $state->lastSuccessAt);
+        if ($age > $staleAfterSeconds) {
+            $summary = \sprintf(
+                'Audit sink "%s": last successful delivery is %d hour(s) old (threshold: %d).',
+                $state->sinkIdentifier,
+                intdiv($age, 3600),
+                intdiv($staleAfterSeconds, 3600),
+            );
+            $risk = 'No record has demonstrably reached this sink within the configured window. Either '
+                . 'no audit events occurred — or evidence has silently stopped flowing.';
+            $remediation = 'Verify end-to-end delivery with vendor/bin/typo3 vault:doctor '
+                . '--active-probes; if the probe fails, fix the sink and re-anchor. Adjust '
+                . '"auditSinkStaleDeliveryHours" if the installation is genuinely this quiet.';
+
+            return $context->isHardened()
+                ? Finding::critical(id: $id, summary: $summary, risk: $risk, remediation: $remediation, docsUrl: DocsLink::AUDIT_SINKS, details: $details)
+                : Finding::warning(id: $id, summary: $summary, risk: $risk, remediation: $remediation, docsUrl: DocsLink::AUDIT_SINKS, details: $details);
+        }
+
+        return Finding::pass(
+            id: $id,
+            summary: \sprintf(
+                'Audit sink "%s" last accepted a record %d minute(s) ago.',
+                $state->sinkIdentifier,
+                intdiv($age, 60),
+            ),
+            docsUrl: DocsLink::AUDIT_SINKS,
+            details: $details,
+        );
     }
 
     /**
@@ -391,10 +516,11 @@ final readonly class AuditCheck implements ReadinessCheckInterface
     /**
      * Did any sink refuse delivery in this process?
      *
-     * Per-process by design (persisting the counter would mean writing to the
-     * storage a sink failure may indicate is broken), so a zero here means "not
-     * in this run", not "never". It still catches the common case: a wrong
-     * webhook URL or an unwritable log path fails on the very first dispatch.
+     * A zero here means "not in this run", not "never" — the persisted state
+     * above ({@see self::checkPersistedDeliveryState()}) answers the
+     * cross-process question. This process-local view still catches the
+     * common case cheaply: a wrong webhook URL or an unwritable log path
+     * fails on the very first dispatch of the current run.
      */
     private function checkSinkFailures(): Finding
     {

--- a/Classes/Service/Doctor/Check/SinkProbeCheck.php
+++ b/Classes/Service/Doctor/Check/SinkProbeCheck.php
@@ -1,0 +1,142 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Service\Doctor\Check;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\Sink\AuditSinkInterface;
+use Netresearch\NrVault\Audit\Sink\SinkDeliveryStateRepositoryInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\DocsLink;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
+use Throwable;
+
+/**
+ * Active end-to-end verification of every enabled audit sink.
+ *
+ * The passive checks can only reason about configuration and recorded
+ * history; a syntactically valid webhook URL whose collector has been dead
+ * for days looks identical to a working one until an event happens to flow.
+ * This check removes the guesswork — but only when the operator asked for it
+ * (`vault:doctor --active-probes`): it talks to external systems, so it must
+ * never run implicitly from the backend status panel or a deployment gate
+ * that expected a passive inspection.
+ *
+ * The probe payload is the CURRENT chain-tip anchor, not a synthetic audit
+ * entry: anchors are re-publishable evidence by design (`vault:audit-anchor`
+ * does exactly this on a schedule), so the probe pollutes nothing and even
+ * refreshes the external anchor. Acceptance is end-to-end: the webhook sink
+ * only returns normally when the collector answered 2xx, the file sink when
+ * the append actually happened, syslog when the message was handed off.
+ */
+final readonly class SinkProbeCheck implements ReadinessCheckInterface
+{
+    /**
+     * @param iterable<AuditSinkInterface> $sinks Tagged `nr_vault.audit_sink` collection
+     */
+    public function __construct(
+        private iterable $sinks,
+        private ChainTipAnchorServiceInterface $anchorService,
+        private ?SinkDeliveryStateRepositoryInterface $deliveryState = null,
+    ) {}
+
+    public function getId(): string
+    {
+        return 'sink-probe';
+    }
+
+    public function appliesTo(SecurityProfile $profile): bool
+    {
+        return true;
+    }
+
+    public function run(DoctorContext $context): array
+    {
+        if (!$context->activeProbes) {
+            return [];
+        }
+
+        $anchor = $this->anchorService->capture();
+        $findings = [];
+        $probed = 0;
+
+        foreach ($this->sinks as $sink) {
+            if (!$this->isEnabledSafely($sink)) {
+                continue;
+            }
+
+            ++$probed;
+            $identifier = $sink->getIdentifier();
+            $id = 'audit.sink_probe.' . $identifier;
+
+            try {
+                $sink->publishAnchor($anchor);
+                $this->deliveryState?->recordSuccess($identifier);
+
+                $findings[] = Finding::pass(
+                    id: $id,
+                    summary: \sprintf(
+                        'Audit sink "%s" accepted the probe (chain-tip anchor, sequence %d).',
+                        $identifier,
+                        $anchor->sequence,
+                    ),
+                    docsUrl: DocsLink::AUDIT_SINKS,
+                    details: ['sink' => $identifier, 'anchorSequence' => $anchor->sequence],
+                );
+            } catch (Throwable $e) {
+                $this->deliveryState?->recordFailure($identifier, $e->getMessage());
+
+                $findings[] = Finding::critical(
+                    id: $id,
+                    summary: \sprintf(
+                        'Audit sink "%s" REFUSED the probe: %s',
+                        $identifier,
+                        $e->getMessage(),
+                    ),
+                    risk: 'The sink is enabled but demonstrably not accepting evidence right now. '
+                        . 'Every audit event since its last successful delivery exists only in the '
+                        . 'database the sink is meant to witness externally.',
+                    remediation: 'Fix the sink (unreachable collector, full disk, unwritable path), '
+                        . 're-run vendor/bin/typo3 vault:doctor --active-probes until the probe '
+                        . 'passes, then re-anchor with vendor/bin/typo3 vault:audit-anchor.',
+                    docsUrl: DocsLink::AUDIT_SINKS,
+                    details: ['sink' => $identifier, 'error' => $e->getMessage()],
+                );
+            }
+        }
+
+        if ($probed === 0) {
+            $findings[] = Finding::pass(
+                id: 'audit.sink_probe.none',
+                summary: 'Active probes requested, but no audit sink is enabled — nothing to probe. '
+                    . 'The audit.external_sink finding covers whether that is acceptable.',
+                docsUrl: DocsLink::AUDIT_SINKS,
+                details: ['probedSinks' => 0],
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * Mirrors AuditSinkRegistry::isEnabledSafely(): a sink whose own
+     * enablement probe throws is treated as disabled — here that simply means
+     * it is not probed (the registry already logs and counts that failure).
+     */
+    private function isEnabledSafely(AuditSinkInterface $sink): bool
+    {
+        try {
+            return $sink->isEnabled();
+        } catch (Throwable) {
+            return false;
+        }
+    }
+}

--- a/Classes/Service/Doctor/DoctorContext.php
+++ b/Classes/Service/Doctor/DoctorContext.php
@@ -33,6 +33,14 @@ final readonly class DoctorContext
         public SecurityProfile $profile,
         /** The profile actually configured in the extension configuration. */
         public SecurityProfile $configuredProfile,
+        /**
+         * Whether the run may perform ACTIVE probes (deliver a test record
+         * through every enabled audit sink). Off by default: the passive
+         * checks are safe on every page load of the status panel, while a
+         * probe talks to external systems and belongs to an explicit
+         * `vault:doctor --active-probes` invocation.
+         */
+        public bool $activeProbes = false,
     ) {}
 
     /**

--- a/Classes/Service/Doctor/VaultDoctorService.php
+++ b/Classes/Service/Doctor/VaultDoctorService.php
@@ -46,12 +46,13 @@ final readonly class VaultDoctorService implements VaultDoctorServiceInterface
         private LoggerInterface $logger,
     ) {}
 
-    public function run(?SecurityProfile $targetProfile = null): DoctorReport
+    public function run(?SecurityProfile $targetProfile = null, bool $activeProbes = false): DoctorReport
     {
         $configuredProfile = $this->resolveConfiguredProfile();
         $context = new DoctorContext(
             profile: $targetProfile ?? $configuredProfile,
             configuredProfile: $configuredProfile,
+            activeProbes: $activeProbes,
         );
 
         $findings = [];

--- a/Classes/Service/Doctor/VaultDoctorServiceInterface.php
+++ b/Classes/Service/Doctor/VaultDoctorServiceInterface.php
@@ -27,6 +27,10 @@ interface VaultDoctorServiceInterface
      *                                            uses the configured profile
      *                                            ("is this deployment ready for
      *                                            what it claims to be?")
+     * @param bool $activeProbes Perform active end-to-end probes (deliver a
+     *                           test record through every enabled audit sink).
+     *                           Reserved for explicit CLI invocations — the
+     *                           backend status panel must stay passive.
      */
-    public function run(?SecurityProfile $targetProfile = null): DoctorReport;
+    public function run(?SecurityProfile $targetProfile = null, bool $activeProbes = false): DoctorReport;
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -104,6 +104,9 @@ services:
   Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface:
     alias: Netresearch\NrVault\Audit\Sink\AuditSinkRegistry
 
+  Netresearch\NrVault\Audit\Sink\SinkDeliveryStateRepositoryInterface:
+    alias: Netresearch\NrVault\Audit\Sink\SinkDeliveryStateRepository
+
   Netresearch\NrVault\Audit\Anchor\AnchorReaderInterface:
     alias: Netresearch\NrVault\Audit\Anchor\AnchorFileReader
 
@@ -149,6 +152,10 @@ services:
   # ----- External audit sinks ---------------------------------------------
 
   Netresearch\NrVault\Audit\Sink\AuditSinkRegistry:
+    arguments:
+      $sinks: !tagged_iterator nr_vault.audit_sink
+
+  Netresearch\NrVault\Service\Doctor\Check\SinkProbeCheck:
     arguments:
       $sinks: !tagged_iterator nr_vault.audit_sink
 

--- a/Documentation/Auditor/ControlMapping.rst
+++ b/Documentation/Auditor/ControlMapping.rst
@@ -255,8 +255,12 @@ and Logging).*
         -   :ref:`security-audit-evidence-sinks`
 
     *   -   Availability of the audit pipeline is observable
-        -   Per-sink failure counters; ``SINK_FAILURE`` and
-            ``NO_EXTERNAL_SINK`` reason codes
+        -   Persisted per-sink delivery state (last success / last failure /
+            consecutive failures, ``sys_registry``) surfaced as
+            ``audit.sink_state.<sink>`` findings; active end-to-end
+            verification via ``vault:doctor --active-probes``
+            (``audit.sink_probe.<sink>``); process-local failure counters;
+            ``SINK_FAILURE`` and ``NO_EXTERNAL_SINK`` reason codes
         -   :ref:`operations-monitoring-counters`
 
     *   -   Machine-readable alerting

--- a/Documentation/Auditor/EvidenceCollection.rst
+++ b/Documentation/Auditor/EvidenceCollection.rst
@@ -124,6 +124,7 @@ Finding ids worth citing directly in an assessment:
     *   -   Audit evidence
         -   ``audit.hash_chain``, ``audit.anchor``,
             ``audit.external_sink``, ``audit.sink_delivery``,
+            ``audit.sink_state.<sink>``,
             ``audit.reads_logged``, ``audit.retention``
 
     *   -   CLI exposure

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -395,6 +395,20 @@ usable external sink is reported as a ``NO_EXTERNAL_SINK`` finding.
    ``http``/``https`` are accepted, so a ``file://`` or ``php://`` value cannot
    turn audit fan-out into a local write.
 
+.. confval:: auditSinkStaleDeliveryHours
+   :name: ext-nrvault-auditSinkStaleDeliveryHours
+   :type: integer
+   :Default: 24
+
+   Hours after which the last successful external delivery of an enabled
+   sink counts as **stale** for :bash:`vault:doctor` (finding
+   ``audit.sink_state.<sink>``: warning under the standard profile, critical
+   under hardened). The per-sink delivery state — last success, last
+   failure, consecutive failures — is persisted in ``sys_registry`` by the
+   sink registry, so a freshly started process still knows a collector has
+   been unreachable for days. Use
+   :bash:`vault:doctor --active-probes` to verify delivery end-to-end.
+
    .. note::
 
       Outbound calls go through the hardened HTTP client, inheriting the

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -956,6 +956,14 @@ Options
    Output format: ``text`` (default) or ``json``. The JSON form carries every
    control — passing ones included — under stable ids.
 
+--active-probes
+   Additionally push the current chain-tip anchor through every enabled audit
+   sink to verify end-to-end delivery (the webhook collector must answer 2xx;
+   the file sink must actually append; syslog must accept the message). Adds
+   one ``audit.sink_probe.<sink>`` finding per enabled sink; a refused probe
+   is critical. Talks to external systems, so it is never run implicitly —
+   neither by the passive checks nor by the backend status panel.
+
 .. _command-doctor-exit-codes:
 
 Exit codes
@@ -1060,12 +1068,28 @@ audit.anchor
 
 audit.sink_delivery
    No sink refused delivery in this process. Warning with the per-sink counts
-   otherwise. Per-process by design, so zero means "not in this run".
+   otherwise. Zero means "not in this run" — the cross-process question is
+   answered by ``audit.sink_state.<sink>``.
+
+audit.sink_state.<sink>
+   One finding per enabled sink, based on the PERSISTED delivery state
+   (``sys_registry``): consecutive failures or a last successful delivery
+   older than ``auditSinkStaleDeliveryHours`` are *warning* / **critical**
+   (hardened); an enabled sink with no recorded delivery yet is *pass* /
+   *warning* (hardened). A freshly started ``vault:doctor`` can therefore no
+   longer report a collector that has been unreachable for days as healthy.
+
+audit.sink_probe.<sink>
+   Emitted only with ``--active-probes``: the current chain-tip anchor is
+   pushed through every enabled sink end-to-end (webhook: the collector must
+   answer 2xx). A refused probe is **critical** in both profiles — the sink
+   is enabled but demonstrably not accepting evidence.
 
 cli.access
-   ``allowCliAccess``. Pass when off. When on: *pass* / *warning* — deployment
-   automation legitimately needs it, but under ``hardened`` a bare CLI actor
-   cannot be attributed to a human.
+   ``allowCliAccess``. Pass when off. When on: *pass* / **critical**
+   (hardened) — deployment automation legitimately needs it under the
+   standard profile, but the hardened profile promises attributability and a
+   bare CLI actor breaks that promise.
 
 cli.access_groups
    Emitted only when CLI access is on. Warning when ``cliAccessGroups`` is empty,
@@ -1179,3 +1203,6 @@ Example
 
    # Machine-readable, for a CI gate or a monitoring probe
    vendor/bin/typo3 vault:doctor --format=json
+
+   # Verify end-to-end sink delivery (talks to the collector)
+   vendor/bin/typo3 vault:doctor --active-probes

--- a/Documentation/Operations/HardenedDeployment.rst
+++ b/Documentation/Operations/HardenedDeployment.rst
@@ -369,8 +369,10 @@ configuration is coherent; these steps say the deployment works.
 *   [ ] ``vault:audit-verify`` reports a valid chain and no findings.
 *   [ ] An anchor exists and is recent — check the newest ``timestamp`` in the
       anchor file.
-*   [ ] Records actually arrive at the collector: perform a reveal, then look
-      for it in syslog or the SIEM. Do not infer delivery from the absence of
+*   [ ] Records actually arrive at the collector: run
+      :bash:`vault:doctor --active-probes` (every enabled sink must accept
+      the chain-tip anchor end-to-end), then perform a reveal and look for it
+      in syslog or the SIEM. Do not infer delivery from the absence of
       errors.
 *   [ ] Break the delivery on purpose once (point the webhook at an
       unreachable host, or make the NDJSON directory read-only), confirm a

--- a/Tests/Unit/Audit/Sink/AuditSinkRegistryTest.php
+++ b/Tests/Unit/Audit/Sink/AuditSinkRegistryTest.php
@@ -16,6 +16,8 @@ use Netresearch\NrVault\Audit\AuditIntegrityReason;
 use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Audit\Sink\AuditSinkInterface;
 use Netresearch\NrVault\Audit\Sink\AuditSinkRegistry;
+use Netresearch\NrVault\Audit\Sink\SinkDeliveryState;
+use Netresearch\NrVault\Audit\Sink\SinkDeliveryStateRepositoryInterface;
 use Netresearch\NrVault\Event\AuditIntegrityAlertEvent;
 use Netresearch\NrVault\Exception\AuditSinkException;
 use Netresearch\NrVault\Tests\Unit\TestCase;
@@ -404,6 +406,31 @@ final class AuditSinkRegistryTest extends TestCase
         self::assertSame(2, $sink->alertCalls);
     }
 
+    #[Test]
+    public function successfulDeliveryIsRecordedInThePersistentState(): void
+    {
+        $deliveryState = new RecordingDeliveryState();
+
+        $this->createSubject([new SpyAuditSink('healthy')], deliveryState: $deliveryState)
+            ->dispatch($this->createEntry(), 'tip');
+
+        self::assertSame(['healthy'], $deliveryState->successes);
+        self::assertSame([], $deliveryState->failures);
+    }
+
+    #[Test]
+    public function failedDeliveryIsRecordedInThePersistentState(): void
+    {
+        $deliveryState = new RecordingDeliveryState();
+        $broken = new SpyAuditSink('broken', throwOnPublish: new RuntimeException('collector unreachable'));
+
+        $this->createSubject([$broken], deliveryState: $deliveryState)
+            ->dispatch($this->createEntry(), 'tip');
+
+        self::assertSame([], $deliveryState->successes);
+        self::assertSame([['broken', 'collector unreachable']], $deliveryState->failures);
+    }
+
     /**
      * @param list<AuditSinkInterface> $sinks
      */
@@ -411,11 +438,13 @@ final class AuditSinkRegistryTest extends TestCase
         array $sinks,
         ?LoggerInterface $logger = null,
         ?EventDispatcherInterface $eventDispatcher = null,
+        ?SinkDeliveryStateRepositoryInterface $deliveryState = null,
     ): AuditSinkRegistry {
         return new AuditSinkRegistry(
             $sinks,
             $logger ?? new NullLogger(),
             $eventDispatcher ?? new RecordingEventDispatcher(),
+            $deliveryState,
         );
     }
 
@@ -623,5 +652,34 @@ final class ReentrantAlertSink implements AuditSinkInterface
     public function isEnabled(): bool
     {
         return true;
+    }
+}
+
+/**
+ * Records delivery-state bookkeeping calls for assertion.
+ *
+ * @internal test helper
+ */
+final class RecordingDeliveryState implements SinkDeliveryStateRepositoryInterface
+{
+    /** @var list<string> */
+    public array $successes = [];
+
+    /** @var list<array{0: string, 1: string}> */
+    public array $failures = [];
+
+    public function recordSuccess(string $sinkIdentifier): void
+    {
+        $this->successes[] = $sinkIdentifier;
+    }
+
+    public function recordFailure(string $sinkIdentifier, string $errorMessage): void
+    {
+        $this->failures[] = [$sinkIdentifier, $errorMessage];
+    }
+
+    public function getState(string $sinkIdentifier): SinkDeliveryState
+    {
+        return new SinkDeliveryState(sinkIdentifier: $sinkIdentifier);
     }
 }

--- a/Tests/Unit/Audit/Sink/SinkDeliveryStateRepositoryTest.php
+++ b/Tests/Unit/Audit/Sink/SinkDeliveryStateRepositoryTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit\Sink;
+
+use Netresearch\NrVault\Audit\Sink\SinkDeliveryState;
+use Netresearch\NrVault\Audit\Sink\SinkDeliveryStateRepository;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\NullLogger;
+use RuntimeException;
+use TYPO3\CMS\Core\Registry;
+
+#[CoversClass(SinkDeliveryStateRepository::class)]
+#[CoversClass(SinkDeliveryState::class)]
+final class SinkDeliveryStateRepositoryTest extends TestCase
+{
+    /** @var array<string, mixed> Simulated sys_registry storage. */
+    private array $storage = [];
+
+    #[Test]
+    public function firstSuccessIsPersisted(): void
+    {
+        $subject = $this->createSubject();
+
+        $subject->recordSuccess('webhook');
+
+        $state = $subject->getState('webhook');
+        self::assertTrue($state->hasEverSucceeded());
+        self::assertFalse($state->isFailing());
+        self::assertSame(0, $state->consecutiveFailures);
+    }
+
+    #[Test]
+    public function failureIncrementsConsecutiveAndTotalCounters(): void
+    {
+        $subject = $this->createSubject();
+
+        $subject->recordFailure('webhook', 'collector unreachable');
+        $subject->recordFailure('webhook', 'still unreachable');
+
+        $state = $subject->getState('webhook');
+        self::assertTrue($state->isFailing());
+        self::assertSame(2, $state->consecutiveFailures);
+        self::assertSame(2, $state->totalFailures);
+        self::assertSame('still unreachable', $state->lastError);
+        self::assertGreaterThan(0, $state->lastFailureAt);
+    }
+
+    #[Test]
+    public function successAfterFailuresResetsTheConsecutiveCounterButKeepsTheTotal(): void
+    {
+        $subject = $this->createSubject();
+
+        $subject->recordFailure('file', 'disk full');
+        $subject->recordSuccess('file');
+
+        $state = $subject->getState('file');
+        self::assertFalse($state->isFailing());
+        self::assertSame(0, $state->consecutiveFailures);
+        self::assertSame(1, $state->totalFailures, 'lifetime counter must survive the recovery');
+        self::assertTrue($state->hasEverSucceeded());
+        self::assertSame('', $state->lastError);
+    }
+
+    #[Test]
+    public function healthySuccessesAreThrottledToOneWritePerInterval(): void
+    {
+        $writes = 0;
+        $subject = $this->createSubject($writes);
+
+        $subject->recordSuccess('syslog');
+        $subject->recordSuccess('syslog');
+        $subject->recordSuccess('syslog');
+
+        self::assertSame(1, $writes, 'repeated healthy successes must not write per audit entry');
+    }
+
+    #[Test]
+    public function unknownSinkYieldsAPristineState(): void
+    {
+        $state = $this->createSubject()->getState('never-seen');
+
+        self::assertFalse($state->hasEverSucceeded());
+        self::assertFalse($state->isFailing());
+        self::assertSame(0, $state->totalFailures);
+    }
+
+    #[Test]
+    public function aThrowingRegistryIsSwallowedFailSafe(): void
+    {
+        $registry = $this->createMock(Registry::class);
+        $registry->method('get')->willThrowException(new RuntimeException('sys_registry broken'));
+        $registry->method('set')->willThrowException(new RuntimeException('sys_registry broken'));
+
+        $subject = new SinkDeliveryStateRepository($registry, new NullLogger());
+
+        // Bookkeeping must never fail the audited operation.
+        $subject->recordSuccess('webhook');
+        $subject->recordFailure('webhook', 'boom');
+
+        $state = $subject->getState('webhook');
+        self::assertFalse($state->hasEverSucceeded());
+    }
+
+    #[Test]
+    public function overlongErrorMessagesAreTruncated(): void
+    {
+        $subject = $this->createSubject();
+
+        $subject->recordFailure('webhook', str_repeat('x', 2000));
+
+        self::assertSame(500, mb_strlen($subject->getState('webhook')->lastError));
+    }
+
+    private function createSubject(?int &$writes = null): SinkDeliveryStateRepository
+    {
+        $registry = $this->createMock(Registry::class);
+        $registry->method('get')->willReturnCallback(
+            fn (string $namespace, string $key): mixed => $this->storage[$namespace . '/' . $key] ?? null,
+        );
+        $registry->method('set')->willReturnCallback(
+            function (string $namespace, string $key, mixed $value) use (&$writes): void {
+                $this->storage[$namespace . '/' . $key] = $value;
+                if ($writes !== null) {
+                    ++$writes;
+                }
+            },
+        );
+
+        return new SinkDeliveryStateRepository($registry, new NullLogger());
+    }
+}

--- a/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
@@ -15,6 +15,8 @@ use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Audit\HashChainVerificationResult;
 use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Audit\Sink\SinkDeliveryState;
+use Netresearch\NrVault\Audit\Sink\SinkDeliveryStateRepositoryInterface;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Configuration\SecurityProfile;
 use Netresearch\NrVault\Service\Doctor\Check\AuditCheck;
@@ -300,6 +302,96 @@ final class AuditCheckTest extends TestCase
         self::assertStringContainsString('webhook', $finding->summary);
     }
 
+    #[Test]
+    public function aFailingSinkInThePersistedStateIsCriticalUnderHardened(): void
+    {
+        $findings = $this->check(
+            sinks: ['webhook'],
+            deliveryState: $this->deliveryStateWith([
+                'webhook' => new SinkDeliveryState(
+                    sinkIdentifier: 'webhook',
+                    lastSuccessAt: time() - 600,
+                    lastFailureAt: time() - 60,
+                    consecutiveFailures: 4,
+                    totalFailures: 4,
+                    lastError: 'connection refused',
+                ),
+            ]),
+        )->run($this->doctorContext(SecurityProfile::Hardened));
+
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $findings,
+            'audit.sink_state.webhook',
+        );
+        self::assertStringContainsString('connection refused', $finding->summary);
+    }
+
+    #[Test]
+    public function aStaleLastSuccessfulDeliveryIsCriticalUnderHardenedAndAWarningUnderStandard(): void
+    {
+        $staleState = $this->deliveryStateWith([
+            'file' => new SinkDeliveryState(
+                sinkIdentifier: 'file',
+                lastSuccessAt: time() - (48 * 3600),
+            ),
+        ]);
+
+        $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $this->check(sinks: ['file'], deliveryState: $staleState)
+                ->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.sink_state.file',
+        );
+
+        $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(sinks: ['file'], deliveryState: $staleState)
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.sink_state.file',
+        );
+    }
+
+    #[Test]
+    public function aSinkThatNeverDeliveredIsAWarningUnderHardenedOnly(): void
+    {
+        // A freshly enabled sink has no history yet — under hardened that is
+        // unproven external evidence (the remediation points at
+        // --active-probes); under standard it is normal ramp-up.
+        $pristine = $this->deliveryStateWith([]);
+
+        $hardened = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(sinks: ['syslog'], deliveryState: $pristine)
+                ->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.sink_state.syslog',
+        );
+        self::assertStringContainsString('--active-probes', $hardened->remediation);
+
+        $standard = $this->findingById(
+            $this->check(sinks: ['syslog'], deliveryState: $pristine)
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.sink_state.syslog',
+        );
+        self::assertTrue($standard->isPass());
+    }
+
+    #[Test]
+    public function aRecentlyDeliveringSinkPasses(): void
+    {
+        $finding = $this->findingById(
+            $this->check(
+                sinks: ['file'],
+                deliveryState: $this->deliveryStateWith([
+                    'file' => new SinkDeliveryState(sinkIdentifier: 'file', lastSuccessAt: time() - 120),
+                ]),
+            )->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.sink_state.file',
+        );
+
+        self::assertTrue($finding->isPass());
+    }
+
     /**
      * A check wired with a healthy audit configuration, overridable per test.
      *
@@ -320,10 +412,12 @@ final class AuditCheckTest extends TestCase
         ?ChainTipAnchor $anchor = null,
         bool $withoutAnchor = false,
         ?AuditLogServiceInterface $auditLogService = null,
+        ?SinkDeliveryStateRepositoryInterface $deliveryState = null,
     ): AuditCheck {
         $configuration = self::createStub(ExtensionConfigurationInterface::class);
         $configuration->method('isAuditReadsEnabled')->willReturn($auditReads);
         $configuration->method('getAuditLogRetention')->willReturn($retention);
+        $configuration->method('getAuditSinkStaleDeliveryHours')->willReturn(24);
 
         if (!$auditLogService instanceof AuditLogServiceInterface) {
             $stub = self::createStub(AuditLogServiceInterface::class);
@@ -365,6 +459,20 @@ final class AuditCheckTest extends TestCase
             $registry,
             $anchorService,
             $anchorReader,
+            $deliveryState,
         );
+    }
+
+    /**
+     * @param array<string, SinkDeliveryState> $states
+     */
+    private function deliveryStateWith(array $states): SinkDeliveryStateRepositoryInterface
+    {
+        $repository = self::createStub(SinkDeliveryStateRepositoryInterface::class);
+        $repository->method('getState')->willReturnCallback(
+            static fn (string $sink): SinkDeliveryState => $states[$sink] ?? new SinkDeliveryState(sinkIdentifier: $sink),
+        );
+
+        return $repository;
     }
 }

--- a/Tests/Unit/Service/Doctor/Check/SinkProbeCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/SinkProbeCheckTest.php
@@ -1,0 +1,149 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditLogEntry;
+use Netresearch\NrVault\Audit\Sink\AuditSinkInterface;
+use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Service\Doctor\Check\SinkProbeCheck;
+use Netresearch\NrVault\Service\Doctor\DoctorContext;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\DoctorFindingTrait;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+use Throwable;
+
+#[CoversClass(SinkProbeCheck::class)]
+final class SinkProbeCheckTest extends TestCase
+{
+    use DoctorFindingTrait;
+
+    #[Test]
+    public function emitsNothingWithoutTheActiveProbesFlag(): void
+    {
+        // The probe talks to external systems — the passive doctor run and
+        // the backend status panel must never trigger it implicitly.
+        $sink = new ProbeSpySink('webhook');
+
+        $findings = $this->check([$sink])->run($this->context(activeProbes: false));
+
+        self::assertSame([], $findings);
+        self::assertSame(0, $sink->anchorCalls);
+    }
+
+    #[Test]
+    public function anAcceptingSinkYieldsAPassWithTheAnchorSequence(): void
+    {
+        $sink = new ProbeSpySink('file');
+
+        $findings = $this->check([$sink])->run($this->context(activeProbes: true));
+
+        $finding = $this->findingById($findings, 'audit.sink_probe.file');
+        self::assertTrue($finding->isPass());
+        self::assertSame(1, $sink->anchorCalls, 'the probe must actually deliver the anchor');
+        self::assertSame(42, $finding->details['anchorSequence']);
+    }
+
+    #[Test]
+    public function aRefusedProbeIsCriticalInBothProfiles(): void
+    {
+        // The review's acceptance scenario: syntactically valid webhook,
+        // collector unreachable => the ACTIVE check must report critical.
+        $sink = new ProbeSpySink('webhook', throwOnAnchor: new RuntimeException('connection refused'));
+
+        foreach ([SecurityProfile::Standard, SecurityProfile::Hardened] as $profile) {
+            $finding = $this->assertFindingSeverity(
+                FindingSeverity::Critical,
+                $this->check([$sink])->run($this->context(activeProbes: true, profile: $profile)),
+                'audit.sink_probe.webhook',
+            );
+
+            self::assertStringContainsString('connection refused', $finding->summary);
+        }
+    }
+
+    #[Test]
+    public function disabledSinksAreNotProbed(): void
+    {
+        $disabled = new ProbeSpySink('syslog', enabled: false);
+
+        $findings = $this->check([$disabled])->run($this->context(activeProbes: true));
+
+        self::assertSame(0, $disabled->anchorCalls);
+        self::assertSame(['audit.sink_probe.none'], $this->findingIds($findings));
+        self::assertTrue($findings[0]->isPass());
+    }
+
+    /**
+     * @param list<AuditSinkInterface> $sinks
+     */
+    private function check(array $sinks): SinkProbeCheck
+    {
+        $anchorService = self::createStub(ChainTipAnchorServiceInterface::class);
+        $anchorService->method('capture')->willReturn(new ChainTipAnchor(42, 'tip-hash', 1_750_000_000, 3));
+
+        return new SinkProbeCheck($sinks, $anchorService);
+    }
+
+    private function context(
+        bool $activeProbes,
+        SecurityProfile $profile = SecurityProfile::Standard,
+    ): DoctorContext {
+        return new DoctorContext(
+            profile: $profile,
+            configuredProfile: $profile,
+            activeProbes: $activeProbes,
+        );
+    }
+}
+
+/**
+ * Minimal probe target: counts anchor deliveries, optionally refuses them.
+ *
+ * @internal test helper
+ */
+final class ProbeSpySink implements AuditSinkInterface
+{
+    public int $anchorCalls = 0;
+
+    public function __construct(
+        private readonly string $identifier,
+        private readonly bool $enabled = true,
+        private readonly ?Throwable $throwOnAnchor = null,
+    ) {}
+
+    public function publish(AuditLogEntry $entry, string $chainTip): void {}
+
+    public function publishAnchor(ChainTipAnchor $anchor): void
+    {
+        ++$this->anchorCalls;
+
+        if ($this->throwOnAnchor instanceof Throwable) {
+            throw $this->throwOnAnchor;
+        }
+    }
+
+    public function publishAlert(AuditIntegrityAlert $alert): void {}
+
+    public function getIdentifier(): string
+    {
+        return $this->identifier;
+    }
+
+    public function isEnabled(): bool
+    {
+        return $this->enabled;
+    }
+}

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -84,6 +84,9 @@ auditSinkWebhookEnabled = 0
 # cat=Audit Sinks; type=string; label=Webhook URL: https:// endpoint receiving the JSON payloads. Outbound calls go through the hardened HTTP client, so a collector on a private/RFC1918 address must be allow-listed literally in $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'] (a filesystem-bound setting, deliberately out of reach of the backend Settings module).
 auditSinkWebhookUrl =
 
+# cat=Audit Sinks; type=int+; label=Stale Delivery Threshold (hours): vault:doctor treats an enabled sink whose last successful external delivery is older than this as stale (hardened profile: critical finding). Persisted delivery state lives in sys_registry.
+auditSinkStaleDeliveryHours = 24
+
 ########################
 ### HASHICORP VAULT ###
 ########################


### PR DESCRIPTION
## Finding (Medium): `vault:doctor` can report a dead webhook sink as working

"Enabled" meant configuration switch + URL syntax (explicitly no reachability check), and the only delivery telemetry was a **per-process** failure counter — a freshly started `vault:doctor` always saw zero failures, so a collector unreachable for days passed `audit.external_sink` with "No audit sink delivery failures observed in this process."

## Fix

**Persistent delivery state** (`SinkDeliveryStateRepository`, `sys_registry`): per sink — last success, last failure, consecutive failures, lifetime failures, last error. Written fail-safe by `AuditSinkRegistry` on every dispatch outcome (healthy-success writes throttled to 1/min per sink; recovery after failures persisted immediately). Bookkeeping can never fail or slow the audited operation.

**New doctor findings** `audit.sink_state.<sink>` per enabled sink:

| State | standard | hardened |
|---|---|---|
| consecutive failures | warning | **critical** |
| last success older than `auditSinkStaleDeliveryHours` (new setting, default 24) | warning | **critical** |
| never delivered yet | pass | warning (remediation: run the probe) |

The per-process finding keeps its stable id `audit.sink_delivery` (control ids are stable API) and now names its process-local scope.

**Active verification** — `vault:doctor --active-probes`: pushes the **current chain-tip anchor** through every enabled sink end-to-end (webhook: collector must answer 2xx; file: append must happen; syslog: handoff must succeed). One `audit.sink_probe.<sink>` finding per sink; a refused probe is **critical in both profiles** — the review's acceptance scenario ("webhook syntaktisch gültig, aber unerreichbar ⇒ Critical"). The anchor is re-publishable evidence by design (`vault:audit-anchor` does the same on a schedule), so the probe pollutes nothing and even refreshes the external anchor. Probes never run implicitly — not from passive checks, not from the backend status panel.

**Interface note:** `VaultDoctorServiceInterface::run()` gains an optional `bool $activeProbes = false` parameter (required by the commissioned `--active-probes` feature).

Docs updated to the now-true claims: control catalogue (new ids + scopes), configuration reference, hardened deployment checklist ("records actually arrive" now starts with the probe), auditor control mapping ("availability of the audit pipeline is observable" now names the persisted state + probe).

## Verification

- `composer ci` (cgl + phpstan + unit 2986 + fuzz 1612): green — incl. the doc-cli guard validating the new `--active-probes` example (188 examples)
- Full functional suite (257 tests): green, exit 0
- Unit: repository (persist/throttle/recovery/truncation/fail-safe on broken `sys_registry`), registry bookkeeping, probe check (flag off ⇒ no probe; refusal ⇒ critical in both profiles; disabled sinks not probed), `audit.sink_state.*` severity matrix

Part 5/5, stacked on #254. This completes the follow-up hardening round (#250 → #251 → #252 → #254 → this).
