### PR TITLE
Report keyless audit epoch and in-DB anchor in vault:doctor

### DIFF
--- a/Classes/Service/Doctor/Check/AuditCheck.php
+++ b/Classes/Service/Doctor/Check/AuditCheck.php
@@ -12,7 +12,10 @@ namespace Netresearch\NrVault\Service\Doctor\Check;
 use Netresearch\NrVault\Audit\Anchor\AnchorReaderInterface;
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\AuditChainAnchorStatus;
+use Netresearch\NrVault\Audit\AuditChainAnchorStoreInterface;
 use Netresearch\NrVault\Audit\AuditIntegrityReason;
+use Netresearch\NrVault\Audit\AuditLogService;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
 use Netresearch\NrVault\Audit\Sink\SinkDeliveryState;
@@ -24,6 +27,8 @@ use Netresearch\NrVault\Service\Doctor\DoctorContext;
 use Netresearch\NrVault\Service\Doctor\Finding;
 use Netresearch\NrVault\Service\Doctor\FindingSeverity;
 use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 
 /**
  * Is the audit trail being written, kept, verifiable, and witnessed externally?
@@ -66,6 +71,15 @@ final readonly class AuditCheck implements ReadinessCheckInterface
         private ChainTipAnchorServiceInterface $anchorService,
         private AnchorReaderInterface $anchorReader,
         /**
+         * The IN-DATABASE tip anchor (`sys_registry`), which is a different
+         * control from the sink-published one {@see $anchorReader} reads. Only
+         * `load()` is ever called: the store's mutators are for the audit write
+         * path, and a check that repaired what it inspects would report a pass
+         * it had just created.
+         */
+        private AuditChainAnchorStoreInterface $anchorStore,
+        private ConnectionPool $connectionPool,
+        /**
          * Persisted per-sink delivery health. Optional so pre-existing test
          * constructions keep working; absent means the persisted-state
          * findings are simply not emitted.
@@ -92,6 +106,8 @@ final readonly class AuditCheck implements ReadinessCheckInterface
             $this->checkReadsLogged($context),
             $this->checkRetention(),
             $this->checkHashChain($currentSequence),
+            $this->checkHmacEpoch(),
+            $this->checkDatabaseAnchor($currentSequence),
             $this->checkExternalSink($context),
             $this->checkAnchor($context, $anchor, $currentSequence),
             $this->checkSinkFailures(),
@@ -380,6 +396,286 @@ final readonly class AuditCheck implements ReadinessCheckInterface
                 $currentSequence,
             ),
             docsUrl: DocsLink::AUDIT_HASH_CHAIN,
+            details: $details,
+        );
+    }
+
+    /**
+     * Is the chain keyed at all?
+     *
+     * `auditHmacEpoch = 0` is a single integer that switches off three separate
+     * controls, and until this finding existed none of them said so:
+     *
+     *  1. rows are hashed with plain SHA-256 instead of HMAC-SHA256, so the
+     *     chain needs no key to recompute;
+     *  2. the epoch-downgrade floor in
+     *     {@see AuditLogServiceInterface::verifyHashChain()} defaults to the
+     *     CONFIGURED epoch, so at 0 no chain can fall below it;
+     *  3. {@see AuditChainAnchorStoreInterface::isEnabled()} is `epoch >= 1`, so
+     *     the in-DB tip anchor is never read, written or verified.
+     *
+     * Critical under both profiles: the standard profile does not promise an
+     * external witness, but it does promise a tamper-evident chain, and at
+     * epoch 0 there is none. The shipped default is 3.
+     */
+    private function checkHmacEpoch(): Finding
+    {
+        $id = 'audit.hmac_epoch';
+        $epoch = $this->configuration->getAuditHmacEpoch();
+        $details = [
+            'auditHmacEpoch' => $epoch,
+            'auditAnchorRequired' => $this->configuration->isAuditAnchorRequired(),
+        ];
+
+        if ($epoch >= 1) {
+            return Finding::pass(
+                id: $id,
+                summary: \sprintf(
+                    'Audit chain HMAC epoch is %d: rows are HMAC-signed, the epoch-downgrade floor '
+                    . 'is armed, and the in-DB tip anchor is active.',
+                    $epoch,
+                ),
+                docsUrl: DocsLink::AUDIT_HMAC_EPOCH,
+                details: $details,
+            );
+        }
+
+        return Finding::critical(
+            id: $id,
+            summary: \sprintf(
+                'Audit HMAC epoch is %d: the audit log hash chain is keyless.',
+                $epoch,
+            ),
+            risk: 'One setting disables three controls at once. (1) Audit rows carry a plain SHA-256 '
+                . 'hash instead of an HMAC, so anyone with database write access can alter entries and '
+                . 'recompute a fully self-consistent chain without holding any key. (2) The '
+                . 'epoch-downgrade floor equals the configured epoch, so at 0 there is nothing left for '
+                . 'a relabelled chain to fall below and the downgrade check can never fire. (3) The '
+                . 'in-DB chain-tip anchor in sys_registry is switched off, so a tail truncation or a '
+                . 'full wipe of tx_nrvault_audit_log leaves a chain that still verifies as valid.',
+            remediation: 'Set "auditHmacEpoch" to 3, re-sign the existing entries with '
+                . 'vendor/bin/typo3 vault:audit-migrate-hmac (or the install-tool "Migrate audit hash '
+                . 'chain" wizard), then arm the anchor with vendor/bin/typo3 vault:audit '
+                . '--reset-anchor.',
+            docsUrl: DocsLink::AUDIT_HMAC_EPOCH,
+            details: $details,
+        );
+    }
+
+    /**
+     * Is the IN-DATABASE tip anchor there, and does it authenticate?
+     *
+     * Distinct from `audit.anchor`, which covers the anchor published to the
+     * external sinks. This one is the `sys_registry` assertion that commits in
+     * the same transaction as the audit row it describes — and no doctor control
+     * looked at it before: `audit.hash_chain` verifies a BOUNDED range, and
+     * {@see AuditLogServiceInterface::verifyHashChain()} evaluates the anchor
+     * only on a full-range pass, so the anchor status reaching this check via
+     * the chain result is permanently `NotChecked`. A deleted anchor row was
+     * therefore invisible to `vault:doctor` even at the default epoch.
+     *
+     * Scope, stated the same way `audit.hash_chain` states its own: a pass here
+     * means the anchor exists and its MAC verifies under the current master key.
+     * Whether the anchored ROW still carries the anchored hash is the deep
+     * comparison in `vault:audit-verify`; duplicating it here would put a second
+     * implementation of it on a page load.
+     */
+    private function checkDatabaseAnchor(int $currentSequence): Finding
+    {
+        $id = 'audit.db_anchor';
+        $required = $this->configuration->isAuditAnchorRequired();
+        $epoch = $this->configuration->getAuditHmacEpoch();
+        $connection = $this->connectionPool->getConnectionForTable(AuditLogService::TABLE_NAME);
+        $load = $this->anchorStore->load($connection);
+        $details = [
+            'anchorStatus' => $load->status->value,
+            'auditAnchorRequired' => $required,
+            'auditHmacEpoch' => $epoch,
+            'currentSequence' => $currentSequence,
+        ];
+
+        if ($load->status === AuditChainAnchorStatus::Disabled) {
+            return $this->anchorDisabledFinding($id, $required, $epoch, $details);
+        }
+
+        if ($load->status === AuditChainAnchorStatus::Unanchored) {
+            return $this->unanchoredFinding($id, $connection, $required, $currentSequence, $details);
+        }
+
+        if ($load->status === AuditChainAnchorStatus::Unreadable) {
+            // Critical whatever "auditAnchorRequired" says, matching
+            // AuditLogService::verifyAnchor(): a row that is present but does
+            // not authenticate is not a pre-anchor installation, it is an
+            // anchor that was written over or a key that changed.
+            return Finding::critical(
+                id: $id,
+                summary: 'The in-DB audit chain tip anchor is unreadable: malformed value or invalid MAC.',
+                risk: 'The anchor was tampered with — blanking its value is the documented way to try to '
+                    . 'get back to silent truncation — or the master key changed without the chain being '
+                    . 're-sealed. Either way the tip is currently not pinned by anything.',
+                remediation: 'Run vendor/bin/typo3 vault:audit-verify first and treat a chain error as an '
+                    . 'incident. If the master key was rotated or the chain re-keyed without a re-seal, '
+                    . 're-arm with vendor/bin/typo3 vault:audit --reset-anchor, which records the reset '
+                    . 'in the chain itself. Do NOT re-arm before verifying — it would sign whatever the '
+                    . 'chain has been cut down to.',
+                docsUrl: DocsLink::AUDIT_TIP_ANCHOR,
+                details: $details,
+            );
+        }
+
+        if ($load->status === AuditChainAnchorStatus::Ok) {
+            return Finding::pass(
+                id: $id,
+                summary: 'The in-DB audit chain tip anchor is present and authenticates. Tip-hash '
+                    . 'comparison against the anchored row is vault:audit-verify.',
+                docsUrl: DocsLink::AUDIT_TIP_ANCHOR,
+                details: $details,
+            );
+        }
+
+        // No load() path produces the remaining statuses today. Reporting the
+        // unknown one rather than falling through to a pass keeps a future
+        // status from being read as healthy by a gate that never saw it.
+        return Finding::warning(
+            id: $id,
+            summary: \sprintf(
+                'The in-DB audit chain tip anchor reported an unexpected status: %s.',
+                $load->status->value,
+            ),
+            risk: 'The control was not conclusively evaluated. Treat it as unknown, not as satisfied.',
+            remediation: 'Run vendor/bin/typo3 vault:audit-verify for the authoritative anchor verdict.',
+            docsUrl: DocsLink::AUDIT_TIP_ANCHOR,
+            details: $details,
+        );
+    }
+
+    /**
+     * The anchor is off because the epoch is below 1.
+     *
+     * With `auditAnchorRequired` on this is a contradiction the rest of the
+     * system cannot report: `verifyAnchor()` returns on `Disabled` BEFORE the
+     * requirement is consulted, so the operator's assertion "this installation
+     * is anchored" is satisfied by an anchor that is switched off.
+     *
+     * @param array<string, bool|int|string> $details
+     */
+    private function anchorDisabledFinding(string $id, bool $required, int $epoch, array $details): Finding
+    {
+        if ($required) {
+            return Finding::critical(
+                id: $id,
+                summary: \sprintf(
+                    'Contradictory configuration: "auditAnchorRequired" is enabled while '
+                    . '"auditHmacEpoch" is %d, which disables the in-DB tip anchor entirely.',
+                    $epoch,
+                ),
+                risk: 'The configuration asserts that this installation is anchored, and the anchor is '
+                    . 'switched off at the source: at epoch 0 the store never reads, writes or verifies '
+                    . 'one. Verification reports "disabled" and returns before the requirement is ever '
+                    . 'consulted, so the setting produces neither a warning nor an error — it silently '
+                    . 'protects nothing while reading as the stricter configuration.',
+                remediation: 'Raise "auditHmacEpoch" to 3 and migrate the chain with vendor/bin/typo3 '
+                    . 'vault:audit-migrate-hmac, then arm the anchor with vendor/bin/typo3 vault:audit '
+                    . '--reset-anchor. If keyless operation is genuinely intended, turn '
+                    . '"auditAnchorRequired" off so the configuration stops claiming a control it does '
+                    . 'not have.',
+                docsUrl: DocsLink::AUDIT_TIP_ANCHOR,
+                details: $details,
+            );
+        }
+
+        return Finding::warning(
+            id: $id,
+            summary: \sprintf(
+                'The in-DB audit chain tip anchor is disabled ("auditHmacEpoch" is %d) and was not '
+                . 'evaluated.',
+                $epoch,
+            ),
+            risk: 'Nothing outside tx_nrvault_audit_log pins how far the chain had grown, so a tail '
+                . 'truncation or a full wipe leaves a chain that still verifies. This is one of the '
+                . 'three consequences reported by audit.hmac_epoch.',
+            remediation: 'Raise "auditHmacEpoch" to 3 and run vendor/bin/typo3 vault:audit-migrate-hmac; '
+                . 'the anchor arms itself on the next audit write.',
+            docsUrl: DocsLink::AUDIT_TIP_ANCHOR,
+            details: $details,
+        );
+    }
+
+    /**
+     * No anchor is readable at the current epoch.
+     *
+     * Three different situations, and they do not deserve the same severity:
+     * `sys_registry` on a foreign connection is a deployment fact no operator
+     * action inside the vault can fix; an empty chain has simply not armed the
+     * anchor yet; a populated chain with no anchor is either that same
+     * pre-anchor state or an anchor someone removed, which is exactly what
+     * `auditAnchorRequired` exists to disambiguate.
+     *
+     * @param array<string, bool|int|string> $details
+     */
+    private function unanchoredFinding(
+        string $id,
+        Connection $connection,
+        bool $required,
+        int $currentSequence,
+        array $details,
+    ): Finding {
+        if (!$this->anchorStore->sharesConnection($connection)) {
+            return Finding::warning(
+                id: $id,
+                summary: 'The in-DB audit chain tip anchor is unavailable: sys_registry and '
+                    . 'tx_nrvault_audit_log are mapped to different database connections.',
+                risk: 'The anchor cannot commit atomically with an audit write across two connections, '
+                    . 'so it is not armed at all and truncation of the audit table stays undetectable '
+                    . 'by this control.',
+                remediation: 'Map both tables to the same connection in '
+                    . '$GLOBALS[TYPO3_CONF_VARS][DB][TableMapping], or rely on an external audit sink '
+                    . 'plus vendor/bin/typo3 vault:audit-anchor for truncation evidence.',
+                docsUrl: DocsLink::AUDIT_TIP_ANCHOR,
+                details: $details,
+            );
+        }
+
+        if ($required) {
+            return Finding::critical(
+                id: $id,
+                summary: 'No in-DB audit chain tip anchor is recorded, although "auditAnchorRequired" '
+                    . 'is enabled.',
+                risk: 'The configuration asserts this installation is already anchored, so an absent '
+                    . 'anchor is not the pre-anchor state — it is an anchor that was removed, the step '
+                    . 'that precedes a truncation. Ordinary audit writes deliberately refuse to re-arm '
+                    . 'it, so this does not heal on its own.',
+                remediation: 'Verify the chain first with vendor/bin/typo3 vault:audit-verify. Only once '
+                    . 'it is clean, arm the anchor with vendor/bin/typo3 vault:audit --reset-anchor, '
+                    . 'which records the reset as an audit entry in the same transaction.',
+                docsUrl: DocsLink::AUDIT_TIP_ANCHOR,
+                details: $details,
+            );
+        }
+
+        if ($currentSequence === 0) {
+            return Finding::pass(
+                id: $id,
+                summary: 'The audit log is empty; the in-DB tip anchor arms itself on the first audit '
+                    . 'write.',
+                docsUrl: DocsLink::AUDIT_TIP_ANCHOR,
+                details: $details,
+            );
+        }
+
+        return Finding::warning(
+            id: $id,
+            summary: \sprintf(
+                'No in-DB audit chain tip anchor is recorded, although the chain has grown to uid %d.',
+                $currentSequence,
+            ),
+            risk: 'Tail truncation and full wipes of tx_nrvault_audit_log are not detectable until the '
+                . 'anchor is armed. A never-armed anchor and a deleted one are indistinguishable from '
+                . 'database state alone, which is why this is a warning rather than an error.',
+            remediation: 'The next audit write arms it. Once it is armed, enable "auditAnchorRequired" '
+                . 'so a later deletion of the anchor row becomes an error instead of this warning — the '
+                . 'setting lives in a settings file and is out of a database-write attacker\'s reach.',
+            docsUrl: DocsLink::AUDIT_TIP_ANCHOR,
             details: $details,
         );
     }

--- a/Classes/Service/Doctor/DocsLink.php
+++ b/Classes/Service/Doctor/DocsLink.php
@@ -36,6 +36,10 @@ final class DocsLink
 
     public const AUDIT_HASH_CHAIN = self::BASE . 'Security/Index.html#security-hash-chain';
 
+    public const AUDIT_HMAC_EPOCH = self::BASE . 'Security/Index.html#security-hmac-audit-chain';
+
+    public const AUDIT_TIP_ANCHOR = self::BASE . 'Security/Index.html#security-audit-chain-anchor';
+
     public const AUDIT_SINKS = self::BASE . 'Configuration/Index.html#configuration-audit-sinks';
 
     public const AUDIT_SINK_SCHEDULING = self::BASE . 'Configuration/Index.html#configuration-audit-sink-scheduling';

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -1073,6 +1073,33 @@ audit.hash_chain
    tail verifies", never "the chain is intact". :ref:`command-audit-verify` is
    the authoritative full-range verifier and belongs on a schedule.
 
+audit.hmac_epoch
+   :confval:`ext-nrvault-auditHmacEpoch` is at least 1. **Critical** in both
+   profiles below that: the one integer switches off three controls at once —
+   rows are hashed with keyless SHA-256, the epoch-downgrade floor equals the
+   configured epoch and so can never be undercut, and the in-DB tip anchor is
+   disabled. The finding names all three, because "epoch is 0" on its own reads
+   like a version marker rather than a disabled chain. The shipped default is 3.
+
+audit.db_anchor
+   The IN-DATABASE tip anchor in ``sys_registry`` — a different control from
+   ``audit.anchor``, which covers the copy published to the external sinks. Pass
+   when the anchor is present and its MAC verifies; *warning* when it is not
+   armed yet on a non-empty chain, when ``sys_registry`` and
+   ``tx_nrvault_audit_log`` are mapped to different database connections (no
+   vault-side action fixes that), and when the anchor is disabled by
+   ``auditHmacEpoch = 0``. **Critical** when it is missing while
+   :confval:`ext-nrvault-auditAnchorRequired` is enabled, when the stored anchor
+   is present but unreadable (tampered value or a master key changed without a
+   re-seal), and for the contradiction ``auditAnchorRequired = 1`` together with
+   ``auditHmacEpoch = 0`` — verification reports ``Disabled`` and returns before
+   the requirement is ever consulted, so that combination protects nothing while
+   reading as the stricter configuration. An empty audit log is a pass: the
+   anchor arms itself on the first audit write. Like ``audit.hash_chain`` this
+   control states its scope — a pass means the anchor authenticates, not that
+   the anchored row still carries the anchored hash; that comparison is
+   :ref:`command-audit-verify`.
+
 audit.external_sink
    At least one external audit sink is enabled. *Pass* / *critical*: sinks are
    documented as opt-in under ``standard``, and flagging a default installation

--- a/Tests/Functional/Command/VaultDoctorCommandTest.php
+++ b/Tests/Functional/Command/VaultDoctorCommandTest.php
@@ -122,6 +122,8 @@ final class VaultDoctorCommandTest extends AbstractVaultFunctionalTestCase
             'audit.reads_logged',
             'audit.retention',
             'audit.hash_chain',
+            'audit.hmac_epoch',
+            'audit.db_anchor',
             'audit.external_sink',
             'audit.anchor',
             'audit.sink_delivery',

--- a/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
@@ -12,6 +12,10 @@ namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
 use Netresearch\NrVault\Audit\Anchor\AnchorReaderInterface;
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\AuditChainAnchor;
+use Netresearch\NrVault\Audit\AuditChainAnchorLoad;
+use Netresearch\NrVault\Audit\AuditChainAnchorStatus;
+use Netresearch\NrVault\Audit\AuditChainAnchorStoreInterface;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Audit\HashChainVerificationResult;
 use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
@@ -26,6 +30,8 @@ use Netresearch\NrVault\Tests\Unit\Traits\DoctorFindingTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
 
 #[CoversClass(AuditCheck::class)]
 final class AuditCheckTest extends TestCase
@@ -67,6 +73,8 @@ final class AuditCheckTest extends TestCase
                 'audit.reads_logged',
                 'audit.retention',
                 'audit.hash_chain',
+                'audit.hmac_epoch',
+                'audit.db_anchor',
                 'audit.external_sink',
                 'audit.anchor',
                 'audit.sink_delivery',
@@ -393,6 +401,241 @@ final class AuditCheckTest extends TestCase
     }
 
     /**
+     * The lowest epoch that still keys the chain. Epoch 1 must pass, so a
+     * relaxed `>= 1` boundary in the check cannot go unnoticed.
+     */
+    #[Test]
+    public function theLowestKeyedEpochPasses(): void
+    {
+        $finding = $this->findingById(
+            $this->check(epoch: 1)->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.hmac_epoch',
+        );
+
+        self::assertTrue($finding->isPass(), $finding->summary);
+        self::assertSame(1, $finding->details['auditHmacEpoch']);
+    }
+
+    /**
+     * Epoch 0 switches off three controls with one integer, and the standard
+     * profile promises a tamper-evident chain just as much as the hardened one —
+     * so this is critical in both, not an escalation.
+     */
+    #[DataProvider('keylessEpochProvider')]
+    #[Test]
+    public function aKeylessEpochIsCriticalUnderBothProfiles(int $epoch): void
+    {
+        foreach ([SecurityProfile::Standard, SecurityProfile::Hardened] as $profile) {
+            $finding = $this->assertFindingSeverity(
+                FindingSeverity::Critical,
+                $this->check(epoch: $epoch)->run($this->doctorContext($profile)),
+                'audit.hmac_epoch',
+            );
+
+            self::assertSame($epoch, $finding->details['auditHmacEpoch']);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function keylessEpochProvider(): iterable
+    {
+        yield 'zero' => [0];
+        yield 'negative' => [-1];
+    }
+
+    /**
+     * The finding is only actionable if it says WHICH controls went inert — an
+     * operator reading "epoch is 0" alone has no reason to treat it as critical.
+     */
+    #[Test]
+    public function theKeylessEpochFindingNamesAllThreeDisabledControls(): void
+    {
+        $finding = $this->findingById(
+            $this->check(epoch: 0, anchorRequired: true)
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.hmac_epoch',
+        );
+
+        self::assertStringContainsString('SHA-256', $finding->risk);
+        self::assertStringContainsString('downgrade', $finding->risk);
+        self::assertStringContainsString('sys_registry', $finding->risk);
+        self::assertStringContainsString('vault:audit-migrate-hmac', $finding->remediation);
+
+        // The epoch finding carries the anchor requirement too: the two settings
+        // are only readable as a contradiction when both values are in the JSON.
+        self::assertTrue($finding->details['auditAnchorRequired']);
+    }
+
+    /**
+     * `auditAnchorRequired` + epoch 0 is the silent contradiction: the store is
+     * disabled, so verification returns `Disabled` before the requirement is
+     * ever consulted and the strict-looking setting protects nothing.
+     */
+    #[Test]
+    public function requiringTheAnchorAtEpochZeroIsReportedAsAContradiction(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $this->check(epoch: 0, anchorRequired: true)
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.db_anchor',
+        );
+
+        self::assertStringContainsString('auditAnchorRequired', $finding->summary);
+        self::assertStringContainsString('auditHmacEpoch', $finding->summary);
+        self::assertSame(AuditChainAnchorStatus::Disabled->value, $finding->details['anchorStatus']);
+        self::assertTrue($finding->details['auditAnchorRequired']);
+    }
+
+    /**
+     * Without the requirement the disabled anchor is still not a pass: the
+     * control was not evaluated, and a gate must not read that as satisfied.
+     */
+    #[Test]
+    public function aDisabledAnchorWarnsThatTheControlWasNotEvaluated(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(epoch: 0)->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.db_anchor',
+        );
+
+        self::assertStringContainsString('auditHmacEpoch', $finding->summary);
+        self::assertSame(0, $finding->details['auditHmacEpoch']);
+    }
+
+    /**
+     * The case the doctor was blind to: at the default epoch the anchor row is
+     * simply gone, and no bounded chain pass evaluates the anchor at all.
+     */
+    #[Test]
+    public function aMissingAnchorOnAPopulatedChainIsAWarning(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(dbAnchorStatus: AuditChainAnchorStatus::Unanchored)
+                ->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.db_anchor',
+        );
+
+        self::assertStringContainsString((string) self::CHAIN_TIP, $finding->summary);
+    }
+
+    /**
+     * With the operator's "this install is anchored" assertion in place, an
+     * absent anchor is a removed anchor — and ordinary audit writes deliberately
+     * refuse to re-arm it, so it does not heal on its own.
+     */
+    #[Test]
+    public function aMissingAnchorIsCriticalWhenItIsRequired(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $this->check(anchorRequired: true, dbAnchorStatus: AuditChainAnchorStatus::Unanchored)
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.db_anchor',
+        );
+
+        self::assertStringContainsString('vault:audit --reset-anchor', $finding->remediation);
+    }
+
+    /**
+     * A chain with no rows has nothing to anchor yet, and the anchor arms itself
+     * on the first audit write — flagging a fresh installation would train
+     * operators to ignore the finding that matters.
+     */
+    #[Test]
+    public function aMissingAnchorOnAnEmptyChainPasses(): void
+    {
+        $finding = $this->findingById(
+            $this->check(chainTip: 0, dbAnchorStatus: AuditChainAnchorStatus::Unanchored)
+                ->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.db_anchor',
+        );
+
+        self::assertTrue($finding->isPass(), $finding->summary);
+        self::assertSame(0, $finding->details['currentSequence']);
+    }
+
+    /**
+     * Two connections is a deployment fact no vault-side action fixes, so it
+     * stays a warning even under the requirement — otherwise the gate demands
+     * something the operator cannot do from here.
+     */
+    #[Test]
+    public function aSplitConnectionStaysAWarningEvenWhenTheAnchorIsRequired(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(
+                anchorRequired: true,
+                dbAnchorStatus: AuditChainAnchorStatus::Unanchored,
+                sharesConnection: false,
+            )->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.db_anchor',
+        );
+
+        self::assertStringContainsString('different database connections', $finding->summary);
+    }
+
+    /**
+     * A present-but-unauthentic anchor is never the pre-anchor state, so it is
+     * critical regardless of profile and of `auditAnchorRequired` — the same
+     * verdict `AuditLogService::verifyAnchor()` reaches.
+     */
+    #[Test]
+    public function anUnreadableAnchorIsCriticalWhetherOrNotItIsRequired(): void
+    {
+        foreach ([true, false] as $required) {
+            $finding = $this->assertFindingSeverity(
+                FindingSeverity::Critical,
+                $this->check(
+                    anchorRequired: $required,
+                    dbAnchorStatus: AuditChainAnchorStatus::Unreadable,
+                )->run($this->doctorContext(SecurityProfile::Standard)),
+                'audit.db_anchor',
+            );
+
+            self::assertStringContainsString('unreadable', $finding->summary);
+        }
+    }
+
+    /**
+     * A status `load()` cannot currently produce must not fall through to a
+     * pass: a gate that never saw the value would read silence as health.
+     */
+    #[Test]
+    public function anUnexpectedAnchorStatusIsReportedRatherThanPassed(): void
+    {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(dbAnchorStatus: AuditChainAnchorStatus::Violated)
+                ->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.db_anchor',
+        );
+
+        self::assertSame(AuditChainAnchorStatus::Violated->value, $finding->details['anchorStatus']);
+    }
+
+    /**
+     * A pass has to admit its scope: the MAC verifies, which is not the same as
+     * the anchored ROW still carrying the anchored hash.
+     */
+    #[Test]
+    public function aHealthyAnchorPassesAndNamesTheDeeperVerifier(): void
+    {
+        $finding = $this->findingById(
+            $this->check()->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.db_anchor',
+        );
+
+        self::assertTrue($finding->isPass(), $finding->summary);
+        self::assertStringContainsString('vault:audit-verify', $finding->summary);
+    }
+
+    /**
      * A check wired with a healthy audit configuration, overridable per test.
      *
      * @param list<string> $sinks Enabled sink identifiers
@@ -401,6 +644,15 @@ final class AuditCheckTest extends TestCase
      *                                    healthy default (ignored when
      *                                    `$withoutAnchor` is true)
      * @param bool $withoutAnchor No anchor could be read at all
+     * @param int $epoch Configured `auditHmacEpoch`
+     * @param bool $anchorRequired Configured `auditAnchorRequired`
+     * @param AuditChainAnchorStatus|null $dbAnchorStatus Status the in-DB anchor
+     *                                                    store reports; null
+     *                                                    derives it from
+     *                                                    `$epoch`, exactly as
+     *                                                    the real store does
+     * @param bool $sharesConnection Whether `sys_registry` resolves to the audit
+     *                               connection
      */
     private function check(
         bool $auditReads = true,
@@ -413,11 +665,17 @@ final class AuditCheckTest extends TestCase
         bool $withoutAnchor = false,
         ?AuditLogServiceInterface $auditLogService = null,
         ?SinkDeliveryStateRepositoryInterface $deliveryState = null,
+        int $epoch = 3,
+        bool $anchorRequired = false,
+        ?AuditChainAnchorStatus $dbAnchorStatus = null,
+        bool $sharesConnection = true,
     ): AuditCheck {
         $configuration = self::createStub(ExtensionConfigurationInterface::class);
         $configuration->method('isAuditReadsEnabled')->willReturn($auditReads);
         $configuration->method('getAuditLogRetention')->willReturn($retention);
         $configuration->method('getAuditSinkStaleDeliveryHours')->willReturn(24);
+        $configuration->method('getAuditHmacEpoch')->willReturn($epoch);
+        $configuration->method('isAuditAnchorRequired')->willReturn($anchorRequired);
 
         if (!$auditLogService instanceof AuditLogServiceInterface) {
             $stub = self::createStub(AuditLogServiceInterface::class);
@@ -459,8 +717,49 @@ final class AuditCheckTest extends TestCase
             $registry,
             $anchorService,
             $anchorReader,
+            $this->anchorStore($epoch, $dbAnchorStatus, $sharesConnection),
+            $this->connectionPool(),
             $deliveryState,
         );
+    }
+
+    /**
+     * The in-DB anchor store, wired to report `$status`.
+     *
+     * When no status is given it is derived from the epoch the same way
+     * `AuditChainAnchorStore::isEnabled()` does (`epoch >= 1`), so a test that
+     * only lowers the epoch cannot accidentally assert against a store that
+     * still claims to be armed.
+     */
+    private function anchorStore(
+        int $epoch,
+        ?AuditChainAnchorStatus $status,
+        bool $sharesConnection,
+    ): AuditChainAnchorStoreInterface {
+        $status ??= $epoch >= 1 ? AuditChainAnchorStatus::Ok : AuditChainAnchorStatus::Disabled;
+
+        $load = new AuditChainAnchorLoad(
+            status: $status,
+            anchor: $status === AuditChainAnchorStatus::Ok
+                ? new AuditChainAnchor(self::CHAIN_TIP, str_repeat('a', 64), 1_700_000_000)
+                : null,
+            raw: $status === AuditChainAnchorStatus::Ok ? 'nrvault-audit-tip.v1|…' : '',
+        );
+
+        $store = self::createStub(AuditChainAnchorStoreInterface::class);
+        $store->method('isEnabled')->willReturn($epoch >= 1);
+        $store->method('sharesConnection')->willReturn($sharesConnection);
+        $store->method('load')->willReturn($load);
+
+        return $store;
+    }
+
+    private function connectionPool(): ConnectionPool
+    {
+        $pool = self::createStub(ConnectionPool::class);
+        $pool->method('getConnectionForTable')->willReturn(self::createStub(Connection::class));
+
+        return $pool;
     }
 
     /**


### PR DESCRIPTION
Fifth finding of the external review round 3 (verified before implementing, and widened during verification): `vault:doctor` was blind to two audit-integrity configuration holes.

## What was missing

- **`auditHmacEpoch = 0` had no finding at all**, although this one setting simultaneously (a) drops row hashes to keyless SHA-256, (b) makes the chain-level epoch-downgrade guard vacuous (the floor equals the configured epoch), and (c) disables the in-DB tip anchor — including silently overriding `auditAnchorRequired = 1`, because `verifyAnchor()` returns on `Disabled` before the requirement is consulted.
- **The in-DB sys_registry anchor was never checked by doctor at any epoch**: `AuditCheck` runs a bounded `verifyHashChain($fromUid)`, and the service evaluates the anchor only on full-range verification — so even at the default epoch 3 with `auditAnchorRequired = 1`, a deleted anchor row was invisible to doctor (the existing `audit.anchor` control covers only the external sink-published anchor).

## New doctor controls (additive, existing ids untouched)

| Control | Behaviour |
|---|---|
| `audit.hmac_epoch` | pass at epoch ≥ 1; **Critical** under both profiles at epoch 0, naming all three consequences |
| `audit.db_anchor` | loads the sys_registry anchor directly: Unreadable (present but MAC-invalid) → **Critical** regardless of profile/required (mirrors `verifyAnchor()`); Missing → **Critical** when `auditAnchorRequired`, Warning otherwise (mirrors `reportUnanchored()`); epoch 0 + required → explicit contradiction **Critical**; split sys_registry connection → Warning (not operator-fixable vault-side); fresh install (empty log, no anchor) → pass |

Deep tip comparison deliberately stays in `vault:audit-verify` — the finding text states its scope, like `audit.hash_chain` does. Docs (`Commands.rst` control list) updated additively; `DocsLink` targets added.

## Verification

- Unit: 3377 tests / Fuzz: 1612 tests / Functional full suite: 296 — all OK
- PHPStan level 10: no errors · CGL: clean · base-class check: clean
- AuditCheck line coverage 99.80 %; every surviving Infection mutant in the new code is a prose-string concat mutant (no logic/boundary escapes). Outside the security-gate scope (Classes/Service/Doctor).
