### PR TITLE
Make record copy and delete fail closed across vault fields

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -2041,7 +2041,7 @@ parameters:
 		-
 			rawMessage: Access to internal property TYPO3\CMS\Core\DataHandling\DataHandler::$copyMappingArray from outside its root namespace TYPO3.
 			identifier: property.internal
-			count: 9
+			count: 12
 			path: ../Tests/Unit/Hook/DataHandlerHookTest.php
 
 		-

--- a/Classes/Hook/DataHandlerHook.php
+++ b/Classes/Hook/DataHandlerHook.php
@@ -288,9 +288,11 @@ final class DataHandlerHook
             }
         }
 
+        $deletedCount = 0;
         foreach ($identifiers as $fieldName => $vaultIdentifier) {
             try {
                 $this->vaultService->delete($vaultIdentifier, 'Record deleted');
+                ++$deletedCount;
             } catch (SecretNotFoundException) {
                 // Idempotent: the goal state — no secret under this identifier
                 // — already holds, so a dangling reference must not make the
@@ -308,7 +310,9 @@ final class DataHandlerHook
                     $vaultIdentifier,
                     $e,
                     $dataHandler,
-                    'Secrets of preceding fields were already deleted and cannot be restored.',
+                    $deletedCount === 0
+                        ? 'No secret of this record was deleted.'
+                        : $deletedCount . ' secret(s) of preceding fields were already deleted and cannot be restored.',
                 );
 
                 return;
@@ -546,7 +550,7 @@ final class DataHandlerHook
             }
         }
 
-        $this->blankVaultFields($connection, $table, $newId, $vaultFields);
+        $blanked = $this->blankVaultFields($connection, $table, $newId, $vaultFields);
 
         $userMessage = $this->failureReporter->report($error, [
             'table' => $table,
@@ -564,29 +568,37 @@ final class DataHandlerHook
             null,
             2,
             'Vault error during copy for field "' . $failedField . '": ' . $userMessage
-            . ' No secret was copied; all vault fields of the new record are empty and must be filled in again.',
+            . ($blanked
+                ? ' No secret was copied; all vault fields of the new record were cleared and must be filled in again.'
+                : ' No secret was copied, but clearing the vault fields of the new record FAILED — it may still'
+                    . ' reference the secrets of the source record and needs manual review.'),
         );
     }
 
     /**
      * Clear every vault field of a record.
      *
-     * Best-effort: if this write fails the copy keeps the source identifiers,
-     * which the DataHandler log entry written by the caller already flags. There
-     * is nothing better to fall back to — the copy exists either way.
+     * Best-effort: if this write fails the copy keeps the source identifiers —
+     * the caller's DataHandler log entry states which of the two end states was
+     * reached. There is nothing better to fall back to; the copy exists either
+     * way.
      *
      * @param list<string> $vaultFields
+     *
+     * @return bool True when the fields were cleared, false when the write failed
      */
-    private function blankVaultFields(Connection $connection, string $table, int $uid, array $vaultFields): void
+    private function blankVaultFields(Connection $connection, string $table, int $uid, array $vaultFields): bool
     {
         if ($uid <= 0 || $vaultFields === []) {
-            return;
+            return false;
         }
 
         try {
             $connection->update($table, array_fill_keys($vaultFields, ''), ['uid' => $uid]);
+
+            return true;
         } catch (Exception) {
-            // Documented by the caller's DataHandler log entry.
+            return false;
         }
     }
 

--- a/Classes/Hook/DataHandlerHook.php
+++ b/Classes/Hook/DataHandlerHook.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Hook;
 
 use Exception;
+use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Hook\Dto\PendingSecret;
 use Netresearch\NrVault\Service\VaultFieldPermission;
 use Netresearch\NrVault\Service\VaultFieldPermissionService;
@@ -18,6 +19,7 @@ use Netresearch\NrVault\Utility\IdentifierValidator;
 use Netresearch\NrVault\Utility\VaultFieldResolver;
 use Throwable;
 use TYPO3\CMS\Core\Authentication\BackendUserAuthentication;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 
@@ -244,6 +246,10 @@ final class DataHandlerHook
             return;
         }
 
+        $uid = (int) $id;
+
+        /** @var array<string, string> $identifiers field name => vault identifier */
+        $identifiers = [];
         foreach ($vaultFields as $fieldName) {
             $vaultIdentifier = $record[$fieldName] ?? '';
             if (!\is_string($vaultIdentifier)) {
@@ -253,33 +259,59 @@ final class DataHandlerHook
                 continue;
             }
 
+            $identifiers[$fieldName] = $vaultIdentifier;
+        }
+
+        if ($identifiers === []) {
+            return;
+        }
+
+        // Preflight: a vault delete is a HARD delete with no restore path, so a
+        // partially applied multi-field cleanup cannot be compensated. Assert
+        // every field's delete gate BEFORE removing the first secret — a record
+        // whose second field is denied must lose neither secret.
+        foreach ($identifiers as $fieldName => $vaultIdentifier) {
+            try {
+                $this->vaultService->assertDeletable($vaultIdentifier);
+            } catch (Throwable $e) {
+                $this->cancelRecordDeletion(
+                    $table,
+                    $uid,
+                    $fieldName,
+                    $vaultIdentifier,
+                    $e,
+                    $dataHandler,
+                    'No secret of this record was deleted.',
+                );
+
+                return;
+            }
+        }
+
+        foreach ($identifiers as $fieldName => $vaultIdentifier) {
             try {
                 $this->vaultService->delete($vaultIdentifier, 'Record deleted');
+            } catch (SecretNotFoundException) {
+                // Idempotent: the goal state — no secret under this identifier
+                // — already holds, so a dangling reference must not make the
+                // record undeletable forever.
+                continue;
             } catch (Throwable $e) {
-                $userMessage = $this->failureReporter->report($e, [
-                    'table' => $table,
-                    'field' => $fieldName,
-                    'uid' => (int) $id,
-                    'identifier' => $vaultIdentifier,
-                    'operation' => 'delete',
-                ]);
-
-                // Fail closed: if the secret cannot be deleted (denied, audit
-                // write failed, vault error), the record delete is cancelled
-                // in processCmdmap() — otherwise the record removal would
-                // orphan the secret and mask the failure.
-                $this->deniedDeletions[$table][(int) $id] = true;
-
-                /** @phpstan-ignore method.internal */
-                $dataHandler->log(
+                // The preflight passed, so this is a failure the gates cannot
+                // predict (audit write, vault outage, revoked in between).
+                // Stop the loop: every further delete would enlarge the
+                // unrecoverable damage while the record is preserved anyway.
+                $this->cancelRecordDeletion(
                     $table,
-                    (int) $id,
-                    3,
-                    null,
-                    1,
-                    'Vault error during delete for field "' . $fieldName . '": ' . $userMessage
-                    . ' The record was preserved.',
+                    $uid,
+                    $fieldName,
+                    $vaultIdentifier,
+                    $e,
+                    $dataHandler,
+                    'Secrets of preceding fields were already deleted and cannot be restored.',
                 );
+
+                return;
             }
         }
     }
@@ -376,7 +408,10 @@ final class DataHandlerHook
                 // Get source secret
                 $sourceValue = $this->vaultService->retrieve($sourceIdentifier);
                 if ($sourceValue === null) {
-                    continue;
+                    // Not a skippable field: leaving the DataHandler-duplicated
+                    // source identifier in place is precisely the outcome this
+                    // method must prevent, so treat it as a copy failure.
+                    throw SecretNotFoundException::forIdentifier($sourceIdentifier);
                 }
 
                 // Generate new UUID for copied record
@@ -394,23 +429,24 @@ final class DataHandlerHook
                 // Track update for the copied record
                 $updates[$fieldName] = $newIdentifier;
             } catch (Throwable $e) {
-                $userMessage = $this->failureReporter->report($e, [
-                    'table' => $table,
-                    'field' => $fieldName,
-                    'uid' => $newId,
-                    'identifier' => $sourceIdentifier,
-                    'operation' => 'copy',
-                ]);
-
-                /** @phpstan-ignore method.internal */
-                $dataHandler->log(
+                // Fail closed across ALL vault fields: DataHandler has already
+                // duplicated the source identifiers into the copy, so anything
+                // short of clearing them leaves the copy sharing the SOURCE
+                // record's secrets — rotating the copy would mutate the source,
+                // deleting the copy would destroy the source's secret.
+                $this->abandonCopiedSecrets(
+                    $connection,
                     $table,
                     $newId,
-                    1,
-                    null,
-                    1,
-                    'Vault error during copy for field "' . $fieldName . '": ' . $userMessage,
+                    $vaultFields,
+                    $updates,
+                    $fieldName,
+                    $sourceIdentifier,
+                    $e,
+                    $dataHandler,
                 );
+
+                return;
             } finally {
                 // Scrub the decrypted plaintext from memory (success or failure).
                 if ($sourceValue !== null && $sourceValue !== '') {
@@ -422,6 +458,135 @@ final class DataHandlerHook
         // Update copied record with new UUIDs
         if ($updates !== []) {
             $connection->update($table, $updates, ['uid' => $newId]);
+        }
+    }
+
+    /**
+     * Fail closed on a record delete whose vault cleanup did not fully succeed:
+     * remember the cancellation for {@see processCmdmap()}, log the cause
+     * server-side and tell the editor the record was preserved.
+     *
+     * Deleting the record while a secret survives would orphan that secret AND
+     * hide the failed (possibly denied) vault delete behind an apparently
+     * successful record removal.
+     */
+    private function cancelRecordDeletion(
+        string $table,
+        int $uid,
+        string $fieldName,
+        string $vaultIdentifier,
+        Throwable $error,
+        DataHandler $dataHandler,
+        string $scopeNotice,
+    ): void {
+        $userMessage = $this->failureReporter->report($error, [
+            'table' => $table,
+            'field' => $fieldName,
+            'uid' => $uid,
+            'identifier' => $vaultIdentifier,
+            'operation' => 'delete',
+        ]);
+
+        $this->deniedDeletions[$table][$uid] = true;
+
+        /** @phpstan-ignore method.internal */
+        $dataHandler->log(
+            $table,
+            $uid,
+            3,
+            null,
+            1,
+            'Vault error during delete for field "' . $fieldName . '": ' . $userMessage
+            . ' The record was preserved. ' . $scopeNotice,
+        );
+    }
+
+    /**
+     * Undo a partially completed record copy.
+     *
+     * Deletes every secret already cloned for this copy and blanks EVERY vault
+     * field of the copied record — not only the ones that were cloned, because
+     * the untouched ones still carry the source identifiers DataHandler
+     * duplicated. The copy therefore ends up with no secrets at all instead of
+     * silently aliasing the source's.
+     *
+     * The failure is logged as a system error (`error = 2`), one level above
+     * the per-field warning the previous implementation emitted: the editor now
+     * has to re-enter the secrets of the copy, which is not a detail they may
+     * miss in a flash-message list.
+     *
+     * @param list<string> $vaultFields every vault field of the table
+     * @param array<string, string> $clonedUpdates field name => identifier of the secrets cloned so far
+     */
+    private function abandonCopiedSecrets(
+        Connection $connection,
+        string $table,
+        int $newId,
+        array $vaultFields,
+        array $clonedUpdates,
+        string $failedField,
+        string $sourceIdentifier,
+        Throwable $error,
+        DataHandler $dataHandler,
+    ): void {
+        foreach ($clonedUpdates as $clonedField => $clonedIdentifier) {
+            try {
+                $this->vaultService->delete($clonedIdentifier, 'Record copy rolled back');
+            } catch (Throwable $compensationError) {
+                // The clone is orphaned rather than dangerous (nothing
+                // references it any more) — record it for the administrator and
+                // keep rolling back the remaining fields.
+                $this->failureReporter->report($compensationError, [
+                    'table' => $table,
+                    'field' => $clonedField,
+                    'uid' => $newId,
+                    'identifier' => $clonedIdentifier,
+                    'operation' => 'copy_rollback',
+                ]);
+            }
+        }
+
+        $this->blankVaultFields($connection, $table, $newId, $vaultFields);
+
+        $userMessage = $this->failureReporter->report($error, [
+            'table' => $table,
+            'field' => $failedField,
+            'uid' => $newId,
+            'identifier' => $sourceIdentifier,
+            'operation' => 'copy',
+        ]);
+
+        /** @phpstan-ignore method.internal */
+        $dataHandler->log(
+            $table,
+            $newId,
+            1,
+            null,
+            2,
+            'Vault error during copy for field "' . $failedField . '": ' . $userMessage
+            . ' No secret was copied; all vault fields of the new record are empty and must be filled in again.',
+        );
+    }
+
+    /**
+     * Clear every vault field of a record.
+     *
+     * Best-effort: if this write fails the copy keeps the source identifiers,
+     * which the DataHandler log entry written by the caller already flags. There
+     * is nothing better to fall back to — the copy exists either way.
+     *
+     * @param list<string> $vaultFields
+     */
+    private function blankVaultFields(Connection $connection, string $table, int $uid, array $vaultFields): void
+    {
+        if ($uid <= 0 || $vaultFields === []) {
+            return;
+        }
+
+        try {
+            $connection->update($table, array_fill_keys($vaultFields, ''), ['uid' => $uid]);
+        } catch (Exception) {
+            // Documented by the caller's DataHandler log entry.
         }
     }
 

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -198,15 +198,7 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
             throw SecretNotFoundException::forIdentifier($identifier);
         }
 
-        // Check access
-        if (!$this->accessControlService->canDelete($secret)) {
-            $this->auditLogService->log($identifier, AuditAction::AccessDenied->value, false, 'Delete access denied');
-
-            throw AccessDeniedException::forIdentifier($identifier, 'delete permission denied');
-        }
-
-        // Separation of duties: per-secret ACL AND operation permission.
-        $this->assertOperationGranted(VaultPermission::SecretDelete, $identifier, 'Delete');
+        $this->assertDeletePermitted($identifier, $secret);
 
         $hashBefore = $secret->getValueChecksum();
 
@@ -241,6 +233,17 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
             $this->accessControlService->getCurrentActorUid(),
             $reason,
         ));
+    }
+
+    public function assertDeletable(string $identifier): void
+    {
+        $secret = $this->adapter->retrieve($identifier);
+        if (!$secret instanceof Secret) {
+            // Nothing to delete — see the interface docblock.
+            return;
+        }
+
+        $this->assertDeletePermitted($identifier, $secret);
     }
 
     public function rotate(string $identifier, #[SensitiveParameter] string $newSecret, string $reason = ''): void
@@ -485,6 +488,26 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
             $identifier,
             'missing ' . VaultPermission::SecretUse->value . ' permission',
         );
+    }
+
+    /**
+     * The complete delete gate: per-secret ACL tier plus the operation
+     * permission (separation of duties).
+     *
+     * Shared by {@see delete()} and {@see assertDeletable()} so the preflight a
+     * multi-secret caller runs and the check the actual delete applies can
+     * never drift apart — a preflight that passes while the delete denies would
+     * be worse than no preflight at all.
+     */
+    private function assertDeletePermitted(string $identifier, Secret $secret): void
+    {
+        if (!$this->accessControlService->canDelete($secret)) {
+            $this->auditLogService->log($identifier, AuditAction::AccessDenied->value, false, 'Delete access denied');
+
+            throw AccessDeniedException::forIdentifier($identifier, 'delete permission denied');
+        }
+
+        $this->assertOperationGranted(VaultPermission::SecretDelete, $identifier, 'Delete');
     }
 
     /**

--- a/Classes/Service/VaultServiceInterface.php
+++ b/Classes/Service/VaultServiceInterface.php
@@ -87,6 +87,29 @@ interface VaultServiceInterface
     public function delete(string $identifier, string $reason = ''): void;
 
     /**
+     * Assert that {@see delete()} is permitted for this identifier — without deleting.
+     *
+     * Exists for callers that delete SEVERAL secrets as one logical unit (the
+     * DataHandler record delete across multiple vault fields). A vault delete is
+     * a hard delete with no restore, so a partially applied batch cannot be
+     * compensated: the only way to keep such a batch all-or-nothing is to run
+     * every permission gate up front and abort before the first deletion.
+     *
+     * A secret that does not exist returns without throwing — the goal state
+     * ("no secret under this identifier") is already reached, so deleting it is
+     * permitted in the only sense a caller can act on. Callers that need to
+     * distinguish absent from present must ask {@see exists()}.
+     *
+     * The gates asserted here are exactly the ones {@see delete()} applies, and
+     * the denial is audited the same way. Passing this check does NOT guarantee
+     * the subsequent delete succeeds — an audit-write failure, or a permission
+     * revoked in between, can still abort it.
+     *
+     * @throws AccessDeniedException If current user lacks permission
+     */
+    public function assertDeletable(string $identifier): void;
+
+    /**
      * Rotate a secret.
      *
      * @throws SecretNotFoundException If secret doesn't exist

--- a/Documentation/Developer/TcaIntegration.rst
+++ b/Documentation/Developer/TcaIntegration.rst
@@ -346,8 +346,23 @@ Record operations
 
 -  **Create**: New vault secret is stored automatically.
 -  **Update**: Secret is rotated (maintains audit trail).
--  **Delete**: Vault secret is removed when record is deleted.
--  **Copy**: Vault secret is copied to new record.
+-  **Delete**: Vault secrets are removed when the record is deleted.
+-  **Copy**: Vault secrets are cloned to the new record under fresh
+   identifiers.
+
+Records with several vault fields are handled all-or-nothing.
+
+A **copy** clones every field or none: if one secret cannot be cloned, the
+secrets already cloned for that copy are deleted again and *all* vault fields
+of the new record are cleared. They are never left holding the source record's
+identifiers — the copy would otherwise share the original's secrets, and
+rotating or deleting one record would silently change the other. The editor
+gets an error message and re-enters the values.
+
+A **delete** checks the delete permission of every vault field *before*
+removing the first secret, because a vault delete cannot be undone. If any
+field is denied, no secret is removed and the record delete is cancelled. A
+field pointing at a secret that no longer exists does not block the delete.
 
 
 .. _tca-security:

--- a/Tests/Functional/Hook/DataHandlerHookTest.php
+++ b/Tests/Functional/Hook/DataHandlerHookTest.php
@@ -40,6 +40,9 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
 #[CoversClass(DataHandlerHook::class)]
 final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
 {
+    /** Non-admin user (uid 3) whose group grants `tx_nrvault:secret.delete`. */
+    private const DELETER_UID = 3;
+
     protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users.csv';
 
     /** @var array<string, mixed> */
@@ -392,6 +395,106 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
         );
     }
 
+    #[Test]
+    public function recordDeleteRemovesNoSecretWhenAnotherFieldIsDenied(): void
+    {
+        $this->skipIfNotSqlite();
+
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $connectionPool = $this->get(ConnectionPool::class);
+        $hook = $this->createHookWithVaultFields('tx_nrvault_hooktest4', ['api_key', 'api_secret']);
+
+        $connection = $connectionPool->getConnectionForTable('tx_nrvault_hooktest4');
+        $connection->executeStatement(
+            'CREATE TABLE IF NOT EXISTS tx_nrvault_hooktest4 (
+                uid INTEGER PRIMARY KEY AUTOINCREMENT,
+                pid INTEGER DEFAULT 0,
+                api_key VARCHAR(255) DEFAULT \'\',
+                api_secret VARCHAR(255) DEFAULT \'\'
+            )',
+        );
+
+        // Seeded as the admin of this test case: the deleter below may not create.
+        $deletableIdentifier = $this->generateUuidV7();
+        $deniedIdentifier = $this->generateUuidV7();
+        $vaultService->store($deletableIdentifier, 'owned-by-the-deleter', ['owner' => self::DELETER_UID]);
+        $vaultService->store($deniedIdentifier, 'owned-by-somebody-else', ['owner' => 1]);
+
+        $connection->insert('tx_nrvault_hooktest4', [
+            'pid' => 0,
+            'api_key' => $deletableIdentifier,
+            'api_secret' => $deniedIdentifier,
+        ]);
+        $recordUid = (int) $connection->lastInsertId();
+
+        // The deleter owns the FIRST field's secret and holds secret.delete, but
+        // not the second field's secret (canDelete is owner/admin only).
+        $this->setUpVaultDeletePermissionUser();
+
+        $dataHandler = $this->createDataHandler();
+        $hook->processCmdmap_preProcess('delete', 'tx_nrvault_hooktest4', $recordUid, null, $dataHandler, false);
+
+        $commandIsProcessed = false;
+        $hook->processCmdmap('delete', 'tx_nrvault_hooktest4', $recordUid, null, $commandIsProcessed, $dataHandler, false);
+
+        self::assertTrue($commandIsProcessed, 'A denied field must cancel the record delete (fail closed).');
+        self::assertTrue(
+            $vaultService->exists($deletableIdentifier),
+            'The preflight must abort BEFORE the first secret is deleted — a vault delete is not reversible.',
+        );
+        self::assertTrue(
+            $vaultService->exists($deniedIdentifier),
+            'The denied secret must survive.',
+        );
+    }
+
+    #[Test]
+    public function recordDeleteProceedsWhenOneFieldReferencesAMissingSecret(): void
+    {
+        $this->skipIfNotSqlite();
+
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $connectionPool = $this->get(ConnectionPool::class);
+        $hook = $this->createHookWithVaultFields('tx_nrvault_hooktest5', ['api_key', 'api_secret']);
+
+        $connection = $connectionPool->getConnectionForTable('tx_nrvault_hooktest5');
+        $connection->executeStatement(
+            'CREATE TABLE IF NOT EXISTS tx_nrvault_hooktest5 (
+                uid INTEGER PRIMARY KEY AUTOINCREMENT,
+                pid INTEGER DEFAULT 0,
+                api_key VARCHAR(255) DEFAULT \'\',
+                api_secret VARCHAR(255) DEFAULT \'\'
+            )',
+        );
+
+        // A dangling reference: never stored, or already cleaned up elsewhere.
+        $missingIdentifier = $this->generateUuidV7();
+        $existingIdentifier = $this->generateUuidV7();
+        $vaultService->store($existingIdentifier, 'still-there');
+
+        $connection->insert('tx_nrvault_hooktest5', [
+            'pid' => 0,
+            'api_key' => $missingIdentifier,
+            'api_secret' => $existingIdentifier,
+        ]);
+        $recordUid = (int) $connection->lastInsertId();
+
+        $dataHandler = $this->createDataHandler();
+        $hook->processCmdmap_preProcess('delete', 'tx_nrvault_hooktest5', $recordUid, null, $dataHandler, false);
+
+        $commandIsProcessed = false;
+        $hook->processCmdmap('delete', 'tx_nrvault_hooktest5', $recordUid, null, $commandIsProcessed, $dataHandler, false);
+
+        self::assertFalse(
+            $commandIsProcessed,
+            'An absent secret already satisfies the goal state and must not make the record undeletable.',
+        );
+        self::assertFalse(
+            $vaultService->exists($existingIdentifier),
+            'The remaining fields must still be cleaned up after a missing one.',
+        );
+    }
+
     /**
      * Build a DataHandlerHook instance with a pre-seeded vault-field cache.
      *
@@ -447,6 +550,17 @@ final class DataHandlerHookTest extends AbstractVaultFunctionalTestCase
     {
         $this->importCSVDataSet(__DIR__ . '/Fixtures/be_users_field_permissions.csv');
         $this->setUpBackendUser(2);
+    }
+
+    /**
+     * Log in the non-admin user who holds the `secret.delete` operation
+     * permission via their group. Administrators pass every per-secret tier, so
+     * only a non-admin can exercise the ownership half of the delete gate.
+     */
+    private function setUpVaultDeletePermissionUser(): void
+    {
+        $this->importCSVDataSet(__DIR__ . '/Fixtures/be_users_delete_permission.csv');
+        $this->setUpBackendUser(self::DELETER_UID);
     }
 
     /**

--- a/Tests/Functional/Hook/Fixtures/be_users_delete_permission.csv
+++ b/Tests/Functional/Hook/Fixtures/be_users_delete_permission.csv
@@ -1,0 +1,6 @@
+"be_users",,,,,,,
+,"uid","username","admin","disable","starttime","endtime","usergroup"
+,3,"vault_deleter",0,0,0,0,"21"
+"be_groups",,,,
+,"uid","pid","title","custom_options"
+,21,0,"vault-deleters","tx_nrvault:secret.delete"

--- a/Tests/Unit/Hook/DataHandlerHookTest.php
+++ b/Tests/Unit/Hook/DataHandlerHookTest.php
@@ -1753,7 +1753,7 @@ final class DataHandlerHookTest extends TestCase
                     return 'the-secret-value';
                 }
 
-                throw new VaultException(self::RETRIEVE_FAILED);
+                throw new VaultException(self::RETRIEVE_FAILED, 5457412304);
             });
 
         $clonedIdentifier = null;
@@ -1822,7 +1822,7 @@ final class DataHandlerHookTest extends TestCase
                     return 'the-secret-value';
                 }
 
-                throw new VaultException(self::RETRIEVE_FAILED);
+                throw new VaultException(self::RETRIEVE_FAILED, 4012154927);
             });
 
         $this->vaultService
@@ -1878,7 +1878,7 @@ final class DataHandlerHookTest extends TestCase
             ->method('assertDeletable')
             ->willReturnCallback(static function (string $identifier): void {
                 if ($identifier === self::SECOND_UUID) {
-                    throw new VaultException('Delete permission denied');
+                    throw new VaultException('Delete permission denied', 9660657200);
                 }
             });
 
@@ -2003,7 +2003,7 @@ final class DataHandlerHookTest extends TestCase
             ->method('delete')
             ->willReturnCallback(static function (string $identifier) use (&$deleted): void {
                 if ($identifier === self::SECOND_UUID) {
-                    throw new VaultException('Audit write failed');
+                    throw new VaultException('Audit write failed', 9781844315);
                 }
 
                 $deleted[] = $identifier;

--- a/Tests/Unit/Hook/DataHandlerHookTest.php
+++ b/Tests/Unit/Hook/DataHandlerHookTest.php
@@ -44,6 +44,12 @@ final class DataHandlerHookTest extends TestCase
 
     private const EXISTING_UUID = '01937b6e-4b6c-7abc-8def-0123456789ab';
 
+    private const SECOND_UUID = '01937b6e-4b6c-7abc-8def-0123456789ac';
+
+    private const THIRD_UUID = '01937b6e-4b6c-7abc-8def-0123456789ad';
+
+    private const RETRIEVE_FAILED = 'Retrieve failed';
+
     private const TEST_TITLE = 'Test Title';
 
     private const STORAGE_FAILED = 'Storage failed';
@@ -1349,7 +1355,7 @@ final class DataHandlerHookTest extends TestCase
     }
 
     #[Test]
-    public function cmdmapPostProcessSkipsCopyWhenSourceValueNull(): void
+    public function cmdmapPostProcessBlanksCopiedFieldWhenSourceSecretIsMissing(): void
     {
         $this->mockTcaSchemaForTable('tx_test', [
             'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
@@ -1379,10 +1385,17 @@ final class DataHandlerHookTest extends TestCase
             ->expects(self::never())
             ->method('store');
 
-        // No update should happen
+        // Leaving the DataHandler-duplicated source UUID in the copy would make
+        // both records share one secret: the field must be cleared instead.
         $connection
-            ->expects(self::never())
-            ->method('update');
+            ->expects(self::once())
+            ->method('update')
+            ->with('tx_test', ['api_key' => ''], ['uid' => 100]);
+
+        $this->dataHandler
+            ->expects(self::once())
+            ->method('log')
+            ->with('tx_test', 100, 1, null, 2, self::stringContains('api_key'));
 
         $this->subject->processCmdmap_postProcess(
             'copy',
@@ -1632,6 +1645,11 @@ final class DataHandlerHookTest extends TestCase
             ->method('retrieve')
             ->willThrowException(new VaultException('Retrieve failed'));
 
+        $connection
+            ->expects(self::once())
+            ->method('update')
+            ->with('tx_test', ['api_key' => ''], ['uid' => 100]);
+
         $this->dataHandler
             ->expects(self::once())
             ->method('log')
@@ -1640,7 +1658,7 @@ final class DataHandlerHookTest extends TestCase
                 100,
                 1,
                 null,
-                1,
+                2,
                 self::stringContains('api_key'),
             );
 
@@ -1652,5 +1670,374 @@ final class DataHandlerHookTest extends TestCase
             $this->dataHandler,
             false,
         );
+    }
+
+    #[Test]
+    public function cmdmapPostProcessBlanksEveryVaultFieldWhenTheFirstFieldFails(): void
+    {
+        $this->mockTcaSchemaForTable('tx_test', [
+            'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+            'api_secret' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+        ]);
+
+        $this->dataHandler->copyMappingArray = ['tx_test' => [42 => 100]];
+
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAssociative')->willReturn([
+            'api_key' => self::EXISTING_UUID,
+            'api_secret' => self::SECOND_UUID,
+        ]);
+        $connection->method('select')->willReturn($result);
+
+        $this->connectionPool
+            ->method('getConnectionForTable')
+            ->willReturn($connection);
+
+        $this->vaultService
+            ->method('retrieve')
+            ->willThrowException(new VaultException(self::RETRIEVE_FAILED));
+
+        // Nothing was cloned, so there is nothing to compensate...
+        $this->vaultService
+            ->expects(self::never())
+            ->method('store');
+        $this->vaultService
+            ->expects(self::never())
+            ->method('delete');
+
+        // ...but BOTH fields still carry the source UUIDs DataHandler copied,
+        // including the one this method never reached.
+        $connection
+            ->expects(self::once())
+            ->method('update')
+            ->with('tx_test', ['api_key' => '', 'api_secret' => ''], ['uid' => 100]);
+
+        $this->subject->processCmdmap_postProcess(
+            'copy',
+            'tx_test',
+            42,
+            null,
+            $this->dataHandler,
+            false,
+        );
+    }
+
+    #[Test]
+    public function cmdmapPostProcessDeletesAlreadyClonedSecretWhenALaterFieldFails(): void
+    {
+        $this->mockTcaSchemaForTable('tx_test', [
+            'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+            'api_secret' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+        ]);
+
+        $this->dataHandler->copyMappingArray = ['tx_test' => [42 => 100]];
+
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAssociative')->willReturn([
+            'api_key' => self::EXISTING_UUID,
+            'api_secret' => self::SECOND_UUID,
+        ]);
+        $connection->method('select')->willReturn($result);
+
+        $this->connectionPool
+            ->method('getConnectionForTable')
+            ->willReturn($connection);
+
+        // First field clones fine, second one cannot be read.
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(static function (string $identifier): string {
+                if ($identifier === self::EXISTING_UUID) {
+                    return 'the-secret-value';
+                }
+
+                throw new VaultException(self::RETRIEVE_FAILED);
+            });
+
+        $clonedIdentifier = null;
+        $this->vaultService
+            ->expects(self::once())
+            ->method('store')
+            ->willReturnCallback(
+                static function (string $identifier) use (&$clonedIdentifier): void {
+                    $clonedIdentifier = $identifier;
+                },
+            );
+
+        $this->vaultService
+            ->expects(self::once())
+            ->method('delete')
+            ->willReturnCallback(
+                static function (string $identifier, string $reason) use (&$clonedIdentifier): void {
+                    self::assertSame($clonedIdentifier, $identifier, 'Only the clone of THIS copy may be deleted.');
+                    self::assertStringContainsString('copy', $reason);
+                },
+            );
+
+        $connection
+            ->expects(self::once())
+            ->method('update')
+            ->with('tx_test', ['api_key' => '', 'api_secret' => ''], ['uid' => 100]);
+
+        $this->subject->processCmdmap_postProcess(
+            'copy',
+            'tx_test',
+            42,
+            null,
+            $this->dataHandler,
+            false,
+        );
+
+        self::assertNotNull($clonedIdentifier, 'The first field must have been cloned before the failure.');
+    }
+
+    #[Test]
+    public function cmdmapPostProcessBlanksFieldsEvenWhenTheRollbackDeleteFails(): void
+    {
+        $this->mockTcaSchemaForTable('tx_test', [
+            'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+            'api_secret' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+        ]);
+
+        $this->dataHandler->copyMappingArray = ['tx_test' => [42 => 100]];
+
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAssociative')->willReturn([
+            'api_key' => self::EXISTING_UUID,
+            'api_secret' => self::SECOND_UUID,
+        ]);
+        $connection->method('select')->willReturn($result);
+
+        $this->connectionPool
+            ->method('getConnectionForTable')
+            ->willReturn($connection);
+
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(static function (string $identifier): string {
+                if ($identifier === self::EXISTING_UUID) {
+                    return 'the-secret-value';
+                }
+
+                throw new VaultException(self::RETRIEVE_FAILED);
+            });
+
+        $this->vaultService
+            ->method('delete')
+            ->willThrowException(new VaultException('Rollback delete failed'));
+
+        // An orphaned clone is inert; a copy still pointing at the source's
+        // secret is not — so the blanking must happen regardless.
+        $connection
+            ->expects(self::once())
+            ->method('update')
+            ->with('tx_test', ['api_key' => '', 'api_secret' => ''], ['uid' => 100]);
+
+        $this->dataHandler
+            ->expects(self::once())
+            ->method('log')
+            ->with('tx_test', 100, 1, null, 2, self::stringContains('api_secret'));
+
+        $this->subject->processCmdmap_postProcess(
+            'copy',
+            'tx_test',
+            42,
+            null,
+            $this->dataHandler,
+            false,
+        );
+    }
+
+    #[Test]
+    public function cmdmapPreProcessDeletesNoSecretWhenAnyFieldIsNotDeletable(): void
+    {
+        $this->mockTcaSchemaForTable('tx_test', [
+            'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+            'api_secret' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+        ]);
+
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAssociative')->willReturn([
+            'api_key' => self::EXISTING_UUID,
+            'api_secret' => self::SECOND_UUID,
+        ]);
+        $connection->method('select')->willReturn($result);
+
+        $this->connectionPool
+            ->method('getConnectionForTable')
+            ->willReturn($connection);
+
+        // The FIRST field is deletable, the second is not: without a preflight
+        // the first secret would already be gone — irrecoverably — by the time
+        // the denial surfaces.
+        $this->vaultService
+            ->method('assertDeletable')
+            ->willReturnCallback(static function (string $identifier): void {
+                if ($identifier === self::SECOND_UUID) {
+                    throw new VaultException('Delete permission denied');
+                }
+            });
+
+        $this->vaultService
+            ->expects(self::never())
+            ->method('delete');
+
+        $this->dataHandler
+            ->expects(self::once())
+            ->method('log')
+            ->with('tx_test', 42, 3, null, 1, self::stringContains('api_secret'));
+
+        $this->subject->processCmdmap_preProcess(
+            'delete',
+            'tx_test',
+            42,
+            null,
+            $this->dataHandler,
+            false,
+        );
+
+        $commandIsProcessed = false;
+        $this->subject->processCmdmap(
+            'delete',
+            'tx_test',
+            42,
+            null,
+            $commandIsProcessed,
+            $this->dataHandler,
+            false,
+        );
+
+        self::assertTrue($commandIsProcessed, 'The record delete must be cancelled.');
+    }
+
+    #[Test]
+    public function cmdmapPreProcessTreatsAnAlreadyMissingSecretAsDeleted(): void
+    {
+        $this->mockTcaSchemaForTable('tx_test', [
+            'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+            'api_secret' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+        ]);
+
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAssociative')->willReturn([
+            'api_key' => self::EXISTING_UUID,
+            'api_secret' => self::SECOND_UUID,
+        ]);
+        $connection->method('select')->willReturn($result);
+
+        $this->connectionPool
+            ->method('getConnectionForTable')
+            ->willReturn($connection);
+
+        $deleted = [];
+        $this->vaultService
+            ->method('delete')
+            ->willReturnCallback(static function (string $identifier) use (&$deleted): void {
+                if ($identifier === self::EXISTING_UUID) {
+                    throw SecretNotFoundException::forIdentifier($identifier);
+                }
+
+                $deleted[] = $identifier;
+            });
+
+        $this->dataHandler
+            ->expects(self::never())
+            ->method('log');
+
+        $this->subject->processCmdmap_preProcess(
+            'delete',
+            'tx_test',
+            42,
+            null,
+            $this->dataHandler,
+            false,
+        );
+
+        // A dangling reference must not stop the loop, and must not make the
+        // record undeletable forever.
+        self::assertSame([self::SECOND_UUID], $deleted);
+
+        $commandIsProcessed = false;
+        $this->subject->processCmdmap(
+            'delete',
+            'tx_test',
+            42,
+            null,
+            $commandIsProcessed,
+            $this->dataHandler,
+            false,
+        );
+
+        self::assertFalse($commandIsProcessed, 'A missing secret must not cancel the record delete.');
+    }
+
+    #[Test]
+    public function cmdmapPreProcessStopsDeletingAfterAMidSequenceFailure(): void
+    {
+        $this->mockTcaSchemaForTable('tx_test', [
+            'api_key' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+            'api_secret' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+            'api_token' => ['type' => 'input', 'renderType' => 'vaultSecret'],
+        ]);
+
+        $connection = $this->createMock(Connection::class);
+        $result = $this->createMock(Result::class);
+        $result->method('fetchAssociative')->willReturn([
+            'api_key' => self::EXISTING_UUID,
+            'api_secret' => self::SECOND_UUID,
+            'api_token' => self::THIRD_UUID,
+        ]);
+        $connection->method('select')->willReturn($result);
+
+        $this->connectionPool
+            ->method('getConnectionForTable')
+            ->willReturn($connection);
+
+        $deleted = [];
+        $this->vaultService
+            ->method('delete')
+            ->willReturnCallback(static function (string $identifier) use (&$deleted): void {
+                if ($identifier === self::SECOND_UUID) {
+                    throw new VaultException('Audit write failed');
+                }
+
+                $deleted[] = $identifier;
+            });
+
+        $this->dataHandler
+            ->expects(self::once())
+            ->method('log')
+            ->with('tx_test', 42, 3, null, 1, self::stringContains('api_secret'));
+
+        $this->subject->processCmdmap_preProcess(
+            'delete',
+            'tx_test',
+            42,
+            null,
+            $this->dataHandler,
+            false,
+        );
+
+        // The record survives either way, so deleting the third secret would
+        // only enlarge the unrecoverable damage.
+        self::assertSame([self::EXISTING_UUID], $deleted);
+
+        $commandIsProcessed = false;
+        $this->subject->processCmdmap(
+            'delete',
+            'tx_test',
+            42,
+            null,
+            $commandIsProcessed,
+            $this->dataHandler,
+            false,
+        );
+
+        self::assertTrue($commandIsProcessed, 'The record delete must be cancelled.');
     }
 }

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -952,6 +952,99 @@ final class VaultServiceTest extends TestCase
     }
 
     #[Test]
+    public function assertDeletableAcceptsADeletableSecretWithoutDeletingIt(): void
+    {
+        $identifier = 'preflightOk';
+        $secret = $this->createSecretEntity($identifier);
+
+        $this->adapter
+            ->method('retrieve')
+            ->willReturn($secret);
+
+        $this->accessControlService
+            ->method('canDelete')
+            ->willReturn(true);
+
+        // A preflight that mutates would defeat its own purpose.
+        $this->adapter->expects(self::never())->method('delete');
+        $this->auditLogService->expects(self::never())->method('log');
+
+        $this->subject->assertDeletable($identifier);
+    }
+
+    #[Test]
+    public function assertDeletableAcceptsAnAbsentSecret(): void
+    {
+        // The goal state — nothing stored under this identifier — already
+        // holds, so a caller batching several deletes must not be blocked.
+        $this->adapter
+            ->method('retrieve')
+            ->willReturn(null);
+
+        $this->adapter->expects(self::never())->method('delete');
+
+        $this->subject->assertDeletable('gone');
+    }
+
+    #[Test]
+    public function assertDeletableRejectsASecretTheActorMayNotDelete(): void
+    {
+        $secret = $this->createSecretEntity('protected');
+
+        $this->adapter
+            ->method('retrieve')
+            ->willReturn($secret);
+
+        $this->accessControlService
+            ->method('canDelete')
+            ->willReturn(false);
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('protected', 'access_denied', false, 'Delete access denied');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $this->subject->assertDeletable('protected');
+    }
+
+    #[Test]
+    public function assertDeletableRejectsAnActorWithoutTheDeleteOperationPermission(): void
+    {
+        // Separation of duties: owning the secret is not enough, and the
+        // preflight must apply the same second gate delete() does.
+        $existing = $this->createSecretEntity('opGatePreflight', uid: 42);
+
+        $noGrantAccess = $this->createMock(AccessControlServiceInterface::class);
+        $noGrantAccess->method('getCurrentActorUid')->willReturn(1);
+        $noGrantAccess->method('getCurrentActorType')->willReturn('backend');
+        $noGrantAccess->method('canDelete')->willReturn(true);
+        $noGrantAccess->method('isGranted')->willReturn(false);
+
+        $subject = new VaultService(
+            $this->adapter,
+            $this->encryptionService,
+            $noGrantAccess,
+            $this->auditLogService,
+            $this->configuration,
+            $this->httpClientFactory,
+        );
+
+        $this->adapter->method('retrieve')->willReturn($existing);
+        $this->adapter->expects(self::never())->method('delete');
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('opGatePreflight', 'access_denied', false, 'Delete denied: missing secret.delete permission');
+
+        $this->expectException(AccessDeniedException::class);
+
+        $subject->assertDeletable('opGatePreflight');
+    }
+
+    #[Test]
     public function rotateUpdatesSecretValue(): void
     {
         $identifier = 'toRotate';


### PR DESCRIPTION
Second finding of the external review round 3 (verified against the code before implementing): record **copy** and record **delete** were not atomic across multiple vault fields.

## Before

- **Copy:** a failed per-field clone (denied `secret.create`, unreadable source, any vault error) was only logged — the copied record kept the DataHandler-duplicated **source identifier**, silently aliasing the source's secret: rotating the copy mutated the source, deleting the copy destroyed the source's secret. A unit test even pinned this as expected (`expects(never())->method('update')`). `retrieve() === null` hit a `continue` with the same aliasing result.
- **Delete:** secrets were deleted sequentially with **no break** — after a mid-sequence failure the remaining fields were still deleted, the record survived pointing at dead secrets. Worse: `SecretNotFoundException` was treated as failure, so a record referencing a missing secret was **permanently undeletable** through the backend (self-reinforcing with the copy bug).

## After

- **Copy fails closed:** on any failure every already-cloned secret is compensated (deleted) and **all** vault fields of the copy are blanked — the copy never shares a secret with the source. Failure now logs as system error (level 2) instead of a quiet per-field notice.
- **Delete pre-flights:** a new non-mutating `VaultServiceInterface::assertDeletable()` (same private gate as `delete()`, so they cannot drift) checks every field **before** the first irreversible delete; a mid-sequence failure stops the loop; a missing secret counts as success (idempotent) so dangling references no longer block record deletion.

Mutation spot-checks: removing the preflight or narrowing the `SecretNotFoundException` catch each fails a dedicated test.

## Verification

- Unit+Fuzz: 4986 tests, 18516 assertions — OK
- Functional (full suite, sqlite): 298 tests — OK (9 pre-existing skips)
- PHPStan: no errors · CGL: clean
