### PR TITLE
Close unit-coverage gaps and make Codecov reporting honest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
       typo3-versions: '["^13.4","^14.3"]'
       run-functional-tests: true
       upload-coverage: true
+      upload-test-results: true
       coverage-tool: 'xdebug'
       php-extensions: 'intl, mbstring, xml, sodium, json'
     secrets:

--- a/Classes/Http/OAuth/OAuthTokenRequestParams.php
+++ b/Classes/Http/OAuth/OAuthTokenRequestParams.php
@@ -34,6 +34,8 @@ use SensitiveParameter;
  */
 final class OAuthTokenRequestParams
 {
+    private bool $wiped = false;
+
     public function __construct(
         public string $grantType,
         #[SensitiveParameter]
@@ -69,15 +71,21 @@ final class OAuthTokenRequestParams
 
     /**
      * Zeroize every credential field. Idempotent and safe to call multiple
-     * times — subsequent calls on already-empty strings are no-ops.
+     * times — the guard flag makes repeat calls no-ops, which matters on
+     * failure paths: `sodium_memzero()` sets the zval to null after zeroing,
+     * so an unguarded second wipe would raise a SodiumException and replace
+     * the real error.
      *
-     * `sodium_memzero()` overwrites the string buffer in place with NUL
-     * bytes; the property remains a (now-empty) string. PHPStan's stub
-     * marks the by-ref param as nullable so we ignore the spurious
-     * "does not accept null" diagnostics on the three lines below.
+     * PHPStan's stub marks the by-ref param as nullable so we ignore the
+     * spurious "does not accept null" diagnostics on the lines below.
      */
     public function wipeCredentials(): void
     {
+        if ($this->wiped) {
+            return;
+        }
+        $this->wiped = true;
+
         /** @phpstan-ignore assign.propertyType */
         sodium_memzero($this->clientId);
         /** @phpstan-ignore assign.propertyType */

--- a/Tests/Unit/Audit/AuditChainAnchorLoadTest.php
+++ b/Tests/Unit/Audit/AuditChainAnchorLoadTest.php
@@ -1,0 +1,143 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit;
+
+use Netresearch\NrVault\Audit\AuditChainAnchor;
+use Netresearch\NrVault\Audit\AuditChainAnchorLoad;
+use Netresearch\NrVault\Audit\AuditChainAnchorStatus;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+
+/**
+ * The double-read stability rule in `AuditLogService::verifyAnchor()` compares
+ * two loads by their `$raw` bytes, not by their parsed anchors: only the raw
+ * form distinguishes "nothing happened" from "re-sealed to the same tip". That
+ * makes byte-exact pass-through of `$raw` — including the empty-string default
+ * for statuses that carry no anchor — the load's actual contract.
+ */
+#[CoversClass(AuditChainAnchorLoad::class)]
+final class AuditChainAnchorLoadTest extends TestCase
+{
+    #[Test]
+    public function carriesStatusAnchorAndRawBytes(): void
+    {
+        $anchor = new AuditChainAnchor(9, str_repeat('a', 64), 1_750_000_000);
+        $raw = '{"uid":9,"entryHash":"' . str_repeat('a', 64) . '","tstamp":1750000000}';
+
+        $load = new AuditChainAnchorLoad(AuditChainAnchorStatus::Ok, $anchor, $raw);
+
+        self::assertSame(AuditChainAnchorStatus::Ok, $load->status);
+        self::assertSame($anchor, $load->anchor);
+        self::assertSame($raw, $load->raw);
+    }
+
+    /**
+     * The statuses that mean "there is nothing to compare against" must be
+     * constructible from the status alone.
+     */
+    #[Test]
+    public function anchorAndRawAreOptionalSoAStatusOnlyLoadIsValid(): void
+    {
+        $load = new AuditChainAnchorLoad(AuditChainAnchorStatus::Unanchored);
+
+        self::assertSame(AuditChainAnchorStatus::Unanchored, $load->status);
+        self::assertNull($load->anchor);
+        self::assertSame('', $load->raw);
+    }
+
+    /**
+     * `Unreadable` is the case where the bytes exist but do not parse or do not
+     * verify — the load must still surface them, or the diagnostics have nothing
+     * to report.
+     */
+    #[Test]
+    public function keepsRawBytesEvenWhenNoAnchorCouldBeParsed(): void
+    {
+        $load = new AuditChainAnchorLoad(AuditChainAnchorStatus::Unreadable, null, 'not-json{');
+
+        self::assertNull($load->anchor);
+        self::assertSame('not-json{', $load->raw);
+    }
+
+    /**
+     * Byte-wise pass-through: no trimming, no normalisation. Two re-seals that
+     * differ only in whitespace or key order must remain distinguishable.
+     */
+    #[Test]
+    public function rawIsStoredByteForByte(): void
+    {
+        $raw = "  {\"uid\": 9,\n \"entryHash\": \"ff\"}\t";
+
+        self::assertSame($raw, (new AuditChainAnchorLoad(AuditChainAnchorStatus::Ok, null, $raw))->raw);
+    }
+
+    /**
+     * Two loads of the same anchor value with different stored bytes stay
+     * distinguishable — that is precisely what the double-read rule relies on.
+     */
+    #[Test]
+    public function equalAnchorValuesWithDifferentBytesRemainDistinguishable(): void
+    {
+        $first = new AuditChainAnchorLoad(
+            AuditChainAnchorStatus::Ok,
+            new AuditChainAnchor(9, 'ff', 1_750_000_000),
+            '{"uid":9,"entryHash":"ff","tstamp":1750000000}',
+        );
+        $second = new AuditChainAnchorLoad(
+            AuditChainAnchorStatus::Ok,
+            new AuditChainAnchor(9, 'ff', 1_750_000_000),
+            '{"entryHash":"ff","tstamp":1750000000,"uid":9}',
+        );
+
+        self::assertEquals($first->anchor, $second->anchor);
+        self::assertNotSame($first->raw, $second->raw);
+    }
+
+    #[Test]
+    #[DataProvider('everyStatusProvider')]
+    public function acceptsEveryAnchorStatus(AuditChainAnchorStatus $status): void
+    {
+        self::assertSame($status, (new AuditChainAnchorLoad($status))->status);
+    }
+
+    /**
+     * Immutability keeps a load usable as the "before" side of the double read:
+     * the second read cannot overwrite the first one's bytes, so the comparison
+     * still describes two distinct observations.
+     */
+    #[Test]
+    public function everyFieldIsReadonlyAndTheClassIsFinal(): void
+    {
+        $reflection = new ReflectionClass(AuditChainAnchorLoad::class);
+
+        self::assertTrue($reflection->isReadOnly(), 'AuditChainAnchorLoad must stay a readonly class');
+        self::assertTrue($reflection->isFinal(), 'AuditChainAnchorLoad must not be subclassable');
+
+        foreach (['status', 'anchor', 'raw'] as $property) {
+            self::assertTrue(
+                $reflection->getProperty($property)->isReadOnly(),
+                \sprintf('%s must be readonly', $property),
+            );
+        }
+    }
+
+    /**
+     * @return iterable<string, array{AuditChainAnchorStatus}>
+     */
+    public static function everyStatusProvider(): iterable
+    {
+        foreach (AuditChainAnchorStatus::cases() as $status) {
+            yield $status->value => [$status];
+        }
+    }
+}

--- a/Tests/Unit/Domain/Dto/UsageBarTest.php
+++ b/Tests/Unit/Domain/Dto/UsageBarTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Domain\Dto;
+
+use Netresearch\NrVault\Domain\Dto\UsageBar;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * One bar of the analytics distribution chart. The DTO computes nothing — the
+ * percentage is worked out by the producing service — so what is worth pinning
+ * is that the three values reach the template unchanged and in their declared
+ * types, since the Fluid layer renders `percent` straight into a style attribute.
+ */
+#[CoversClass(UsageBar::class)]
+final class UsageBarTest extends TestCase
+{
+    #[Test]
+    public function exposesConstructorData(): void
+    {
+        $bar = new UsageBar(label: 'local', value: 42, percent: 66);
+
+        self::assertSame('local', $bar->label);
+        self::assertSame(42, $bar->value);
+        self::assertSame(66, $bar->percent);
+    }
+
+    /**
+     * An empty distribution is a legitimate state (a fresh installation), not an
+     * error the DTO has to reject — the chart just renders a zero-width bar.
+     */
+    #[Test]
+    public function acceptsAZeroBar(): void
+    {
+        $bar = new UsageBar(label: '', value: 0, percent: 0);
+
+        self::assertSame('', $bar->label);
+        self::assertSame(0, $bar->value);
+        self::assertSame(0, $bar->percent);
+    }
+}

--- a/Tests/Unit/Domain/Dto/VaultUsageStatsTest.php
+++ b/Tests/Unit/Domain/Dto/VaultUsageStatsTest.php
@@ -1,0 +1,126 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Domain\Dto;
+
+use Netresearch\NrVault\Domain\Dto\UsageBar;
+use Netresearch\NrVault\Domain\Dto\VaultUsageStats;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The analytics dashboard reads eleven separate counters off this object, all of
+ * them `int`, several of them adjacent in the constructor signature — `expired`,
+ * `frontendAccessible` and `neverRotated` sit next to each other and would swap
+ * silently. Named arguments plus a per-property assertion make that swap a test
+ * failure rather than a wrong KPI tile.
+ */
+#[CoversClass(VaultUsageStats::class)]
+final class VaultUsageStatsTest extends TestCase
+{
+    #[Test]
+    public function exposesEveryCounterUnderItsOwnName(): void
+    {
+        $stats = new VaultUsageStats(
+            total: 30,
+            active: 27,
+            disabled: 3,
+            expired: 4,
+            frontendAccessible: 5,
+            neverRotated: 6,
+            automatedReads: 700,
+            manualReveals: 8,
+            windowDays: 30,
+            byAdapter: [],
+            byContext: [],
+        );
+
+        self::assertSame(30, $stats->total);
+        self::assertSame(27, $stats->active);
+        self::assertSame(3, $stats->disabled);
+        self::assertSame(4, $stats->expired);
+        self::assertSame(5, $stats->frontendAccessible);
+        self::assertSame(6, $stats->neverRotated);
+        self::assertSame(700, $stats->automatedReads);
+        self::assertSame(8, $stats->manualReveals);
+        self::assertSame(30, $stats->windowDays);
+    }
+
+    /**
+     * The two distributions are separate lists and must stay that way — the
+     * dashboard renders them as two charts with different labels, so crossing
+     * them would put context names under the adapter heading.
+     */
+    #[Test]
+    public function keepsTheAdapterAndContextDistributionsApart(): void
+    {
+        $byAdapter = [new UsageBar(label: 'local', value: 20, percent: 67)];
+        $byContext = [
+            new UsageBar(label: 'payment', value: 18, percent: 60),
+            new UsageBar(label: '', value: 12, percent: 40),
+        ];
+
+        $stats = $this->statsWith($byAdapter, $byContext);
+
+        self::assertSame($byAdapter, $stats->byAdapter);
+        self::assertSame($byContext, $stats->byContext);
+        self::assertSame('local', $stats->byAdapter[0]->label);
+        self::assertCount(2, $stats->byContext);
+    }
+
+    /**
+     * A vault with no secrets yet: every counter zero and both distributions
+     * empty. The dashboard renders this on a fresh installation, so it must be a
+     * constructible state rather than something the DTO rejects.
+     */
+    #[Test]
+    public function acceptsAnEmptyVault(): void
+    {
+        $stats = new VaultUsageStats(
+            total: 0,
+            active: 0,
+            disabled: 0,
+            expired: 0,
+            frontendAccessible: 0,
+            neverRotated: 0,
+            automatedReads: 0,
+            manualReveals: 0,
+            windowDays: 7,
+            byAdapter: [],
+            byContext: [],
+        );
+
+        self::assertSame(0, $stats->total);
+        self::assertSame(7, $stats->windowDays);
+        self::assertSame([], $stats->byAdapter);
+        self::assertSame([], $stats->byContext);
+    }
+
+    /**
+     * @param list<UsageBar> $byAdapter
+     * @param list<UsageBar> $byContext
+     */
+    private function statsWith(array $byAdapter, array $byContext): VaultUsageStats
+    {
+        return new VaultUsageStats(
+            total: 30,
+            active: 30,
+            disabled: 0,
+            expired: 0,
+            frontendAccessible: 0,
+            neverRotated: 0,
+            automatedReads: 0,
+            manualReveals: 0,
+            windowDays: 30,
+            byAdapter: $byAdapter,
+            byContext: $byContext,
+        );
+    }
+}

--- a/Tests/Unit/Event/AuditIntegrityAlertEventTest.php
+++ b/Tests/Unit/Event/AuditIntegrityAlertEventTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Event;
+
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Event\AuditIntegrityAlertEvent;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use ReflectionMethod;
+
+/**
+ * The event is what a SIEM / paging listener subscribes to. Two things matter to
+ * such a listener: it gets the alert unchanged (it forwards the payload
+ * verbatim), and the two convenience accessors agree with the alert they are
+ * derived from — a listener that routes on `isTamperEvidence()` must not reach a
+ * different verdict than one that reads `getAlert()->reason` itself.
+ */
+#[CoversClass(AuditIntegrityAlertEvent::class)]
+final class AuditIntegrityAlertEventTest extends TestCase
+{
+    #[Test]
+    public function getAlertReturnsTheVeryInstanceItWasConstructedWith(): void
+    {
+        $alert = new AuditIntegrityAlert(
+            AuditIntegrityReason::HashMismatch,
+            'row 7 hashes differently',
+            1_750_000_000,
+            ['affectedRows' => 1],
+        );
+
+        $event = new AuditIntegrityAlertEvent($alert);
+
+        self::assertSame($alert, $event->getAlert());
+    }
+
+    /**
+     * A listener switching on the reason code must see exactly the alert's code,
+     * not a re-derived one.
+     */
+    #[Test]
+    #[DataProvider('everyReasonProvider')]
+    public function getReasonMirrorsTheAlertsReason(AuditIntegrityReason $reason): void
+    {
+        $event = new AuditIntegrityAlertEvent(AuditIntegrityAlert::create($reason, 'detail'));
+
+        self::assertSame($reason, $event->getReason());
+    }
+
+    /**
+     * The discriminator between "page someone" and "log it". It is delegated, so
+     * the event can never disagree with the enum about what counts as tampering.
+     */
+    #[Test]
+    #[DataProvider('everyReasonProvider')]
+    public function isTamperEvidenceDelegatesToTheReason(AuditIntegrityReason $reason): void
+    {
+        $event = new AuditIntegrityAlertEvent(AuditIntegrityAlert::create($reason, 'detail'));
+
+        self::assertSame($reason->isTamperEvidence(), $event->isTamperEvidence());
+    }
+
+    #[Test]
+    public function tamperCodesAreFlaggedAndDeliveryProblemsAreNot(): void
+    {
+        $tamper = new AuditIntegrityAlertEvent(
+            AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'chain shrank from 9 to 2'),
+        );
+        $delivery = new AuditIntegrityAlertEvent(
+            AuditIntegrityAlert::create(AuditIntegrityReason::SinkFailure, 'webhook refused'),
+        );
+
+        self::assertTrue($tamper->isTamperEvidence());
+        self::assertFalse($delivery->isTamperEvidence());
+    }
+
+    /**
+     * The event is informational, not vetoable: it exposes no mutator and no
+     * cancellation flag, so a listener cannot alter what the dispatch site
+     * already committed.
+     */
+    #[Test]
+    public function exposesOnlyReadAccessors(): void
+    {
+        $methods = array_map(
+            static fn (ReflectionMethod $method): string => $method->getName(),
+            (new ReflectionClass(AuditIntegrityAlertEvent::class))->getMethods(ReflectionMethod::IS_PUBLIC),
+        );
+        sort($methods);
+
+        self::assertSame(
+            ['__construct', 'getAlert', 'getReason', 'isTamperEvidence'],
+            $methods,
+        );
+    }
+
+    /**
+     * @return iterable<string, array{AuditIntegrityReason}>
+     */
+    public static function everyReasonProvider(): iterable
+    {
+        foreach (AuditIntegrityReason::cases() as $reason) {
+            yield $reason->value => [$reason];
+        }
+    }
+}

--- a/Tests/Unit/Event/BreakGlassActivatedEventTest.php
+++ b/Tests/Unit/Event/BreakGlassActivatedEventTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Event;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Netresearch\NrVault\Event\BreakGlassActivatedEvent;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+
+/**
+ * The event carries the four facts an out-of-band alert needs: who opened the
+ * window, why, and when it closes by itself. All four have to survive the
+ * hand-off verbatim — a paging listener quotes them into an incident ticket, and
+ * the justification is the operator's own text, not something to be normalised.
+ */
+#[CoversClass(BreakGlassActivatedEvent::class)]
+final class BreakGlassActivatedEventTest extends TestCase
+{
+    #[Test]
+    public function everyConstructorArgumentIsReadableUnchanged(): void
+    {
+        $expiresAt = new DateTimeImmutable('2026-08-02 14:30:00', new DateTimeZone('UTC'));
+
+        $event = new BreakGlassActivatedEvent(42, 'incident.responder', 'INC-4711 payment outage', $expiresAt);
+
+        self::assertSame(42, $event->getActorUid());
+        self::assertSame('incident.responder', $event->getActorUsername());
+        self::assertSame('INC-4711 payment outage', $event->getReason());
+        self::assertSame($expiresAt, $event->getExpiresAt());
+    }
+
+    /**
+     * The expiry is the one field a listener does arithmetic on (window length,
+     * "still open?" checks), so its instant and timezone must arrive untouched.
+     */
+    #[Test]
+    public function expiryKeepsItsInstantAndTimezone(): void
+    {
+        $expiresAt = new DateTimeImmutable('2026-08-02 16:45:00', new DateTimeZone('Europe/Berlin'));
+
+        $event = new BreakGlassActivatedEvent(1, 'admin', 'reason', $expiresAt);
+
+        self::assertSame($expiresAt->getTimestamp(), $event->getExpiresAt()->getTimestamp());
+        self::assertSame('Europe/Berlin', $event->getExpiresAt()->getTimezone()->getName());
+    }
+
+    /**
+     * The justification is free-form operator input and is reproduced byte for
+     * byte — no trimming, no case folding, no length clamp.
+     */
+    #[Test]
+    public function reasonIsCarriedVerbatimIncludingWhitespaceAndUnicode(): void
+    {
+        $reason = "  Schlüsselverlust — Notzugriff\n(zweite Zeile)  ";
+
+        $event = new BreakGlassActivatedEvent(7, 'ops', $reason, new DateTimeImmutable('@1750000000'));
+
+        self::assertSame($reason, $event->getReason());
+    }
+
+    /**
+     * Nothing is validated at construction: the service decides what a valid
+     * window is, the event only reports what it decided. A zero uid (CLI /
+     * technical actor) must not be rejected here.
+     */
+    #[Test]
+    public function acceptsAZeroActorUidWithoutComplaint(): void
+    {
+        $event = new BreakGlassActivatedEvent(0, '_cli_', 'scheduled drill', new DateTimeImmutable('@0'));
+
+        self::assertSame(0, $event->getActorUid());
+        self::assertSame('_cli_', $event->getActorUsername());
+    }
+
+    /**
+     * Readonly: a listener cannot rewrite the announcement before the next
+     * listener sees it.
+     */
+    #[Test]
+    public function isReadonlyAndFinal(): void
+    {
+        $reflection = new ReflectionClass(BreakGlassActivatedEvent::class);
+
+        self::assertTrue($reflection->isReadOnly());
+        self::assertTrue($reflection->isFinal());
+    }
+}

--- a/Tests/Unit/Event/BreakGlassDeactivatedEventTest.php
+++ b/Tests/Unit/Event/BreakGlassDeactivatedEventTest.php
@@ -1,0 +1,96 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Event;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Netresearch\NrVault\Event\BreakGlassDeactivatedEvent;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+
+/**
+ * Closing a window early is itself an auditable act, so the event carries the
+ * same four facts as the activation — including `expiresAt`, which here means
+ * "when it WOULD have lapsed". That distinction only holds if the value is
+ * passed through unchanged rather than replaced by the closing time.
+ */
+#[CoversClass(BreakGlassDeactivatedEvent::class)]
+final class BreakGlassDeactivatedEventTest extends TestCase
+{
+    #[Test]
+    public function everyConstructorArgumentIsReadableUnchanged(): void
+    {
+        $expiresAt = new DateTimeImmutable('2026-08-02 14:30:00', new DateTimeZone('UTC'));
+
+        $event = new BreakGlassDeactivatedEvent(42, 'incident.responder', 'incident closed', $expiresAt);
+
+        self::assertSame(42, $event->getActorUid());
+        self::assertSame('incident.responder', $event->getActorUsername());
+        self::assertSame('incident closed', $event->getReason());
+        self::assertSame($expiresAt, $event->getExpiresAt());
+    }
+
+    /**
+     * The expiry is the window's original deadline, not "now" — a listener
+     * subtracting it from the current time learns how much of the window was
+     * given back.
+     */
+    #[Test]
+    public function expiryMayLieInTheFutureBecauseTheWindowWasClosedEarly(): void
+    {
+        $expiresAt = new DateTimeImmutable('+30 minutes');
+
+        $event = new BreakGlassDeactivatedEvent(3, 'admin', 'no longer needed', $expiresAt);
+
+        self::assertGreaterThan(time(), $event->getExpiresAt()->getTimestamp());
+        self::assertSame($expiresAt->getTimestamp(), $event->getExpiresAt()->getTimestamp());
+    }
+
+    #[Test]
+    public function expiryKeepsItsInstantAndTimezone(): void
+    {
+        $expiresAt = new DateTimeImmutable('2026-08-02 16:45:00', new DateTimeZone('Europe/Berlin'));
+
+        $event = new BreakGlassDeactivatedEvent(1, 'admin', 'reason', $expiresAt);
+
+        self::assertSame($expiresAt->getTimestamp(), $event->getExpiresAt()->getTimestamp());
+        self::assertSame('Europe/Berlin', $event->getExpiresAt()->getTimezone()->getName());
+    }
+
+    #[Test]
+    public function reasonIsCarriedVerbatimIncludingWhitespaceAndUnicode(): void
+    {
+        $reason = "  Notzugriff beendet — Ursache behoben\n(zweite Zeile)  ";
+
+        $event = new BreakGlassDeactivatedEvent(7, 'ops', $reason, new DateTimeImmutable('@1750000000'));
+
+        self::assertSame($reason, $event->getReason());
+    }
+
+    #[Test]
+    public function acceptsAZeroActorUidWithoutComplaint(): void
+    {
+        $event = new BreakGlassDeactivatedEvent(0, '_cli_', 'drill over', new DateTimeImmutable('@0'));
+
+        self::assertSame(0, $event->getActorUid());
+        self::assertSame('_cli_', $event->getActorUsername());
+    }
+
+    #[Test]
+    public function isReadonlyAndFinal(): void
+    {
+        $reflection = new ReflectionClass(BreakGlassDeactivatedEvent::class);
+
+        self::assertTrue($reflection->isReadOnly());
+        self::assertTrue($reflection->isFinal());
+    }
+}

--- a/Tests/Unit/EventListener/AuditIntegrityAlertSinkListenerTest.php
+++ b/Tests/Unit/EventListener/AuditIntegrityAlertSinkListenerTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\EventListener;
+
+use Netresearch\NrVault\Audit\AuditIntegrityAlert;
+use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Event\AuditIntegrityAlertEvent;
+use Netresearch\NrVault\EventListener\AuditIntegrityAlertSinkListener;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+use TYPO3\CMS\Core\Attribute\AsEventListener;
+
+/**
+ * The listener is the default wiring that turns an integrity finding into a SIEM
+ * alert. It must forward the alert unchanged and unconditionally: filtering by
+ * reason code, or by whether the finding is tamper evidence, is the collector's
+ * job — a listener that dropped `SINK_FAILURE` would hide exactly the outage
+ * that makes the other codes undetectable.
+ */
+#[CoversClass(AuditIntegrityAlertSinkListener::class)]
+final class AuditIntegrityAlertSinkListenerTest extends TestCase
+{
+    #[Test]
+    public function forwardsTheAlertInstanceUnchangedToTheRegistry(): void
+    {
+        $alert = new AuditIntegrityAlert(
+            AuditIntegrityReason::HashMismatch,
+            'row 7 hashes differently',
+            1_750_000_000,
+            ['affectedRows' => 1],
+        );
+
+        $registry = $this->createMock(AuditSinkRegistryInterface::class);
+        $registry->expects(self::once())
+            ->method('dispatchAlert')
+            ->with(self::identicalTo($alert))
+            ->willReturn(2);
+
+        (new AuditIntegrityAlertSinkListener($registry))(new AuditIntegrityAlertEvent($alert));
+    }
+
+    /**
+     * Every reason code is forwarded — availability findings included.
+     */
+    #[Test]
+    #[DataProvider('everyReasonProvider')]
+    public function forwardsRegardlessOfTheReasonCode(AuditIntegrityReason $reason): void
+    {
+        $alert = AuditIntegrityAlert::create($reason, 'detail');
+
+        $registry = $this->createMock(AuditSinkRegistryInterface::class);
+        $registry->expects(self::once())
+            ->method('dispatchAlert')
+            ->with(self::identicalTo($alert))
+            ->willReturn(1);
+
+        (new AuditIntegrityAlertSinkListener($registry))(new AuditIntegrityAlertEvent($alert));
+    }
+
+    /**
+     * A dispatch that reached no sink is not an error here: the registry decides
+     * what a delivery failure means and contains it. The listener must not turn
+     * a zero into an exception inside the audited operation's write path.
+     */
+    #[Test]
+    public function acceptsAZeroAcceptedCountWithoutThrowing(): void
+    {
+        $registry = $this->createMock(AuditSinkRegistryInterface::class);
+        $registry->expects(self::once())->method('dispatchAlert')->willReturn(0);
+
+        $listener = new AuditIntegrityAlertSinkListener($registry);
+        $listener(new AuditIntegrityAlertEvent(
+            AuditIntegrityAlert::create(AuditIntegrityReason::SinkFailure, 'webhook refused'),
+        ));
+    }
+
+    /**
+     * Only `dispatchAlert()` is used: the listener must not consult
+     * `hasExternalAuditSink()` and skip on a default installation, because the
+     * registry already skips disabled sinks itself.
+     */
+    #[Test]
+    public function touchesNoOtherRegistryMethod(): void
+    {
+        $registry = $this->createMock(AuditSinkRegistryInterface::class);
+        $registry->expects(self::once())->method('dispatchAlert')->willReturn(1);
+        $registry->expects(self::never())->method('hasExternalAuditSink');
+        $registry->expects(self::never())->method('dispatch');
+        $registry->expects(self::never())->method('dispatchAnchor');
+        $registry->expects(self::never())->method('getEnabledSinkIdentifiers');
+
+        (new AuditIntegrityAlertSinkListener($registry))(new AuditIntegrityAlertEvent(
+            AuditIntegrityAlert::create(AuditIntegrityReason::TableReset, 'chain shrank'),
+        ));
+    }
+
+    /**
+     * One invocation forwards exactly once — no retry loop that would multiply
+     * an alert storm across the collector.
+     */
+    #[Test]
+    public function forwardsOncePerInvocation(): void
+    {
+        $registry = $this->createMock(AuditSinkRegistryInterface::class);
+        $registry->expects(self::exactly(3))->method('dispatchAlert')->willReturn(1);
+
+        $listener = new AuditIntegrityAlertSinkListener($registry);
+        foreach ([AuditIntegrityReason::UidGap, AuditIntegrityReason::EpochDowngrade, AuditIntegrityReason::BreakGlass] as $reason) {
+            $listener(new AuditIntegrityAlertEvent(AuditIntegrityAlert::create($reason, 'detail')));
+        }
+    }
+
+    /**
+     * The registration is what makes this "on by default"; the identifier is the
+     * handle an integrator uses to override or remove the listener, so it is API.
+     */
+    #[Test]
+    public function isRegisteredAsAnEventListenerUnderItsPublishedIdentifier(): void
+    {
+        $attributes = (new ReflectionClass(AuditIntegrityAlertSinkListener::class))
+            ->getAttributes(AsEventListener::class);
+
+        self::assertCount(1, $attributes);
+        self::assertSame(
+            'nr-vault/audit-integrity-alert-sinks',
+            $attributes[0]->newInstance()->identifier,
+        );
+    }
+
+    /**
+     * @return iterable<string, array{AuditIntegrityReason}>
+     */
+    public static function everyReasonProvider(): iterable
+    {
+        foreach (AuditIntegrityReason::cases() as $reason) {
+            yield $reason->value => [$reason];
+        }
+    }
+}

--- a/Tests/Unit/Hook/PendingSecretExtractorTest.php
+++ b/Tests/Unit/Hook/PendingSecretExtractorTest.php
@@ -1,0 +1,321 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Hook;
+
+use Netresearch\NrVault\Hook\Dto\PendingSecret;
+use Netresearch\NrVault\Hook\PendingSecretExtractor;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use stdClass;
+
+/**
+ * The extractor decides — for every vault field save — whether a secret is
+ * created, rotated, deleted or left untouched. Two of those four outcomes are
+ * destructive, so the tests below are written around the question "what must
+ * NOT happen": a plain re-save must never wipe a stored secret (issue #223),
+ * and a rotation must never be mistaken for a fresh store (which would orphan
+ * the previous identifier).
+ */
+#[CoversClass(PendingSecretExtractor::class)]
+final class PendingSecretExtractorTest extends TestCase
+{
+    private const UUID_V7_PATTERN = '/^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i';
+
+    private const EXISTING_UUID = '01937b6e-4b6c-7abc-8def-0123456789ab';
+
+    private const EXISTING_CHECKSUM = 'checksum-of-the-stored-secret';
+
+    private PendingSecretExtractor $subject;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->subject = new PendingSecretExtractor();
+    }
+
+    /**
+     * A bare scalar carries no identifier and no checksum, so it can only ever
+     * describe a brand-new secret.
+     */
+    #[Test]
+    public function scalarValueBecomesANewSecretWithAGeneratedIdentifier(): void
+    {
+        $plaintext = $this->fakeSecret();
+
+        $pending = $this->subject->extract($plaintext);
+
+        self::assertInstanceOf(PendingSecret::class, $pending);
+        self::assertSame($plaintext, $pending->value);
+        self::assertTrue($pending->isNew);
+        self::assertSame('', $pending->originalChecksum);
+        self::assertMatchesRegularExpression(self::UUID_V7_PATTERN, $pending->identifier);
+    }
+
+    #[Test]
+    public function everyNewSecretGetsItsOwnIdentifier(): void
+    {
+        $first = $this->subject->extract($this->fakeSecret());
+        $second = $this->subject->extract($this->fakeSecret());
+
+        self::assertInstanceOf(PendingSecret::class, $first);
+        self::assertInstanceOf(PendingSecret::class, $second);
+        self::assertNotSame(
+            $first->identifier,
+            $second->identifier,
+            'Reusing an identifier would overwrite an unrelated secret',
+        );
+    }
+
+    /**
+     * Identifier + checksum together mean "there is a stored secret and the
+     * form still knows it": the new plaintext rotates it in place instead of
+     * creating a second entry and orphaning the old one.
+     */
+    #[Test]
+    public function valueWithIdentifierAndChecksumRotatesTheExistingSecret(): void
+    {
+        $plaintext = $this->fakeSecret();
+
+        $pending = $this->subject->extract([
+            'value' => $plaintext,
+            '_vault_identifier' => self::EXISTING_UUID,
+            '_vault_checksum' => self::EXISTING_CHECKSUM,
+        ]);
+
+        self::assertInstanceOf(PendingSecret::class, $pending);
+        self::assertSame($plaintext, $pending->value);
+        self::assertFalse($pending->isNew);
+        self::assertSame(self::EXISTING_UUID, $pending->identifier);
+        self::assertSame(self::EXISTING_CHECKSUM, $pending->originalChecksum);
+    }
+
+    /**
+     * A blanked checksum is the clear control's signal. Combined with a new
+     * plaintext it means "replace what was there", which is handled as a fresh
+     * store under a fresh identifier rather than a rotation of the old one.
+     */
+    #[Test]
+    public function valueWithIdentifierButBlankedChecksumStoresUnderAFreshIdentifier(): void
+    {
+        $pending = $this->subject->extract([
+            'value' => $this->fakeSecret(),
+            '_vault_identifier' => self::EXISTING_UUID,
+            '_vault_checksum' => '',
+        ]);
+
+        self::assertInstanceOf(PendingSecret::class, $pending);
+        self::assertTrue($pending->isNew);
+        self::assertNotSame(self::EXISTING_UUID, $pending->identifier);
+        self::assertMatchesRegularExpression(self::UUID_V7_PATTERN, $pending->identifier);
+    }
+
+    /**
+     * Issue #223: the plaintext is never rendered back into the edit form, so
+     * an untouched re-save arrives with an empty value. The surviving checksum
+     * is what distinguishes it from an explicit clear — mis-reading it would
+     * silently destroy the stored secret on every unrelated record save.
+     */
+    #[Test]
+    public function untouchedResaveKeepsTheStoredSecret(): void
+    {
+        $pending = $this->subject->extract([
+            'value' => '',
+            '_vault_identifier' => self::EXISTING_UUID,
+            '_vault_checksum' => self::EXISTING_CHECKSUM,
+        ]);
+
+        self::assertNull($pending, 'An untouched re-save must not produce any vault operation');
+    }
+
+    /**
+     * Checksum blanked while the identifier survives: the user pressed clear,
+     * so the stored secret is deleted. An empty-value pending IS the delete
+     * instruction, hence the identifier must be carried through.
+     */
+    #[Test]
+    public function clearedFieldRequestsDeletionOfTheStoredSecret(): void
+    {
+        $pending = $this->subject->extract([
+            'value' => '',
+            '_vault_identifier' => self::EXISTING_UUID,
+            '_vault_checksum' => '',
+        ]);
+
+        self::assertInstanceOf(PendingSecret::class, $pending);
+        self::assertSame('', $pending->value);
+        self::assertSame(self::EXISTING_UUID, $pending->identifier);
+        self::assertFalse($pending->isNew);
+        self::assertSame('', $pending->originalChecksum);
+    }
+
+    #[Test]
+    public function emptyFieldThatNeverHeldASecretIsANoOp(): void
+    {
+        self::assertNull($this->subject->extract(''));
+        self::assertNull($this->subject->extract([
+            'value' => '',
+            '_vault_identifier' => '',
+            '_vault_checksum' => '',
+        ]));
+    }
+
+    /**
+     * The FormEngine element submits `value`, but a plain TCA input arrives as
+     * a positional array. Both shapes must reach the same decision.
+     */
+    #[Test]
+    public function positionalArrayValueIsReadFromIndexZero(): void
+    {
+        $plaintext = $this->fakeSecret();
+
+        $pending = $this->subject->extract([$plaintext]);
+
+        self::assertInstanceOf(PendingSecret::class, $pending);
+        self::assertSame($plaintext, $pending->value);
+    }
+
+    #[Test]
+    public function namedValueKeyWinsOverThePositionalFallback(): void
+    {
+        $named = $this->fakeSecret();
+
+        $pending = $this->subject->extract(['value' => $named, 0 => 'positional-decoy']);
+
+        self::assertInstanceOf(PendingSecret::class, $pending);
+        self::assertSame($named, $pending->value);
+    }
+
+    /**
+     * `'0'` and `0` are falsy but perfectly valid secrets — a truthiness check
+     * here would drop the value and, worse, be read as an explicit clear.
+     */
+    #[DataProvider('falsyButRealValueProvider')]
+    #[Test]
+    public function falsyScalarIsTreatedAsARealSecret(mixed $value, string $expected): void
+    {
+        $pending = $this->subject->extract($value);
+
+        self::assertInstanceOf(PendingSecret::class, $pending);
+        self::assertSame($expected, $pending->value);
+        self::assertTrue($pending->isNew);
+    }
+
+    /**
+     * @return iterable<string, array{0: mixed, 1: string}>
+     */
+    public static function falsyButRealValueProvider(): iterable
+    {
+        yield 'string zero' => ['0', '0'];
+        yield 'integer zero' => [0, '0'];
+        yield 'string zero in array shape' => [['value' => '0'], '0'];
+    }
+
+    #[Test]
+    public function integerValueIsNormalisedToItsStringForm(): void
+    {
+        $pending = $this->subject->extract(4711);
+
+        self::assertInstanceOf(PendingSecret::class, $pending);
+        self::assertSame('4711', $pending->value);
+    }
+
+    /**
+     * Anything the extractor cannot faithfully render as a string is discarded
+     * rather than coerced — a stringified object or a `true` would otherwise be
+     * stored as the secret.
+     */
+    #[DataProvider('unusableScalarProvider')]
+    #[Test]
+    public function valueOfAnUnsupportedTypeIsTreatedAsEmpty(mixed $value): void
+    {
+        self::assertNull($this->subject->extract($value));
+    }
+
+    /**
+     * @return iterable<string, array{0: mixed}>
+     */
+    public static function unusableScalarProvider(): iterable
+    {
+        yield 'null' => [null];
+        yield 'boolean true' => [true];
+        yield 'boolean false' => [false];
+        yield 'float' => [1.5];
+        yield 'object' => [new stdClass()];
+    }
+
+    /**
+     * A nested array in the value slot must not become a pending secret, and —
+     * because it collapses to the empty value with no checksum and no
+     * identifier — it must not trigger a delete either.
+     */
+    #[Test]
+    public function nestedArrayValueYieldsNoOperation(): void
+    {
+        self::assertNull($this->subject->extract(['value' => ['nested']]));
+    }
+
+    /**
+     * Identifier and checksum arrive from the request. A non-string there must
+     * degrade to "absent" rather than being coerced: a coerced identifier would
+     * address the wrong vault entry.
+     */
+    #[DataProvider('nonStringMetadataProvider')]
+    #[Test]
+    public function nonStringIdentifierOrChecksumIsIgnored(mixed $identifier, mixed $checksum): void
+    {
+        $pending = $this->subject->extract([
+            'value' => $this->fakeSecret(),
+            '_vault_identifier' => $identifier,
+            '_vault_checksum' => $checksum,
+        ]);
+
+        self::assertInstanceOf(PendingSecret::class, $pending);
+        self::assertTrue($pending->isNew, 'Unusable metadata must not be read as "an existing secret"');
+        self::assertMatchesRegularExpression(self::UUID_V7_PATTERN, $pending->identifier);
+        self::assertSame('', $pending->originalChecksum);
+    }
+
+    /**
+     * @return iterable<string, array{0: mixed, 1: mixed}>
+     */
+    public static function nonStringMetadataProvider(): iterable
+    {
+        yield 'integer identifier' => [42, self::EXISTING_CHECKSUM];
+        yield 'array identifier' => [[self::EXISTING_UUID], self::EXISTING_CHECKSUM];
+        yield 'integer checksum' => [self::EXISTING_UUID, 42];
+        yield 'null checksum' => [self::EXISTING_UUID, null];
+    }
+
+    /**
+     * A non-string identifier on an otherwise-empty submission collapses to
+     * "no identifier", so nothing is deleted — the extractor never guesses
+     * which entry to remove.
+     */
+    #[Test]
+    public function emptySubmissionWithUnusableIdentifierDeletesNothing(): void
+    {
+        self::assertNull($this->subject->extract([
+            'value' => '',
+            '_vault_identifier' => 42,
+            '_vault_checksum' => '',
+        ]));
+    }
+
+    /**
+     * A clearly synthetic, runtime-generated stand-in for secret material.
+     */
+    private function fakeSecret(): string
+    {
+        return 'FAKE-TEST-SECRET-' . bin2hex(random_bytes(8));
+    }
+}

--- a/Tests/Unit/Hook/PendingSecretPersisterTest.php
+++ b/Tests/Unit/Hook/PendingSecretPersisterTest.php
@@ -1,0 +1,380 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Hook;
+
+use Error;
+use Exception;
+use Netresearch\NrVault\Exception\VaultException;
+use Netresearch\NrVault\Hook\Dto\PendingSecret;
+use Netresearch\NrVault\Hook\PendingSecretPersister;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use ReflectionProperty;
+use RuntimeException;
+use Throwable;
+use TYPO3\CMS\Core\Messaging\FlashMessage;
+use TYPO3\CMS\Core\Messaging\FlashMessageQueue;
+use TYPO3\CMS\Core\Messaging\FlashMessageService;
+use TYPO3\CMS\Core\Type\ContextualFeedbackSeverity;
+
+/**
+ * The persister is the last decision point before a secret is written or
+ * removed. The tests assert which vault call each pending shape maps to (a
+ * mis-dispatch either loses the audit trail of a rotation or deletes an entry
+ * that was never cleared), and that the failure path surfaces the error without
+ * carrying plaintext into the backend flash message.
+ */
+#[CoversClass(PendingSecretPersister::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class PendingSecretPersisterTest extends TestCase
+{
+    private const IDENTIFIER = '01937b6e-4b6c-7abc-8def-0123456789ab';
+
+    private const DELETE_REASON = 'Field cleared in record 42';
+
+    private const ROTATE_REASON = 'Field updated in record 42';
+
+    private const REDACTED_MESSAGE = 'Vault operation failed: [REDACTED]';
+
+    private PendingSecretPersister $subject;
+
+    private VaultServiceInterface&MockObject $vaultService;
+
+    private FlashMessageService&MockObject $flashMessageService;
+
+    /** @var list<FlashMessage> */
+    private array $flashMessages = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->vaultService = $this->createMock(VaultServiceInterface::class);
+        $this->flashMessageService = $this->createMock(FlashMessageService::class);
+
+        $queue = $this->createMock(FlashMessageQueue::class);
+        $queue->method('addMessage')->willReturnCallback(
+            function (FlashMessage $message): void {
+                $this->flashMessages[] = $message;
+            },
+        );
+        $this->flashMessageService->method('getMessageQueueByIdentifier')->willReturn($queue);
+
+        $this->subject = new PendingSecretPersister($this->vaultService, $this->flashMessageService);
+    }
+
+    #[Test]
+    public function newPendingIsStoredWithTheGivenMetadata(): void
+    {
+        $plaintext = $this->fakeSecret();
+        $options = ['table' => 'tx_test', 'field' => 'api_key'];
+
+        $this->vaultService
+            ->expects(self::once())
+            ->method('store')
+            ->with(self::IDENTIFIER, $plaintext, $options);
+        $this->vaultService->expects(self::never())->method('rotate');
+        $this->vaultService->expects(self::never())->method('delete');
+
+        $error = $this->subject->persist(
+            PendingSecret::createNew($plaintext, self::IDENTIFIER),
+            $options,
+            self::DELETE_REASON,
+            self::ROTATE_REASON,
+            $this->redactingMessage(),
+        );
+
+        self::assertNull($error);
+    }
+
+    /**
+     * An existing secret is replaced via rotate(), never via store(): rotate is
+     * what records the before/after hashes in the audit chain.
+     */
+    #[Test]
+    public function existingPendingIsRotatedWithTheAuditReason(): void
+    {
+        $plaintext = $this->fakeSecret();
+
+        $this->vaultService
+            ->expects(self::once())
+            ->method('rotate')
+            ->with(self::IDENTIFIER, $plaintext, self::ROTATE_REASON);
+        $this->vaultService->expects(self::never())->method('store');
+        $this->vaultService->expects(self::never())->method('delete');
+
+        $error = $this->subject->persist(
+            PendingSecret::createUpdate($plaintext, self::IDENTIFIER, 'previous-checksum'),
+            [],
+            self::DELETE_REASON,
+            self::ROTATE_REASON,
+            $this->redactingMessage(),
+        );
+
+        self::assertNull($error);
+    }
+
+    #[Test]
+    public function emptyValueWithAnIdentifierDeletesWithTheAuditReason(): void
+    {
+        $this->vaultService
+            ->expects(self::once())
+            ->method('delete')
+            ->with(self::IDENTIFIER, self::DELETE_REASON);
+        $this->vaultService->expects(self::never())->method('store');
+        $this->vaultService->expects(self::never())->method('rotate');
+
+        $error = $this->subject->persist(
+            PendingSecret::createUpdate('', self::IDENTIFIER, ''),
+            [],
+            self::DELETE_REASON,
+            self::ROTATE_REASON,
+            $this->redactingMessage(),
+        );
+
+        self::assertNull($error);
+    }
+
+    /**
+     * Issue #223: the identifier — not the checksum, which the clear control
+     * blanks — is the "a secret existed" signal. Without one there is nothing
+     * to delete, and the persister must not invent a target.
+     */
+    #[Test]
+    public function emptyValueWithoutAnIdentifierNeverTouchesTheVault(): void
+    {
+        $this->vaultService->expects(self::never())->method('delete');
+        $this->vaultService->expects(self::never())->method('store');
+        $this->vaultService->expects(self::never())->method('rotate');
+
+        $error = $this->subject->persist(
+            PendingSecret::createUpdate('', '', ''),
+            [],
+            self::DELETE_REASON,
+            self::ROTATE_REASON,
+            $this->redactingMessage(),
+        );
+
+        self::assertNull($error);
+        self::assertSame([], $this->flashMessages);
+    }
+
+    #[Test]
+    public function persistenceFailureIsReturnedToTheCaller(): void
+    {
+        $thrown = new VaultException('Adapter unreachable');
+        $this->vaultService->method('store')->willThrowException($thrown);
+
+        $error = $this->subject->persist(
+            PendingSecret::createNew($this->fakeSecret(), self::IDENTIFIER),
+            [],
+            self::DELETE_REASON,
+            self::ROTATE_REASON,
+            $this->redactingMessage(),
+        );
+
+        self::assertSame($thrown, $error, 'The caller needs the original throwable for hook-specific logging');
+    }
+
+    /**
+     * `catch (Throwable)` — an Error raised deep in an adapter must be turned
+     * into a reported failure too, not escape into the DataHandler.
+     */
+    #[Test]
+    public function nonExceptionThrowableIsAlsoCaughtAndReported(): void
+    {
+        $thrown = new Error('Adapter contract violated');
+        $this->vaultService->method('rotate')->willThrowException($thrown);
+
+        $error = $this->subject->persist(
+            PendingSecret::createUpdate($this->fakeSecret(), self::IDENTIFIER, 'previous-checksum'),
+            [],
+            self::DELETE_REASON,
+            self::ROTATE_REASON,
+            $this->redactingMessage(),
+        );
+
+        self::assertSame($thrown, $error);
+        self::assertCount(1, $this->flashMessages);
+    }
+
+    #[Test]
+    public function failureEmitsAnErrorFlashMessageBuiltFromTheThrowable(): void
+    {
+        $this->vaultService->method('delete')->willThrowException(new RuntimeException('Delete failed'));
+
+        $this->subject->persist(
+            PendingSecret::createUpdate('', self::IDENTIFIER, ''),
+            [],
+            self::DELETE_REASON,
+            self::ROTATE_REASON,
+            static fn (Throwable $e): string => 'Could not clear the secret: ' . $e->getMessage(),
+        );
+
+        self::assertCount(1, $this->flashMessages);
+        $message = $this->flashMessages[0];
+        self::assertSame('Could not clear the secret: Delete failed', $message->getMessage());
+        self::assertSame('Vault Error', $message->getTitle());
+        // `getSeverity()` is @internal in TYPO3, so the property is read
+        // directly rather than through the accessor.
+        self::assertSame(
+            ContextualFeedbackSeverity::ERROR,
+            (new ReflectionProperty(FlashMessage::class, 'severity'))->getValue($message),
+        );
+    }
+
+    /**
+     * The flash message body is entirely the caller's to build — the persister
+     * adds nothing of its own, so the plaintext it was handed can never reach
+     * the backend UI unless the caller puts it there.
+     */
+    #[Test]
+    public function flashMessageCarriesNoPlaintextOfTheFailedSecret(): void
+    {
+        $plaintext = $this->fakeSecret();
+        $this->vaultService->method('store')->willThrowException(new VaultException('Adapter unreachable'));
+
+        $this->subject->persist(
+            PendingSecret::createNew($plaintext, self::IDENTIFIER),
+            ['table' => 'tx_test'],
+            self::DELETE_REASON,
+            self::ROTATE_REASON,
+            $this->redactingMessage(),
+        );
+
+        self::assertCount(1, $this->flashMessages);
+        self::assertSame(self::REDACTED_MESSAGE, $this->flashMessages[0]->getMessage());
+        self::assertStringNotContainsString($plaintext, $this->flashMessages[0]->getMessage());
+    }
+
+    /**
+     * The rollback restores the record field to its pre-save state; it has to
+     * run before the user is told anything, so the message never describes a
+     * state the record is not yet in.
+     */
+    #[Test]
+    public function rollbackRunsBeforeTheFlashMessageIsEmitted(): void
+    {
+        $this->vaultService->method('store')->willThrowException(new VaultException('Adapter unreachable'));
+
+        $sequence = [];
+        $queue = $this->createMock(FlashMessageQueue::class);
+        $queue->method('addMessage')->willReturnCallback(
+            static function () use (&$sequence): void {
+                $sequence[] = 'flash';
+            },
+        );
+        $flashMessageService = $this->createMock(FlashMessageService::class);
+        $flashMessageService->method('getMessageQueueByIdentifier')->willReturn($queue);
+
+        $subject = new PendingSecretPersister($this->vaultService, $flashMessageService);
+        $subject->persist(
+            PendingSecret::createNew($this->fakeSecret(), self::IDENTIFIER),
+            [],
+            self::DELETE_REASON,
+            self::ROTATE_REASON,
+            $this->redactingMessage(),
+            static function () use (&$sequence): void {
+                $sequence[] = 'rollback';
+            },
+        );
+
+        self::assertSame(['rollback', 'flash'], $sequence);
+    }
+
+    #[Test]
+    public function rollbackIsNotRunOnSuccess(): void
+    {
+        $rollbackRuns = 0;
+
+        $error = $this->subject->persist(
+            PendingSecret::createNew($this->fakeSecret(), self::IDENTIFIER),
+            [],
+            self::DELETE_REASON,
+            self::ROTATE_REASON,
+            $this->redactingMessage(),
+            static function () use (&$rollbackRuns): void {
+                ++$rollbackRuns;
+            },
+        );
+
+        self::assertNull($error);
+        self::assertSame(0, $rollbackRuns);
+    }
+
+    #[Test]
+    public function failureWithoutARollbackCallbackStillReportsTheError(): void
+    {
+        $thrown = new VaultException('Adapter unreachable');
+        $this->vaultService->method('store')->willThrowException($thrown);
+
+        $error = $this->subject->persist(
+            PendingSecret::createNew($this->fakeSecret(), self::IDENTIFIER),
+            [],
+            self::DELETE_REASON,
+            self::ROTATE_REASON,
+            $this->redactingMessage(),
+            null,
+        );
+
+        self::assertSame($thrown, $error);
+        self::assertCount(1, $this->flashMessages);
+    }
+
+    /**
+     * There is no flash-message queue on the CLI. The reporting attempt must
+     * not replace the original vault failure with a messaging failure.
+     */
+    #[Test]
+    public function unavailableFlashMessageServiceDoesNotMaskTheVaultFailure(): void
+    {
+        $thrown = new VaultException('Adapter unreachable');
+        $this->vaultService->method('store')->willThrowException($thrown);
+
+        $flashMessageService = $this->createMock(FlashMessageService::class);
+        $flashMessageService
+            ->method('getMessageQueueByIdentifier')
+            ->willThrowException(new Exception('No flash message queue in this context'));
+
+        $subject = new PendingSecretPersister($this->vaultService, $flashMessageService);
+        $error = $subject->persist(
+            PendingSecret::createNew($this->fakeSecret(), self::IDENTIFIER),
+            [],
+            self::DELETE_REASON,
+            self::ROTATE_REASON,
+            $this->redactingMessage(),
+        );
+
+        self::assertSame($thrown, $error);
+    }
+
+    /**
+     * A message builder that behaves like the production hooks: it reports the
+     * failure without echoing anything it was given about the secret.
+     *
+     * @return callable(Throwable): string
+     */
+    private function redactingMessage(): callable
+    {
+        return static fn (Throwable $e): string => self::REDACTED_MESSAGE;
+    }
+
+    /**
+     * A clearly synthetic, runtime-generated stand-in for secret material.
+     */
+    private function fakeSecret(): string
+    {
+        return 'FAKE-TEST-SECRET-' . bin2hex(random_bytes(8));
+    }
+}

--- a/Tests/Unit/Hook/PendingSecretPersisterTest.php
+++ b/Tests/Unit/Hook/PendingSecretPersisterTest.php
@@ -325,7 +325,6 @@ final class PendingSecretPersisterTest extends TestCase
             self::DELETE_REASON,
             self::ROTATE_REASON,
             $this->redactingMessage(),
-            null,
         );
 
         self::assertSame($thrown, $error);

--- a/Tests/Unit/Http/DefaultDnsResolverTest.php
+++ b/Tests/Unit/Http/DefaultDnsResolverTest.php
@@ -1,0 +1,316 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Http {
+    use Netresearch\NrVault\Tests\Unit\Http\DefaultDnsResolverTest;
+
+    /**
+     * Namespaced shadow of the native `dns_get_record()`.
+     *
+     * `DefaultDnsResolver` calls the function unqualified, so PHP resolves it
+     * against this namespace first — which lets the test drive the resolver
+     * without a single real DNS query. With no handler installed the call is
+     * forwarded to the global function, so any other code in this namespace
+     * keeps its production behaviour.
+     *
+     * @param array<mixed>|null $authoritativeNameServers Accepted for signature
+     *                                                    parity only — the resolver never asks for the diagnostic
+     *                                                    record sets, so the fallback does not forward them.
+     * @param array<mixed>|null $additionalRecords Accepted for signature parity only
+     *
+     * @return array<mixed>|false
+     */
+    function dns_get_record(
+        string $hostname,
+        int $type = DNS_ANY,
+        ?array &$authoritativeNameServers = null,
+        ?array &$additionalRecords = null,
+        bool $raw = false,
+    ): array|false {
+        $handler = DefaultDnsResolverTest::$dnsHandler;
+
+        if ($handler === null) {
+            // Called through a variable so the global function is reached
+            // without a `\` prefix: the CGL rule `native_function_invocation`
+            // (strict, @compiler_optimized only) would strip that prefix and
+            // turn the fallback into infinite self-recursion.
+            $native = 'dns_get_record';
+            $nativeNameServers = null;
+            $nativeAdditionalRecords = null;
+
+            return $native($hostname, $type, $nativeNameServers, $nativeAdditionalRecords, $raw);
+        }
+
+        return $handler($hostname, $type);
+    }
+}
+
+namespace Netresearch\NrVault\Tests\Unit\Http {
+    use Closure;
+    use Netresearch\NrVault\Http\DefaultDnsResolver;
+    use Netresearch\NrVault\Tests\Unit\TestCase;
+    use PHPUnit\Framework\Attributes\CoversClass;
+    use PHPUnit\Framework\Attributes\Test;
+    use RuntimeException;
+
+    /**
+     * This resolver feeds the SSRF defence. Everything it returns is treated as
+     * "an address this request may end up connecting to", so the tests below are
+     * about what the mapping lets through: the lookup must ask for AAAA as well
+     * as A (or an IPv6-only internal target would never be inspected), and any
+     * record shape it cannot read as an address must be dropped rather than
+     * forwarded half-formed.
+     *
+     * No real DNS traffic: the native lookup is shadowed by the namespaced
+     * `dns_get_record()` declared above.
+     */
+    #[CoversClass(DefaultDnsResolver::class)]
+    final class DefaultDnsResolverTest extends TestCase
+    {
+        /**
+         * Installed lookup double, read by the namespaced `dns_get_record()`.
+         *
+         * @var (Closure(string, int): (array<mixed>|false))|null
+         */
+        public static ?Closure $dnsHandler = null;
+
+        private DefaultDnsResolver $subject;
+
+        protected function setUp(): void
+        {
+            parent::setUp();
+
+            $this->subject = new DefaultDnsResolver();
+        }
+
+        protected function tearDown(): void
+        {
+            self::$dnsHandler = null;
+
+            parent::tearDown();
+        }
+
+        /**
+         * An A-only lookup would leave every AAAA-reachable internal target
+         * uninspected by the SSRF guard.
+         */
+        #[Test]
+        public function lookupAsksForBothAddressFamilies(): void
+        {
+            $requestedType = null;
+            self::$dnsHandler = static function (string $host, int $type) use (&$requestedType): array {
+                $requestedType = $type;
+
+                return [];
+            };
+
+            $this->subject->resolve('vault.example.com');
+
+            self::assertSame(DNS_A | DNS_AAAA, $requestedType);
+        }
+
+        #[Test]
+        public function hostnameIsPassedThroughUnchanged(): void
+        {
+            $requestedHost = null;
+            self::$dnsHandler = static function (string $host) use (&$requestedHost): array {
+                $requestedHost = $host;
+
+                return [];
+            };
+
+            $this->subject->resolve('vault.example.com');
+
+            self::assertSame('vault.example.com', $requestedHost);
+        }
+
+        #[Test]
+        public function bothAddressFamiliesAreReturned(): void
+        {
+            self::$dnsHandler = static fn (): array => [
+                ['host' => 'vault.example.com', 'class' => 'IN', 'ttl' => 60, 'type' => 'A', 'ip' => '198.51.100.7'],
+                ['host' => 'vault.example.com', 'class' => 'IN', 'ttl' => 60, 'type' => 'AAAA', 'ipv6' => '2001:db8::7'],
+            ];
+
+            self::assertSame(
+                [['ip' => '198.51.100.7'], ['ipv6' => '2001:db8::7']],
+                $this->subject->resolve('vault.example.com'),
+            );
+        }
+
+        /**
+         * Only the address fields survive: the SSRF guard iterates the result
+         * and must not be handed TTL/type metadata it might key off.
+         */
+        #[Test]
+        public function recordMetadataIsStrippedFromTheResult(): void
+        {
+            self::$dnsHandler = static fn (): array => [
+                ['host' => 'vault.example.com', 'ttl' => 60, 'type' => 'A', 'ip' => '198.51.100.7'],
+            ];
+
+            self::assertSame([['ip' => '198.51.100.7']], $this->subject->resolve('vault.example.com'));
+        }
+
+        #[Test]
+        public function recordCarryingBothFamiliesKeepsBothAddresses(): void
+        {
+            self::$dnsHandler = static fn (): array => [
+                ['ip' => '198.51.100.7', 'ipv6' => '2001:db8::7'],
+            ];
+
+            self::assertSame(
+                [['ip' => '198.51.100.7', 'ipv6' => '2001:db8::7']],
+                $this->subject->resolve('vault.example.com'),
+            );
+        }
+
+        /**
+         * NXDOMAIN / SERVFAIL / timeout all surface as `false`. The empty list
+         * hands the decision back to the HTTP client's normal connection-error
+         * path instead of inventing an address.
+         */
+        #[Test]
+        public function failedLookupYieldsTheEmptyList(): void
+        {
+            self::$dnsHandler = static fn (): false => false;
+
+            self::assertSame([], $this->subject->resolve('nxdomain.example.invalid'));
+        }
+
+        #[Test]
+        public function emptyRecordSetYieldsTheEmptyList(): void
+        {
+            self::$dnsHandler = static fn (): array => [];
+
+            self::assertSame([], $this->subject->resolve('vault.example.com'));
+        }
+
+        /**
+         * A record with no address field (CNAME/TXT shapes surface here when a
+         * resolver answers loosely) must be dropped, not forwarded as an empty
+         * entry the guard would then have to special-case.
+         */
+        #[Test]
+        public function recordsWithoutAnAddressAreDropped(): void
+        {
+            self::$dnsHandler = static fn (): array => [
+                ['host' => 'vault.example.com', 'type' => 'CNAME', 'target' => 'origin.example.com'],
+                ['host' => 'vault.example.com', 'type' => 'TXT', 'txt' => 'v=spf1 -all'],
+            ];
+
+            self::assertSame([], $this->subject->resolve('vault.example.com'));
+        }
+
+        /**
+         * A non-string address cannot be checked against the private-range
+         * rules, so it is dropped rather than coerced into something that would
+         * pass those checks by accident.
+         */
+        #[Test]
+        public function nonStringAddressesAreDropped(): void
+        {
+            self::$dnsHandler = static fn (): array => [
+                ['ip' => 2130706433],
+                ['ipv6' => ['2001:db8::7']],
+                ['ip' => null, 'ipv6' => null],
+            ];
+
+            self::assertSame([], $this->subject->resolve('vault.example.com'));
+        }
+
+        /**
+         * Dropping records must not leave gaps in the keys — the contract is a
+         * list, and a gapped array breaks callers that iterate positionally.
+         */
+        #[Test]
+        public function resultStaysAListAfterRecordsAreDropped(): void
+        {
+            self::$dnsHandler = static fn (): array => [
+                ['type' => 'CNAME', 'target' => 'origin.example.com'],
+                ['ip' => '198.51.100.7'],
+                ['type' => 'TXT', 'txt' => 'v=spf1 -all'],
+                ['ipv6' => '2001:db8::7'],
+            ];
+
+            $resolved = $this->subject->resolve('vault.example.com');
+
+            self::assertTrue(array_is_list($resolved));
+            self::assertSame([['ip' => '198.51.100.7'], ['ipv6' => '2001:db8::7']], $resolved);
+        }
+
+        /**
+         * `dns_get_record()` warns on a failed lookup. The resolver silences it
+         * deliberately (the `@` operator is banned by the PHPStan ruleset) —
+         * under `failOnWarning` an escaping diagnostic would fail this test.
+         */
+        #[Test]
+        public function lookupDiagnosticsAreSuppressed(): void
+        {
+            self::$dnsHandler = static function (): false {
+                trigger_error('DNS Query failed', E_USER_WARNING);
+
+                return false;
+            };
+
+            self::assertSame([], $this->subject->resolve('nxdomain.example.invalid'));
+        }
+
+        #[Test]
+        public function errorHandlerIsRestoredAfterTheLookup(): void
+        {
+            self::$dnsHandler = static fn (): array => [['ip' => '198.51.100.7']];
+
+            $sentinel = static fn (): bool => true;
+            set_error_handler($sentinel);
+
+            $this->subject->resolve('vault.example.com');
+
+            self::assertSame($sentinel, $this->currentErrorHandler());
+
+            restore_error_handler();
+        }
+
+        /**
+         * The suppression sits in a `try/finally`: an exception escaping the
+         * lookup must not leave the whole request running under a swallow-all
+         * error handler.
+         */
+        #[Test]
+        public function errorHandlerIsRestoredWhenTheLookupThrows(): void
+        {
+            self::$dnsHandler = static function (): never {
+                throw new RuntimeException('resolver exploded');
+            };
+
+            $sentinel = static fn (): bool => true;
+            set_error_handler($sentinel);
+
+            try {
+                $this->subject->resolve('vault.example.com');
+                self::fail('The exception from the lookup should propagate');
+            } catch (RuntimeException) {
+                self::assertSame($sentinel, $this->currentErrorHandler());
+            } finally {
+                restore_error_handler();
+            }
+        }
+
+        /**
+         * Reads the active error handler without changing the stack depth.
+         */
+        private function currentErrorHandler(): mixed
+        {
+            $current = set_error_handler(static fn (): bool => true);
+            restore_error_handler();
+
+            return $current;
+        }
+    }
+}

--- a/Tests/Unit/Http/DefaultDnsResolverTest.php
+++ b/Tests/Unit/Http/DefaultDnsResolverTest.php
@@ -35,7 +35,7 @@ namespace Netresearch\NrVault\Http {
     ): array|false {
         $handler = DefaultDnsResolverTest::$dnsHandler;
 
-        if ($handler === null) {
+        if (!$handler instanceof \Closure) {
             // Called through a variable so the global function is reached
             // without a `\` prefix: the CGL rule `native_function_invocation`
             // (strict, @compiler_optimized only) would strip that prefix and
@@ -286,7 +286,7 @@ namespace Netresearch\NrVault\Tests\Unit\Http {
         public function errorHandlerIsRestoredWhenTheLookupThrows(): void
         {
             self::$dnsHandler = static function (): never {
-                throw new RuntimeException('resolver exploded');
+                throw new RuntimeException('resolver exploded', 8304165671);
             };
 
             $sentinel = static fn (): bool => true;

--- a/Tests/Unit/Http/OAuth/OAuthTokenRequestParamsTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenRequestParamsTest.php
@@ -194,8 +194,8 @@ final class OAuthTokenRequestParamsTest extends TestCase
 
         $params->wipeCredentials();
 
-        self::assertZeroized($params->clientId);
-        self::assertZeroized($params->clientSecret);
+        $this->assertZeroized($params->clientId);
+        $this->assertZeroized($params->clientSecret);
         self::assertNull($params->refreshToken);
     }
 

--- a/Tests/Unit/Http/OAuth/OAuthTokenRequestParamsTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenRequestParamsTest.php
@@ -1,0 +1,333 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Http\OAuth;
+
+use Netresearch\NrVault\Http\OAuth\OAuthTokenRequestParams;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use SodiumException;
+
+/**
+ * This value object holds OAuth client credentials in plaintext between the
+ * vault read and the token POST. Two properties matter beyond the encoding:
+ * every field that reaches the wire must be exactly the one that was set (the
+ * per-deployment escape hatch can silently shadow a credential), and
+ * `wipeCredentials()` must leave nothing behind for a stack trace to dump.
+ */
+#[CoversClass(OAuthTokenRequestParams::class)]
+final class OAuthTokenRequestParamsTest extends TestCase
+{
+    #[Test]
+    public function requiredFieldsAreAlwaysPresentInTheBody(): void
+    {
+        $clientId = $this->fakeCredential('client-id');
+        $clientSecret = $this->fakeCredential('client-secret');
+
+        $params = new OAuthTokenRequestParams('client_credentials', $clientId, $clientSecret);
+
+        self::assertSame(
+            [
+                'grant_type' => 'client_credentials',
+                'client_id' => $clientId,
+                'client_secret' => $clientSecret,
+            ],
+            $this->decode($params->toHttpQuery()),
+        );
+    }
+
+    /**
+     * Sending `scope=` or `refresh_token=` when neither was configured makes
+     * strict token endpoints reject the request, so absent must stay absent
+     * rather than becoming an empty field.
+     */
+    #[Test]
+    public function optionalFieldsAreOmittedWhenNotConfigured(): void
+    {
+        $params = new OAuthTokenRequestParams(
+            'client_credentials',
+            $this->fakeCredential('client-id'),
+            $this->fakeCredential('client-secret'),
+        );
+
+        $decoded = $this->decode($params->toHttpQuery());
+
+        self::assertArrayNotHasKey('scope', $decoded);
+        self::assertArrayNotHasKey('refresh_token', $decoded);
+    }
+
+    #[Test]
+    public function scopeIsIncludedWhenConfigured(): void
+    {
+        $params = new OAuthTokenRequestParams(
+            'client_credentials',
+            $this->fakeCredential('client-id'),
+            $this->fakeCredential('client-secret'),
+            'read:secrets write:secrets',
+        );
+
+        self::assertSame('read:secrets write:secrets', $this->decode($params->toHttpQuery())['scope'] ?? null);
+    }
+
+    /**
+     * An explicitly configured empty scope is a deliberate "ask for the default
+     * scope set" and is distinct from "no scope configured".
+     */
+    #[Test]
+    public function explicitlyEmptyScopeIsStillSent(): void
+    {
+        $params = new OAuthTokenRequestParams(
+            'client_credentials',
+            $this->fakeCredential('client-id'),
+            $this->fakeCredential('client-secret'),
+            '',
+        );
+
+        $decoded = $this->decode($params->toHttpQuery());
+
+        self::assertArrayHasKey('scope', $decoded);
+        self::assertSame('', $decoded['scope']);
+    }
+
+    #[Test]
+    public function refreshTokenIsIncludedForTheRefreshGrant(): void
+    {
+        $refreshToken = $this->fakeCredential('refresh-token');
+
+        $params = new OAuthTokenRequestParams(
+            'refresh_token',
+            $this->fakeCredential('client-id'),
+            $this->fakeCredential('client-secret'),
+            null,
+            $refreshToken,
+        );
+
+        $decoded = $this->decode($params->toHttpQuery());
+
+        self::assertSame('refresh_token', $decoded['grant_type']);
+        self::assertSame($refreshToken, $decoded['refresh_token'] ?? null);
+    }
+
+    #[Test]
+    public function additionalParamsAreAppendedToTheBody(): void
+    {
+        $params = new OAuthTokenRequestParams(
+            'client_credentials',
+            $this->fakeCredential('client-id'),
+            $this->fakeCredential('client-secret'),
+            null,
+            null,
+            ['audience' => 'https://api.example.com', 'resource' => 'urn:example:api'],
+        );
+
+        $decoded = $this->decode($params->toHttpQuery());
+
+        self::assertSame('https://api.example.com', $decoded['audience'] ?? null);
+        self::assertSame('urn:example:api', $decoded['resource'] ?? null);
+    }
+
+    /**
+     * `array_merge()` puts the escape hatch last, so a deployment-supplied key
+     * shadows the credential composed from the vault. Whoever configures
+     * `additionalParams` can therefore replace what is authenticated with —
+     * pinned here so the precedence cannot flip unnoticed.
+     */
+    #[Test]
+    public function additionalParamsOverrideTheComposedCredentials(): void
+    {
+        $vaultSecret = $this->fakeCredential('vault-client-secret');
+        $overrideSecret = $this->fakeCredential('override-client-secret');
+
+        $params = new OAuthTokenRequestParams(
+            'client_credentials',
+            $this->fakeCredential('client-id'),
+            $vaultSecret,
+            null,
+            null,
+            ['client_secret' => $overrideSecret],
+        );
+
+        $decoded = $this->decode($params->toHttpQuery());
+
+        self::assertSame($overrideSecret, $decoded['client_secret']);
+        self::assertNotSame($vaultSecret, $decoded['client_secret']);
+    }
+
+    /**
+     * Credentials routinely contain `&`, `=`, `+` and `%`. Unencoded, those
+     * would split the body and truncate or corrupt the secret in transit.
+     */
+    #[Test]
+    public function reservedCharactersInCredentialsSurviveTheEncoding(): void
+    {
+        $awkwardSecret = 'fake+secret&with=reserved%chars and spaces/ü';
+
+        $params = new OAuthTokenRequestParams(
+            'client_credentials',
+            $this->fakeCredential('client-id'),
+            $awkwardSecret,
+        );
+
+        $query = $params->toHttpQuery();
+
+        self::assertStringNotContainsString('&with=', $query, 'A raw & would split the body into extra fields');
+        self::assertSame($awkwardSecret, $this->decode($query)['client_secret']);
+    }
+
+    #[Test]
+    public function wipeCredentialsClearsEveryCredentialField(): void
+    {
+        $params = new OAuthTokenRequestParams(
+            'refresh_token',
+            $this->fakeCredential('client-id'),
+            $this->fakeCredential('client-secret'),
+            'read:secrets',
+            $this->fakeCredential('refresh-token'),
+        );
+
+        $params->wipeCredentials();
+
+        self::assertZeroized($params->clientId);
+        self::assertZeroized($params->clientSecret);
+        self::assertNull($params->refreshToken);
+    }
+
+    /**
+     * The non-credential fields describe the request, not the caller's
+     * identity — wiping must not damage them, or a retry would build a
+     * different request than the one that failed.
+     */
+    #[Test]
+    public function wipeCredentialsLeavesTheNonSecretFieldsIntact(): void
+    {
+        $params = new OAuthTokenRequestParams(
+            'client_credentials',
+            $this->fakeCredential('client-id'),
+            $this->fakeCredential('client-secret'),
+            'read:secrets',
+            null,
+            ['audience' => 'https://api.example.com'],
+        );
+
+        $params->wipeCredentials();
+
+        self::assertSame('client_credentials', $params->grantType);
+        self::assertSame('read:secrets', $params->scope);
+        self::assertSame(['audience' => 'https://api.example.com'], $params->additionalParams);
+    }
+
+    /**
+     * Pins the real behaviour of a repeated wipe, which contradicts the class
+     * docblock ("Idempotent and safe to call multiple times"): PHP's
+     * `sodium_memzero()` converts the zval to NULL after zeroing it, so the
+     * second call is handed a null and raises. The single production caller
+     * (`OAuthTokenManager::dispatchTokenRequest()`) wipes exactly once in a
+     * `finally`, so nothing hits this today — but a second wipe added anywhere
+     * on a failure path would replace the real error with a SodiumException.
+     */
+    #[Test]
+    public function secondWipeRaisesBecauseTheFirstOneNulledTheProperty(): void
+    {
+        $params = new OAuthTokenRequestParams(
+            'refresh_token',
+            $this->fakeCredential('client-id'),
+            $this->fakeCredential('client-secret'),
+            null,
+            $this->fakeCredential('refresh-token'),
+        );
+
+        $params->wipeCredentials();
+
+        $this->expectException(SodiumException::class);
+
+        $params->wipeCredentials();
+    }
+
+    #[Test]
+    public function wipeCredentialsWithoutARefreshTokenDoesNotFail(): void
+    {
+        $params = new OAuthTokenRequestParams(
+            'client_credentials',
+            $this->fakeCredential('client-id'),
+            $this->fakeCredential('client-secret'),
+        );
+
+        $params->wipeCredentials();
+
+        self::assertNull($params->refreshToken);
+    }
+
+    /**
+     * The point of the wipe: after it, nothing that re-reads the object — a
+     * retry, a dump, a serialiser — can recover the credential material. The
+     * zeroed fields drop out of the body entirely, because `http_build_query()`
+     * skips the nulls `sodium_memzero()` leaves behind.
+     */
+    #[Test]
+    public function bodyBuiltAfterTheWipeCarriesNoCredentialMaterial(): void
+    {
+        $clientSecret = $this->fakeCredential('client-secret');
+        $refreshToken = $this->fakeCredential('refresh-token');
+        // urlencode() returns fresh strings, so these needles survive the
+        // in-place zeroing that wipeCredentials() performs on the properties.
+        $secretNeedle = urlencode($clientSecret);
+        $refreshNeedle = urlencode($refreshToken);
+
+        $params = new OAuthTokenRequestParams(
+            'refresh_token',
+            $this->fakeCredential('client-id'),
+            $clientSecret,
+            null,
+            $refreshToken,
+        );
+
+        $params->wipeCredentials();
+        $query = $params->toHttpQuery();
+
+        $decoded = $this->decode($query);
+
+        self::assertStringNotContainsString($secretNeedle, $query);
+        self::assertStringNotContainsString($refreshNeedle, $query);
+        self::assertArrayNotHasKey('client_id', $decoded);
+        self::assertArrayNotHasKey('client_secret', $decoded);
+        self::assertArrayNotHasKey('refresh_token', $decoded);
+    }
+
+    /**
+     * `sodium_memzero()` overwrites the string buffer and then converts the
+     * zval to NULL, so a wiped credential reads back as null on every
+     * supported PHP version — not as the empty string the class docblock
+     * describes. Accept either so the assertion tracks "unreadable", not the
+     * ext-sodium implementation detail.
+     */
+    private static function assertZeroized(mixed $value): void
+    {
+        self::assertContains($value, [null, ''], 'Credential was not zeroized');
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function decode(string $query): array
+    {
+        parse_str($query, $decoded);
+
+        /** @var array<string, string> $decoded */
+        return $decoded;
+    }
+
+    /**
+     * A clearly synthetic, runtime-generated stand-in for credential material.
+     */
+    private function fakeCredential(string $label): string
+    {
+        return 'FAKE-TEST-' . $label . '-' . bin2hex(random_bytes(8));
+    }
+}

--- a/Tests/Unit/Http/OAuth/OAuthTokenRequestParamsTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenRequestParamsTest.php
@@ -13,7 +13,6 @@ use Netresearch\NrVault\Http\OAuth\OAuthTokenRequestParams;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
-use SodiumException;
 
 /**
  * This value object holds OAuth client credentials in plaintext between the
@@ -224,16 +223,13 @@ final class OAuthTokenRequestParamsTest extends TestCase
     }
 
     /**
-     * Pins the real behaviour of a repeated wipe, which contradicts the class
-     * docblock ("Idempotent and safe to call multiple times"): PHP's
-     * `sodium_memzero()` converts the zval to NULL after zeroing it, so the
-     * second call is handed a null and raises. The single production caller
-     * (`OAuthTokenManager::dispatchTokenRequest()`) wipes exactly once in a
-     * `finally`, so nothing hits this today — but a second wipe added anywhere
-     * on a failure path would replace the real error with a SodiumException.
+     * Pins the documented idempotency contract: PHP's `sodium_memzero()`
+     * converts the zval to NULL after zeroing it, so without the guard flag a
+     * second wipe on a failure path would raise a SodiumException and replace
+     * the real error. The guard makes repeat calls no-ops.
      */
     #[Test]
-    public function secondWipeRaisesBecauseTheFirstOneNulledTheProperty(): void
+    public function aSecondWipeIsANoOpInsteadOfRaising(): void
     {
         $params = new OAuthTokenRequestParams(
             'refresh_token',
@@ -244,10 +240,11 @@ final class OAuthTokenRequestParamsTest extends TestCase
         );
 
         $params->wipeCredentials();
-
-        $this->expectException(SodiumException::class);
-
         $params->wipeCredentials();
+
+        $this->assertZeroized($params->clientId);
+        $this->assertZeroized($params->clientSecret);
+        self::assertNull($params->refreshToken);
     }
 
     #[Test]
@@ -307,7 +304,7 @@ final class OAuthTokenRequestParamsTest extends TestCase
      * describes. Accept either so the assertion tracks "unreadable", not the
      * ext-sodium implementation detail.
      */
-    private static function assertZeroized(mixed $value): void
+    private function assertZeroized(mixed $value): void
     {
         self::assertContains($value, [null, ''], 'Credential was not zeroized');
     }

--- a/Tests/Unit/Http/VaultHttpClientFactoryTest.php
+++ b/Tests/Unit/Http/VaultHttpClientFactoryTest.php
@@ -45,12 +45,15 @@ final class VaultHttpClientFactoryTest extends TestCase
 
     private VaultServiceInterface&MockObject $vaultService;
 
+    private mixed $originalGlobals = null;
+
     protected function setUp(): void
     {
         parent::setUp();
 
         // No allowed-hosts / proxy configuration: the factory must build a
         // working client from the platform defaults alone.
+        $this->originalGlobals = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
         $GLOBALS['TYPO3_CONF_VARS'] = ['HTTP' => []];
 
         $this->auditLogService = $this->createMock(AuditLogServiceInterface::class);
@@ -65,6 +68,16 @@ final class VaultHttpClientFactoryTest extends TestCase
             $this->auditLogService,
             new SecureHttpClientFactory($dnsResolver),
         );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        if ($this->originalGlobals !== null) {
+            $GLOBALS['TYPO3_CONF_VARS'] = $this->originalGlobals;
+        } else {
+            unset($GLOBALS['TYPO3_CONF_VARS']);
+        }
     }
 
     #[Test]

--- a/Tests/Unit/Http/VaultHttpClientFactoryTest.php
+++ b/Tests/Unit/Http/VaultHttpClientFactoryTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Http;
+
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Http\DnsResolverInterface;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Http\VaultHttpClient;
+use Netresearch\NrVault\Http\VaultHttpClientFactory;
+use Netresearch\NrVault\Http\VaultHttpClientInterface;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Client\ClientInterface;
+use ReflectionProperty;
+
+/**
+ * The factory is the only place a VaultHttpClient is assembled for callers of
+ * `VaultServiceInterface::http()`. Its wiring decides two things that matter
+ * beyond "an object comes back": the client must talk through the hardened
+ * client built by SecureHttpClientFactory (a bare Guzzle client would have no
+ * SSRF defence and would log request bodies in debug mode), and it must carry
+ * the audit log service, since an unaudited HTTP client would use secrets
+ * without leaving a trace.
+ */
+#[CoversClass(VaultHttpClientFactory::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class VaultHttpClientFactoryTest extends TestCase
+{
+    use GuzzleClientConfigTrait;
+
+    private VaultHttpClientFactory $subject;
+
+    private AuditLogServiceInterface&MockObject $auditLogService;
+
+    private VaultServiceInterface&MockObject $vaultService;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // No allowed-hosts / proxy configuration: the factory must build a
+        // working client from the platform defaults alone.
+        $GLOBALS['TYPO3_CONF_VARS'] = ['HTTP' => []];
+
+        $this->auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $this->vaultService = $this->createMock(VaultServiceInterface::class);
+
+        // A resolver double keeps the seam free of real DNS traffic even if a
+        // future change resolves eagerly instead of at request time.
+        $dnsResolver = $this->createMock(DnsResolverInterface::class);
+        $dnsResolver->method('resolve')->willReturn([]);
+
+        $this->subject = new VaultHttpClientFactory(
+            $this->auditLogService,
+            new SecureHttpClientFactory($dnsResolver),
+        );
+    }
+
+    #[Test]
+    public function createReturnsAVaultHttpClient(): void
+    {
+        self::assertInstanceOf(VaultHttpClient::class, $this->subject->create($this->vaultService));
+    }
+
+    /**
+     * VaultHttpClient is an immutable per-call-chain object: handing out a
+     * shared instance would leak one caller's configured authentication into
+     * the next caller's requests.
+     */
+    #[Test]
+    public function everyCallReturnsAFreshClient(): void
+    {
+        self::assertNotSame(
+            $this->subject->create($this->vaultService),
+            $this->subject->create($this->vaultService),
+        );
+    }
+
+    #[Test]
+    public function clientIsBoundToTheVaultServiceItWasCreatedFor(): void
+    {
+        $otherVaultService = $this->createMock(VaultServiceInterface::class);
+
+        $first = $this->subject->create($this->vaultService);
+        $second = $this->subject->create($otherVaultService);
+
+        self::assertSame($this->vaultService, $this->readProperty($first, 'vaultService'));
+        self::assertSame($otherVaultService, $this->readProperty($second, 'vaultService'));
+    }
+
+    /**
+     * The audit service comes from DI, not from the caller — every client the
+     * factory hands out writes to the same audit chain.
+     */
+    #[Test]
+    public function clientIsBoundToTheInjectedAuditLogService(): void
+    {
+        $client = $this->subject->create($this->vaultService);
+
+        self::assertSame($this->auditLogService, $this->readProperty($client, 'auditLogService'));
+    }
+
+    /**
+     * The inner transport must be the hardened one: `debug` off so request
+     * bodies carrying secrets are never dumped, `http_errors` off so failures
+     * reach the audit log instead of throwing past it, and redirects off so a
+     * 302 cannot replay the Authorization header at another origin.
+     */
+    #[Test]
+    public function innerClientIsTheHardenedTransport(): void
+    {
+        $client = $this->subject->create($this->vaultService);
+
+        $innerClient = $this->readProperty($client, 'innerClient');
+        self::assertInstanceOf(ClientInterface::class, $innerClient);
+
+        $config = $this->getGuzzleConfig($innerClient);
+
+        self::assertFalse($config['debug']);
+        self::assertFalse($config['http_errors']);
+        self::assertFalse($config['allow_redirects']);
+    }
+
+    /**
+     * A freshly created client authenticates nothing until a `with*()` call
+     * configures it — otherwise it would attach a secret to requests the
+     * caller never asked to authenticate.
+     */
+    #[Test]
+    public function freshClientCarriesNoAuthenticationConfiguration(): void
+    {
+        $client = $this->subject->create($this->vaultService);
+
+        self::assertNull($this->readProperty($client, 'secretIdentifier'));
+        self::assertNull($this->readProperty($client, 'placement'));
+        self::assertNull($this->readProperty($client, 'oauthConfig'));
+    }
+
+    private function readProperty(VaultHttpClientInterface $client, string $property): mixed
+    {
+        return (new ReflectionProperty(VaultHttpClient::class, $property))->getValue($client);
+    }
+}

--- a/Tests/Unit/Security/TechnicalActorTest.php
+++ b/Tests/Unit/Security/TechnicalActorTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Security;
+
+use Netresearch\NrVault\Security\TechnicalActor;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use ReflectionClass;
+
+/**
+ * `AccessControlService` treats this snapshot as equivalent to an authenticated
+ * backend user for the duration of a `runAs()` scope, so its three
+ * decision-relevant fields — the admin flag and the resolved group ids, plus the
+ * uid used for audit attribution — must be exactly what `TechnicalActorContext`
+ * read out of `be_users`, and must stay immutable while the scope is open.
+ */
+#[CoversClass(TechnicalActor::class)]
+final class TechnicalActorTest extends TestCase
+{
+    #[Test]
+    public function exposesEveryConstructorArgumentUnchanged(): void
+    {
+        $actor = new TechnicalActor(42, '_vault_technical', false, [3, 7, 11]);
+
+        self::assertSame(42, $actor->uid);
+        self::assertSame('_vault_technical', $actor->username);
+        self::assertFalse($actor->admin);
+        self::assertSame([3, 7, 11], $actor->groupIds);
+    }
+
+    /**
+     * The admin flag is the input to the one admin-bypass seam. It is stored as
+     * given — never inferred from uid 1 or from an empty group list.
+     */
+    #[Test]
+    public function adminFlagIsStoredAsGivenAndNotInferred(): void
+    {
+        self::assertTrue((new TechnicalActor(1, 'admin', true, []))->admin);
+        self::assertFalse((new TechnicalActor(1, 'admin', false, []))->admin);
+    }
+
+    /**
+     * A non-admin actor in no group is the least-privileged case and must be
+     * representable — it is what an unprivileged technical user resolves to.
+     */
+    #[Test]
+    public function representsAnActorWithoutAnyGroups(): void
+    {
+        $actor = new TechnicalActor(9, 'restricted', false, []);
+
+        self::assertSame([], $actor->groupIds);
+    }
+
+    /**
+     * The list is the resolved closure including subgroups; order and duplicates
+     * are the resolver's business, so the snapshot must not silently reorder or
+     * deduplicate what it was handed.
+     */
+    #[Test]
+    public function groupIdsAreKeptInTheOrderTheResolverProducedThem(): void
+    {
+        $actor = new TechnicalActor(5, 'svc', false, [11, 3, 11, 2]);
+
+        self::assertSame([11, 3, 11, 2], $actor->groupIds);
+    }
+
+    /**
+     * Immutability is the point of the snapshot: nothing inside a `runAs()`
+     * scope may promote the actor to admin or widen its groups after the
+     * identity was validated. Enforced by the engine, so the guarantee is the
+     * `readonly` declaration itself — dropping it would silently reopen the
+     * privilege fields to a consumer.
+     */
+    #[Test]
+    public function everyFieldIsReadonlyAndTheClassIsFinal(): void
+    {
+        $reflection = new ReflectionClass(TechnicalActor::class);
+
+        self::assertTrue($reflection->isReadOnly(), 'TechnicalActor must stay a readonly class');
+        self::assertTrue($reflection->isFinal(), 'TechnicalActor must not be subclassable');
+
+        foreach (['uid', 'username', 'admin', 'groupIds'] as $property) {
+            self::assertTrue(
+                $reflection->getProperty($property)->isReadOnly(),
+                \sprintf('%s must be readonly', $property),
+            );
+        }
+    }
+}

--- a/Tests/Unit/Service/Doctor/Check/VersionCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/VersionCheckTest.php
@@ -11,29 +11,52 @@ namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
 
 use Netresearch\NrVault\Configuration\SecurityProfile;
 use Netresearch\NrVault\Service\Doctor\Check\VersionCheck;
+use Netresearch\NrVault\Service\Doctor\Finding;
 use Netresearch\NrVault\Service\Doctor\FindingSeverity;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use Netresearch\NrVault\Tests\Unit\Traits\DoctorFindingTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use ReflectionMethod;
 use TYPO3\CMS\Core\Information\Typo3Version;
 
 /**
  * A unit process has no package manager, so `ExtensionManagementUtility::extPath()`
  * cannot resolve and `ext_emconf.php` is unreadable here. That is exactly the
- * degraded path this test asserts: version metadata is the one area where being
- * unable to look must warn rather than crash, because a `check.crashed` critical
- * over unreadable provenance data would block a deployment for nothing.
+ * degraded path the `run()` tests below assert: version metadata is the one area
+ * where being unable to look must warn rather than crash, because a
+ * `check.crashed` critical over unreadable provenance data would block a
+ * deployment for nothing.
  *
- * The happy path — real emconf, real core version, both controls passing — is
- * covered by `Tests/Functional/Command/VaultDoctorCommandTest`, where a real
- * bootstrap exists. The range comparison itself is covered exhaustively by
+ * That degraded path also means `run()` can only ever reach one branch per
+ * control in a unit process. The two controls are therefore also exercised
+ * directly, with the emconf array they would have read, so the judgement each one
+ * makes — supported core, unsupported core, unparseable or absent constraint — is
+ * pinned here rather than only through a functional bootstrap. Reflection is the
+ * price of keeping them private; the alternative, installing a package manager
+ * into the static `ExtensionManagementUtility` seam, cannot be undone afterwards
+ * and would leak into every later test in the process.
+ *
+ * The end-to-end happy path — real emconf, real core version, both controls
+ * passing — is covered by `Tests/Functional/Command/VaultDoctorCommandTest`, where
+ * a real bootstrap exists. The range comparison itself is covered exhaustively by
  * {@see Typo3VersionRangeTest}.
  */
 #[CoversClass(VersionCheck::class)]
 final class VersionCheckTest extends TestCase
 {
     use DoctorFindingTrait;
+
+    /**
+     * The id is what a crash of this check is reported under (`check.crashed`
+     * carries it) and what a CI gate allow-lists, so it is external API.
+     */
+    #[Test]
+    public function isIdentifiedAsTheVersionCheck(): void
+    {
+        self::assertSame('version', (new VersionCheck(new Typo3Version()))->getId());
+    }
 
     #[Test]
     public function appliesToBothProfiles(): void
@@ -79,5 +102,166 @@ final class VersionCheckTest extends TestCase
         );
 
         self::assertSame((new Typo3Version())->getVersion(), $finding->details['typo3Version']);
+    }
+
+    #[Test]
+    public function aReadableExtensionVersionPassesAndIsNamedInTheReport(): void
+    {
+        $finding = $this->extensionVersionFinding('1.4.0');
+
+        self::assertSame(FindingSeverity::Pass, $finding->severity);
+        self::assertStringContainsString('1.4.0', $finding->summary);
+        self::assertSame('1.4.0', $finding->details['extensionVersion']);
+    }
+
+    #[Test]
+    public function aCoreInsideTheDeclaredRangePasses(): void
+    {
+        $finding = $this->typo3SupportedFinding(
+            $this->emConfDeclaring('13.4.0-14.99.99'),
+            running: '14.3.5',
+        );
+
+        self::assertSame(FindingSeverity::Pass, $finding->severity);
+        self::assertSame('14.3.5', $finding->details['typo3Version']);
+        self::assertSame('13.4.0-14.99.99', $finding->details['constraint']);
+        self::assertSame('1.4.0', $finding->details['extensionVersion']);
+    }
+
+    /**
+     * Both bounds are inclusive: a core sitting exactly on the declared minimum
+     * or maximum is a supported installation, and reporting it as untested would
+     * make the control cry wolf on the two versions most likely to be running.
+     */
+    #[Test]
+    #[DataProvider('coreOnABoundProvider')]
+    public function aCoreOnEitherBoundIsSupported(string $running): void
+    {
+        $finding = $this->typo3SupportedFinding($this->emConfDeclaring('13.4.0-14.99.99'), $running);
+
+        self::assertSame(FindingSeverity::Pass, $finding->severity);
+    }
+
+    /**
+     * @return iterable<string, array{string}>
+     */
+    public static function coreOnABoundProvider(): iterable
+    {
+        yield 'exactly the minimum' => ['13.4.0'];
+        yield 'exactly the maximum' => ['14.99.99'];
+    }
+
+    /**
+     * The hand-assembled deployment the check exists for. It warns rather than
+     * fails: composer already refused this combination, so reaching it means the
+     * installation was assembled by hand — worth naming, not worth blocking on.
+     */
+    #[Test]
+    public function aCoreOutsideTheDeclaredRangeWarns(): void
+    {
+        $finding = $this->assertWarningWithRemediation(
+            $this->typo3SupportedFinding($this->emConfDeclaring('13.4.0-14.99.99'), running: '12.4.8'),
+        );
+
+        self::assertStringContainsString('12.4.8', $finding->summary);
+        self::assertStringContainsString('13.4.0-14.99.99', $finding->summary);
+        self::assertSame('12.4.8', $finding->details['typo3Version']);
+    }
+
+    /**
+     * A composer-style caret constraint is not the `<min>-<max>` form
+     * `ext_emconf.php` uses, so compatibility is unknown — which must read as
+     * "could not be confirmed", never as a silent pass.
+     */
+    #[Test]
+    public function anUnparseableConstraintWarnsAndQuotesWhatItRead(): void
+    {
+        $finding = $this->assertWarningWithRemediation(
+            $this->typo3SupportedFinding($this->emConfDeclaring('^13.4'), running: '14.3.5'),
+        );
+
+        self::assertStringContainsString('^13.4', $finding->summary);
+        self::assertSame('^13.4', $finding->details['constraint']);
+        self::assertSame('14.3.5', $finding->details['typo3Version']);
+    }
+
+    /**
+     * Every shape an `include`d emconf can hand back that is not a TYPO3
+     * constraint string collapses to the same "no constraint declared" warning —
+     * the check reads a data file it cannot type-check, so each level of the
+     * lookup has to survive junk without an exception.
+     *
+     * @param array<mixed> $emConf
+     */
+    #[Test]
+    #[DataProvider('emConfWithoutAConstraintProvider')]
+    public function anEmConfWithoutAUsableConstraintWarns(array $emConf): void
+    {
+        $finding = $this->assertWarningWithRemediation(
+            $this->typo3SupportedFinding($emConf, running: '14.3.5'),
+        );
+
+        self::assertStringContainsString('no TYPO3 version constraint', $finding->summary);
+        self::assertSame('14.3.5', $finding->details['typo3Version']);
+        self::assertArrayNotHasKey('constraint', $finding->details);
+    }
+
+    /**
+     * @return iterable<string, array{array<mixed>}>
+     */
+    public static function emConfWithoutAConstraintProvider(): iterable
+    {
+        yield 'empty emconf' => [[]];
+        yield 'constraints is not an array' => [['constraints' => 'depends']];
+        yield 'no depends block' => [['constraints' => ['conflicts' => []]]];
+        yield 'depends is not an array' => [['constraints' => ['depends' => 'typo3']]];
+        yield 'no typo3 dependency' => [['constraints' => ['depends' => ['php' => '8.2.0-8.5.99']]]];
+        yield 'typo3 dependency is not a string' => [['constraints' => ['depends' => ['typo3' => ['13.4.0']]]]];
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    private function emConfDeclaring(string $constraint): array
+    {
+        return [
+            'version' => '1.4.0',
+            'constraints' => ['depends' => ['typo3' => $constraint]],
+        ];
+    }
+
+    private function assertWarningWithRemediation(Finding $finding): Finding
+    {
+        self::assertSame(FindingSeverity::Warning, $finding->severity);
+        self::assertNotSame('', $finding->risk, $finding->id . ' must state the risk');
+        self::assertNotSame('', $finding->remediation, $finding->id . ' must state a remediation');
+
+        return $finding;
+    }
+
+    private function extensionVersionFinding(string $extensionVersion): Finding
+    {
+        $finding = (new ReflectionMethod(VersionCheck::class, 'checkExtensionVersion'))
+            ->invoke(new VersionCheck(new Typo3Version()), $extensionVersion);
+
+        self::assertInstanceOf(Finding::class, $finding);
+
+        return $finding;
+    }
+
+    /**
+     * @param array<mixed> $emConf
+     */
+    private function typo3SupportedFinding(array $emConf, string $running): Finding
+    {
+        $typo3Version = self::createStub(Typo3Version::class);
+        $typo3Version->method('getVersion')->willReturn($running);
+
+        $finding = (new ReflectionMethod(VersionCheck::class, 'checkTypo3Supported'))
+            ->invoke(new VersionCheck($typo3Version), $emConf, '1.4.0');
+
+        self::assertInstanceOf(Finding::class, $finding);
+
+        return $finding;
     }
 }

--- a/Tests/Unit/Service/VaultHealthServiceTest.php
+++ b/Tests/Unit/Service/VaultHealthServiceTest.php
@@ -1,0 +1,200 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service;
+
+use Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface;
+use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
+use Netresearch\NrVault\Exception\ConfigurationException;
+use Netresearch\NrVault\Exception\MasterKeyException;
+use Netresearch\NrVault\Service\VaultHealthService;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
+use Psr\Log\LoggerInterface;
+use Throwable;
+
+/**
+ * Unit tests for the read-only master-key liveness probe.
+ *
+ * Two contracts are under test, and the second one is why the service exists:
+ * the four booleans must describe what the probe found, and no failure detail
+ * may travel out of it. Every failure path here asserts both — the status object
+ * stays free of exception text (SEC-INJECTION-LEAK-2: the message can carry the
+ * master-key file path) while the detail reaches PSR-3.
+ */
+#[CoversClass(VaultHealthService::class)]
+final class VaultHealthServiceTest extends TestCase
+{
+    private LoggerInterface&MockObject $logger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->logger = $this->createMock(LoggerInterface::class);
+    }
+
+    #[Test]
+    public function reportsAHealthyVaultWhenTheKeyCanBeRead(): void
+    {
+        $factory = $this->factoryReturning(
+            $this->provider(identifier: 'file', available: true, key: 'a-readable-master-key'),
+        );
+
+        $this->logger->expects(self::never())->method('warning');
+
+        $status = (new VaultHealthService($factory, $this->logger))->checkHealth();
+
+        self::assertTrue($status->masterKeyAvailable);
+        self::assertTrue($status->encryptionWorking);
+        self::assertFalse($status->hasIssues);
+        self::assertSame('file', $status->masterKeyProvider);
+    }
+
+    /**
+     * A provider that answers "available" and then hands back nothing is the
+     * case a plain `isAvailable()` check reports as healthy — the probe exists
+     * to catch exactly that.
+     */
+    #[Test]
+    public function anEmptyKeyIsAnIssueEvenThoughTheProviderIsAvailable(): void
+    {
+        $factory = $this->factoryReturning($this->provider(identifier: 'env', available: true, key: ''));
+
+        $this->logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('empty key'),
+                ['provider' => 'env'],
+            );
+
+        $status = (new VaultHealthService($factory, $this->logger))->checkHealth();
+
+        self::assertTrue($status->masterKeyAvailable);
+        self::assertFalse($status->encryptionWorking);
+        self::assertTrue($status->hasIssues);
+        self::assertSame('env', $status->masterKeyProvider);
+    }
+
+    #[Test]
+    public function anUnreadableKeyIsAnIssueAndTheReasonReachesTheLogOnly(): void
+    {
+        $factory = $this->factoryReturning($this->provider(
+            identifier: 'file',
+            available: true,
+            key: '',
+            failure: new MasterKeyException('/var/secrets/master.key is not readable'),
+        ));
+
+        $this->logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('could not be read'),
+                [
+                    'provider' => 'file',
+                    'exception' => '/var/secrets/master.key is not readable',
+                ],
+            );
+
+        $status = (new VaultHealthService($factory, $this->logger))->checkHealth();
+
+        self::assertTrue($status->masterKeyAvailable);
+        self::assertFalse($status->encryptionWorking);
+        self::assertTrue($status->hasIssues);
+        // The key path from the exception must not travel into the UI: the only
+        // string the caller gets back is the provider identifier.
+        self::assertSame('file', $status->masterKeyProvider);
+    }
+
+    #[Test]
+    public function aConfiguredButUnavailableProviderIsAnIssue(): void
+    {
+        $provider = $this->createMock(MasterKeyProviderInterface::class);
+        $provider->method('getIdentifier')->willReturn('typo3');
+        $provider->method('isAvailable')->willReturn(false);
+        // Reading the key of a provider that just said it has none would be a
+        // pointless failure path — and, for the file provider, a stat of a path
+        // that is not there.
+        $provider->expects(self::never())->method('getMasterKey');
+
+        $factory = $this->factoryReturning($provider);
+
+        $this->logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('not available'),
+                ['provider' => 'typo3'],
+            );
+
+        $status = (new VaultHealthService($factory, $this->logger))->checkHealth();
+
+        self::assertFalse($status->masterKeyAvailable);
+        self::assertFalse($status->encryptionWorking);
+        self::assertTrue($status->hasIssues);
+        self::assertSame('typo3', $status->masterKeyProvider);
+    }
+
+    /**
+     * No provider at all: the identifier stays empty because there is nothing to
+     * name, and the configuration message — which in the hardened profile spells
+     * out the rejected provider — is logged rather than returned.
+     */
+    #[Test]
+    public function aFailingProviderFactoryIsAnIssueWithoutAProviderName(): void
+    {
+        $factory = self::createStub(MasterKeyProviderFactoryInterface::class);
+        $factory->method('getAvailableProvider')
+            ->willThrowException(new ConfigurationException('provider "typo3" is forbidden'));
+
+        $this->logger->expects(self::once())
+            ->method('warning')
+            ->with(
+                self::stringContains('no master key provider'),
+                ['exception' => 'provider "typo3" is forbidden'],
+            );
+
+        $status = (new VaultHealthService($factory, $this->logger))->checkHealth();
+
+        self::assertFalse($status->masterKeyAvailable);
+        self::assertFalse($status->encryptionWorking);
+        self::assertTrue($status->hasIssues);
+        self::assertSame('', $status->masterKeyProvider);
+    }
+
+    private function factoryReturning(
+        MasterKeyProviderInterface $provider,
+    ): MasterKeyProviderFactoryInterface&Stub {
+        $factory = self::createStub(MasterKeyProviderFactoryInterface::class);
+        $factory->method('getAvailableProvider')->willReturn($provider);
+
+        return $factory;
+    }
+
+    private function provider(
+        string $identifier,
+        bool $available,
+        string $key,
+        ?Throwable $failure = null,
+    ): MasterKeyProviderInterface&Stub {
+        $provider = self::createStub(MasterKeyProviderInterface::class);
+        $provider->method('getIdentifier')->willReturn($identifier);
+        $provider->method('isAvailable')->willReturn($available);
+
+        if ($failure instanceof Throwable) {
+            $provider->method('getMasterKey')->willThrowException($failure);
+        } else {
+            $provider->method('getMasterKey')->willReturn($key);
+        }
+
+        return $provider;
+    }
+}

--- a/Tests/Unit/Service/VaultHealthStatusTest.php
+++ b/Tests/Unit/Service/VaultHealthStatusTest.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Service;
+
+use Netresearch\NrVault\Service\VaultHealthStatus;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The status object is the whole boundary between the health probe and the
+ * presentation layer, so what it can carry is a security property, not a
+ * detail: four operational values, all of them named, and no free-form text
+ * field an exception message could be poured into.
+ */
+#[CoversClass(VaultHealthStatus::class)]
+final class VaultHealthStatusTest extends TestCase
+{
+    #[Test]
+    public function exposesTheProbeResultAsReadOnlyData(): void
+    {
+        $status = new VaultHealthStatus(
+            masterKeyAvailable: true,
+            masterKeyProvider: 'file',
+            encryptionWorking: true,
+            hasIssues: false,
+        );
+
+        self::assertTrue($status->masterKeyAvailable);
+        self::assertSame('file', $status->masterKeyProvider);
+        self::assertTrue($status->encryptionWorking);
+        self::assertFalse($status->hasIssues);
+    }
+
+    #[Test]
+    public function carriesNothingBeyondTheFourProbeValues(): void
+    {
+        self::assertSame(
+            ['masterKeyAvailable', 'masterKeyProvider', 'encryptionWorking', 'hasIssues'],
+            array_keys(get_object_vars(new VaultHealthStatus(
+                masterKeyAvailable: false,
+                masterKeyProvider: '',
+                encryptionWorking: false,
+                hasIssues: true,
+            ))),
+        );
+    }
+}

--- a/Tests/Unit/Utility/LocalisationHelperTest.php
+++ b/Tests/Unit/Utility/LocalisationHelperTest.php
@@ -1,0 +1,146 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Utility;
+
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use Netresearch\NrVault\Utility\LocalisationHelper;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Localization\LanguageService;
+
+/**
+ * The whole point of the helper is the case `sL($key) ?: $fallback` gets wrong:
+ * a missing translation comes back as the `LLL:` key itself, which is truthy, so
+ * the idiomatic fallback never fires and the raw key reaches the UI. These tests
+ * pin the three shapes `sL()` can return — a translation, the key verbatim, and
+ * the empty string — plus the pass-through for plain strings that makes the
+ * helper a drop-in replacement.
+ */
+#[CoversClass(LocalisationHelper::class)]
+final class LocalisationHelperTest extends TestCase
+{
+    private const KEY = 'LLL:EXT:nr_vault/Resources/Private/Language/locallang.xlf:some_label';
+
+    #[Test]
+    public function returnsTheTranslationWhenTheKeyResolves(): void
+    {
+        self::assertSame(
+            'Reveal secret',
+            LocalisationHelper::translateOrFallback(
+                $this->languageService(self::KEY, 'Reveal secret'),
+                self::KEY,
+                'fallback',
+            ),
+        );
+    }
+
+    /**
+     * The regression this class exists for: `sL()` echoing the key back is a
+     * missing translation, not a label.
+     */
+    #[Test]
+    public function fallsBackWhenTheLanguageServiceEchoesTheKeyBack(): void
+    {
+        self::assertSame(
+            'fallback',
+            LocalisationHelper::translateOrFallback(
+                $this->languageService(self::KEY, self::KEY),
+                self::KEY,
+                'fallback',
+            ),
+        );
+    }
+
+    #[Test]
+    public function fallsBackOnAnEmptyTranslation(): void
+    {
+        self::assertSame(
+            'fallback',
+            LocalisationHelper::translateOrFallback(
+                $this->languageService(self::KEY, ''),
+                self::KEY,
+                'fallback',
+            ),
+        );
+    }
+
+    /**
+     * Any `LLL:` prefixed answer is unresolved, whichever key it names — a
+     * chained XLIFF reference that itself fails to resolve must not leak either.
+     */
+    #[Test]
+    public function fallsBackOnAnyUnresolvedLllAnswer(): void
+    {
+        self::assertSame(
+            'fallback',
+            LocalisationHelper::translateOrFallback(
+                $this->languageService(self::KEY, 'LLL:EXT:other/Resources/Private/Language/db.xlf:label'),
+                self::KEY,
+                'fallback',
+            ),
+        );
+    }
+
+    /**
+     * A plain input is handed to `sL()` unchanged, matching its own shape, so
+     * call sites can pass a literal label without special-casing it.
+     */
+    #[Test]
+    public function passesPlainNonLllInputThrough(): void
+    {
+        self::assertSame(
+            'Already a label',
+            LocalisationHelper::translateOrFallback(
+                $this->languageService('Already a label', 'Already a label'),
+                'Already a label',
+                'fallback',
+            ),
+        );
+    }
+
+    #[Test]
+    #[DataProvider('emptyFallbackProvider')]
+    public function theFallbackIsReturnedVerbatimIncludingEmptyString(
+        string $translated,
+        string $fallback,
+        string $expected,
+    ): void {
+        self::assertSame(
+            $expected,
+            LocalisationHelper::translateOrFallback(
+                $this->languageService(self::KEY, $translated),
+                self::KEY,
+                $fallback,
+            ),
+        );
+    }
+
+    /**
+     * @return iterable<string, array{string, string, string}>
+     */
+    public static function emptyFallbackProvider(): iterable
+    {
+        yield 'empty fallback for an unresolved key' => ['', '', ''];
+        yield 'unresolved key, whitespace fallback' => [self::KEY, ' ', ' '];
+        yield 'resolved key wins over the fallback' => ['Label', 'fallback', 'Label'];
+    }
+
+    private function languageService(string $expectedKey, string $translated): LanguageService
+    {
+        $languageService = $this->createMock(LanguageService::class);
+        $languageService->expects(self::once())
+            ->method('sL')
+            ->with($expectedKey)
+            ->willReturn($translated);
+
+        return $languageService;
+    }
+}

--- a/codecov.yml
+++ b/codecov.yml
@@ -92,3 +92,28 @@ ignore:
   - "Tests/**/*"
   - ".Build/**/*"
   - ".ddev/**/*"
+  # ---------------------------------------------------------------------------
+  # Mirror of the <exclude> list in Build/phpunit.xml — keep the two in sync.
+  # Without this, Codecov counts files the coverage run deliberately skips and
+  # reports a project number lower than what the suite actually measures.
+  # ---------------------------------------------------------------------------
+  # Backend controllers + form element: depend on final TYPO3 classes, covered
+  # through functional/E2E tests (which upload no coverage).
+  - "Classes/Controller/AuditController.php"
+  - "Classes/Controller/MigrationController.php"
+  - "Classes/Controller/OverviewController.php"
+  - "Classes/Controller/SecretsController.php"
+  - "Classes/Controller/ModuleAccessGuard.php"
+  - "Classes/Form/Element/VaultSecretInputElement.php"
+  # Enums: PHPUnit 12 cannot attribute coverage to enum classes.
+  - "Classes/Http/SecretPlacement.php"
+  - "Classes/Service/Detection/Severity.php"
+  - "Classes/Service/VaultFieldPermission.php"
+  - "Classes/Security/VaultPermission.php"
+  - "Classes/Service/Doctor/FindingSeverity.php"
+  - "Classes/Secret/SecretIdentifierKind.php"
+  # Constant holders without executable code.
+  - "Classes/Service/Doctor/DocsLink.php"
+  - "Classes/Service/Detection/SecretFinding.php"
+  # Exceptions: excluded as a directory in Build/phpunit.xml.
+  - "Classes/Exception/**/*"


### PR DESCRIPTION
Closes the coverage gaps surfaced by the Codecov file list and makes the reported number honest. Three atomic commits:

## 1. Unit tests for previously uncovered classes

16 classes had no test file at all; all now sit at **100 % line coverage**, verified with a targeted `--coverage-text` run:

| Area | Classes |
|---|---|
| Secret write path (hooks) | `PendingSecretExtractor`, `PendingSecretPersister` |
| HTTP / SSRF boundary | `DefaultDnsResolver`, `OAuthTokenRequestParams`, `VaultHttpClientFactory` |
| Health | `VaultHealthService`, `VaultHealthStatus` |
| Events | `AuditIntegrityAlertEvent`, `BreakGlassActivatedEvent`, `BreakGlassDeactivatedEvent`, `AuditIntegrityAlertSinkListener` |
| Small DTOs/helpers | `TechnicalActor`, `AuditChainAnchorLoad`, `UsageBar`, `VaultUsageStats`, `LocalisationHelper` |

Plus `VersionCheck` extended 45.54 % → **90.91 %** lines.

## 2. codecov.yml mirrors the phpunit excludes

Codecov counted files the coverage run deliberately skips (backend controllers + form element covered functionally/E2E, enums PHPUnit 12 cannot attribute, constant holders, exceptions) and reported a lower project number than the suite measures. The ignore list now mirrors the `<exclude>` list in `Build/phpunit.xml`, with a comment to keep the two in sync.

## 3. Codecov Test Analytics opt-in

Sets `upload-test-results: true`, using the input added to the shared workflow in [netresearch/typo3-ci-workflows#149](https://github.com/netresearch/typo3-ci-workflows/pull/149) — this populates the currently empty [tests tab](https://app.codecov.io/gh/netresearch/t3x-nr-vault/tests/new) (flaky-test detection, per-test durations), same pattern ofelia uses via `go-check.yml`.

## Verification

- `.Build/bin/phpunit -c Build/phpunit.xml --testsuite Unit,Fuzz` — OK, 4976 tests (+159), 18406 assertions
- `php Tests/scripts/check-test-base-class.php` — no new violations
- `composer ci:test:php:phpstan` — no errors
- `composer ci:cgl` — 0 fixes needed
