### PR TITLE
Raise security mutation gate to MSI 86 after assertion-hardening pass

### DIFF
--- a/Tests/Unit/Audit/Anchor/AnchorFileReaderTest.php
+++ b/Tests/Unit/Audit/Anchor/AnchorFileReaderTest.php
@@ -19,6 +19,7 @@ use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
+use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 
 /**
@@ -54,6 +55,30 @@ final class AnchorFileReaderTest extends TestCase
         $path = $this->writeFile('');
 
         self::assertTrue($this->createSubject($path)->isAvailable());
+    }
+
+    /**
+     * A directory is readable but is not a file, so both guards have to hold at
+     * once: `is_file() && is_readable()`. A misconfigured path pointing at the
+     * containing directory must be rejected before the open is even attempted —
+     * otherwise the reader opens a directory handle and reports the failure as a
+     * warning, turning a configuration typo into log noise on every run.
+     */
+    #[Test]
+    public function aDirectoryAtTheAnchorPathIsRejectedBeforeAnyOpenIsAttempted(): void
+    {
+        vfsStream::newDirectory('store')->at($this->root);
+        $path = $this->root->url() . '/store';
+
+        self::assertTrue(is_readable($path), 'precondition: only is_file() separates this from an anchor file');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('warning');
+
+        $subject = $this->createSubject($path, $logger);
+
+        self::assertFalse($subject->isAvailable());
+        self::assertNull($subject->readLatestAnchor());
     }
 
     #[Test]
@@ -100,6 +125,26 @@ final class AnchorFileReaderTest extends TestCase
         self::assertInstanceOf(ChainTipAnchor::class, $anchor);
         self::assertSame(100, $anchor->sequence);
         self::assertSame('tip-100', $anchor->chainTip);
+    }
+
+    /**
+     * The same rule one step further: a later line at the sequence that is
+     * already the maximum must not replace it either. `>` rather than `>=` means
+     * the first anchor seen at a sequence wins, so an attacker who can append
+     * cannot overwrite the tip recorded for a sequence with one of their own.
+     */
+    #[Test]
+    public function aLaterAnchorAtTheSameSequenceDoesNotReplaceTheOneAlreadySeen(): void
+    {
+        $path = $this->writeFile(
+            $this->anchorLine(5, 'tip-genuine', 1_750_000_000, 3)
+            . $this->anchorLine(5, 'tip-forged', 1_750_000_900, 3),
+        );
+
+        $anchor = $this->createSubject($path)->readLatestAnchor();
+
+        self::assertInstanceOf(ChainTipAnchor::class, $anchor);
+        self::assertSame('tip-genuine', $anchor->chainTip);
     }
 
     #[Test]
@@ -181,6 +226,61 @@ final class AnchorFileReaderTest extends TestCase
         self::assertNull($this->createSubject($path)->readLatestAnchor());
     }
 
+    /**
+     * A record is only a baseline when it says `type: "anchor"`. An `alert`
+     * record carrying an otherwise well-formed `anchor` payload is exactly what
+     * an attacker with append access to the shared stream would write to plant a
+     * weaker baseline, so the type check has to reject it even though the
+     * payload parses.
+     */
+    #[Test]
+    public function anAlertRecordCarryingAnAnchorPayloadIsNotUsedAsABaseline(): void
+    {
+        $path = $this->writeFile(
+            '{"type":"alert","anchor":{"sequence":1,"chainTip":"tip-1","timestamp":1,"hmacEpoch":3}}' . "\n",
+        );
+
+        self::assertNull($this->createSubject($path)->readLatestAnchor());
+    }
+
+    /**
+     * A torn write can leave the line padded with NUL bytes (a delayed-allocation
+     * filesystem after a power loss). The payload itself is intact, so trimming
+     * the padding keeps the anchor usable instead of losing the baseline to
+     * bytes that carry no data.
+     */
+    #[Test]
+    public function aLineNulPaddedByATornWriteIsStillParsed(): void
+    {
+        $path = $this->writeFile(
+            rtrim($this->anchorLine(6, 'tip-6', 1_750_000_000, 3), "\n") . "\0\0\0\n",
+        );
+
+        $anchor = $this->createSubject($path)->readLatestAnchor();
+
+        self::assertInstanceOf(ChainTipAnchor::class, $anchor);
+        self::assertSame(6, $anchor->sequence);
+    }
+
+    /**
+     * The anchor file lives on a filesystem this code does not control, so the
+     * decoder keeps PHP's default nesting cap of 512: a hand-crafted line cannot
+     * push the parser arbitrarily deep, and a line just inside the cap still
+     * yields its anchor.
+     */
+    #[Test]
+    public function theDecoderKeepsTheDefaultNestingCap(): void
+    {
+        // 2 levels of anchor envelope + the padding array = exactly the cap.
+        $atTheCap = $this->createSubject($this->writeFile($this->paddedAnchorLine(509)))->readLatestAnchor();
+
+        self::assertInstanceOf(ChainTipAnchor::class, $atTheCap);
+        self::assertSame(8, $atTheCap->sequence);
+
+        // One level deeper: rejected as a whole line, no anchor.
+        self::assertNull($this->createSubject($this->writeFile($this->paddedAnchorLine(510)))->readLatestAnchor());
+    }
+
     #[Test]
     public function nonJsonLinesAreSkipped(): void
     {
@@ -206,8 +306,21 @@ final class AnchorFileReaderTest extends TestCase
     {
         FailingStreamWrapper::register(FailingStreamWrapper::MODE_OPEN_REFUSED);
 
+        $path = FailingStreamWrapper::path('anchor.ndjson');
+
+        // Silence is the danger here: an operator who never learns the baseline
+        // went away reads "chain valid" as "chain anchored". The path travels in
+        // the context because that is what tells them which mount to fix.
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                'nr-vault could not open the audit anchor file; verification has no external baseline.',
+                ['path' => $path],
+            );
+
         try {
-            $subject = $this->createSubject(FailingStreamWrapper::path('anchor.ndjson'));
+            $subject = $this->createSubject($path, $logger);
 
             // `isAvailable()` still reports true: the file is there, which is
             // exactly why the read path needs its own guard.
@@ -235,12 +348,22 @@ final class AnchorFileReaderTest extends TestCase
         }
     }
 
-    private function createSubject(string $path): AnchorFileReader
+    private function createSubject(string $path, ?LoggerInterface $logger = null): AnchorFileReader
     {
         $configuration = self::createStub(ExtensionConfigurationInterface::class);
         $configuration->method('getAuditSinkAnchorPath')->willReturn($path);
 
-        return new AnchorFileReader($configuration, new NullLogger());
+        return new AnchorFileReader($configuration, $logger ?? new NullLogger());
+    }
+
+    /**
+     * A valid anchor record whose payload carries `$depth` extra array levels,
+     * on top of the two levels of `{"type":…,"anchor":{…}}` envelope.
+     */
+    private function paddedAnchorLine(int $depth): string
+    {
+        return '{"type":"anchor","anchor":{"sequence":8,"chainTip":"tip-8","timestamp":1,"hmacEpoch":3,'
+            . '"padding":' . str_repeat('[', $depth) . '1' . str_repeat(']', $depth) . '}}' . "\n";
     }
 
     private function writeFile(string $contents): string

--- a/Tests/Unit/Audit/Anchor/ChainTipAnchorServiceTest.php
+++ b/Tests/Unit/Audit/Anchor/ChainTipAnchorServiceTest.php
@@ -50,6 +50,13 @@ use UnexpectedValueException;
 #[CoversClass(ChainTipAnchorService::class)]
 final class ChainTipAnchorServiceTest extends TestCase
 {
+    /**
+     * Every `setMaxResults()` argument the service passed, in call order.
+     *
+     * @var list<int|null>
+     */
+    private array $setMaxResultsCalls = [];
+
     // -------------------------------------------------------------------------
     // publish()
     // -------------------------------------------------------------------------
@@ -69,8 +76,12 @@ final class ChainTipAnchorServiceTest extends TestCase
         $logger = $this->createMock(LoggerInterface::class);
         $logger->expects(self::once())
             ->method('error')
+            // Asserted verbatim: the second sentence is the part that tells the
+            // operator what to DO, and a message that loses it still "contains"
+            // the alarming half while being useless.
             ->with(
-                self::stringContains('zero external sinks'),
+                'nr-vault published an audit chain anchor to zero external sinks; '
+                . 'the anchor provides no table-reset protection. Enable at least one audit sink.',
                 ['sequence' => 12],
             );
         $logger->expects(self::never())->method('info');
@@ -142,6 +153,25 @@ final class ChainTipAnchorServiceTest extends TestCase
         self::assertSame('', $anchor->chainTip);
     }
 
+    /**
+     * On an empty chain there is no row to hash, so the tip is '' by
+     * construction — the latest hash is not even asked for. Anchoring a hash
+     * that belongs to no row (a stale value the writer still holds) would
+     * publish a baseline no future chain can ever satisfy.
+     */
+    #[Test]
+    public function captureOnAnEmptyChainAnchorsAnEmptyTipRatherThanTheLatestHash(): void
+    {
+        $auditLogService = self::createStub(AuditLogServiceInterface::class);
+        $auditLogService->method('getLatestHash')->willReturn('stale-tip');
+
+        $anchor = $this->createSubject(auditLogService: $auditLogService, maxUid: 0)->capture();
+
+        self::assertSame(0, $anchor->sequence);
+        self::assertSame('', $anchor->chainTip);
+        self::assertTrue($anchor->isEmpty());
+    }
+
     // -------------------------------------------------------------------------
     // Chain-error classification
     // -------------------------------------------------------------------------
@@ -188,7 +218,114 @@ final class ChainTipAnchorServiceTest extends TestCase
         self::assertCount(1, $downgrades);
         self::assertSame(4, $downgrades[0]->context['affectedRows']);
         self::assertSame(11, $downgrades[0]->context['firstUid'], 'the earliest affected row locates the break');
-        self::assertStringContainsString('4 row(s)', $downgrades[0]->detail);
+        self::assertSame(
+            'Audit chain HMAC epoch was downgraded on 4 row(s); a weaker or keyless '
+            . 'verification algorithm was selected.',
+            $downgrades[0]->detail,
+        );
+    }
+
+    /**
+     * The classifier matches marker substrings case-insensitively so it keeps
+     * working when the verifier rewords or re-cases its messages. Losing the
+     * fold would silently reclassify a downgrade as a generic hash mismatch —
+     * the fallback path — and point the operator at the wrong incident.
+     */
+    #[Test]
+    public function markerMatchingIsCaseInsensitive(): void
+    {
+        $report = $this->createSubject(
+            chainResult: HashChainVerificationResult::invalid([
+                4 => 'HMAC key EPOCH DOWNGRADE DETECTED: 3 -> 0 (possible algorithm-downgrade forgery)',
+            ]),
+        )->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::EpochDowngrade));
+        self::assertFalse($report->hasReason(AuditIntegrityReason::HashMismatch));
+    }
+
+    /**
+     * A uid-gap error is skipped, not treated as the end of the error list: the
+     * verifier reports errors keyed by uid, so a gap early in the chain is
+     * routinely followed by the rewritten rows that matter most.
+     */
+    #[Test]
+    public function aUidGapErrorDoesNotStopTheClassificationOfLaterErrors(): void
+    {
+        $report = $this->createSubject(
+            chainResult: HashChainVerificationResult::invalid(
+                [
+                    3 => 'Audit log uid gap detected: missing uids 2..2',
+                    5 => 'Entry hash mismatch - possible tampering',
+                ],
+                [],
+                [2],
+                1,
+            ),
+        )->verify();
+
+        self::assertTrue($report->hasReason(AuditIntegrityReason::UidGap));
+        self::assertTrue(
+            $report->hasReason(AuditIntegrityReason::HashMismatch),
+            'the rewritten row after the gap must still be reported',
+        );
+    }
+
+    /**
+     * The uid-gap finding carries the full count plus a bounded sample: the
+     * sample lands in a syslog line and a webhook payload, so it is capped at the
+     * FIRST 20 uids — the ones that bound the start of the deletion — while the
+     * count keeps the true size of the damage visible.
+     */
+    #[Test]
+    public function theUidGapFindingCarriesTheFullCountAndTheFirstTwentyUidsOnly(): void
+    {
+        $missing = range(2, 30);
+
+        $report = $this->createSubject(
+            chainResult: HashChainVerificationResult::invalid(
+                [31 => 'Audit log uid gap detected: missing uids 2..30'],
+                [],
+                $missing,
+                29,
+            ),
+        )->verify();
+
+        $findings = array_values(array_filter(
+            $report->findings,
+            static fn (AuditIntegrityAlert $finding): bool => $finding->reason === AuditIntegrityReason::UidGap,
+        ));
+
+        self::assertCount(1, $findings);
+        self::assertSame(29, $findings[0]->context['missingUidCount']);
+        self::assertSame(implode(',', range(2, 21)), $findings[0]->context['missingUidSample']);
+        self::assertSame('Audit chain has 29 missing uid(s); rows were deleted from the chain.', $findings[0]->detail);
+    }
+
+    /**
+     * The hash-mismatch finding collapses its rows the same way, and must carry
+     * both the row count and the earliest affected uid — the count sizes the
+     * damage, the uid locates where the chain diverged.
+     */
+    #[Test]
+    public function theHashMismatchFindingCarriesTheRowCountAndTheEarliestUid(): void
+    {
+        $report = $this->createSubject(
+            chainResult: HashChainVerificationResult::invalid([
+                6 => 'Entry hash mismatch - possible tampering',
+                7 => 'Entry hash mismatch - possible tampering',
+            ]),
+        )->verify();
+
+        $findings = array_values(array_filter(
+            $report->findings,
+            static fn (AuditIntegrityAlert $finding): bool => $finding->reason === AuditIntegrityReason::HashMismatch,
+        ));
+
+        self::assertCount(1, $findings);
+        self::assertSame(2, $findings[0]->context['affectedRows']);
+        self::assertSame(6, $findings[0]->context['firstUid']);
+        self::assertSame('Audit chain hash verification failed on 2 row(s).', $findings[0]->detail);
     }
 
     /**
@@ -273,7 +410,12 @@ final class ChainTipAnchorServiceTest extends TestCase
 
         self::assertCount(1, $findings);
         self::assertSame('hardened', $findings[0]->context['profile']);
-        self::assertStringContainsString('only in the database it is meant to protect', $findings[0]->detail);
+        self::assertSame(
+            'Hardened profile requires at least one external audit sink, but none is enabled '
+            . 'and usable. The audit trail exists only in the database it is meant to protect, '
+            . 'and no chain-tip anchor can be published.',
+            $findings[0]->detail,
+        );
         self::assertFalse($report->hasTamperEvidence(), 'a configuration gap is not tamper evidence');
     }
 
@@ -455,6 +597,58 @@ final class ChainTipAnchorServiceTest extends TestCase
     }
 
     /**
+     * A chain sitting exactly at its anchored sequence has not shrunk — it is
+     * simply an installation that has not written since the last anchoring run.
+     * Reporting that as a table reset would fire TABLE_RESET at every quiet site
+     * and train operators to ignore the one alert that matters.
+     */
+    #[Test]
+    public function aChainSittingExactlyAtItsAnchoredSequenceIsValid(): void
+    {
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn(new ChainTipAnchor(6, 'tip-6', 1_750_000_000, 3));
+
+        $report = $this->createSubject(
+            anchorReader: $anchorReader,
+            maxUid: 6,
+            rowAtAnchor: ['entry_hash' => 'tip-6', 'hmac_key_epoch' => 3],
+        )->verify();
+
+        self::assertTrue($report->isValid(), 'findings: ' . implode(',', $report->getReasonCodes()));
+    }
+
+    /**
+     * The driver hands back whatever the column type maps to — for MySQL/PDO
+     * that is a numeric STRING. The report's sequence is an int, so the value has
+     * to be coerced rather than passed through.
+     */
+    #[Test]
+    public function aNumericStringFromTheDriverBecomesAnIntSequence(): void
+    {
+        self::assertSame(7, $this->createSubject(maxUid: '7')->verify()->currentSequence);
+    }
+
+    /**
+     * Both queries are point lookups: the highest uid and the single anchored
+     * row. Dropping the limit turns the first into a full-table scan on a table
+     * that grows without bound, and neither needs a second row.
+     */
+    #[Test]
+    public function bothLookupsAreLimitedToASingleRow(): void
+    {
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn(new ChainTipAnchor(2, 'tip-2', 1_750_000_000, 3));
+
+        $this->createSubject(
+            anchorReader: $anchorReader,
+            maxUid: 4,
+            rowAtAnchor: ['entry_hash' => 'tip-2', 'hmac_key_epoch' => 3],
+        )->verify();
+
+        self::assertSame([1, 1], $this->setMaxResultsCalls);
+    }
+
+    /**
      * A row whose stored hash is not a string (a NULL column after a partial
      * write) must not compare equal to the anchored tip by collapsing to ''.
      */
@@ -489,7 +683,107 @@ final class ChainTipAnchorServiceTest extends TestCase
             rowAtAnchor: ['entry_hash' => 'tip-2', 'hmac_key_epoch' => 'not-a-number'],
         )->verify();
 
-        self::assertTrue($report->hasReason(AuditIntegrityReason::EpochDowngrade));
+        $findings = array_values(array_filter(
+            $report->findings,
+            static fn (AuditIntegrityAlert $finding): bool => $finding->reason === AuditIntegrityReason::EpochDowngrade,
+        ));
+
+        self::assertCount(1, $findings);
+        // 0, not 1 and not -1: the unreadable column has to degrade to "no HMAC
+        // protection at all", the level that is below every configurable epoch.
+        self::assertSame(0, $findings[0]->context['currentEpoch']);
+    }
+
+    /**
+     * The anchored row is still there and still hashes as anchored, but reports a
+     * lower epoch than the anchor witnessed: the chain was relabelled down to a
+     * weaker (or keyless) algorithm. The in-chain check cannot see this — only
+     * the external anchor knows which level was actually in force.
+     */
+    #[Test]
+    public function anEpochBelowTheAnchoredOneIsReportedAgainstTheAnchoredEvidence(): void
+    {
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn(new ChainTipAnchor(2, 'tip-2', 1_750_000_000, 3));
+
+        $report = $this->createSubject(
+            anchorReader: $anchorReader,
+            maxUid: 4,
+            // A string epoch is what the driver hands back for an int column.
+            rowAtAnchor: ['entry_hash' => 'tip-2', 'hmac_key_epoch' => '1'],
+        )->verify();
+
+        $findings = array_values(array_filter(
+            $report->findings,
+            static fn (AuditIntegrityAlert $finding): bool => $finding->reason === AuditIntegrityReason::EpochDowngrade,
+        ));
+
+        self::assertCount(1, $findings);
+        self::assertSame(
+            'Audit row 2 now reports HMAC epoch 1 but epoch 3 was anchored; the '
+            . 'verification algorithm was downgraded.',
+            $findings[0]->detail,
+        );
+        self::assertSame(2, $findings[0]->context['anchoredSequence']);
+        self::assertSame(1, $findings[0]->context['currentEpoch']);
+        self::assertSame(3, $findings[0]->context['anchoredEpoch']);
+    }
+
+    /**
+     * The substitution check. The row survives and the chain is long enough, so
+     * the only remaining evidence is that the row no longer hashes to the
+     * anchored tip — and the finding has to name the capture time, because that
+     * bounds the window in which the chain was rebuilt.
+     */
+    #[Test]
+    public function anAnchoredRowHashingDifferentlyIsReportedAsATableReset(): void
+    {
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn(new ChainTipAnchor(4, 'tip-4', 1_750_000_000, 3));
+
+        $report = $this->createSubject(
+            anchorReader: $anchorReader,
+            maxUid: 6,
+            rowAtAnchor: ['entry_hash' => 'rebuilt-hash', 'hmac_key_epoch' => 3],
+        )->verify();
+
+        $findings = array_values(array_filter(
+            $report->findings,
+            static fn (AuditIntegrityAlert $finding): bool => $finding->reason === AuditIntegrityReason::TableReset,
+        ));
+
+        self::assertCount(1, $findings);
+        self::assertSame(
+            'Audit row 4 hashes differently than anchored: the chain at that sequence is '
+            . 'not the chain that was anchored on 2025-06-15 15:06:40 UTC.',
+            $findings[0]->detail,
+        );
+        self::assertSame(4, $findings[0]->context['anchoredSequence']);
+        self::assertSame(1_750_000_000, $findings[0]->context['anchoredAt']);
+    }
+
+    /**
+     * A rebuilt chain commonly trips both checks at once — a different hash AND a
+     * lower epoch. Reporting only the first would hide the algorithm downgrade,
+     * which is the finding that decides whether the stored hashes can be trusted
+     * at all.
+     */
+    #[Test]
+    public function aRowThatBothHashesDifferentlyAndReportsALowerEpochYieldsBothFindings(): void
+    {
+        $anchorReader = self::createStub(AnchorReaderInterface::class);
+        $anchorReader->method('readLatestAnchor')->willReturn(new ChainTipAnchor(4, 'tip-4', 1_750_000_000, 3));
+
+        $report = $this->createSubject(
+            anchorReader: $anchorReader,
+            maxUid: 6,
+            rowAtAnchor: ['entry_hash' => 'rebuilt-hash', 'hmac_key_epoch' => 0],
+        )->verify();
+
+        self::assertSame(
+            [AuditIntegrityReason::TableReset->value, AuditIntegrityReason::EpochDowngrade->value],
+            $report->getReasonCodes(),
+        );
     }
 
     /**
@@ -515,7 +809,11 @@ final class ChainTipAnchorServiceTest extends TestCase
         self::assertSame(2, $findings[0]->context['currentSequence']);
         self::assertSame(9, $findings[0]->context['anchoredSequence']);
         self::assertSame(1_750_000_000, $findings[0]->context['anchoredAt']);
-        self::assertStringContainsString('2025-06-15 15:06:40 UTC', $findings[0]->detail);
+        self::assertSame(
+            'Audit chain shrank: highest uid is 2 but sequence 9 was anchored on 2025-06-15 15:06:40 UTC. '
+            . 'The audit table was truncated or rows were deleted wholesale.',
+            $findings[0]->detail,
+        );
         self::assertTrue($report->hasTamperEvidence());
     }
 
@@ -543,7 +841,11 @@ final class ChainTipAnchorServiceTest extends TestCase
         self::assertCount(1, $findings);
         self::assertSame(3, $findings[0]->context['anchoredSequence']);
         self::assertSame(11, $findings[0]->context['currentSequence']);
-        self::assertStringContainsString('no longer exists', $findings[0]->detail);
+        self::assertSame(
+            'Anchored audit row 3 no longer exists although the chain reaches uid 11; '
+            . 'the chain was rebuilt.',
+            $findings[0]->detail,
+        );
     }
 
     /**
@@ -571,7 +873,12 @@ final class ChainTipAnchorServiceTest extends TestCase
 
         self::assertCount(1, $findings);
         self::assertFalse($findings[0]->context['anchorAvailable']);
-        self::assertStringContainsString('vault:audit-anchor', $findings[0]->detail);
+        self::assertSame(
+            'Hardened profile requires an external chain-tip anchor, but none could be read. '
+            . 'A full audit-table reset would be undetectable. Run vault:audit-anchor '
+            . '(or schedule the anchor task).',
+            $findings[0]->detail,
+        );
     }
 
     /**
@@ -652,7 +959,13 @@ final class ChainTipAnchorServiceTest extends TestCase
         $queryBuilder->method('from')->willReturnSelf();
         $queryBuilder->method('where')->willReturnSelf();
         $queryBuilder->method('orderBy')->willReturnSelf();
-        $queryBuilder->method('setMaxResults')->willReturnSelf();
+        $queryBuilder->method('setMaxResults')->willReturnCallback(
+            function (?int $maxResults) use ($queryBuilder): QueryBuilder {
+                $this->setMaxResultsCalls[] = $maxResults;
+
+                return $queryBuilder;
+            },
+        );
         $queryBuilder->method('createNamedParameter')->willReturn('?');
         $queryBuilder->method('executeQuery')->willReturn($result);
 

--- a/Tests/Unit/Audit/AuditChainAnchorStoreTest.php
+++ b/Tests/Unit/Audit/AuditChainAnchorStoreTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Audit;
 
 use Doctrine\DBAL\Result;
+use InvalidArgumentException;
 use Netresearch\NrVault\Audit\AuditChainAnchor;
 use Netresearch\NrVault\Audit\AuditChainAnchorStatus;
 use Netresearch\NrVault\Audit\AuditChainAnchorStore;
@@ -44,6 +45,12 @@ final class AuditChainAnchorStoreTest extends TestCase
 
     private Connection&MockObject $connection;
 
+    /**
+     * The restriction container the wired query builder hands out — the seam
+     * that proves the anchor lookup drops the default restrictions.
+     */
+    private QueryRestrictionContainerInterface&MockObject $restrictions;
+
     private ConnectionPool $connectionPool;
 
     private ExtensionConfigurationInterface $extensionConfiguration;
@@ -53,6 +60,7 @@ final class AuditChainAnchorStoreTest extends TestCase
         parent::setUp();
 
         $this->connection = $this->createMock(Connection::class);
+        $this->restrictions = $this->createMock(QueryRestrictionContainerInterface::class);
         $this->connectionPool = self::createStub(ConnectionPool::class);
         $this->connectionPool->method('getConnectionForTable')->willReturn($this->connection);
         $this->extensionConfiguration = self::createStub(ExtensionConfigurationInterface::class);
@@ -84,7 +92,20 @@ final class AuditChainAnchorStoreTest extends TestCase
     {
         $this->wireReads([$this->anchorRow($this->encode(4, self::HASH_A))], [self::HASH_A]);
 
-        $this->connection->expects(self::once())->method('update');
+        // The full argument list is pinned: an UPDATE that carries no value
+        // blanks the anchor, one that drops the namespace from its WHERE hits
+        // every extension's registry entry under the same key, and one that
+        // drops the LOB type corrupts the value on PostgreSQL.
+        $this->connection
+            ->expects(self::once())
+            ->method('update')
+            ->with(
+                'sys_registry',
+                self::callback(static fn (array $data): bool => \is_string($data['entry_value'] ?? null)
+                    && str_starts_with($data['entry_value'], 'nrvault-audit-tip.v1|9|' . self::HASH_B . '|')),
+                ['entry_namespace' => 'tx_nrvault_audit_anchor', 'entry_key' => 'auditChainTip'],
+                ['entry_value' => Connection::PARAM_LOB],
+            );
         $this->connection->expects(self::never())->method('insert');
 
         $this->subject()->advance($this->connection, new AuditChainAnchor(9, self::HASH_B, 1_700_000_000));
@@ -166,16 +187,53 @@ final class AuditChainAnchorStoreTest extends TestCase
     #[Test]
     public function advanceWritesNothingAtEpochZero(): void
     {
-        $configuration = self::createStub(ExtensionConfigurationInterface::class);
-        $configuration->method('getAuditHmacEpoch')->willReturn(0);
+        $this->connection->expects(self::never())->method('update');
+        $this->connection->expects(self::never())->method('insert');
+
+        $subject = $this->subjectAtEpoch(0);
+        $subject->advance($this->connection, new AuditChainAnchor(1, self::HASH_A, 1_700_000_000));
+
+        self::assertFalse($subject->isEnabled());
+    }
+
+    /**
+     * Epoch 1 is the FIRST anchored epoch, not the second: the anchor exists to
+     * pin a KEYED chain, and a chain is keyed from epoch 1 upwards. Anchoring
+     * only from epoch 2 would leave every install that stopped at the first
+     * HMAC epoch silently unanchored.
+     */
+    #[Test]
+    public function theAnchorIsEnabledFromTheFirstKeyedEpoch(): void
+    {
+        self::assertFalse($this->subjectAtEpoch(0)->isEnabled());
+        self::assertTrue($this->subjectAtEpoch(1)->isEnabled());
+    }
+
+    /**
+     * Both guards are independent refusals, not a conjunction: a disabled
+     * anchor must stay unwritten even though the registry is on the audit
+     * connection, which is the ordinary single-connection installation.
+     */
+    #[Test]
+    public function resealWritesNothingAtEpochZero(): void
+    {
+        $this->wireReads([['uid' => 4, 'entry_hash' => self::HASH_A], false]);
 
         $this->connection->expects(self::never())->method('update');
         $this->connection->expects(self::never())->method('insert');
 
-        $subject = new AuditChainAnchorStore($this->connectionPool, $this->masterKeyProvider(), $configuration);
-        $subject->advance($this->connection, new AuditChainAnchor(1, self::HASH_A, 1_700_000_000));
+        $this->subjectAtEpoch(0)->reseal($this->connection);
+    }
 
-        self::assertFalse($subject->isEnabled());
+    #[Test]
+    public function armWritesNothingAtEpochZero(): void
+    {
+        $this->wireReads([['uid' => 4, 'entry_hash' => self::HASH_A], false]);
+
+        $this->connection->expects(self::never())->method('update');
+        $this->connection->expects(self::never())->method('insert');
+
+        self::assertFalse($this->subjectAtEpoch(0)->arm($this->connection));
     }
 
     #[Test]
@@ -442,9 +500,204 @@ final class AuditChainAnchorStoreTest extends TestCase
         self::assertFalse($this->subject()->arm($this->connection));
     }
 
+    /**
+     * The "already asserts exactly this tip" short-circuit is what stops a
+     * re-seal from rewriting the row on every call. It has to fire on (uid,
+     * entry_hash) equality alone — and it has to fire while the anchored row is
+     * still present, which is the state every legitimate repeat re-seal is in.
+     * Falling through to the truncation guard instead only looks harmless
+     * because that guard also refuses; wire the row in and the fall-through
+     * writes.
+     */
+    #[Test]
+    public function resealWritesNothingWhenTheStoredTipMatchesAndTheAnchoredRowIsStillThere(): void
+    {
+        $this->wireReads(
+            [['uid' => 4, 'entry_hash' => self::HASH_A], $this->anchorRow($this->encode(4, self::HASH_A))],
+            [self::HASH_A],
+        );
+
+        $this->connection->expects(self::never())->method('update');
+        $this->connection->expects(self::never())->method('insert');
+
+        $this->subject()->reseal($this->connection);
+    }
+
+    /**
+     * `auditAnchorRequired` gates the ABSENT-anchor case only. A re-seal over an
+     * anchor that is PRESENT must still happen under the flag — otherwise a
+     * master-key rotation on a hardened installation leaves the anchor signed
+     * under the old key, and every later verification reports a violation that
+     * never happened.
+     */
+    #[Test]
+    public function resealStillRewritesAPresentAnchorWhenImplicitArmingIsRefused(): void
+    {
+        $this->wireReads(
+            [['uid' => 4, 'entry_hash' => self::HASH_B], $this->anchorRow($this->encode(4, self::HASH_A))],
+            [self::HASH_B],
+        );
+
+        $this->connection->expects(self::once())->method('update');
+
+        $this->subjectWithAnchorRequired()->reseal($this->connection);
+    }
+
+    /**
+     * The anchor lookup runs with every default restriction removed.
+     * `sys_registry` has no `deleted`/`hidden`/workspace columns, so a
+     * restriction that survives here turns the read into an SQL error — and an
+     * anchor that cannot be read is an anchor that cannot report a truncation.
+     */
+    #[Test]
+    public function theAnchorLookupDropsAllDefaultQueryRestrictions(): void
+    {
+        $this->wireReads([$this->anchorRow($this->encode(3, self::HASH_A))]);
+
+        $this->restrictions->expects(self::atLeastOnce())->method('removeAll');
+
+        self::assertSame(AuditChainAnchorStatus::Ok, $this->subject()->load($this->connection)->status);
+    }
+
+    /**
+     * Storing bytes our own reader rejects would leave the installation
+     * reporting `Unreadable` forever, so each guard fails loudly on its own.
+     * The caller turns this into an `AuditWriteException`, taking the audited
+     * operation down with it — fail closed.
+     *
+     * @param int $uid uid of the tip that must not be anchored
+     * @param string $entryHash entry hash of the tip that must not be anchored
+     * @param int $tstamp timestamp of the tip that must not be anchored
+     */
+    #[Test]
+    #[DataProvider('unanchorableTipProvider')]
+    public function anchoringATipOurOwnReaderWouldRejectFailsLoudly(
+        int $uid,
+        string $entryHash,
+        int $tstamp,
+    ): void {
+        $this->wireReads([false]);
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionCode(1753900002);
+
+        $this->subject()->advance($this->connection, new AuditChainAnchor($uid, $entryHash, $tstamp));
+    }
+
+    /**
+     * @return iterable<string, array{int, string, int}>
+     */
+    public static function unanchorableTipProvider(): iterable
+    {
+        yield 'uid below the first row' => [0, self::HASH_A, 1_700_000_000];
+        yield 'hash that is not 64 lowercase hex' => [7, strtoupper(self::HASH_A), 1_700_000_000];
+        yield 'negative timestamp' => [7, self::HASH_A, -1];
+    }
+
+    /**
+     * `tstamp` is a point in time, not a duration: the stored format accepts
+     * `\d{1,10}`, so 0 is a value the reader takes back. Only NEGATIVE
+     * timestamps are refused — rejecting 0 would make the guard stricter than
+     * the format it exists to protect.
+     */
+    #[Test]
+    public function aTipWithAZeroTimestampIsAnchored(): void
+    {
+        $this->wireReads([false]);
+
+        $this->expectInsertedValueStartingWith('nrvault-audit-tip.v1|7|' . self::HASH_A . '|0|');
+
+        $this->subject()->advance($this->connection, new AuditChainAnchor(7, self::HASH_A, 0));
+    }
+
+    /**
+     * uid 1 is the first row of a fresh chain — the tip a brand-new
+     * installation arms on. Refusing it (in the tip read or in the encoder)
+     * would leave exactly that installation unanchorable.
+     */
+    #[Test]
+    public function armAnchorsATipAtTheVeryFirstUid(): void
+    {
+        $this->wireReads([['uid' => 1, 'entry_hash' => self::HASH_A], false]);
+
+        $this->expectInsertedValueStartingWith('nrvault-audit-tip.v1|1|' . self::HASH_A . '|');
+
+        self::assertTrue($this->subject()->arm($this->connection));
+    }
+
+    /**
+     * Drivers hand `uid` back as a string on more than one supported platform,
+     * so the tip read normalises it. Without the cast the anchor DTO refuses the
+     * value outright and every anchored write dies with a TypeError.
+     */
+    #[Test]
+    public function theTipUidIsNormalisedFromADriverSuppliedString(): void
+    {
+        $this->wireReads([['uid' => '7', 'entry_hash' => self::HASH_A], false]);
+
+        $this->expectInsertedValueStartingWith('nrvault-audit-tip.v1|7|' . self::HASH_A . '|');
+
+        self::assertTrue($this->subject()->arm($this->connection));
+    }
+
+    /**
+     * A tip row the reader cannot make sense of yields NO anchor rather than an
+     * invented one: an unusable uid must not fall back to a plausible-looking
+     * row number, and a malformed hash must not be signed at all. Both
+     * substitutions would MAC-attest a tip that does not exist.
+     *
+     * @param mixed $uid raw `uid` column value
+     * @param mixed $entryHash raw `entry_hash` column value
+     */
+    #[Test]
+    #[DataProvider('unusableTipRowProvider')]
+    public function armIgnoresATipRowItCannotRead(mixed $uid, mixed $entryHash): void
+    {
+        $this->wireReads([['uid' => $uid, 'entry_hash' => $entryHash], false]);
+
+        $this->connection->expects(self::never())->method('update');
+        $this->connection->expects(self::never())->method('insert');
+
+        self::assertFalse($this->subject()->arm($this->connection));
+    }
+
+    /**
+     * @return iterable<string, array{mixed, mixed}>
+     */
+    public static function unusableTipRowProvider(): iterable
+    {
+        yield 'uid is not numeric' => [null, self::HASH_A];
+        yield 'entry hash is malformed' => [5, 'not-a-sha256-digest'];
+    }
+
     // =====================================================================
     // Helpers
     // =====================================================================
+
+    /**
+     * Expect exactly one anchor INSERT whose stored value starts with $prefix.
+     */
+    private function expectInsertedValueStartingWith(string $prefix): void
+    {
+        $this->connection->expects(self::never())->method('update');
+        $this->connection
+            ->expects(self::once())
+            ->method('insert')
+            ->with(
+                'sys_registry',
+                self::callback(static fn (array $data): bool => \is_string($data['entry_value'] ?? null)
+                    && str_starts_with($data['entry_value'], $prefix)),
+                ['entry_value' => Connection::PARAM_LOB],
+            );
+    }
+
+    private function subjectAtEpoch(int $epoch): AuditChainAnchorStore
+    {
+        $configuration = self::createStub(ExtensionConfigurationInterface::class);
+        $configuration->method('getAuditHmacEpoch')->willReturn($epoch);
+
+        return new AuditChainAnchorStore($this->connectionPool, $this->masterKeyProvider(), $configuration);
+    }
 
     private function subjectWithAnchorRequired(): AuditChainAnchorStore
     {
@@ -524,17 +777,26 @@ final class AuditChainAnchorStoreTest extends TestCase
         $expressionBuilder = self::createStub(ExpressionBuilder::class);
         $expressionBuilder->method('eq')->willReturn('c = :p');
 
-        $restrictions = self::createStub(QueryRestrictionContainerInterface::class);
-
-        $queryBuilder = self::createStub(QueryBuilder::class);
-        $queryBuilder->method('getRestrictions')->willReturn($restrictions);
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('getRestrictions')->willReturn($this->restrictions);
         $queryBuilder->method('expr')->willReturn($expressionBuilder);
         $queryBuilder->method('createNamedParameter')->willReturn(':p');
         $queryBuilder->method('select')->willReturnSelf();
         $queryBuilder->method('from')->willReturnSelf();
         $queryBuilder->method('where')->willReturnSelf();
         $queryBuilder->method('orderBy')->willReturnSelf();
-        $queryBuilder->method('setMaxResults')->willReturnSelf();
+        // Every read this class performs is a single-row lookup — the anchor
+        // row, the anchored audit row, the chain tip. The bound is checked here
+        // rather than in one test so that no call site can quietly grow a
+        // second row (an anchor "read" that returns two rows is a read whose
+        // result depends on row order) or lose the limit altogether.
+        $queryBuilder->method('setMaxResults')->willReturnCallback(
+            static function (?int $maxResults) use ($queryBuilder): QueryBuilder {
+                self::assertSame(1, $maxResults, 'every anchor-store read is a single-row lookup');
+
+                return $queryBuilder;
+            },
+        );
         $queryBuilder->method('executeQuery')->willReturn($result);
 
         $this->connection->method('createQueryBuilder')->willReturn($queryBuilder);

--- a/Tests/Unit/Audit/AuditChainRekeyServiceTest.php
+++ b/Tests/Unit/Audit/AuditChainRekeyServiceTest.php
@@ -10,10 +10,12 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Audit;
 
 use Doctrine\DBAL\Result;
+use Netresearch\NrVault\Audit\AuditChainAnchorStoreInterface;
 use Netresearch\NrVault\Audit\AuditChainRekeyService;
 use Netresearch\NrVault\Audit\AuditLogService;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
@@ -39,6 +41,21 @@ use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 final class AuditChainRekeyServiceTest extends TestCase
 {
     private const NEW_MASTER_KEY_MATERIAL = 'rotation-target-key-material-32b';
+
+    /**
+     * Rows per keyset batch, mirroring the service's own `BATCH_SIZE`. A batch
+     * of exactly this size is what makes the walk ask for another one.
+     */
+    private const BATCH_SIZE = 1000;
+
+    /**
+     * Values bound as the keyset lower bound, in call order — one per batch.
+     * The chain walk is only correct if this sequence is `[0, <last uid of the
+     * previous batch>, …]`.
+     *
+     * @var list<mixed>
+     */
+    private array $keysetBounds = [];
 
     /**
      * The load-bearing case: one chain holding a row of every epoch. Each row's
@@ -190,17 +207,138 @@ final class AuditChainRekeyServiceTest extends TestCase
     }
 
     /**
+     * The rewrite invalidates the entry hash the tip anchor asserts, so
+     * re-signing it is part of THIS method's contract rather than a caller
+     * obligation: as a docblock every future caller had to honour it, and
+     * skipping it makes an entirely healthy chain report a tip-anchor violation
+     * on every subsequent verification. It is re-signed under the NEW key — the
+     * master-key provider still holds the old one at this point.
+     */
+    #[Test]
+    public function theTipAnchorIsResealedUnderTheNewKey(): void
+    {
+        $anchorStore = $this->createMock(AuditChainAnchorStoreInterface::class);
+        $anchorStore
+            ->expects(self::once())
+            ->method('reseal')
+            ->with(self::isInstanceOf(Connection::class), self::NEW_MASTER_KEY_MATERIAL);
+
+        $updates = [];
+
+        self::assertSame(1, $this->rekey([$this->row(uid: 1, epoch: 3)], $updates, $anchorStore));
+    }
+
+    /**
+     * The keyset walk starts BELOW the first uid. The bound is exclusive
+     * (`uid > :bound`), so it has to be 0 — starting at 1 would skip the very
+     * first row of the chain, and the row it skips is the one every later link
+     * hangs off.
+     */
+    #[Test]
+    public function theKeysetWalkStartsBelowTheFirstUid(): void
+    {
+        $updates = [];
+        $this->rekey([$this->row(uid: 1, epoch: 3)], $updates);
+
+        self::assertSame([0], $this->keysetBounds);
+    }
+
+    /**
+     * A chain longer than one batch has to be walked to its end, and each batch
+     * has to resume at the highest uid the previous one returned. Stopping after
+     * the first full batch would leave the tail of a large log signed under the
+     * OLD key, which verifies as a tampered chain.
+     *
+     * The rows carry `uid` as a STRING, the way the drivers actually hand it
+     * back: the bound is bound as `PARAM_INT`, so it has to be normalised
+     * before it is handed to the next query.
+     */
+    #[Test]
+    public function theWalkResumesAtTheLastUidOfAFullBatch(): void
+    {
+        $firstBatch = [];
+        for ($uid = 1; $uid <= self::BATCH_SIZE; $uid++) {
+            $row = $this->row(uid: $uid, epoch: 0);
+            $row['uid'] = (string) $uid;
+            $firstBatch[] = $row;
+        }
+
+        $updates = [];
+        $rewritten = $this->rekeyBatches(
+            [$firstBatch, [$this->row(uid: self::BATCH_SIZE + 1, epoch: 0)]],
+            $updates,
+        );
+
+        self::assertSame(self::BATCH_SIZE + 1, $rewritten, 'the walk stopped at the first full batch');
+        self::assertSame([0, self::BATCH_SIZE], $this->keysetBounds);
+    }
+
+    /**
+     * A batch whose rows carry no usable uid must not move the bound forward.
+     * An invented bound skips whatever sits between the real position and the
+     * invented one — silently leaving those rows signed under the old key, in
+     * the one situation where nobody can tell a stale hash from a tampered one.
+     *
+     * @param string|null $uid raw `uid` column value; null removes the column entirely
+     */
+    #[Test]
+    #[DataProvider('unusableUidProvider')]
+    public function aBatchWithoutUsableUidsDoesNotMoveTheBoundForward(?string $uid): void
+    {
+        $row = $this->row(uid: 1, epoch: 0);
+        if ($uid === null) {
+            unset($row['uid']);
+        } else {
+            $row['uid'] = $uid;
+        }
+
+        $updates = [];
+        $rewritten = $this->rekeyBatches(
+            [array_fill(0, self::BATCH_SIZE, $row), [$this->row(uid: 2, epoch: 0)]],
+            $updates,
+        );
+
+        self::assertSame(self::BATCH_SIZE + 1, $rewritten);
+        self::assertSame([0, 0], $this->keysetBounds);
+    }
+
+    /**
+     * @return iterable<string, array{string|null}>
+     */
+    public static function unusableUidProvider(): iterable
+    {
+        yield 'uid column absent' => [null];
+        yield 'uid column not numeric' => ['not-a-uid'];
+    }
+
+    /**
      * Run the re-key over `$rows` and collect every UPDATE the service issued.
      *
      * @param list<array<string, mixed>> $rows
      * @param list<array{uid: mixed, entry_hash: mixed, previous_hash: mixed}> $updates
      */
-    private function rekey(array $rows, array &$updates): int
+    private function rekey(array $rows, array &$updates, ?AuditChainAnchorStoreInterface $anchorStore = null): int
     {
+        return $this->rekeyBatches([$rows], $updates, $anchorStore);
+    }
+
+    /**
+     * Run the re-key over consecutive keyset batches, collecting every UPDATE
+     * and every keyset bound the service asked for.
+     *
+     * @param non-empty-list<list<array<string, mixed>>> $batches consecutive `fetchAllAssociative()` results
+     * @param list<array{uid: mixed, entry_hash: mixed, previous_hash: mixed}> $updates
+     */
+    private function rekeyBatches(
+        array $batches,
+        array &$updates,
+        ?AuditChainAnchorStoreInterface $anchorStore = null,
+    ): int {
         $collected = [];
+        $this->keysetBounds = [];
 
         $result = self::createStub(Result::class);
-        $result->method('fetchAllAssociative')->willReturn($rows);
+        $result->method('fetchAllAssociative')->willReturn(...$batches);
 
         $queryBuilder = self::createStub(QueryBuilder::class);
         $queryBuilder->method('expr')->willReturn(self::createStub(ExpressionBuilder::class));
@@ -209,7 +347,13 @@ final class AuditChainRekeyServiceTest extends TestCase
         $queryBuilder->method('where')->willReturnSelf();
         $queryBuilder->method('orderBy')->willReturnSelf();
         $queryBuilder->method('setMaxResults')->willReturnSelf();
-        $queryBuilder->method('createNamedParameter')->willReturn('?');
+        $queryBuilder->method('createNamedParameter')->willReturnCallback(
+            function (mixed $value): string {
+                $this->keysetBounds[] = $value;
+
+                return '?';
+            },
+        );
         $queryBuilder->method('executeQuery')->willReturn($result);
 
         $connection = self::createStub(Connection::class);
@@ -226,7 +370,8 @@ final class AuditChainRekeyServiceTest extends TestCase
             },
         );
 
-        $rewritten = (new AuditChainRekeyService())->rekeyChain($connection, self::NEW_MASTER_KEY_MATERIAL);
+        $rewritten = (new AuditChainRekeyService($anchorStore))
+            ->rekeyChain($connection, self::NEW_MASTER_KEY_MATERIAL);
 
         $updates = $collected;
 

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -76,6 +76,21 @@ final class AuditLogServiceTest extends TestCase
      */
     private AuditChainAnchorStoreInterface&MockObject $anchorStore;
 
+    /**
+     * LIMIT / OFFSET recorded per query by `setupPagingQueryMocks()`, and the
+     * LIMIT recorded by `verifyWithAnchorLoads()`. Paging and single-row reads
+     * are only observable through the arguments the builder received.
+     *
+     * @var list<int|null>
+     */
+    private array $recordedLimits = [];
+
+    /** @var list<int|null> */
+    private array $recordedOffsets = [];
+
+    /** @var list<int|null> */
+    private array $recordedMaxResults = [];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -1454,6 +1469,150 @@ final class AuditLogServiceTest extends TestCase
 
         self::assertSame(64, \strlen($hash), 'hash_hmac sha256 hex output is 64 chars');
         self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $hash);
+    }
+
+    /**
+     * The v3 payload adds the attribution fields, which come from the same
+     * arbitrary-byte sources; hashing must not throw there either.
+     */
+    #[Test]
+    public function calculateHashV3SurvivesInvalidUtf8InTheAttributionFields(): void
+    {
+        $hash = AuditLogService::calculateHashV3(
+            $this->makeV3Row(actorUsername: "valid prefix \xC3\x28 broken sequence"),
+            '',
+            str_repeat("\xAA", 32),
+        );
+
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $hash);
+    }
+
+    /**
+     * `success` is a flag, not a number: every truthy driver representation
+     * has to hash identically, or the same logical row would verify
+     * differently depending on which driver read it.
+     */
+    #[Test]
+    public function calculateHashV2TreatsAnyTruthySuccessAsOne(): void
+    {
+        $hmacKey = str_repeat("\xAA", 32);
+
+        self::assertSame(
+            AuditLogService::calculateHashV2($this->makeV2Row(success: 1), '', $hmacKey),
+            AuditLogService::calculateHashV2($this->makeV2Row(success: 2), '', $hmacKey),
+        );
+    }
+
+    /**
+     * The master-key-taking derivation is the single home of the HKDF
+     * parameters, called by the master-key rotation from outside this class —
+     * so it has to stay reachable, and agree with the provider-based variant.
+     */
+    #[Test]
+    public function theMasterKeyTakingHmacDerivationIsPubliclyReachable(): void
+    {
+        $derived = AuditLogService::deriveHmacKeyFromMasterKey(str_repeat("\x01", 32));
+
+        self::assertSame(32, \strlen($derived));
+        self::assertSame(AuditLogService::deriveHmacKey($this->masterKeyProviderMock()), $derived);
+    }
+
+    /**
+     * Doctrine hands integer columns back as strings on several drivers. The
+     * extractors exist to restore the integer type — the hash payload is JSON,
+     * where `"7"` and `7` are different values and would break the chain.
+     */
+    #[Test]
+    public function extractHashRowCoercesNumericStringsToIntegers(): void
+    {
+        $extracted = AuditLogService::extractHashRow([
+            'uid' => '7',
+            'secret_identifier' => 'sek',
+            'action' => 'read',
+            'actor_uid' => '3',
+            'crdate' => '1704067200',
+            'hmac_key_epoch' => '2',
+        ]);
+
+        self::assertSame(7, $extracted['uid']);
+        self::assertSame(3, $extracted['actorUid']);
+        self::assertSame(1704067200, $extracted['crdate']);
+        self::assertSame(2, $extracted['epoch']);
+    }
+
+    /**
+     * A value that is not a number at all falls back to 0 — the neutral value
+     * a fresh row would carry, never a sentinel that could collide with a real
+     * uid or shift the epoch dispatch.
+     */
+    #[Test]
+    public function extractHashRowFallsBackToZeroForUnusableFields(): void
+    {
+        $extracted = AuditLogService::extractHashRow([
+            'uid' => 'not-a-number',
+            'actor_uid' => null,
+            'crdate' => 'not-a-number',
+            'hmac_key_epoch' => 'not-a-number',
+        ]);
+
+        self::assertSame(0, $extracted['uid']);
+        self::assertSame(0, $extracted['actorUid']);
+        self::assertSame(0, $extracted['crdate']);
+        self::assertSame(0, $extracted['epoch']);
+    }
+
+    #[Test]
+    public function extractV2HashRowCoercesNumericStringsToIntegers(): void
+    {
+        $extracted = AuditLogService::extractV2HashRow([
+            'uid' => '7',
+            'actor_uid' => '3',
+            'crdate' => '1704067200',
+        ]);
+
+        self::assertSame(7, $extracted['uid']);
+        self::assertSame(3, $extracted['actor_uid']);
+        self::assertSame(1704067200, $extracted['crdate']);
+    }
+
+    #[Test]
+    public function extractV2HashRowFallsBackToZeroForUnusableFields(): void
+    {
+        $extracted = AuditLogService::extractV2HashRow([
+            'uid' => 'not-a-number',
+            'actor_uid' => 'not-a-number',
+            'crdate' => 'not-a-number',
+            // Neither a bool nor numeric: outside the accepted driver shapes.
+            'success' => 'not-a-number',
+        ]);
+
+        self::assertSame(0, $extracted['uid']);
+        self::assertSame(0, $extracted['actor_uid']);
+        self::assertSame(0, $extracted['crdate']);
+        self::assertSame(0, $extracted['success']);
+    }
+
+    /**
+     * `success` is a flag: anything truthy normalises to 1, so the value that
+     * enters the hash does not depend on how a driver spelled "true".
+     */
+    #[Test]
+    public function extractV2HashRowNormalisesAnyTruthySuccessToOne(): void
+    {
+        self::assertSame(1, AuditLogService::extractV2HashRow(['success' => 2])['success']);
+        self::assertSame(1, AuditLogService::extractV2HashRow(['success' => true])['success']);
+        self::assertSame(0, AuditLogService::extractV2HashRow(['success' => false])['success']);
+    }
+
+    /**
+     * The epoch is the algorithm selector the v3 payload authenticates, so it
+     * has to reach the hash as an integer and default to the keyless 0.
+     */
+    #[Test]
+    public function extractV3HashRowCoercesTheEpochToAnInteger(): void
+    {
+        self::assertSame(3, AuditLogService::extractV3HashRow(['hmac_key_epoch' => '3'])['hmac_key_epoch']);
+        self::assertSame(0, AuditLogService::extractV3HashRow(['hmac_key_epoch' => 'not-a-number'])['hmac_key_epoch']);
     }
 
     // =========================================================================
@@ -3036,6 +3195,751 @@ final class AuditLogServiceTest extends TestCase
         $subject->log('secret', 'create', true);
     }
 
+    // =========================================================================
+    // Write path — the lock lifecycle, the values that reach the row, and the
+    // fan-out that must never fail the audited operation.
+    // =========================================================================
+
+    #[Test]
+    public function theNamedLockIsReleasedAfterASuccessfulWrite(): void
+    {
+        $this->setupDatabaseMocks();
+
+        $statements = [];
+        $this->connectionMock()
+            ->method('executeStatement')
+            ->willReturnCallback(static function (string $sql) use (&$statements): int {
+                $statements[] = $sql;
+
+                return 0;
+            });
+
+        $this->getSubject()->log('s', 'create', true);
+
+        self::assertContains('SELECT RELEASE_LOCK("nr_vault_audit")', $statements);
+    }
+
+    /**
+     * The release lives in a `finally` for this case: a write that fails must
+     * not leave the named lock held for the lifetime of the connection, where
+     * it would block every subsequent audit writer.
+     */
+    #[Test]
+    public function theNamedLockIsReleasedWhenTheWriteFails(): void
+    {
+        $this->setupDatabaseMocks();
+
+        $statements = [];
+        $this->connectionMock()
+            ->method('executeStatement')
+            ->willReturnCallback(static function (string $sql) use (&$statements): int {
+                $statements[] = $sql;
+
+                return 0;
+            });
+        $this->connectionMock()
+            ->method('insert')
+            ->willThrowException(new RuntimeException('constraint violation'));
+
+        try {
+            $this->getSubject()->log('s', 'create', true);
+            self::fail('a failed write must surface as an AuditWriteException');
+        } catch (AuditWriteException) {
+            self::assertContains('SELECT RELEASE_LOCK("nr_vault_audit")', $statements);
+        }
+    }
+
+    /**
+     * The UID reserved by the INSERT addresses the row the UPDATE seals, and
+     * the driver hands it out as a string.
+     */
+    #[Test]
+    public function theHashUpdateTargetsTheInsertIdAsAnInteger(): void
+    {
+        $this->setupDatabaseMocks();
+        $this->connectionMock()->method('lastInsertId')->willReturn('42');
+
+        $criteria = [];
+        $this->connectionMock()
+            ->expects(self::once())
+            ->method('update')
+            ->with(
+                AuditLogService::TABLE_NAME,
+                self::anything(),
+                self::callback(static function (array $identifier) use (&$criteria): bool {
+                    $criteria = $identifier;
+
+                    return true;
+                }),
+            );
+
+        $this->getSubject()->log('s', 'create', true);
+
+        self::assertSame(['uid' => 42], $criteria);
+    }
+
+    /**
+     * The anchor pins the row that was just written: its own uid and its own
+     * entry hash. Anchoring anything else would either point at a row that
+     * does not exist or assert a hash no row carries.
+     */
+    #[Test]
+    public function theTipAnchorIsBuiltFromThePersistedRow(): void
+    {
+        $this->setupDatabaseMocks();
+        $this->connectionMock()->method('lastInsertId')->willReturn('42');
+
+        $storedHash = null;
+        $this->connectionMock()
+            ->expects(self::once())
+            ->method('update')
+            ->with(
+                AuditLogService::TABLE_NAME,
+                self::callback(static function (array $fields) use (&$storedHash): bool {
+                    $storedHash = $fields['entry_hash'] ?? null;
+
+                    return true;
+                }),
+                self::anything(),
+            );
+
+        $anchored = null;
+        $this->anchorStore
+            ->expects(self::once())
+            ->method('advance')
+            ->willReturnCallback(static function (Connection $connection, AuditChainAnchor $tip) use (&$anchored): void {
+                $anchored = $tip;
+            });
+
+        $this->getSubject()->log('s', 'create', true);
+
+        self::assertInstanceOf(AuditChainAnchor::class, $anchored);
+        self::assertSame(42, $anchored->uid);
+        self::assertIsString($storedHash);
+        self::assertSame($storedHash, $anchored->entryHash);
+    }
+
+    /**
+     * Epoch 1 binds the identity fields under the HMAC key — not the v3
+     * forensic payload the later epochs use. A row sealed with the wrong
+     * algorithm reports a tamper on every subsequent verification.
+     */
+    #[Test]
+    public function epochOneWritesTheIdentityOnlyHmacEntryHash(): void
+    {
+        [$insertedRow, $storedHash] = $this->captureWriteAtEpoch(1);
+
+        $v1 = AuditLogService::extractHashRow(['uid' => 42] + $insertedRow);
+
+        self::assertSame(
+            AuditLogService::calculateHash(
+                $v1['uid'],
+                $v1['secretId'],
+                $v1['action'],
+                $v1['actorUid'],
+                $v1['crdate'],
+                '',
+                AuditLogService::deriveHmacKey($this->masterKeyProviderMock()),
+            ),
+            $storedHash,
+        );
+    }
+
+    #[Test]
+    public function theCallerSuppliedReasonIsSealedIntoTheRowVerbatim(): void
+    {
+        $captured = $this->captureInsertPayload(reason: 'rotation requested by ops');
+
+        self::assertSame('rotation requested by ops', $captured['reason']);
+    }
+
+    /**
+     * Column widths are counted in characters, so a value that fits in
+     * characters must be stored whole even when its UTF-8 encoding needs more
+     * bytes than the column has columns.
+     */
+    #[Test]
+    public function aMultiByteHeaderThatFitsInCharactersIsStoredWhole(): void
+    {
+        // 300 two-byte characters: 600 bytes, but only 300 of the 500 columns.
+        $userAgent = str_repeat('ä', 300);
+        $this->stubServerRequest(userAgent: $userAgent);
+
+        $captured = $this->captureInsertPayload();
+
+        self::assertSame($userAgent, $captured['user_agent']);
+    }
+
+    /**
+     * Clipping keeps the START of the value — the part that identifies the
+     * client — not an arbitrary window into it.
+     */
+    #[Test]
+    public function anOversizedHeaderKeepsItsLeadingCharacters(): void
+    {
+        $this->stubServerRequest(userAgent: 'Z' . str_repeat('b', 600));
+
+        $captured = $this->captureInsertPayload();
+
+        self::assertSame('Z' . str_repeat('b', 499), $captured['user_agent']);
+    }
+
+    /**
+     * Control characters collapse to spaces, which can leave the message
+     * padded at both ends; the stored value is the trimmed one.
+     */
+    #[Test]
+    public function theSanitizedErrorMessageCarriesNoSurroundingWhitespace(): void
+    {
+        $captured = $this->captureInsertPayload(errorMessage: "\n  decryption failed  \n");
+
+        self::assertSame('decryption failed', $captured['error_message']);
+    }
+
+    /**
+     * The 200-character bound is counted in characters too: a multi-byte
+     * message that fits must not be truncated just because its byte length
+     * exceeds the bound.
+     */
+    #[Test]
+    public function aMultiByteErrorMessageIsBoundedInCharactersNotBytes(): void
+    {
+        // 150 two-byte characters: 300 bytes, 150 of the 200 characters.
+        $errorMessage = str_repeat('ä', 150);
+
+        $captured = $this->captureInsertPayload(errorMessage: $errorMessage);
+
+        self::assertSame($errorMessage, $captured['error_message']);
+    }
+
+    /**
+     * An over-long message keeps its first 197 characters plus the ellipsis —
+     * cut on a character boundary, so the stored value stays well-formed
+     * UTF-8 and is exactly 200 characters wide.
+     */
+    #[Test]
+    public function anOversizedErrorMessageKeepsItsFirstCharactersUpToTheEllipsis(): void
+    {
+        $captured = $this->captureInsertPayload(errorMessage: 'Z' . str_repeat('ä', 299));
+
+        self::assertSame('Z' . str_repeat('ä', 196) . '...', $captured['error_message']);
+        self::assertIsString($captured['error_message']);
+        self::assertSame(200, mb_strlen($captured['error_message']));
+    }
+
+    /**
+     * With no request in scope the write is a CLI one, and the audit row says
+     * so instead of recording an empty actor environment.
+     */
+    #[Test]
+    public function aWriteWithoutAServerRequestIsAttributedToTheCli(): void
+    {
+        unset($GLOBALS['TYPO3_REQUEST']);
+
+        $captured = $this->captureInsertPayload();
+
+        self::assertSame('CLI', $captured['ip_address']);
+        self::assertSame('CLI', $captured['user_agent']);
+    }
+
+    #[Test]
+    public function aWriteUnderAServerRequestRecordsItsRemoteAddress(): void
+    {
+        $this->stubServerRequest();
+
+        $captured = $this->captureInsertPayload();
+
+        self::assertSame(self::IP_ADDRESS, $captured['ip_address']);
+    }
+
+    /**
+     * Without an inbound correlation header the row still gets a request id,
+     * generated from 16 random bytes so entries of one request can be tied
+     * together after the fact.
+     */
+    #[Test]
+    public function aRequestWithoutACorrelationHeaderGetsAGeneratedRequestId(): void
+    {
+        $this->stubServerRequest();
+
+        $captured = $this->captureInsertPayload();
+
+        self::assertIsString($captured['request_id']);
+        self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $captured['request_id']);
+    }
+
+    /**
+     * No sinks configured is the default deployment, not a fan-out failure —
+     * it must not produce an error-level log line on every audited operation.
+     */
+    #[Test]
+    public function aMissingSinkRegistryIsNotReportedAsAFanOutFailure(): void
+    {
+        $this->setupDatabaseMocks();
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('error');
+
+        $subject = new AuditLogService(
+            $this->connectionPoolMock(),
+            $this->accessControlMock(),
+            $this->masterKeyProviderMock(),
+            $this->extensionConfigurationMock(),
+            $this->anchorStore,
+            null,
+            $logger,
+        );
+
+        $this->connectionMock()->expects(self::once())->method('insert');
+
+        $subject->log('s', 'create', true);
+    }
+
+    /**
+     * The logger is optional, so a broken fan-out on a logger-less service must
+     * still be contained: the chain row is committed and the audited operation
+     * completes.
+     */
+    #[Test]
+    public function aBrokenSinkFanOutWithoutALoggerStillCompletesTheAuditedOperation(): void
+    {
+        $this->setupDatabaseMocks();
+
+        $sinkRegistry = $this->createMock(AuditSinkRegistryInterface::class);
+        $sinkRegistry->method('dispatch')->willThrowException(new RuntimeException('registry unavailable'));
+
+        $subject = new AuditLogService(
+            $this->connectionPoolMock(),
+            $this->accessControlMock(),
+            $this->masterKeyProviderMock(),
+            $this->extensionConfigurationMock(),
+            $this->anchorStore,
+            $sinkRegistry,
+            null,
+        );
+
+        $captured = [];
+        $this->connectionMock()
+            ->expects(self::once())
+            ->method('insert')
+            ->with(
+                AuditLogService::TABLE_NAME,
+                self::callback(static function (array $data) use (&$captured): bool {
+                    $captured = $data;
+
+                    return true;
+                }),
+            );
+
+        $subject->log('s', 'create', true);
+
+        self::assertSame('create', $captured['action']);
+    }
+
+    // =========================================================================
+    // Read/verify path — each test below pins one behaviour of the chain walk
+    // that would otherwise be free to drift.
+    // =========================================================================
+
+    /**
+     * `count()` must issue a COUNT over the audit table. Without the builder
+     * calls the query degrades to an unbounded SELECT whose first column is
+     * returned as the "count".
+     */
+    #[Test]
+    public function countAsksTheDatabaseForACountOverTheAuditTable(): void
+    {
+        $result = $this->createMock(Result::class);
+        $result->method('fetchOne')->willReturn(7);
+
+        $this->connectionPoolMock()->method('getConnectionForTable')->willReturn($this->connectionMock());
+        $this->connectionMock()->method('createQueryBuilder')->willReturn($this->queryBuilderMock());
+
+        $queryBuilder = $this->queryBuilderMock();
+        $queryBuilder->expects(self::once())->method('count')->with('uid')->willReturnSelf();
+        $queryBuilder->expects(self::once())->method('from')->with(AuditLogService::TABLE_NAME)->willReturnSelf();
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        self::assertSame(7, $this->getSubject()->count());
+    }
+
+    /**
+     * The chain walk depends on ascending-uid order: gap detection, the
+     * previous-hash link and the epoch-transition check all compare a row
+     * against its immediate predecessor.
+     */
+    #[Test]
+    public function verifyHashChainSelectsEveryColumnOrderedByAscendingUid(): void
+    {
+        $result = $this->createMock(Result::class);
+        $result->method('iterateAssociative')->willReturnCallback(static fn (): Iterator => new ArrayIterator([]));
+
+        $this->connectionPoolMock()->method('getConnectionForTable')->willReturn($this->connectionMock());
+        $this->connectionMock()->method('createQueryBuilder')->willReturn($this->queryBuilderMock());
+
+        $queryBuilder = $this->queryBuilderMock();
+        $queryBuilder->expects(self::once())->method('select')->with('*')->willReturnSelf();
+        $queryBuilder->expects(self::once())->method('from')->with(AuditLogService::TABLE_NAME)->willReturnSelf();
+        $queryBuilder->expects(self::once())->method('orderBy')->with('uid', 'ASC')->willReturnSelf();
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        self::assertTrue($this->getSubject()->verifyHashChain()->valid);
+    }
+
+    /**
+     * The default window is a literal 1000 rows — the bound that keeps peak
+     * memory O(chunkSize) instead of O(table).
+     */
+    #[Test]
+    public function exportIterableDefaultsToAThousandRowWindow(): void
+    {
+        $this->setupPagingQueryMocks([[]]);
+
+        self::assertSame([], iterator_to_array($this->getSubject()->exportIterable()));
+        self::assertSame([1000], $this->recordedLimits);
+    }
+
+    /**
+     * Every round advances the offset by exactly one window, and the loop
+     * keeps going while the window came back full.
+     */
+    #[Test]
+    public function exportIterablePagesForwardByOneWindowPerRound(): void
+    {
+        $this->setupPagingQueryMocks([
+            [['uid' => 1], ['uid' => 2]],
+            [['uid' => 3], ['uid' => 4]],
+            [['uid' => 5]],
+        ]);
+
+        $entries = iterator_to_array($this->getSubject()->exportIterable(chunkSize: 2));
+
+        self::assertCount(5, $entries);
+        self::assertSame([0, 2, 4], $this->recordedOffsets);
+        self::assertSame([2, 2, 2], $this->recordedLimits);
+    }
+
+    /**
+     * A non-positive chunk size is clamped to 1, not to 0 — a zero-row window
+     * would return an empty chunk forever while the loop condition
+     * (`count($chunk) === $chunkSize`) stayed true.
+     */
+    #[Test]
+    public function exportIterableClampsANonPositiveWindowToASingleRow(): void
+    {
+        $this->setupPagingQueryMocks([[['uid' => 1]], []]);
+
+        $entries = iterator_to_array($this->getSubject()->exportIterable(chunkSize: 0));
+
+        self::assertCount(1, $entries);
+        self::assertSame([1, 1], $this->recordedLimits);
+    }
+
+    /**
+     * The re-seal gate verifies under the chain's OWN stored epochs. An
+     * install configured for a higher epoch must not make its own
+     * not-yet-migrated chain unresealable — that chain is exactly what the
+     * migration exists to lift.
+     */
+    #[Test]
+    public function resealVerificationIgnoresTheConfiguredEpochFloorEntirely(): void
+    {
+        // Every row sits at epoch 0 while the subject is configured for epoch 1.
+        $this->setupResealMocks(rows: $this->epochZeroChain([1, 2]), hmacRowCount: 1);
+
+        self::assertNull($this->getSubject()->verifyChainForReseal());
+    }
+
+    /**
+     * A range verification starts one uid BELOW the requested start, so rows
+     * deleted between `$fromUid` and the first surviving row are still
+     * reported instead of falling outside the window unnoticed.
+     */
+    #[Test]
+    public function verifyHashChainDetectsAGapBelowTheFirstRowOfARequestedRange(): void
+    {
+        $this->setupQueryMocksWithFilter(
+            $this->createMock(ExpressionBuilder::class),
+            [$this->epochZeroRow(7, '')],
+        );
+
+        $verification = $this->getSubject()->verifyHashChain(fromUid: 5);
+
+        self::assertSame([5, 6], $verification->missingUids);
+    }
+
+    /**
+     * The mirror image: on a full scan there is no prior row to compare the
+     * first one against, so a chain whose lowest uid is not 1 must not be
+     * reported as starting with a gap.
+     */
+    #[Test]
+    public function verifyHashChainDoesNotInventAGapBeforeTheFirstRowOfAFullScan(): void
+    {
+        $this->setupQueryMocks($this->epochZeroChain([5, 6]));
+
+        $verification = $this->subjectWithConfiguredEpoch(0)->verifyHashChain();
+
+        self::assertSame([], $verification->missingUids);
+        self::assertSame(0, $verification->missingUidCount);
+        self::assertTrue($verification->valid);
+    }
+
+    /**
+     * The enumerated list is capped to bound memory after a mass purge, but
+     * the reported COUNT stays exact — that is the number an operator uses to
+     * judge the scale of the hole.
+     */
+    #[Test]
+    public function theEnumeratedMissingUidListIsCappedWhileTheCountStaysExact(): void
+    {
+        // Two 600-uid gaps: the 1000-entry cap admits all of the first and 400
+        // of the second, while the count must still report the true 1200.
+        $this->setupQueryMocks($this->epochZeroChain([1, 602, 1203]));
+
+        $verification = $this->subjectWithConfiguredEpoch(0)->verifyHashChain();
+
+        self::assertCount(1000, $verification->missingUids);
+        self::assertSame(1200, $verification->missingUidCount);
+        self::assertSame(2, $verification->missingUids[0]);
+        self::assertSame(1002, $verification->missingUids[999]);
+    }
+
+    /**
+     * Gap sizes accumulate across gaps; the count is the total, not the size
+     * of the last one.
+     */
+    #[Test]
+    public function everyMissingUidAcrossSeveralGapsIsCounted(): void
+    {
+        $this->setupQueryMocks($this->epochZeroChain([1, 4, 8]));
+
+        $verification = $this->subjectWithConfiguredEpoch(0)->verifyHashChain();
+
+        self::assertSame([2, 3, 5, 6, 7], $verification->missingUids);
+        self::assertSame(5, $verification->missingUidCount);
+    }
+
+    /**
+     * A row whose `hmac_key_epoch` drops BELOW its predecessor's is a
+     * downgrade — including the negative value a DB-write attacker can set to
+     * slip past the epoch dispatch. It must be an error (chain invalid), never
+     * the non-fatal warning an epoch INCREASE gets.
+     */
+    #[Test]
+    public function anEpochDropBelowZeroIsReportedAsADowngradeError(): void
+    {
+        $first = $this->epochZeroRow(1, '');
+        $second = [
+            'uid' => 2,
+            'secret_identifier' => 'a',
+            'action' => 'create',
+            'success' => 1,
+            'actor_uid' => 1,
+            'crdate' => 100,
+            'error_message' => '',
+            'reason' => '',
+            'ip_address' => '',
+            'user_agent' => '',
+            'hash_before' => '',
+            'hash_after' => '',
+            'context' => '{}',
+            'actor_type' => 'backend',
+            'actor_username' => 'admin',
+            'actor_role' => 'backend',
+            'request_id' => '',
+            'previous_hash' => $first['entry_hash'],
+            'hmac_key_epoch' => -1,
+        ];
+        // Sign the tampered row correctly, so the ONLY finding left is the
+        // epoch downgrade itself rather than a hash mismatch on the same key.
+        $second['entry_hash'] = AuditLogService::calculateHashV3(
+            AuditLogService::extractV3HashRow($second),
+            $first['entry_hash'],
+            AuditLogService::deriveHmacKey($this->masterKeyProviderMock()),
+        );
+
+        $this->setupQueryMocks([$first, $second]);
+
+        $verification = $this->subjectWithConfiguredEpoch(0)->verifyHashChain();
+
+        self::assertFalse($verification->valid);
+        self::assertArrayHasKey(2, $verification->errors);
+        self::assertStringContainsString('downgrade', $verification->errors[2]);
+    }
+
+    /**
+     * A keyless chain carries no HMAC evidence to authenticate, so the re-seal
+     * — the operation that FIRST protects those rows — must not be blocked by
+     * their content. Only the anchor half of the gate applies.
+     */
+    #[Test]
+    public function resealVerificationOfAKeylessChainSkipsTheRowWalkEntirely(): void
+    {
+        $this->setupResealMocks(
+            rows: [
+                // A hash that matches nothing: were the rows walked, this would
+                // report tampering and refuse the re-seal.
+                ['uid' => 1, 'secret_identifier' => 'a', 'action' => 'create', 'actor_uid' => 1, 'crdate' => 100, 'previous_hash' => '', 'entry_hash' => str_repeat('0', 64), 'hmac_key_epoch' => 0],
+            ],
+            hmacRowCount: 0,
+        );
+
+        self::assertNull($this->getSubject()->verifyChainForReseal());
+    }
+
+    /**
+     * The anchor-only half of the gate never walked the rows, so it must not
+     * claim a missing-uid count it did not measure.
+     */
+    #[Test]
+    public function anAnchorOnlyResealFailureReportsNoMissingUids(): void
+    {
+        $this->setupResealMocks(rows: [], hmacRowCount: 0);
+
+        // Status Ok with no anchor payload is the "unreadable anchor" case.
+        $anchorStore = $this->createMock(AuditChainAnchorStoreInterface::class);
+        $anchorStore->method('load')->willReturn(new AuditChainAnchorLoad(AuditChainAnchorStatus::Ok));
+
+        $subject = new AuditLogService(
+            $this->connectionPoolMock(),
+            $this->accessControlMock(),
+            $this->masterKeyProviderMock(),
+            $this->extensionConfigurationMock(),
+            $anchorStore,
+        );
+
+        $result = $subject->verifyChainForReseal();
+
+        self::assertInstanceOf(HashChainVerificationResult::class, $result);
+        self::assertSame(AuditChainAnchorStatus::Unreadable, $result->anchorStatus);
+        self::assertSame([], $result->missingUids);
+        self::assertSame(0, $result->missingUidCount);
+    }
+
+    /**
+     * "Carries HMAC evidence" means epoch >= 1. Probing for a different
+     * threshold would either skip the verification of a protected chain or
+     * apply it to a genuinely keyless one.
+     */
+    #[Test]
+    public function theHmacRowProbeAsksForEpochOneOrHigher(): void
+    {
+        $result = $this->createMock(Result::class);
+        $result->method('fetchOne')->willReturn(0);
+
+        $this->connectionPoolMock()->method('getConnectionForTable')->willReturn($this->connectionMock());
+        $this->connectionMock()->method('createQueryBuilder')->willReturn($this->queryBuilderMock());
+
+        $queryBuilder = $this->queryBuilderMock();
+        $queryBuilder->method('expr')->willReturn($this->createMock(ExpressionBuilder::class));
+        $queryBuilder->method('count')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder
+            ->expects(self::once())
+            ->method('createNamedParameter')
+            ->with(1, Connection::PARAM_INT)
+            ->willReturn('?');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        self::assertNull($this->getSubject()->verifyChainForReseal());
+    }
+
+    /**
+     * The violation message is what an operator acts on, so both halves of it
+     * — which uid, and what the mismatch means — have to survive.
+     */
+    #[Test]
+    public function aStableAnchorMismatchNamesTheAnchoredUidAndWhatItMeans(): void
+    {
+        $verification = $this->verifyWithAnchorLoads(['raw-1', 'raw-1']);
+
+        self::assertSame(
+            'Audit chain tip anchor for uid 1 does not match the stored entry hash - the '
+            . 'anchored row was replaced (e.g. truncation followed by re-inserted entries)',
+            $verification->errors[-3],
+        );
+    }
+
+    #[Test]
+    public function anInFlightAnchorWarningSaysWhatHappenedAndWhatToDo(): void
+    {
+        $verification = $this->verifyWithAnchorLoads(['raw-1', 'raw-2', 'raw-3', 'raw-4']);
+
+        self::assertSame(
+            'Audit chain tip anchor changed while it was '
+            . 'being verified (concurrent re-seal); re-run the verification',
+            $verification->warnings[-3],
+        );
+    }
+
+    /**
+     * The anchored row is addressed by its primary key, so exactly one row can
+     * ever match — a wider limit would read rows the anchor says nothing about.
+     */
+    #[Test]
+    public function theAnchoredRowIsReadWithAnExactSingleRowLimit(): void
+    {
+        $this->verifyWithAnchorLoads(['raw-1', 'raw-1']);
+
+        self::assertSame([1], $this->recordedMaxResults);
+    }
+
+    #[Test]
+    public function getLatestHashReadsExactlyOneRow(): void
+    {
+        $tip = str_repeat('a', 64);
+
+        $result = $this->createMock(Result::class);
+        $result->method('fetchOne')->willReturn($tip);
+
+        $this->connectionPoolMock()->method('getConnectionForTable')->willReturn($this->connectionMock());
+        $this->connectionMock()->method('createQueryBuilder')->willReturn($this->queryBuilderMock());
+
+        $queryBuilder = $this->queryBuilderMock();
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('orderBy')->willReturnSelf();
+        $queryBuilder->expects(self::once())->method('setMaxResults')->with(1)->willReturnSelf();
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        self::assertSame($tip, $this->getSubject()->getLatestHash());
+    }
+
+    /**
+     * Only a string is a hash. A numeric column value (some drivers coerce, an
+     * empty table returns `false`) is "no tip", never a tip of its own.
+     */
+    #[Test]
+    public function getLatestHashReturnsNullForANonStringColumnValue(): void
+    {
+        $this->setupDatabaseMocks(0);
+
+        self::assertNull($this->getSubject()->getLatestHash());
+    }
+
+    /**
+     * Both chain-level checks are restricted to a FULL pass: a bounded range
+     * may legitimately exclude the higher-epoch rows and the tip, so neither
+     * the epoch floor nor the anchor may be applied to it.
+     */
+    #[Test]
+    public function aBoundedRangeVerificationSkipsTheEpochFloorAndTheAnchor(): void
+    {
+        $this->setupQueryMocksWithFilter(
+            $this->createMock(ExpressionBuilder::class),
+            $this->epochZeroChain([1, 2]),
+        );
+
+        // Configured for epoch 3 while every row sits at epoch 0: on a full
+        // scan that is a downgrade, on a sub-range it is out of scope.
+        $verification = $this->subjectWithConfiguredEpoch(3)->verifyHashChain(fromUid: 1);
+
+        self::assertTrue($verification->valid);
+        self::assertSame(AuditChainAnchorStatus::NotChecked, $verification->anchorStatus);
+    }
+
     /**
      * Run one `log()` at the given epoch and return the inserted row plus the
      * `entry_hash` the second-step UPDATE stored.
@@ -3168,7 +4072,7 @@ final class AuditLogServiceTest extends TestCase
      *
      * @return array<string, mixed>
      */
-    private function captureInsertPayload(): array
+    private function captureInsertPayload(?string $errorMessage = null, ?string $reason = null): array
     {
         $this->setupDatabaseMocks();
 
@@ -3185,7 +4089,7 @@ final class AuditLogServiceTest extends TestCase
                 }),
             );
 
-        $this->getSubject()->log('s', 'create', true);
+        $this->getSubject()->log('s', 'create', true, $errorMessage, $reason);
 
         self::assertIsArray($captured);
 
@@ -3485,7 +4389,13 @@ final class AuditLogServiceTest extends TestCase
         $this->queryBuilder->method('from')->willReturnSelf();
         $this->queryBuilder->method('where')->willReturnSelf();
         $this->queryBuilder->method('orderBy')->willReturnSelf();
-        $this->queryBuilder->method('setMaxResults')->willReturnSelf();
+        $this->queryBuilder->method('setMaxResults')->willReturnCallback(
+            function (?int $limit): QueryBuilder {
+                $this->recordedMaxResults[] = $limit;
+
+                return $this->queryBuilderMock();
+            },
+        );
         $this->queryBuilder->method('executeQuery')->willReturn($result);
 
         $anchoredHash = str_repeat('c', 64);
@@ -3513,6 +4423,108 @@ final class AuditLogServiceTest extends TestCase
             $extensionConfig,
             $anchorStore,
         ))->verifyHashChain();
+    }
+
+    /**
+     * One epoch-0 chain row carrying its correct legacy hash, linked to
+     * `$previousHash`.
+     *
+     * @return array{uid: int, secret_identifier: string, action: string, actor_uid: int, crdate: int, previous_hash: string, entry_hash: string, hmac_key_epoch: int}
+     */
+    private function epochZeroRow(int $uid, string $previousHash): array
+    {
+        return [
+            'uid' => $uid,
+            'secret_identifier' => 'a',
+            'action' => 'create',
+            'actor_uid' => 1,
+            'crdate' => 100,
+            'previous_hash' => $previousHash,
+            'entry_hash' => AuditLogService::calculateHash($uid, 'a', 'create', 1, 100, $previousHash),
+            'hmac_key_epoch' => 0,
+        ];
+    }
+
+    /**
+     * A correctly-linked epoch-0 chain over the given uids, so a test that is
+     * about gaps or epochs is not also about hash mismatches.
+     *
+     * @param list<int> $uids
+     *
+     * @return list<array<string, mixed>>
+     */
+    private function epochZeroChain(array $uids): array
+    {
+        $rows = [];
+        $previousHash = '';
+        foreach ($uids as $uid) {
+            $row = $this->epochZeroRow($uid, $previousHash);
+            $previousHash = $row['entry_hash'];
+            $rows[] = $row;
+        }
+
+        return $rows;
+    }
+
+    /**
+     * The default subject is configured for epoch 1; tests about the epoch
+     * floor need to state the configured epoch themselves.
+     */
+    private function subjectWithConfiguredEpoch(int $epoch): AuditLogService
+    {
+        $extensionConfiguration = $this->createMock(ExtensionConfigurationInterface::class);
+        $extensionConfiguration->method('getAuditHmacEpoch')->willReturn($epoch);
+
+        return new AuditLogService(
+            $this->connectionPoolMock(),
+            $this->accessControlMock(),
+            $this->masterKeyProviderMock(),
+            $extensionConfiguration,
+            $this->anchorStore,
+        );
+    }
+
+    /**
+     * Wire `query()` so consecutive calls return the given windows, recording
+     * the LIMIT / OFFSET each call asked for in `$recordedLimits` /
+     * `$recordedOffsets`.
+     *
+     * @param list<list<array<string, mixed>>> $windows rows per consecutive query
+     */
+    private function setupPagingQueryMocks(array $windows): void
+    {
+        $call = 0;
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAllAssociative')->willReturnCallback(
+            static function () use ($windows, &$call): array {
+                $rows = $windows[$call] ?? [];
+                ++$call;
+
+                return $rows;
+            },
+        );
+
+        $queryBuilder = $this->queryBuilderMock();
+        $this->connectionPoolMock()->method('getConnectionForTable')->willReturn($this->connectionMock());
+        $this->connectionMock()->method('createQueryBuilder')->willReturn($queryBuilder);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('orderBy')->willReturnSelf();
+        $queryBuilder->method('setMaxResults')->willReturnCallback(
+            function (?int $limit) use ($queryBuilder): QueryBuilder {
+                $this->recordedLimits[] = $limit;
+
+                return $queryBuilder;
+            },
+        );
+        $queryBuilder->method('setFirstResult')->willReturnCallback(
+            function (?int $offset) use ($queryBuilder): QueryBuilder {
+                $this->recordedOffsets[] = $offset;
+
+                return $queryBuilder;
+            },
+        );
+        $queryBuilder->method('executeQuery')->willReturn($result);
     }
 
     /**

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -3515,7 +3515,6 @@ final class AuditLogServiceTest extends TestCase
             $this->extensionConfigurationMock(),
             $this->anchorStore,
             $sinkRegistry,
-            null,
         );
 
         $captured = [];

--- a/Tests/Unit/Crypto/EncryptionServiceTest.php
+++ b/Tests/Unit/Crypto/EncryptionServiceTest.php
@@ -18,6 +18,7 @@ use Netresearch\NrVault\Exception\EncryptionException;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 
@@ -236,6 +237,88 @@ final class EncryptionServiceTest extends TestCase
             'not-valid',
             'nope',
             'test',
+        );
+    }
+
+    /**
+     * Each of the four base64 inputs is validated independently: a single
+     * malformed field must be refused before any key material is unwrapped,
+     * not only when several of them are malformed at once.
+     */
+    #[Test]
+    #[DataProvider('singleMalformedDecryptFieldProvider')]
+    public function decryptRejectsASingleMalformedBase64Field(string $field): void
+    {
+        $encrypted = $this->subject->encrypt('field-validation', 'field-validation-test');
+
+        $arguments = [
+            'encryptedValue' => $encrypted->encryptedValue,
+            'encryptedDek' => $encrypted->encryptedDek,
+            'dekNonce' => $encrypted->dekNonce,
+            'valueNonce' => $encrypted->valueNonce,
+        ];
+        $arguments[$field] = '!!!not-base64!!!';
+
+        $this->expectException(EncryptionException::class);
+        $this->expectExceptionMessage('Invalid base64 encoding');
+
+        $this->subject->decrypt(
+            $arguments['encryptedValue'],
+            $arguments['encryptedDek'],
+            $arguments['dekNonce'],
+            $arguments['valueNonce'],
+            'field-validation-test',
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function singleMalformedDecryptFieldProvider(): iterable
+    {
+        yield 'encrypted value' => ['encryptedValue'];
+        yield 'encrypted dek' => ['encryptedDek'];
+        yield 'dek nonce' => ['dekNonce'];
+        yield 'value nonce' => ['valueNonce'];
+    }
+
+    #[Test]
+    public function reEncryptDekRejectsAMalformedEncryptedDekAlone(): void
+    {
+        $encrypted = $this->subject->encrypt('rewrap', 'rewrap-test');
+
+        $this->expectException(EncryptionException::class);
+        $this->expectExceptionMessage('Invalid base64 encoding');
+
+        $this->subject->reEncryptDek(
+            '!!!not-base64!!!',
+            $encrypted->dekNonce,
+            'rewrap-test',
+            $this->testMasterKey,
+            random_bytes(32),
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
+        );
+    }
+
+    #[Test]
+    public function reEncryptDekRejectsAMalformedDekNonceAlone(): void
+    {
+        $encrypted = $this->subject->encrypt('rewrap', 'rewrap-test');
+
+        $this->expectException(EncryptionException::class);
+        $this->expectExceptionMessage('Invalid base64 encoding');
+
+        $this->subject->reEncryptDek(
+            $encrypted->encryptedDek,
+            '!!!not-base64!!!',
+            'rewrap-test',
+            $this->testMasterKey,
+            random_bytes(32),
+            $encrypted->encryptionVersion,
+            $encrypted->encryptionAlgorithm->value,
         );
     }
 

--- a/Tests/Unit/Crypto/FileMasterKeyProviderTest.php
+++ b/Tests/Unit/Crypto/FileMasterKeyProviderTest.php
@@ -14,7 +14,9 @@ use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\FileMasterKeyProvider;
 use Netresearch\NrVault\Exception\MasterKeyException;
 use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\ErrorSuppressionTrait;
 use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
@@ -23,6 +25,8 @@ use PHPUnit\Framework\Attributes\Test;
 #[AllowMockObjectsWithoutExpectations]
 final class FileMasterKeyProviderTest extends TestCase
 {
+    use ErrorSuppressionTrait;
+
     private const MASTER_KEY_PATH = 'vault/master.key';
 
     private const NONEXISTENT_KEY_PATH = 'vault/nonexistent.key';
@@ -31,12 +35,21 @@ final class FileMasterKeyProviderTest extends TestCase
 
     private const INVALID_KEY_LENGTH_MESSAGE = 'Invalid master key length';
 
+    private vfsStreamDirectory $root;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         FileMasterKeyProvider::clearCachedKey();
-        vfsStream::setup('vault');
+        $this->root = vfsStream::setup('vault');
+    }
+
+    protected function tearDown(): void
+    {
+        FileMasterKeyProvider::clearCachedKey();
+
+        parent::tearDown();
     }
 
     #[Test]
@@ -320,5 +333,187 @@ final class FileMasterKeyProviderTest extends TestCase
         $key = $provider->generateMasterKey();
 
         self::assertEquals(32, \strlen($key));
+    }
+
+    #[Test]
+    public function storeMasterKeyChmodsTheKeyFileToOwnerReadOnly(): void
+    {
+        $keyPath = vfsStream::url('vault/perm.key');
+
+        $config = $this->createMock(ExtensionConfigurationInterface::class);
+        $config->method('getMasterKeySource')->willReturn($keyPath);
+
+        (new FileMasterKeyProvider($config))->storeMasterKey(sodium_crypto_secretbox_keygen());
+
+        $file = $this->root->getChild('perm.key');
+        self::assertNotNull($file);
+        self::assertSame(0o400, $file->getPermissions());
+    }
+
+    #[Test]
+    public function storeMasterKeyCreatesTheKeyDirectoryWithOwnerOnlyPermissions(): void
+    {
+        $keyPath = vfsStream::url('vault/created/deep/master.key');
+
+        $config = $this->createMock(ExtensionConfigurationInterface::class);
+        $config->method('getMasterKeySource')->willReturn($keyPath);
+
+        (new FileMasterKeyProvider($config))->storeMasterKey(sodium_crypto_secretbox_keygen());
+
+        $outer = $this->root->getChild('created');
+        self::assertNotNull($outer);
+        self::assertSame(0o700, $outer->getPermissions());
+
+        $inner = $this->root->getChild('created/deep');
+        self::assertNotNull($inner);
+        self::assertSame(0o700, $inner->getPermissions());
+    }
+
+    #[Test]
+    public function storeMasterKeyRestoresThePreviousUmask(): void
+    {
+        $keyPath = vfsStream::url('vault/umask.key');
+
+        $config = $this->createMock(ExtensionConfigurationInterface::class);
+        $config->method('getMasterKeySource')->willReturn($keyPath);
+
+        $outerUmask = umask(0o022);
+
+        try {
+            (new FileMasterKeyProvider($config))->storeMasterKey(sodium_crypto_secretbox_keygen());
+
+            self::assertSame(0o022, umask());
+        } finally {
+            umask($outerUmask);
+        }
+    }
+
+    #[Test]
+    public function storeMasterKeyReportsAnUncreatableDirectoryRatherThanTheFailedWrite(): void
+    {
+        // A read-only parent makes the recursive mkdir() fail, which must be
+        // reported as such instead of leaking through to the write attempt.
+        mkdir(vfsStream::url('vault/readonly'), 0o500);
+        $keyPath = vfsStream::url('vault/readonly/nested/master.key');
+
+        $config = $this->createMock(ExtensionConfigurationInterface::class);
+        $config->method('getMasterKeySource')->willReturn($keyPath);
+
+        $provider = new FileMasterKeyProvider($config);
+
+        try {
+            $this->withoutPhpDiagnostics(
+                static fn (): null => $provider->storeMasterKey(sodium_crypto_secretbox_keygen()),
+            );
+            self::fail('Expected MasterKeyException was not thrown.');
+        } catch (MasterKeyException $e) {
+            self::assertSame(
+                'Cannot store master key: Cannot create directory: ' . vfsStream::url('vault/readonly/nested'),
+                $e->getMessage(),
+            );
+        }
+    }
+
+    #[Test]
+    public function getMasterKeyRefusesAnUnconfiguredPathEvenWhenAnAutoKeyExists(): void
+    {
+        // The empty-path guard fires BEFORE the auto-key fallback: an operator
+        // who cleared the setting must get a configuration error, not a silent
+        // switch to the development key.
+        $autoKeyPath = vfsStream::url('vault/present-auto.key');
+        file_put_contents($autoKeyPath, base64_encode(sodium_crypto_secretbox_keygen()));
+
+        $config = $this->createMock(ExtensionConfigurationInterface::class);
+        $config->method('getMasterKeySource')->willReturn(ExtensionConfiguration::DEFAULT_MASTER_KEY_SOURCE);
+        $config->method('getAutoKeyPath')->willReturn($autoKeyPath);
+
+        $provider = new FileMasterKeyProvider($config);
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionMessage('Master key not found at: No path configured');
+
+        $provider->getMasterKey();
+    }
+
+    #[Test]
+    public function getMasterKeyReportsAMissingFileWithoutClaimingItIsUnreadable(): void
+    {
+        $config = $this->createMock(ExtensionConfigurationInterface::class);
+        $config->method('getMasterKeySource')->willReturn(vfsStream::url(self::NONEXISTENT_KEY_PATH));
+        $config->method('getAutoKeyPath')->willReturn(vfsStream::url('vault/also-missing.key'));
+
+        $provider = new FileMasterKeyProvider($config);
+
+        try {
+            $provider->getMasterKey();
+            self::fail('Expected MasterKeyException was not thrown.');
+        } catch (MasterKeyException $e) {
+            self::assertSame(
+                'Master key not found at: ' . vfsStream::url(self::NONEXISTENT_KEY_PATH),
+                $e->getMessage(),
+            );
+        }
+    }
+
+    #[Test]
+    public function getMasterKeyNamesThePathAndTheReasonWhenTheKeyFileIsUnreadable(): void
+    {
+        $keyPath = vfsStream::url('vault/unreadable.key');
+        file_put_contents($keyPath, base64_encode(sodium_crypto_secretbox_keygen()));
+        chmod($keyPath, 0o000);
+
+        $config = $this->createMock(ExtensionConfigurationInterface::class);
+        $config->method('getMasterKeySource')->willReturn($keyPath);
+
+        $provider = new FileMasterKeyProvider($config);
+
+        try {
+            $provider->getMasterKey();
+            self::fail('Expected MasterKeyException was not thrown.');
+        } catch (MasterKeyException $e) {
+            self::assertSame(
+                'Master key not found at: ' . $keyPath . ' (not readable)',
+                $e->getMessage(),
+            );
+        }
+    }
+
+    #[Test]
+    public function getMasterKeyTrimsATrailingNewlineFromARawBinaryKey(): void
+    {
+        // A 32-byte raw key written by `printf ... > file` picks up a newline.
+        // Only the trimmed value has the key length; the untrimmed bytes are
+        // neither 32 bytes nor decodable base64.
+        $key = '12345678901234567890123456789012';
+        $keyPath = vfsStream::url('vault/raw-newline.key');
+        file_put_contents($keyPath, $key . "\n");
+
+        $config = $this->createMock(ExtensionConfigurationInterface::class);
+        $config->method('getMasterKeySource')->willReturn($keyPath);
+
+        $provider = new FileMasterKeyProvider($config);
+
+        self::assertSame($key, $provider->getMasterKey());
+    }
+
+    #[Test]
+    public function destructionClearsTheRequestLifetimeKeyCache(): void
+    {
+        $keyPath = vfsStream::url(self::MASTER_KEY_PATH);
+
+        $config = $this->createMock(ExtensionConfigurationInterface::class);
+        $config->method('getMasterKeySource')->willReturn($keyPath);
+
+        $first = sodium_crypto_secretbox_keygen();
+        file_put_contents($keyPath, base64_encode($first));
+
+        $provider = new FileMasterKeyProvider($config);
+        self::assertSame($first, $provider->getMasterKey());
+        unset($provider);
+
+        $second = sodium_crypto_secretbox_keygen();
+        file_put_contents($keyPath, base64_encode($second));
+
+        self::assertSame($second, (new FileMasterKeyProvider($config))->getMasterKey());
     }
 }

--- a/Tests/Unit/Crypto/TransitMasterKeyProviderTest.php
+++ b/Tests/Unit/Crypto/TransitMasterKeyProviderTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Crypto\TransitMasterKeyProvider;
 use Netresearch\NrVault\Exception\MasterKeyException;
 use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Tests\Unit\Traits\ErrorSuppressionTrait;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamContent;
 use org\bovigo\vfs\vfsStreamDirectory;
@@ -32,6 +33,8 @@ use RuntimeException;
 #[AllowMockObjectsWithoutExpectations]
 final class TransitMasterKeyProviderTest extends TestCase
 {
+    use ErrorSuppressionTrait;
+
     private const ADDRESS = 'https://vault.example.com:8200';
 
     private const TOKEN_ENV_VAR = 'NR_VAULT_TEST_TRANSIT_TOKEN';
@@ -451,6 +454,316 @@ final class TransitMasterKeyProviderTest extends TestCase
         self::assertSame(self::TOKEN, $config->token);
     }
 
+    #[Test]
+    public function isAvailableReturnsFalseWhenMountPathIsUnsafe(): void
+    {
+        // Availability must fail closed on an unsafe key reference, otherwise a
+        // traversal mount is only caught once the hot path builds the URL.
+        $this->writeWrappedKeyFile();
+
+        $provider = $this->createProvider(
+            $this->createMock(ClientInterface::class),
+            $this->transitConfig(mount: '../../sys'),
+        );
+
+        self::assertFalse($provider->isAvailable());
+    }
+
+    #[Test]
+    public function getMasterKeyThrowsWhenPlaintextIsAnEmptyString(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        $provider = $this->createProvider(
+            $this->clientReturning($this->transitResponse(['plaintext' => ''])),
+        );
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionCode(1754100006);
+
+        $provider->getMasterKey();
+    }
+
+    #[Test]
+    public function getMasterKeyRejectsAStatusOfExactlyThreeHundred(): void
+    {
+        // 300 is outside the 2xx success band; only a `>= 300` bound rejects it.
+        $this->writeWrappedKeyFile();
+
+        $body = json_encode(
+            ['data' => ['plaintext' => base64_encode(sodium_crypto_secretbox_keygen())]],
+            JSON_THROW_ON_ERROR,
+        );
+
+        $provider = $this->createProvider($this->clientReturning(new Response(300, [], $body)));
+
+        $this->expectException(MasterKeyException::class);
+        $this->expectExceptionCode(1754100004);
+
+        $provider->getMasterKey();
+    }
+
+    #[Test]
+    public function getMasterKeyAcceptsAResponseAtTheSupportedJsonDepth(): void
+    {
+        $key = sodium_crypto_secretbox_keygen();
+        $this->writeWrappedKeyFile();
+
+        $provider = $this->createProvider(
+            $this->clientReturning(new Response(200, [], $this->nestedTransitBody($key, 29))),
+        );
+
+        self::assertSame($key, $provider->getMasterKey());
+    }
+
+    #[Test]
+    public function getMasterKeyRejectsAResponseNestedBeyondTheSupportedJsonDepth(): void
+    {
+        // A deliberately over-nested body must be refused rather than parsed —
+        // the depth cap is the defence against decoder resource exhaustion.
+        $this->writeWrappedKeyFile();
+
+        $provider = $this->createProvider(
+            $this->clientReturning(
+                new Response(200, [], $this->nestedTransitBody(sodium_crypto_secretbox_keygen(), 30)),
+            ),
+        );
+
+        try {
+            $provider->getMasterKey();
+            self::fail('Expected MasterKeyException was not thrown.');
+        } catch (MasterKeyException $e) {
+            self::assertSame(1754100006, $e->getCode());
+            self::assertStringContainsString('not valid JSON', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function getMasterKeyReadsPlaintextFromAMultiFieldDataObject(): void
+    {
+        // Vault answers with `key_version` alongside `plaintext`; the whole data
+        // object must be handed back, not just its first entry.
+        $key = sodium_crypto_secretbox_keygen();
+        $this->writeWrappedKeyFile();
+
+        $provider = $this->createProvider(
+            $this->clientReturning($this->transitResponse([
+                'key_version' => '1',
+                'plaintext' => base64_encode($key),
+            ])),
+        );
+
+        self::assertSame($key, $provider->getMasterKey());
+    }
+
+    #[Test]
+    public function getMasterKeyReportsAMissingWrappedKeyWithoutClaimingItIsUnreadable(): void
+    {
+        $provider = $this->createProvider($this->createMock(ClientInterface::class));
+
+        try {
+            $provider->getMasterKey();
+            self::fail('Expected MasterKeyException was not thrown.');
+        } catch (MasterKeyException $e) {
+            self::assertSame('Master key not found at: ' . $this->wrappedKeyPath(), $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function wrappedKeyFileIsTrimmedBeforeItIsSentToVault(): void
+    {
+        // Editors and shell redirection add surrounding whitespace; the prefix
+        // check and the submitted ciphertext must both see the trimmed blob.
+        $key = sodium_crypto_secretbox_keygen();
+        file_put_contents($this->wrappedKeyPath(), " \n" . self::WRAPPED_CIPHERTEXT . "\n");
+
+        $client = $this->clientReturning($this->transitResponse(['plaintext' => base64_encode($key)]));
+        $provider = $this->createProvider($client);
+
+        self::assertSame($key, $provider->getMasterKey());
+        self::assertSame(
+            ['ciphertext' => self::WRAPPED_CIPHERTEXT],
+            json_decode((string) $this->assertSingleRequest()->getBody(), true, 8, JSON_THROW_ON_ERROR),
+        );
+    }
+
+    #[Test]
+    public function transportFailureMessageEndsWithTheCausingExceptionClass(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        $transportError = new class ('cURL error 7: connection refused') extends RuntimeException implements ClientExceptionInterface {};
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->method('sendRequest')->willThrowException($transportError);
+
+        try {
+            $this->createProvider($client)->getMasterKey();
+            self::fail('Expected MasterKeyException was not thrown.');
+        } catch (MasterKeyException $e) {
+            self::assertStringStartsWith(
+                'Vault Transit decrypt request could not be sent: cURL error 7: connection refused',
+                $e->getMessage(),
+            );
+            self::assertStringEndsWith(
+                \sprintf(' (caused by %s)', $transportError::class),
+                $e->getMessage(),
+            );
+        }
+    }
+
+    #[Test]
+    public function transportFailureRedactsHeaderTokensAndBareServiceTokens(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        // Clearly synthetic, generated at runtime: the legacy `s.` service-token
+        // shape the third redaction pattern targets.
+        $bareToken = 's.' . bin2hex(random_bytes(12));
+        $headerToken = 'unit-test-header-token-' . bin2hex(random_bytes(4));
+
+        $client = $this->createMock(ClientInterface::class);
+        $client->method('sendRequest')->willThrowException(
+            new class ('sending failed with X-Vault-Token: ' . $headerToken . ' using ' . $bareToken . ' downstream') extends RuntimeException implements ClientExceptionInterface {},
+        );
+
+        try {
+            $this->createProvider($client)->getMasterKey();
+            self::fail('Expected MasterKeyException was not thrown.');
+        } catch (MasterKeyException $e) {
+            self::assertStringNotContainsString($headerToken, $e->getMessage());
+            self::assertStringNotContainsString($bareToken, $e->getMessage());
+            // The header NAME survives (only its value is replaced), and the
+            // bare token is replaced rather than dropped.
+            self::assertStringContainsString('X-Vault-Token: [REDACTED]', $e->getMessage());
+            self::assertStringContainsString('using [REDACTED] downstream', $e->getMessage());
+        }
+    }
+
+    #[Test]
+    public function storeMasterKeyCreatesTheKeyDirectoryWithOwnerOnlyPermissions(): void
+    {
+        $client = $this->clientReturning($this->transitResponse(['ciphertext' => self::WRAPPED_CIPHERTEXT]));
+
+        $provider = $this->createProvider($client, $this->transitConfig(
+            wrappedKeyPath: vfsStream::url('transit/created/deep/wrapped.key'),
+        ));
+        $provider->storeMasterKey(sodium_crypto_secretbox_keygen());
+
+        $outer = $this->root->getChild('created');
+        self::assertNotNull($outer);
+        self::assertSame(0o700, $outer->getPermissions());
+
+        $inner = $this->root->getChild('created/deep');
+        self::assertNotNull($inner);
+        self::assertSame(0o700, $inner->getPermissions());
+    }
+
+    #[Test]
+    public function storeMasterKeyReportsAnUncreatableDirectoryRatherThanTheFailedWrite(): void
+    {
+        mkdir(vfsStream::url('transit/readonly'), 0o500);
+
+        $client = $this->clientReturning($this->transitResponse(['ciphertext' => self::WRAPPED_CIPHERTEXT]));
+        $provider = $this->createProvider($client, $this->transitConfig(
+            wrappedKeyPath: vfsStream::url('transit/readonly/nested/wrapped.key'),
+        ));
+
+        try {
+            $this->withoutPhpDiagnostics(
+                static fn (): null => $provider->storeMasterKey(sodium_crypto_secretbox_keygen()),
+            );
+            self::fail('Expected MasterKeyException was not thrown.');
+        } catch (MasterKeyException $e) {
+            self::assertSame(
+                'Cannot store master key: Cannot create directory: ' . vfsStream::url('transit/readonly/nested'),
+                $e->getMessage(),
+            );
+        }
+    }
+
+    #[Test]
+    public function storeMasterKeyRestoresThePreviousUmask(): void
+    {
+        $client = $this->clientReturning($this->transitResponse(['ciphertext' => self::WRAPPED_CIPHERTEXT]));
+        $provider = $this->createProvider($client);
+
+        $outerUmask = umask(0o022);
+
+        try {
+            $provider->storeMasterKey(sodium_crypto_secretbox_keygen());
+
+            self::assertSame(0o022, umask());
+        } finally {
+            umask($outerUmask);
+        }
+    }
+
+    #[Test]
+    public function storeMasterKeyRestoresThePreviousUmaskWhenTheWriteFails(): void
+    {
+        // The umask is tightened for the write; a failing write must not leak
+        // the tightened value into the rest of the request.
+        mkdir(vfsStream::url('transit/readonly'), 0o500);
+
+        $client = $this->clientReturning($this->transitResponse(['ciphertext' => self::WRAPPED_CIPHERTEXT]));
+        $provider = $this->createProvider($client, $this->transitConfig(
+            wrappedKeyPath: vfsStream::url('transit/readonly/wrapped.key'),
+        ));
+
+        $outerUmask = umask(0o022);
+
+        try {
+            $this->withoutPhpDiagnostics(
+                static fn (): null => $provider->storeMasterKey(sodium_crypto_secretbox_keygen()),
+            );
+            self::fail('Expected MasterKeyException was not thrown.');
+        } catch (MasterKeyException $e) {
+            self::assertStringContainsString('Cannot write to', $e->getMessage());
+            self::assertSame(0o022, umask());
+        } finally {
+            umask($outerUmask);
+        }
+    }
+
+    #[Test]
+    public function destructionClearsTheRequestLifetimeKeyCache(): void
+    {
+        $this->writeWrappedKeyFile();
+
+        $first = sodium_crypto_secretbox_keygen();
+        $provider = $this->createProvider(
+            $this->clientReturning($this->transitResponse(['plaintext' => base64_encode($first)])),
+        );
+        self::assertSame($first, $provider->getMasterKey());
+        unset($provider);
+
+        $second = sodium_crypto_secretbox_keygen();
+        $successor = $this->createProvider(
+            $this->clientReturning($this->transitResponse(['plaintext' => base64_encode($second)])),
+        );
+
+        self::assertSame($second, $successor->getMasterKey());
+    }
+
+    /**
+     * A syntactically valid transit response whose `data` object carries an
+     * extra branch nested $levels deep, used to probe the json_decode() depth
+     * cap from both sides.
+     */
+    private function nestedTransitBody(string $key, int $levels): string
+    {
+        $nested = 1;
+        for ($i = 0; $i < $levels; ++$i) {
+            $nested = [$nested];
+        }
+
+        return json_encode(
+            ['data' => ['plaintext' => base64_encode($key), 'deep' => $nested]],
+            JSON_THROW_ON_ERROR,
+        );
+    }
+
     private function createProvider(
         ClientInterface $client,
         ?TransitConfig $config = null,
@@ -470,12 +783,13 @@ final class TransitMasterKeyProviderTest extends TestCase
         string $keyName = 'nr-vault-master',
         string $authMethod = 'token',
         string $token = '',
+        ?string $wrappedKeyPath = null,
     ): TransitConfig {
         return new TransitConfig(
             address: self::ADDRESS,
             mount: $mount,
             keyName: $keyName,
-            wrappedKeyPath: $this->wrappedKeyPath(),
+            wrappedKeyPath: $wrappedKeyPath ?? $this->wrappedKeyPath(),
             authMethod: $authMethod,
             tokenEnvVar: self::TOKEN_ENV_VAR,
             token: $token,

--- a/Tests/Unit/Security/AccessControlServiceIsGrantedTest.php
+++ b/Tests/Unit/Security/AccessControlServiceIsGrantedTest.php
@@ -224,6 +224,84 @@ final class AccessControlServiceIsGrantedTest extends TestCase
     }
 
     /**
+     * The unattributable actor — no backend user, no technical actor, and not
+     * a real CLI process — must fail closed even when the operation IS on the
+     * CLI allowlist. Both halves of the conjunction are load-bearing: the
+     * allowlist alone describes what a CLI operator may do, never who counts
+     * as one.
+     */
+    #[Test]
+    #[DataProvider('allPermissionsProvider')]
+    public function noActorIsDeniedEvenWhenTheOperationIsCliAllowlisted(VaultPermission $permission): void
+    {
+        $this->configuration->method('isCliAccessAllowed')->willReturn(true);
+        $this->configuration->method('getCliAllowedOperations')->willReturn(
+            array_map(static fn (VaultPermission $case): string => $case->value, VaultPermission::cases()),
+        );
+
+        self::assertFalse($this->subject->isGranted($permission));
+    }
+
+    /**
+     * A CommandLineUserAuthentication whose record carries no usable uid was
+     * never logged in — the CLI trust switch decides, not the (empty) user
+     * record, whose every group/admin check would fail closed for the wrong
+     * reason.
+     */
+    #[Test]
+    public function commandLineUserWithAnUnusableUidIsTreatedAsUnauthenticated(): void
+    {
+        $this->configuration->method('isCliAccessAllowed')->willReturn(true);
+        $this->configuration->method('getCliAllowedOperations')->willReturn(['secret.reveal']);
+
+        $cliUser = $this->createMock(CommandLineUserAuthentication::class);
+        /** @phpstan-ignore property.internal */
+        $cliUser->user = ['uid' => 'not-a-uid'];
+
+        $GLOBALS['BE_USER'] = $cliUser;
+
+        self::assertTrue($this->subject->isGranted(VaultPermission::SecretReveal));
+    }
+
+    /**
+     * The mirror case: an AUTHENTICATED `_cli_` user keeps user-based
+     * semantics, and a driver that returns the uid as a string must not push
+     * it back onto the unauthenticated branch — where its grants would come
+     * from the CLI trust switch instead of its own groups.
+     */
+    #[Test]
+    public function commandLineUserWithANumericStringUidKeepsItsUserBasedSemantics(): void
+    {
+        $this->configuration->method('isCliAccessAllowed')->willReturn(false);
+
+        $cliUser = $this->createMock(CommandLineUserAuthentication::class);
+        /** @phpstan-ignore property.internal */
+        $cliUser->user = ['uid' => '3', 'username' => '_cli_', 'disable' => 0];
+        /** @phpstan-ignore property.internal */
+        $cliUser->groupData['custom_options'] = 'tx_nrvault:secret.reveal';
+
+        $GLOBALS['BE_USER'] = $cliUser;
+
+        self::assertTrue($this->subject->isGranted(VaultPermission::SecretReveal));
+    }
+
+    /**
+     * `custom_options` is a nullable be_groups column: an unpopulated one must
+     * deny, not raise a TypeError out of the permission check.
+     */
+    #[Test]
+    public function backendUserWithoutAnyCustomOptionsValueIsDenied(): void
+    {
+        $backendUser = $this->createMockBackendUser(uid: 5);
+        /** @phpstan-ignore property.internal */
+        $backendUser->groupData['custom_options'] = null;
+
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        self::assertFalse($this->subject->isGranted(VaultPermission::SecretReveal));
+    }
+
+    /**
      * @return iterable<string, array{VaultPermission}>
      */
     public static function allPermissionsProvider(): iterable
@@ -255,6 +333,26 @@ final class AccessControlServiceIsGrantedTest extends TestCase
         self::assertTrue($subject->isGranted(VaultPermission::SecretRotate));
         self::assertFalse($subject->isGranted(VaultPermission::SecretDelete), 'not granted by the group');
         self::assertFalse($subject->isGranted(VaultPermission::SecretReveal), 'never implicit');
+    }
+
+    /**
+     * The scan must cover every group the actor holds. A group without any
+     * custom options is a gap in the list, not the end of it — stopping there
+     * would make a grant depend on the row order the database happens to
+     * return.
+     */
+    #[Test]
+    public function technicalActorGrantIsFoundBehindAGroupWithoutCustomOptions(): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(
+            admin: false,
+            groupRows: [
+                ['uid' => 5, 'custom_options' => ''],
+                ['uid' => 6, 'custom_options' => 'tx_nrvault:secret.create'],
+            ],
+        );
+
+        self::assertTrue($subject->isGranted(VaultPermission::SecretCreate));
     }
 
     #[Test]
@@ -312,6 +410,10 @@ final class AccessControlServiceIsGrantedTest extends TestCase
         ));
 
         $connectionPool = $this->createMock(ConnectionPool::class);
+        // An actor without groups is answered from the empty list alone —
+        // neither the existing-group filter nor the custom-options lookup may
+        // reach the database.
+        $connectionPool->expects(self::never())->method('getQueryBuilderForTable');
 
         $subject = new AccessControlService($this->configuration, $connectionPool, $context);
 

--- a/Tests/Unit/Security/AccessControlServiceTest.php
+++ b/Tests/Unit/Security/AccessControlServiceTest.php
@@ -23,6 +23,7 @@ use PHPUnit\Framework\MockObject\MockObject;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
 use TYPO3\CMS\Core\Authentication\CommandLineUserAuthentication;
 use TYPO3\CMS\Core\Core\SystemEnvironmentBuilder;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -160,6 +161,83 @@ final class AccessControlServiceTest extends TestCase
     {
         // No CLI mode, no backend user
         self::assertFalse($this->subject->canCreate());
+    }
+
+    /**
+     * `allowCliAccess` describes what a CLI operator may do — it never decides
+     * who counts as one. An unattributable web actor stays denied.
+     */
+    #[Test]
+    public function canCreateIsDeniedWithoutAnyActorEvenWhenCliAccessIsAllowed(): void
+    {
+        $this->configuration->method('isCliAccessAllowed')->willReturn(true);
+
+        self::assertFalse($this->subject->canCreate());
+    }
+
+    /**
+     * The `disable` column is optional in the session record, and a driver may
+     * hand it over as a string. "Absent" and "'0'" both mean enabled — reading
+     * either as disabled locks legitimate users out of their own secrets.
+     */
+    #[Test]
+    public function backendUserRecordWithoutADisableColumnIsNotDisabled(): void
+    {
+        $backendUser = $this->createMockBackendUser(uid: 5);
+        /** @phpstan-ignore property.internal */
+        $backendUser->user = ['uid' => 5, 'username' => 'no_disable_column'];
+
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        self::assertTrue($this->subject->canCreate());
+    }
+
+    #[Test]
+    public function backendUserWithADisableColumnOfStringZeroIsNotDisabled(): void
+    {
+        $backendUser = $this->createMockBackendUser(uid: 5);
+        /** @phpstan-ignore property.internal */
+        $backendUser->user = ['uid' => 5, 'username' => 'string_columns', 'disable' => '0'];
+
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        self::assertTrue($this->subject->canCreate());
+    }
+
+    /**
+     * A session record without a usable uid must not accidentally *own*
+     * anything: the fallback uid is the one value no real be_users row can
+     * carry, so no owner check can match it.
+     */
+    #[Test]
+    public function backendUserWithoutAUidOwnsNoSecret(): void
+    {
+        $backendUser = $this->createMockBackendUser(uid: 5);
+        /** @phpstan-ignore property.internal */
+        $backendUser->user = ['username' => 'no_uid', 'disable' => 0];
+
+        $GLOBALS['BE_USER'] = $backendUser;
+
+        self::assertFalse($this->subject->canRead($this->createSecret(ownerUid: 1)));
+        self::assertFalse($this->subject->canRead($this->createSecret(ownerUid: -1)));
+    }
+
+    /**
+     * `TYPO3_cliMode` is a legacy constant; only the value `true` classifies a
+     * request as CLI. Reading a falsy one as CLI would attribute every web
+     * access to the trusted CLI operator.
+     *
+     * Defining it as `false` is inert for the rest of the suite — that is
+     * exactly the branch the production code ignores.
+     */
+    #[Test]
+    public function actorTypeIgnoresAFalsyLegacyCliModeConstant(): void
+    {
+        if (!\defined('TYPO3_cliMode')) {
+            \define('TYPO3_cliMode', false);
+        }
+
+        self::assertSame('api', $this->subject->getCurrentActorType());
     }
 
     #[Test]
@@ -1015,6 +1093,78 @@ final class AccessControlServiceTest extends TestCase
         self::assertFalse($nonAdmin->isCurrentActorAdmin());
     }
 
+    /**
+     * Holding *an* existing group is not holding the secret's group. Without
+     * the intersection every actor with any surviving group would read every
+     * group-scoped secret.
+     */
+    #[Test]
+    public function technicalActorGroupsMustIntersectTheSecretGroups(): void
+    {
+        $subject = $this->createSubjectWithTechnicalActor(
+            new TechnicalActor(uid: 10, username: 'tech_indexer', admin: false, groupIds: [9]),
+            existingGroupUids: [9],
+        );
+
+        self::assertFalse($subject->canRead($this->createSecret(ownerUid: 1, allowedGroups: [5])));
+    }
+
+    /**
+     * The stale-group filter is the reason a deleted group cannot grant
+     * access, so its query must see deleted rows (restrictions removed) and
+     * exclude them by its own `deleted = 0` constraint.
+     */
+    #[Test]
+    public function existingGroupLookupDropsRestrictionsAndExcludesDeletedGroups(): void
+    {
+        $restrictions = $this->createMock(DefaultRestrictionContainer::class);
+        $restrictions->expects(self::once())->method('removeAll');
+
+        $parameters = [];
+        $subject = $this->createSubjectWithObservableGroupLookup(
+            [['uid' => 7]],
+            restrictions: $restrictions,
+            capturedParameters: $parameters,
+        );
+
+        self::assertSame([7], $subject->filterExistingGroupIds([7]));
+        self::assertContains(
+            [0, Connection::PARAM_INT],
+            $parameters,
+            'Deleted groups must be excluded by the query itself',
+        );
+    }
+
+    #[Test]
+    public function existingGroupLookupIsCachedForTheLifetimeOfTheService(): void
+    {
+        $subject = $this->createSubjectWithObservableGroupLookup([['uid' => 7]], expectedQueries: 1);
+
+        self::assertSame([7], $subject->filterExistingGroupIds([7]));
+        self::assertSame([7], $subject->filterExistingGroupIds([7]));
+    }
+
+    #[Test]
+    public function filteringAnEmptyGroupListAnswersWithoutQuerying(): void
+    {
+        $subject = $this->createSubjectWithObservableGroupLookup([], expectedQueries: 0);
+
+        self::assertSame([], $subject->filterExistingGroupIds([]));
+    }
+
+    /**
+     * Group uids arriving as strings must become integers: the filtered list
+     * is compared against a secret's group list, and a '007' that never became
+     * 7 would silently stop matching.
+     */
+    #[Test]
+    public function numericStringGroupUidsFromTheDatabaseAreNormalisedToIntegers(): void
+    {
+        $subject = $this->createSubjectWithObservableGroupLookup([['uid' => '007']]);
+
+        self::assertSame([7], $subject->filterExistingGroupIds([7]));
+    }
+
     // ----- Characterization: behaviour without an active runAs() scope ------
 
     #[Test]
@@ -1182,6 +1332,58 @@ final class AccessControlServiceTest extends TestCase
 
         $connectionPool = $this->createMock(ConnectionPool::class);
         $connectionPool
+            ->method('getQueryBuilderForTable')
+            ->with('be_groups')
+            ->willReturn($queryBuilder);
+
+        return new AccessControlService($this->configuration, $connectionPool);
+    }
+
+    /**
+     * Build an AccessControlService whose be_groups lookup is observable: how
+     * often it runs, which restrictions it drops and which named parameters it
+     * binds.
+     *
+     * @param list<array<string, mixed>> $rows rows the lookup returns
+     * @param int|null $expectedQueries exact number of lookups
+     *                                  expected; null = at least one
+     * @param list<array{mixed, mixed}> $capturedParameters collects every
+     *                                                      createNamedParameter() call as [value, type]
+     */
+    private function createSubjectWithObservableGroupLookup(
+        array $rows,
+        ?int $expectedQueries = null,
+        ?DefaultRestrictionContainer $restrictions = null,
+        array &$capturedParameters = [],
+    ): AccessControlService {
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAllAssociative')->willReturn($rows);
+
+        $expressionBuilder = $this->createMock(ExpressionBuilder::class);
+        $expressionBuilder->method('eq')->willReturn('deleted = 0');
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder
+            ->method('getRestrictions')
+            ->willReturn($restrictions ?? $this->createMock(DefaultRestrictionContainer::class));
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('expr')->willReturn($expressionBuilder);
+        $queryBuilder
+            ->method('createNamedParameter')
+            ->willReturnCallback(
+                static function (mixed $value, mixed $type = null) use (&$capturedParameters): string {
+                    $capturedParameters[] = [$value, $type];
+
+                    return ':dcValue1';
+                },
+            );
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool
+            ->expects($expectedQueries === null ? self::atLeastOnce() : self::exactly($expectedQueries))
             ->method('getQueryBuilderForTable')
             ->with('be_groups')
             ->willReturn($queryBuilder);

--- a/Tests/Unit/Security/FrontendPlaceholderPolicyTest.php
+++ b/Tests/Unit/Security/FrontendPlaceholderPolicyTest.php
@@ -122,6 +122,46 @@ final class FrontendPlaceholderPolicyTest extends TestCase
         self::assertFalse($this->subject->isResolvable('', $cObj));
     }
 
+    #[Test]
+    public function aSecondGrantDoesNotDropTheFirst(): void
+    {
+        $request = $this->frontendRequest();
+        $cObj = $this->contentObjectRenderer($request);
+
+        $this->subject->allowIdentifier('first_grant', $request);
+        $this->subject->allowIdentifier('second_grant', $request);
+
+        self::assertTrue($this->subject->isResolvable('first_grant', $cObj), 'the earlier grant must survive');
+        self::assertTrue($this->subject->isResolvable('second_grant', $cObj));
+    }
+
+    /**
+     * `scopeRequest()` removes `$GLOBALS['TYPO3_REQUEST']` for the duration of
+     * the call so `getRequest()` cannot smuggle it back in. It must put back
+     * exactly what it found: leaving the global emptied would change the
+     * behaviour of every later consumer in the same request.
+     */
+    #[Test]
+    public function scopingRestoresTheGlobalRequestItTemporarilyRemoved(): void
+    {
+        $stale = $this->backendRequest();
+        $GLOBALS['TYPO3_REQUEST'] = $stale;
+
+        $this->subject->isResolvable(self::IDENTIFIER, $this->contentObjectRenderer($this->frontendRequest()));
+
+        self::assertSame($stale, $GLOBALS['TYPO3_REQUEST'] ?? null);
+    }
+
+    #[Test]
+    public function scopingDoesNotInventAGlobalRequestWhereThereWasNone(): void
+    {
+        unset($GLOBALS['TYPO3_REQUEST']);
+
+        $this->subject->isResolvable(self::IDENTIFIER, $this->contentObjectRenderer($this->frontendRequest()));
+
+        self::assertArrayNotHasKey('TYPO3_REQUEST', $GLOBALS);
+    }
+
     /**
      * The policy is a container singleton, so a grant that is not bound to the
      * request object outlives the request. In a worker SAPI that means an eID
@@ -326,6 +366,122 @@ final class FrontendPlaceholderPolicyTest extends TestCase
 
         self::assertTrue($this->subject->isResolvable('id_0000', $cObj));
         self::assertFalse($this->subject->isResolvable('id_1099', $cObj), 'Beyond 1000 identifiers the set only shrinks');
+    }
+
+    /**
+     * The caps are exact, not approximate. One level or one identifier of
+     * slack is a level or an identifier an integrator never published.
+     */
+    #[Test]
+    public function theDepthCapIsExact(): void
+    {
+        $cObj = $this->contentObjectRenderer($this->frontendRequest([
+            'a.' => $this->nest('%vault(at_the_cap)%', 30),
+            'b.' => $this->nest('%vault(past_the_cap)%', 31),
+        ]));
+
+        self::assertTrue($this->subject->isResolvable('at_the_cap', $cObj), 'the last level inside the cap');
+        self::assertFalse($this->subject->isResolvable('past_the_cap', $cObj), 'the first level beyond it');
+    }
+
+    #[Test]
+    public function theIdentifierCapIsExact(): void
+    {
+        $setup = [];
+        for ($i = 0; $i < 1000; ++$i) {
+            $setup['key' . $i] = \sprintf('%%vault(id_%04d)%%', $i);
+        }
+
+        // Both harvest sources meet the full set and must refuse to add to it.
+        $setup['overflow'] = '%vault(leaf_overflow)%';
+        $setup['plugin.'] = ['tx_nrvault.' => ['frontendResolvableIdentifiers' => 'optin_overflow']];
+
+        $cObj = $this->contentObjectRenderer($this->frontendRequest($setup));
+
+        self::assertTrue($this->subject->isResolvable('id_0999', $cObj), 'the thousandth identifier still fits');
+        self::assertFalse($this->subject->isResolvable('leaf_overflow', $cObj), 'the 1001st from a setup leaf');
+        self::assertFalse($this->subject->isResolvable('optin_overflow', $cObj), 'the 1001st from the opt-in list');
+    }
+
+    /**
+     * The walk must visit every sibling. A nested node and a leaf without a
+     * placeholder are both things to skip over, not places to stop — an
+     * integrator's identifier further down the same array would silently stop
+     * being resolvable.
+     */
+    #[Test]
+    public function harvestContinuesPastNestedNodesAndPlaceholderFreeLeaves(): void
+    {
+        $cObj = $this->contentObjectRenderer($this->frontendRequest([
+            'nested.' => ['value' => '%vault(nested_key)%'],
+            'plain' => 'nothing to resolve here',
+            'later' => '%vault(sibling_key)%',
+        ]));
+
+        self::assertTrue($this->subject->isResolvable('nested_key', $cObj));
+        self::assertTrue($this->subject->isResolvable('sibling_key', $cObj), 'a later sibling must still be harvested');
+    }
+
+    #[Test]
+    public function optInListSkipsEmptyEntriesInsteadOfStoppingAtThem(): void
+    {
+        $cObj = $this->contentObjectRenderer($this->frontendRequest([
+            'plugin.' => ['tx_nrvault.' => ['frontendResolvableIdentifiers' => ', ,' . self::IDENTIFIER]],
+        ]));
+
+        self::assertTrue($this->subject->isResolvable(self::IDENTIFIER, $cObj));
+    }
+
+    /**
+     * A2 has two halves and neither is redundant: the site *configuration*
+     * carries identifiers that are not settings at all.
+     */
+    #[Test]
+    public function siteConfigurationOutsideSettingsPublishesIdentifiers(): void
+    {
+        $site = new Site('acme', 1, [
+            'base' => 'https://example.com/',
+            'websiteTitle' => '%vault(' . self::IDENTIFIER . ')%',
+        ]);
+        $cObj = $this->contentObjectRenderer($this->frontendRequest()->withAttribute('site', $site));
+
+        self::assertTrue($this->subject->isResolvable(self::IDENTIFIER, $cObj));
+    }
+
+    /**
+     * …and the flat settings view reaches leaves the configuration walk cannot:
+     * settings are merged back into the configuration as a *tree*, so a deeply
+     * nested one sits past the depth cap there while `getAllFlat()` presents it
+     * one level down.
+     */
+    #[Test]
+    public function deeplyNestedSiteSettingsAreStillHarvestedThroughTheFlatView(): void
+    {
+        $tree = ['value' => '%vault(' . self::IDENTIFIER . ')%'];
+        for ($i = 0; $i < 40; ++$i) {
+            $tree = ['level' => $tree];
+        }
+
+        $site = new Site('acme', 1, ['base' => 'https://example.com/', 'settings' => $tree]);
+        $cObj = $this->contentObjectRenderer($this->frontendRequest()->withAttribute('site', $site));
+
+        self::assertTrue($this->subject->isResolvable(self::IDENTIFIER, $cObj));
+    }
+
+    #[Test]
+    public function everyIdentifierOfASitePublishesNotJustTheFirst(): void
+    {
+        $site = new Site('acme', 1, [
+            'base' => 'https://example.com/',
+            'first' => '%vault(first_site_key)%',
+            'second' => '%vault(second_site_key)%',
+        ]);
+        $cObj = $this->contentObjectRenderer($this->frontendRequest()->withAttribute('site', $site));
+
+        // Asked for before the first one, so a truncated set cannot be masked
+        // by the memo that is filled on the way out.
+        self::assertTrue($this->subject->isResolvable('second_site_key', $cObj));
+        self::assertTrue($this->subject->isResolvable('first_site_key', $cObj));
     }
 
     #[Test]

--- a/Tests/Unit/Security/TechnicalActorContextTest.php
+++ b/Tests/Unit/Security/TechnicalActorContextTest.php
@@ -22,6 +22,7 @@ use Psr\EventDispatcher\EventDispatcherInterface;
 use ReflectionClass;
 use RuntimeException;
 use TYPO3\CMS\Core\Authentication\GroupResolver;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
@@ -196,6 +197,132 @@ final class TechnicalActorContextTest extends TestCase
         });
     }
 
+    /**
+     * A row that carries none of the optional columns must default to
+     * "root level, enabled, unrestricted, non-admin". Every other default is a
+     * security bug in one direction or the other: a non-zero `pid`/`disable`
+     * default locks a valid technical user out, a non-zero `admin` default
+     * silently promotes it to a full bypass.
+     */
+    #[Test]
+    public function recordWithoutOptionalColumnsIsAnEnabledRootLevelNonAdminUser(): void
+    {
+        $subject = $this->createSubject([['uid' => 42, 'username' => 'sparse_user']]);
+
+        $subject->runAs(42, static function () use ($subject): void {
+            $actor = $subject->getCurrentActor();
+
+            self::assertInstanceOf(TechnicalActor::class, $actor);
+            self::assertFalse($actor->admin, 'A missing admin column must never mean "admin"');
+        });
+    }
+
+    /**
+     * Both boundaries of the activity window, exactly on the second: a user is
+     * active AT its starttime and inactive AT its endtime — the same
+     * `>` / `<=` pair a real backend login evaluates.
+     */
+    #[Test]
+    public function userIsActiveAtExactlyItsStarttime(): void
+    {
+        $subject = $this->createSubject([$this->userRow(uid: 42, starttime: time())]);
+
+        self::assertSame('ok', $subject->runAs(42, static fn (): string => 'ok'));
+    }
+
+    #[Test]
+    public function userIsRejectedAtExactlyItsEndtime(): void
+    {
+        $subject = $this->createSubject([$this->userRow(uid: 42, endtime: time())]);
+
+        $this->expectException(TechnicalActorException::class);
+        $this->expectExceptionCode(1784000004);
+
+        $subject->runAs(42, static fn (): bool => true);
+    }
+
+    /**
+     * Drivers that return every column as a string must not turn '0' into a
+     * truthy flag — `disable`/`pid` would then reject every user, and `admin`
+     * would grant the bypass on the string '0'.
+     */
+    #[Test]
+    public function numericStringColumnsAreNormalisedToIntegers(): void
+    {
+        $subject = $this->createSubject([[
+            'uid' => 42,
+            'pid' => '0',
+            'username' => 'string_columns',
+            'admin' => '1',
+            'disable' => '0',
+            'starttime' => '0',
+            'endtime' => '0',
+            'usergroup' => '',
+        ]]);
+
+        $subject->runAs(42, static function () use ($subject): void {
+            $actor = $subject->getCurrentActor();
+
+            self::assertInstanceOf(TechnicalActor::class, $actor);
+            self::assertTrue($actor->admin);
+        });
+    }
+
+    /**
+     * The group uids reaching the actor snapshot must be real integers: they
+     * are compared with `array_intersect()` against a secret's group list, and
+     * that comparison is by string value — a '5' that never became 5 would
+     * silently stop matching normalised uids.
+     */
+    #[Test]
+    public function stringGroupUidsAreNormalisedToIntegers(): void
+    {
+        $subject = $this->createSubject(
+            [$this->userRow(uid: 42, usergroup: '5')],
+            [['uid' => '5', 'subgroup' => '']],
+        );
+
+        $subject->runAs(42, static function () use ($subject): void {
+            $actor = $subject->getCurrentActor();
+
+            self::assertInstanceOf(TechnicalActor::class, $actor);
+            self::assertSame([5], $actor->groupIds);
+        });
+    }
+
+    /**
+     * The lookup evaluates the enable columns itself (so each rejection can
+     * carry its own typed exception), which is only sound because it drops
+     * core's restrictions AND filters `deleted = 0` explicitly. Losing either
+     * half turns a deleted user into a usable technical actor.
+     */
+    #[Test]
+    public function userLookupDropsRestrictionsAndExcludesDeletedRowsItself(): void
+    {
+        $restrictions = $this->createMock(DefaultRestrictionContainer::class);
+        $restrictions->expects(self::once())->method('removeAll');
+
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAssociative')->willReturn($this->userRow(uid: 42));
+
+        $parameters = [];
+
+        $connectionPool = $this->createMock(ConnectionPool::class);
+        $connectionPool
+            ->method('getQueryBuilderForTable')
+            ->willReturn($this->createQueryBuilderMock($result, $restrictions, $parameters));
+
+        $subject = new TechnicalActorContext($connectionPool, $this->createGroupResolver([]));
+        $subject->runAs(42, static fn (): bool => true);
+
+        self::assertContains([42, Connection::PARAM_INT], $parameters);
+        self::assertContains(
+            [0, Connection::PARAM_INT],
+            $parameters,
+            'The lookup must constrain deleted = 0 itself',
+        );
+    }
+
     #[Test]
     public function runAsRestoresThePreviousStateWhenTheCallableThrows(): void
     {
@@ -305,19 +432,36 @@ final class TechnicalActorContextTest extends TestCase
         return $reflection->newInstance($eventDispatcher);
     }
 
-    private function createQueryBuilderMock(Result&MockObject $result): QueryBuilder&MockObject
-    {
+    /**
+     * @param list<array{mixed, mixed}> $capturedParameters collects every
+     *                                                      createNamedParameter() call as [value, type]
+     */
+    private function createQueryBuilderMock(
+        Result&MockObject $result,
+        ?DefaultRestrictionContainer $restrictions = null,
+        array &$capturedParameters = [],
+    ): QueryBuilder&MockObject {
         $expressionBuilder = $this->createMock(ExpressionBuilder::class);
         $expressionBuilder->method('eq')->willReturn('field = :value');
         $expressionBuilder->method('in')->willReturn('field IN (:value)');
 
         $queryBuilder = $this->createMock(QueryBuilder::class);
-        $queryBuilder->method('getRestrictions')->willReturn($this->createMock(DefaultRestrictionContainer::class));
+        $queryBuilder
+            ->method('getRestrictions')
+            ->willReturn($restrictions ?? $this->createMock(DefaultRestrictionContainer::class));
         $queryBuilder->method('select')->willReturnSelf();
         $queryBuilder->method('from')->willReturnSelf();
         $queryBuilder->method('where')->willReturnSelf();
         $queryBuilder->method('expr')->willReturn($expressionBuilder);
-        $queryBuilder->method('createNamedParameter')->willReturn(':dcValue1');
+        $queryBuilder
+            ->method('createNamedParameter')
+            ->willReturnCallback(
+                static function (mixed $value, mixed $type = null) use (&$capturedParameters): string {
+                    $capturedParameters[] = [$value, $type];
+
+                    return ':dcValue' . \count($capturedParameters);
+                },
+            );
         $queryBuilder->method('executeQuery')->willReturn($result);
 
         return $queryBuilder;

--- a/infection-security.json5
+++ b/infection-security.json5
@@ -60,18 +60,20 @@
     //   * Deleting or excluding a file/directory from `source` above has the
     //     same effect as lowering the threshold and needs the same sign-off.
     //
-    // MEASUREMENT (2026-07-31, PHP 8.5, Unit+Fuzz):
-    //   909 mutants — 681 killed, 227 escaped, 1 timed out, 0 not covered
-    //   MSI 75.03 %, covered-code MSI 75.03 %, mutation code coverage 100 %
-    //   wall time 50 s at --threads=max
+    // MEASUREMENT (2026-08-02, PHP 8.5, Unit+Fuzz):
+    //   2338 mutants — 2049 killed, 286 escaped, 1 timed out, 0 not covered
+    //   MSI 87.77 %, covered-code MSI 87.77 %, mutation code coverage 100 %
+    //   (previous 2026-07-31 baseline: MSI 75.03 % — raised by a targeted
+    //   assertion-hardening pass over Crypto/Security/Audit)
     //
-    // The thresholds sit ~1 point under the measurement so run-to-run jitter in
-    // timing-sensitive tests cannot fail an unrelated PR, while any real
+    // The thresholds sit ~1.5 points under the measurement so run-to-run jitter
+    // in timing-sensitive tests cannot fail an unrelated PR, while any real
     // regression (a deleted assertion, a weakened test) still trips the gate.
     // Mutation code coverage is already 100 % here: every mutant is reached by a
-    // test, so the 227 escapes are assertion gaps, not coverage gaps — which is
-    // exactly the kind of weakness this gate is meant to hold the line on.
+    // test, so the remaining escapes are assertion gaps, not coverage gaps —
+    // which is exactly the kind of weakness this gate is meant to hold the
+    // line on.
     // ------------------------------------------------------------------------
-    "minMsi": 74,
-    "minCoveredMsi": 74
+    "minMsi": 86,
+    "minCoveredMsi": 86
 }


### PR DESCRIPTION
Raises the security mutation gate (`infection-security.json5`) from MSI 74 to 86 after a targeted assertion-hardening pass over the three security-critical source trees.

## What changed

Test-only (plus the ratchet floor) — no production code touched. 273 previously escaped mutants killed by pinning unasserted semantics:

| Cluster | Escapes before | Test files hardened |
|---|---|---|
| `Audit/AuditLogService` | 131 | AuditLogServiceTest |
| `Crypto/{Transit,File}MasterKeyProvider`, `EncryptionService` | 84 | 3 files |
| `Security/{AccessControlService,TechnicalActorContext,FrontendPlaceholderPolicy}` | 76 | 4 files |
| `Audit/Anchor/{ChainTipAnchorService,AnchorFileReader}` | 64 | 2 files |
| `Audit/{AuditChainAnchorStore,AuditChainRekeyService}` | 51 | 2 files |

## Measurement (2026-08-02, PHP 8.5, Unit+Fuzz, `--threads=max`)

- Before (same scope, current main): 2297 mutants, 559 escaped, **MSI 75.66 %**
- After: 2338 mutants, 2049 killed, 286 escaped, **MSI 87.77 %**, mutation code coverage 100 %
- Ratchet floor raised 74 → 86 (≈1.5 pt jitter margin below the measurement, raise-only policy)

## Verification

- `.Build/bin/phpunit -c Build/phpunit.xml --testsuite Unit,Fuzz` — OK, 4817 tests, 18023 assertions
- `composer ci:test:php:phpstan` — no errors
- `composer ci:cgl` — 0 fixes needed
- `composer ci:test:php:mutation:security` — green against the new floor (87.77 % ≥ 86)
