### PR TITLE
Restore ACL MM relations when a FormEngine audit write fails

### DIFF
--- a/Classes/Domain/Model/Secret.php
+++ b/Classes/Domain/Model/Secret.php
@@ -379,6 +379,14 @@ final readonly class Secret
      * caller must look them up and pass them here — there is no
      * second-step `setAllowedGroups()` after construction.
      *
+     * The row's own `allowed_groups`/`write_groups` columns are deliberately
+     * NOT consulted: for MM-backed TCA group fields they hold the relation
+     * COUNT, not the related UIDs (DataHandler writes
+     * `RelationHandler::countItems()` there, and `toDatabaseRow()` mirrors
+     * that). Reading them as a UID list would turn "3 groups are allowed"
+     * into "group 3 is allowed" — a silent ACL forgery. The MM tables are
+     * the single source of truth for both tiers.
+     *
      * @param array<string, mixed> $row
      * @param int[] $allowedGroups Read-tier group UIDs (from MM table)
      * @param int[] $writeGroups Write-tier group UIDs (from MM table)
@@ -389,23 +397,6 @@ final readonly class Secret
         if (!empty($row['metadata'])) {
             $decoded = json_decode((string) $row['metadata'], true);
             $metadata = \is_array($decoded) ? $decoded : [];
-        }
-
-        // If the caller didn't pre-load the MM table, fall back to the
-        // comma-separated denormalised column some legacy rows still carry.
-        if ($allowedGroups === [] && !empty($row['allowed_groups'])) {
-            $groups = (string) $row['allowed_groups'];
-            $allowedGroups = array_values(array_filter(
-                array_map(\intval(...), explode(',', $groups)),
-            ));
-        }
-
-        // Same legacy-CSV fallback for the write-tier groups.
-        if ($writeGroups === [] && !empty($row['write_groups'])) {
-            $wGroups = (string) $row['write_groups'];
-            $writeGroups = array_values(array_filter(
-                array_map(\intval(...), explode(',', $wGroups)),
-            ));
         }
 
         $encryptedValue = $row['encrypted_value'] ?? null;
@@ -453,9 +444,13 @@ final readonly class Secret
      * These three columns are therefore DB-managed; a `fromDatabaseRow()`
      * → `toDatabaseRow()` round-trip is not an identity for them.
      *
-     * The `allowed_groups`/`write_groups` CSV columns are written for
-     * legacy-read fallback only; the authoritative source of truth for
-     * group relations is the MM tables (written by `SecretRepository`).
+     * The `allowed_groups`/`write_groups` columns are MM-backed TCA group
+     * fields, so their column value is the relation COUNT — the convention
+     * DataHandler writes on the FormEngine path
+     * (`RelationHandler::countItems()`). Writing the same count here keeps
+     * one meaning for the column no matter which writer produced the row;
+     * the group UIDs themselves live solely in the MM tables, written by
+     * `SecretRepository::save()` from the very lists counted here.
      *
      * @return array<string, mixed>
      */
@@ -473,8 +468,8 @@ final readonly class Secret
             'encryption_algorithm' => $this->encryptionAlgorithm,
             'value_checksum' => $this->valueChecksum,
             'owner_uid' => $this->ownerUid,
-            'allowed_groups' => implode(',', $this->allowedGroups),
-            'write_groups' => implode(',', $this->writeGroups),
+            'allowed_groups' => \count($this->allowedGroups),
+            'write_groups' => \count($this->writeGroups),
             'context' => $this->context,
             'frontend_accessible' => $this->frontendAccessible ? 1 : 0,
             'version' => $this->version,

--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -177,7 +177,7 @@ final class SecretTcaHook
         // For existing records, prevent identifier changes
         if (!str_starts_with((string) $id, 'NEW') && isset($fieldArray['identifier'])) {
             // Get the original identifier
-            $originalRecord = BackendUtility::getRecord(self::TABLE, (int) $id, 'identifier');
+            $originalRecord = $this->readRecord((int) $id, ['identifier']);
             $originalIdentifier = \is_string($originalRecord['identifier'] ?? null) ? $originalRecord['identifier'] : '';
             if ($originalRecord !== null && $fieldArray['identifier'] !== $originalIdentifier) {
                 // Identifier change attempted - revert to original
@@ -225,7 +225,7 @@ final class SecretTcaHook
         if (!str_starts_with((string) $id, 'NEW') && $fieldArray !== []) {
             $columns = $this->submittedColumns($fieldArray);
             if ($columns !== []) {
-                $original = BackendUtility::getRecord(self::TABLE, (int) $id, implode(',', $columns));
+                $original = $this->readRecord((int) $id, $columns);
                 if ($original !== null) {
                     $this->originalMetadata[(string) $id] = array_intersect_key(
                         $original,
@@ -268,7 +268,7 @@ final class SecretTcaHook
         $uid = is_numeric($uidRaw) ? (int) $uidRaw : 0;
 
         // Get the secret identifier for operations
-        $record = BackendUtility::getRecord(self::TABLE, $uid, 'identifier,owner_uid,allowed_groups,scope_pid');
+        $record = $this->readRecord($uid, ['identifier', 'owner_uid', 'allowed_groups', 'scope_pid']);
         if ($record === null) {
             return;
         }
@@ -634,6 +634,71 @@ final class SecretTcaHook
     }
 
     /**
+     * Read the requested columns of one secret row, soft-deleted rows
+     * excluded — the semantics of BackendUtility::getRecord(), but through
+     * the injected ConnectionPool.
+     *
+     * The static call is avoided because its internals differ across the
+     * supported TYPO3 range: v13 gates on `$GLOBALS['TCA'][$table]`, v14 on
+     * a TcaSchemaFactory resolved through GeneralUtility. That made this
+     * hook's record reads depend on which core version was installed. The
+     * `deleted = 0` predicate is spelled out for the same reason — core's
+     * DeletedRestriction resolves the schema on v14 as well; it matches the
+     * restriction set getRecord() applies (removeAll() plus DeletedRestriction).
+     *
+     * Without a ConnectionPool (construction without DI) the static call is
+     * kept so those callers keep working unchanged.
+     *
+     * @param list<string> $columns
+     *
+     * @return array<string, mixed>|null
+     */
+    private function readRecord(int $uid, array $columns): ?array
+    {
+        if ($uid < 1) {
+            return null;
+        }
+
+        if (!$this->connectionPool instanceof ConnectionPool) {
+            $record = BackendUtility::getRecord(self::TABLE, $uid, implode(',', $columns));
+            if ($record === null) {
+                return null;
+            }
+
+            // Core annotates the return as a bare `array`; re-key so the
+            // string-keyed row this method promises is established rather
+            // than assumed. An explicit loop, like submittedColumns().
+            $row = [];
+            foreach ($record as $column => $value) {
+                $row[(string) $column] = $value;
+            }
+
+            return $row;
+        }
+
+        $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        $row = $queryBuilder
+            ->select(...$columns)
+            ->from(self::TABLE)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'uid',
+                    $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT),
+                ),
+                $queryBuilder->expr()->eq(
+                    'deleted',
+                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT),
+                ),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        return $row === false ? null : $row;
+    }
+
+    /**
      * Write the compensating revert: `null` removes the just-created row,
      * a value map restores the captured pre-change column values.
      *
@@ -842,11 +907,7 @@ final class SecretTcaHook
         }
 
         $uid = is_numeric($id) ? (int) $id : 0;
-        $original = BackendUtility::getRecord(
-            self::TABLE,
-            $uid,
-            'owner_uid,frontend_accessible,scope_pid',
-        );
+        $original = $this->readRecord($uid, ['owner_uid', 'frontend_accessible', 'scope_pid']);
         if ($original === null) {
             return;
         }

--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -19,6 +19,7 @@ use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Throwable;
 use TYPO3\CMS\Backend\Utility\BackendUtility;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
 
@@ -49,16 +50,29 @@ final class SecretTcaHook
     ];
 
     /**
-     * Privileged ACL columns backed by MM relation tables. The row column
-     * only holds the relation COUNT, so it cannot be reverted by writing a
-     * value back — the submitted change is instead dropped from $fieldArray
-     * entirely, leaving DataHandler to keep the existing MM relations.
+     * Privileged ACL columns backed by MM relation tables, mapped to the MM
+     * table holding their relations. The row column only holds the relation
+     * COUNT, so the effective ACL cannot be restored by writing that column
+     * back — the MM rows themselves are the source of truth
+     * (`SecretRepository::loadGroupsForSecret()`).
      *
-     * @var list<string>
+     * Two consequences follow, and both are implemented below:
+     *  - An unauthorized change is dropped from $fieldArray entirely
+     *    (see enforcePrivilegedColumnPolicy()), leaving DataHandler to keep
+     *    the existing MM relations rather than replacing them.
+     *  - An authorized change that later fails its audit write is rolled
+     *    back by restoring the snapshotted MM rows, not just the count
+     *    column (see snapshotMmRelations()/restoreMmRelations()).
+     *
+     * The table names are duplicated from SecretRepository rather than read
+     * from $GLOBALS['TCA'] so the rollback keeps working on the CLI/scheduler
+     * paths, where the hook may run before TCA is fully built.
+     *
+     * @var array<string, string>
      */
     private const PRIVILEGED_MM_COLUMNS = [
-        'allowed_groups',
-        'write_groups',
+        'allowed_groups' => 'tx_nrvault_secret_begroups_mm',
+        'write_groups' => 'tx_nrvault_secret_writegroups_mm',
     ];
 
     /**
@@ -91,6 +105,38 @@ final class SecretTcaHook
      * @var array<string, array<string, mixed>>
      */
     private array $originalMetadata = [];
+
+    /**
+     * Pre-change MM relation rows for every privileged MM column a datamap
+     * UPDATE submits, keyed by record id and then by MM table. Captured in
+     * processDatamap_preProcessFieldArray() — DataHandler writes the new MM
+     * rows during checkValue(), i.e. before this hook's
+     * afterDatabaseOperations() runs, so by rollback time the widened set is
+     * already committed and only a snapshot taken beforehand can restore it.
+     *
+     * An entry with an empty row list is meaningful: it records "this tier
+     * had no groups", which the rollback restores by deleting the rows the
+     * failed change added.
+     *
+     * @var array<string, array<string, list<array{uid_foreign: int, sorting: int, sorting_foreign: int}>>>
+     */
+    private array $originalMmRelations = [];
+
+    /**
+     * UIDs whose record creation was rolled back because the creation audit
+     * write failed, awaiting the MM purge in
+     * processDatamap_afterAllOperations().
+     *
+     * For a 'new' record DataHandler defers the MM writes to
+     * $dbAnalysisStore (the uid is unknown during checkValue) and flushes
+     * them in dbAnalysisStoreExec() — after every afterDatabaseOperations()
+     * hook has run. The row is therefore deleted BEFORE its MM rows are
+     * written, and without this purge the reverted creation would leave
+     * orphaned relation rows pointing at a uid that no longer exists.
+     *
+     * @var array<int, true>
+     */
+    private array $revertedCreations = [];
 
     public function __construct(
         private readonly VaultServiceInterface $vaultService,
@@ -169,9 +215,13 @@ final class SecretTcaHook
         // Always remove secret_input from fieldArray - it's not a real database column
         unset($fieldArray['secret_input']);
 
-        // Capture the pre-change values of the real columns this UPDATE
-        // submits, for the compensating rollback should the metadata-update
-        // audit write fail in afterDatabaseOperations (SEC-3 atomicity).
+        // Capture the pre-change state of everything this UPDATE submits, for
+        // the compensating rollback should the metadata-update audit write
+        // fail in afterDatabaseOperations (SEC-3 atomicity): the real column
+        // values, plus the MM relation rows behind the privileged ACL columns
+        // (whose column value is only a count). Both snapshots are taken here
+        // because DataHandler has overwritten neither yet — checkValue() and
+        // updateDB() both run after this hook.
         if (!str_starts_with((string) $id, 'NEW') && $fieldArray !== []) {
             $columns = $this->submittedColumns($fieldArray);
             if ($columns !== []) {
@@ -182,6 +232,12 @@ final class SecretTcaHook
                         array_flip($columns),
                     );
                 }
+
+                // Assigned unconditionally, empty result included: a save that
+                // submits no ACL column must clear any snapshot a previous
+                // save left behind on a DI-shared instance, never inherit it
+                // and "restore" a state two edits old.
+                $this->originalMmRelations[(string) $id] = $this->snapshotMmRelations((int) $id, $columns);
             }
         }
     }
@@ -280,7 +336,8 @@ final class SecretTcaHook
         // well (SEC-3): if the audit write fails, the database change is
         // reverted so no mutation persists without a tamper-evident record.
         $originalMetadata = $this->originalMetadata[$originalId] ?? null;
-        unset($this->originalMetadata[$originalId]);
+        $originalMmRelations = $this->originalMmRelations[$originalId] ?? [];
+        unset($this->originalMetadata[$originalId], $this->originalMmRelations[$originalId]);
 
         if ($status === 'new') {
             if (!$secretStored) {
@@ -295,7 +352,52 @@ final class SecretTcaHook
             return;
         }
 
-        $this->auditMetadataUpdateOrCompensate($identifier, $uid, $changedColumns, $originalMetadata, $dataHandler);
+        $this->auditMetadataUpdateOrCompensate(
+            $identifier,
+            $uid,
+            $changedColumns,
+            $originalMetadata,
+            $originalMmRelations,
+            $dataHandler,
+        );
+    }
+
+    /**
+     * Called once every datamap operation — including DataHandler's deferred
+     * MM writes (dbAnalysisStoreExec()) — has finished. Purges the relation
+     * rows those deferred writes just created for records whose creation this
+     * hook rolled back, so a reverted create leaves no orphaned MM rows
+     * behind (see $revertedCreations).
+     *
+     * Cleaning up here rather than filtering DataHandler's public-but-internal
+     * $dbAnalysisStore keeps the fix on a documented extension point, and it
+     * is idempotent: deleting by uid_local removes whatever was written for
+     * that uid, in whichever order the store was flushed.
+     *
+     * Entries are consumed so a DI-shared hook instance cannot carry a stale
+     * uid into a later DataHandler run (same discipline as $pendingSecrets).
+     */
+    public function processDatamap_afterAllOperations(DataHandler $dataHandler): void// NOSONAR: TYPO3 DataHandler hook method name (fixed API contract)
+    {
+        $revertedUids = array_keys($this->revertedCreations);
+        $this->revertedCreations = [];
+
+        foreach ($revertedUids as $uid) {
+            if ($this->purgeMmRelations($uid)) {
+                continue;
+            }
+
+            /** @phpstan-ignore method.internal */
+            $dataHandler->log(
+                self::TABLE,
+                $uid,
+                2,
+                null,
+                1,
+                'Vault secret ACL relations of the reverted record creation could not be purged; '
+                . 'manual reconciliation required.',
+            );
+        }
     }
 
     /**
@@ -400,7 +502,9 @@ final class SecretTcaHook
      * Audit the FormEngine creation of a record that carries no secret value
      * (a value-bearing create is audited by VaultService::store()). If the
      * audit write fails, the just-created row is removed again — a record
-     * must not exist without its audit entry.
+     * must not exist without its audit entry. Its ACL relation rows are
+     * purged in processDatamap_afterAllOperations(), because DataHandler
+     * writes them only after this hook has run.
      *
      * @param array<string, mixed> $fieldArray
      */
@@ -420,6 +524,13 @@ final class SecretTcaHook
             );
         } catch (Throwable $e) {
             $reverted = $this->revertRow($uid, null);
+            if ($reverted) {
+                // The deferred MM writes for this uid have not run yet; queue
+                // the purge for after dbAnalysisStoreExec(). Only a genuinely
+                // removed row gets queued — if the revert failed the record
+                // still exists and its relations rightfully belong to it.
+                $this->revertedCreations[$uid] = true;
+            }
 
             /** @phpstan-ignore method.internal */
             $dataHandler->log(
@@ -436,18 +547,27 @@ final class SecretTcaHook
 
     /**
      * Audit a metadata-only column change. If the audit write fails, the
-     * captured pre-change values are written back (scalar columns; MM
-     * relation rows are owned by DataHandler and only their count column is
-     * restored) so the change does not persist unaudited.
+     * captured pre-change state is written back so the change does not
+     * persist unaudited: the scalar column values AND the MM relation rows
+     * behind the privileged ACL columns.
+     *
+     * Restoring the count column alone would be worse than not reverting at
+     * all — it would leave the row claiming the old number of groups while
+     * the MM tables still granted the widened set, and the effective ACL is
+     * read from the MM tables. The revert therefore only counts as done when
+     * both halves succeeded; a partial result is reported as
+     * "NOT revertible" so the inconsistency is surfaced, not hidden.
      *
      * @param list<string> $changedColumns
      * @param array<string, mixed>|null $originalMetadata
+     * @param array<string, list<array{uid_foreign: int, sorting: int, sorting_foreign: int}>> $originalMmRelations
      */
     private function auditMetadataUpdateOrCompensate(
         string $identifier,
         int $uid,
         array $changedColumns,
         ?array $originalMetadata,
+        array $originalMmRelations,
         DataHandler $dataHandler,
     ): void {
         try {
@@ -462,6 +582,13 @@ final class SecretTcaHook
             $reverted = $originalMetadata !== null
                 && $originalMetadata !== []
                 && $this->revertRow($uid, $originalMetadata);
+
+            // Restore the relation rows even when the row revert failed, so
+            // the effective ACL stops granting the unaudited widening either
+            // way; $reverted stays false so the log reports the row half.
+            if ($originalMmRelations !== [] && !$this->restoreMmRelations($uid, $originalMmRelations)) {
+                $reverted = false;
+            }
 
             /** @phpstan-ignore method.internal */
             $dataHandler->log(
@@ -525,6 +652,130 @@ final class SecretTcaHook
         } catch (Throwable) {
             return false;
         }
+    }
+
+    /**
+     * Read the current MM relation rows of every privileged ACL column among
+     * $submittedColumns, so a failed audit write can restore them verbatim.
+     *
+     * `sorting` is carried along because it is what orders the group list in
+     * the FormEngine field and in
+     * `SecretRepository::loadGroupsForSecret()` — a rollback that restored
+     * the same groups in a different order would still alter the record.
+     *
+     * @param list<string> $submittedColumns
+     *
+     * @return array<string, list<array{uid_foreign: int, sorting: int, sorting_foreign: int}>>
+     */
+    private function snapshotMmRelations(int $uid, array $submittedColumns): array
+    {
+        if ($uid <= 0 || !$this->connectionPool instanceof ConnectionPool) {
+            return [];
+        }
+
+        $snapshot = [];
+
+        foreach (self::PRIVILEGED_MM_COLUMNS as $column => $mmTable) {
+            if (!\in_array($column, $submittedColumns, true)) {
+                continue;
+            }
+
+            try {
+                $queryBuilder = $this->connectionPool->getQueryBuilderForTable($mmTable);
+                $rows = $queryBuilder
+                    ->select('uid_foreign', 'sorting', 'sorting_foreign')
+                    ->from($mmTable)
+                    ->where($queryBuilder->expr()->eq(
+                        'uid_local',
+                        $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT),
+                    ))
+                    ->orderBy('sorting', 'ASC')
+                    ->executeQuery()
+                    ->fetchAllAssociative();
+            } catch (Throwable) {
+                // An unreadable tier cannot be restored. Skip it rather than
+                // recording an empty snapshot, which the rollback would
+                // "restore" by deleting the record's real relations.
+                continue;
+            }
+
+            $snapshot[$mmTable] = array_map(
+                static fn (array $row): array => [
+                    'uid_foreign' => is_numeric($row['uid_foreign'] ?? null) ? (int) $row['uid_foreign'] : 0,
+                    'sorting' => is_numeric($row['sorting'] ?? null) ? (int) $row['sorting'] : 0,
+                    'sorting_foreign' => is_numeric($row['sorting_foreign'] ?? null) ? (int) $row['sorting_foreign'] : 0,
+                ],
+                $rows,
+            );
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * Write a snapshot taken by snapshotMmRelations() back: replace the
+     * record's current relation rows in each snapshotted tier with the
+     * captured ones. An empty captured list is honoured — it means the tier
+     * held no groups before the change, so the rows the change added are
+     * deleted and nothing is re-inserted.
+     *
+     * @param array<string, list<array{uid_foreign: int, sorting: int, sorting_foreign: int}>> $snapshot
+     *
+     * @return bool True only if every snapshotted tier was fully restored
+     */
+    private function restoreMmRelations(int $uid, array $snapshot): bool
+    {
+        if ($uid <= 0 || !$this->connectionPool instanceof ConnectionPool) {
+            return false;
+        }
+
+        $restored = true;
+
+        foreach ($snapshot as $mmTable => $rows) {
+            try {
+                $connection = $this->connectionPool->getConnectionForTable($mmTable);
+                $connection->delete($mmTable, ['uid_local' => $uid]);
+
+                foreach ($rows as $row) {
+                    $connection->insert($mmTable, ['uid_local' => $uid, ...$row]);
+                }
+            } catch (Throwable) {
+                // Keep going: restoring the remaining tiers narrows the
+                // unaudited widening even when one tier cannot be repaired.
+                $restored = false;
+            }
+        }
+
+        return $restored;
+    }
+
+    /**
+     * Delete every privileged ACL relation row pointing at $uid, in both
+     * tiers. Used to clean up after a reverted record creation, whose MM
+     * rows DataHandler writes only after the revert has already removed the
+     * row they reference.
+     *
+     * @return bool True if both tiers were purged
+     */
+    private function purgeMmRelations(int $uid): bool
+    {
+        if ($uid <= 0 || !$this->connectionPool instanceof ConnectionPool) {
+            return false;
+        }
+
+        $purged = true;
+
+        foreach (self::PRIVILEGED_MM_COLUMNS as $mmTable) {
+            try {
+                $this->connectionPool
+                    ->getConnectionForTable($mmTable)
+                    ->delete($mmTable, ['uid_local' => $uid]);
+            } catch (Throwable) {
+                $purged = false;
+            }
+        }
+
+        return $purged;
     }
 
     /**
@@ -625,7 +876,7 @@ final class SecretTcaHook
             $reverted = true;
         }
 
-        foreach (self::PRIVILEGED_MM_COLUMNS as $column) {
+        foreach (array_keys(self::PRIVILEGED_MM_COLUMNS) as $column) {
             if (!\array_key_exists($column, $fieldArray)) {
                 continue;
             }

--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -590,6 +590,15 @@ final class SecretTcaHook
                 $reverted = false;
             }
 
+            // A changed ACL column whose tier is absent from the snapshot
+            // means the pre-change read failed: the relations cannot be
+            // restored, so the change must not be reported as reverted.
+            foreach (self::PRIVILEGED_MM_COLUMNS as $column => $mmTable) {
+                if (\in_array($column, $changedColumns, true) && !\array_key_exists($mmTable, $originalMmRelations)) {
+                    $reverted = false;
+                }
+            }
+
             /** @phpstan-ignore method.internal */
             $dataHandler->log(
                 self::TABLE,
@@ -734,11 +743,18 @@ final class SecretTcaHook
         foreach ($snapshot as $mmTable => $rows) {
             try {
                 $connection = $this->connectionPool->getConnectionForTable($mmTable);
-                $connection->delete($mmTable, ['uid_local' => $uid]);
+                // Transactional per tier: without it, an insert failure after
+                // the delete would leave the tier EMPTY — locking out the
+                // legitimate groups, which is worse than the unaudited
+                // widening the rollback set out to undo. On rollback the tier
+                // keeps its current rows and the caller reports NOT revertible.
+                $connection->transactional(static function () use ($connection, $mmTable, $uid, $rows): void {
+                    $connection->delete($mmTable, ['uid_local' => $uid]);
 
-                foreach ($rows as $row) {
-                    $connection->insert($mmTable, ['uid_local' => $uid, ...$row]);
-                }
+                    foreach ($rows as $row) {
+                        $connection->insert($mmTable, ['uid_local' => $uid, ...$row]);
+                    }
+                });
             } catch (Throwable) {
                 // Keep going: restoring the remaining tiers narrows the
                 // unaudited widening even when one tier cannot be repaired.

--- a/Tests/Functional/Hook/Fixtures/be_users_and_groups.csv
+++ b/Tests/Functional/Hook/Fixtures/be_users_and_groups.csv
@@ -1,0 +1,9 @@
+"be_users",,,,,,,
+,"uid","username","password","admin","disable","starttime","endtime"
+,1,"admin","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",1,0,0,0
+"be_groups",,,,,,,
+,"uid","pid","title",,,,
+,10,0,"vault-readers-a",,,,
+,11,0,"vault-readers-b",,,,
+,20,0,"vault-writers",,,,
+,99,0,"vault-widened",,,,

--- a/Tests/Functional/Hook/SecretTcaHookAuditAtomicityTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookAuditAtomicityTest.php
@@ -29,6 +29,10 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  * - "AuditLogService throws on the FormEngine delete => the secret
  *   survives" — the delete runs through VaultService::delete(), whose
  *   compensation re-stores the record (deleted=0).
+ * - The same guarantee for the ACL group tiers, whose effective value lives
+ *   in the MM relation tables rather than in the row: a reverted change must
+ *   restore the relations themselves, and a reverted creation must not leave
+ *   its relation rows behind.
  */
 #[CoversClass(SecretTcaHook::class)]
 final class SecretTcaHookAuditAtomicityTest extends AbstractVaultFunctionalTestCase
@@ -37,7 +41,11 @@ final class SecretTcaHookAuditAtomicityTest extends AbstractVaultFunctionalTestC
 
     private const AUDIT_TABLE = 'tx_nrvault_audit_log';
 
-    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users.csv';
+    private const READ_MM_TABLE = 'tx_nrvault_secret_begroups_mm';
+
+    private const WRITE_MM_TABLE = 'tx_nrvault_secret_writegroups_mm';
+
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_and_groups.csv';
 
     #[Test]
     public function metadataChangeIsRevertedWhenAuditWriteFails(): void
@@ -111,6 +119,151 @@ final class SecretTcaHookAuditAtomicityTest extends AbstractVaultFunctionalTestC
     }
 
     /**
+     * The regression this test pins: the rollback used to restore only the
+     * main row, whose ACL columns hold nothing but the relation COUNT. The
+     * widened MM rows — the ones the ACL is actually read from — survived,
+     * leaving a record that claimed the old number of groups while granting
+     * the new ones.
+     */
+    #[Test]
+    public function aclGroupRelationsAreRevertedWhenAuditWriteFails(): void
+    {
+        $identifier = 'atomic_acl_' . bin2hex(random_bytes(4));
+        $recordUid = $this->createRecord($identifier, 'ACL rollback');
+
+        // Seed the ACL tiers through a separate, still-audited edit. Setting
+        // them in the create datamap would not do: on a value-bearing create
+        // VaultService::store() re-saves the entity with empty group tiers
+        // after DataHandler's insert but before its deferred MM writes, which
+        // leaves the count column at 0 — a create-path inconsistency of its
+        // own, and not what this test is about.
+        $this->updateAclGroups($recordUid, '10,11', '20');
+
+        // Precondition: DataHandler really wrote the seeded relations, and
+        // the count columns agree with them.
+        self::assertSame([10, 11], $this->loadMmGroups(self::READ_MM_TABLE, $recordUid));
+        self::assertSame([20], $this->loadMmGroups(self::WRITE_MM_TABLE, $recordUid));
+        self::assertSame('2', $this->readColumn($recordUid, 'allowed_groups'));
+        self::assertSame('1', $this->readColumn($recordUid, 'write_groups'));
+
+        $this->breakAuditWrites();
+
+        $updateHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $updateHandler->start(
+            [
+                self::SECRET_TABLE => [
+                    $recordUid => [
+                        // Widen BOTH tiers with group 99, and reorder the read
+                        // tier so a restore that ignored `sorting` would show.
+                        'allowed_groups' => '11,10,99',
+                        'write_groups' => '20,99',
+                    ],
+                ],
+            ],
+            [],
+        );
+        $updateHandler->process_datamap();
+
+        self::assertSame(
+            [10, 11],
+            $this->loadMmGroups(self::READ_MM_TABLE, $recordUid),
+            'The read-tier MM relations must be restored exactly, order included.',
+        );
+        self::assertSame(
+            [20],
+            $this->loadMmGroups(self::WRITE_MM_TABLE, $recordUid),
+            'The write-tier MM relations must be restored exactly.',
+        );
+
+        // The count columns must agree with the restored relations — the
+        // inconsistency the old rollback produced was precisely a restored
+        // count over a widened relation set.
+        self::assertSame('2', $this->readColumn($recordUid, 'allowed_groups'));
+        self::assertSame('1', $this->readColumn($recordUid, 'write_groups'));
+
+        /** @phpstan-ignore property.internal */
+        $errorLog = $updateHandler->errorLog;
+        self::assertNotEmpty($errorLog, 'The reverted save must surface in the DataHandler error log.');
+    }
+
+    /**
+     * Create path: DataHandler defers a new record's MM writes until after
+     * every afterDatabaseOperations() hook has run, so the compensating
+     * delete of the record happens BEFORE its relation rows are written.
+     * Without the deferred purge, a reverted creation left MM rows pointing
+     * at a uid that no longer exists.
+     */
+    #[Test]
+    public function revertedRecordCreationLeavesNoOrphanedAclRelations(): void
+    {
+        $this->breakAuditWrites();
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start(
+            [
+                self::SECRET_TABLE => [
+                    'NEW1' => [
+                        'pid' => 0,
+                        'identifier' => 'atomic_orphan_' . bin2hex(random_bytes(4)),
+                        'description' => 'Value-less create with ACL groups',
+                        // No secret_input: the hook itself audits this
+                        // creation, so its failure triggers the hook's own
+                        // compensating delete.
+                        'allowed_groups' => '10,11',
+                        'write_groups' => '20',
+                    ],
+                ],
+            ],
+            [],
+        );
+        $dataHandler->process_datamap();
+
+        $recordUid = (int) ($dataHandler->substNEWwithIDs['NEW1'] ?? 0);
+        self::assertGreaterThan(0, $recordUid, 'The record must have been inserted before being reverted.');
+
+        self::assertSame(
+            '',
+            $this->readColumn($recordUid, 'identifier'),
+            'The record creation must be reverted when its audit write fails.',
+        );
+        self::assertSame(
+            [],
+            $this->loadMmGroups(self::READ_MM_TABLE, $recordUid),
+            'A reverted creation must leave no orphaned read-tier relations.',
+        );
+        self::assertSame(
+            [],
+            $this->loadMmGroups(self::WRITE_MM_TABLE, $recordUid),
+            'A reverted creation must leave no orphaned write-tier relations.',
+        );
+    }
+
+    /**
+     * Set both ACL group tiers through the real DataHandler while the audit
+     * log is still healthy, so the edit is accepted and persisted.
+     */
+    private function updateAclGroups(int $recordUid, string $allowedGroups, string $writeGroups): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start(
+            [
+                self::SECRET_TABLE => [
+                    $recordUid => [
+                        'allowed_groups' => $allowedGroups,
+                        'write_groups' => $writeGroups,
+                    ],
+                ],
+            ],
+            [],
+        );
+        $dataHandler->process_datamap();
+
+        /** @phpstan-ignore property.internal */
+        $errorLog = $dataHandler->errorLog;
+        self::assertSame([], $errorLog, 'Seeding the ACL tiers must succeed without DataHandler errors.');
+    }
+
+    /**
      * Create a value-bearing secret record through the real DataHandler
      * (audit still healthy at this point).
      */
@@ -156,6 +309,36 @@ final class SecretTcaHookAuditAtomicityTest extends AbstractVaultFunctionalTestC
         $this->getConnectionPool()
             ->getConnectionForTable(self::AUDIT_TABLE)
             ->executeStatement('DROP TABLE ' . self::AUDIT_TABLE);
+    }
+
+    /**
+     * The secret's related group UIDs for one tier, in relation order — the
+     * same `sorting` order `SecretRepository::loadGroupsForSecret()` reads
+     * the effective ACL in.
+     *
+     * @return list<int>
+     */
+    private function loadMmGroups(string $mmTable, int $secretUid): array
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable($mmTable);
+        $queryBuilder->getRestrictions()->removeAll();
+        $rows = $queryBuilder
+            ->select('uid_foreign')
+            ->from($mmTable)
+            ->where($queryBuilder->expr()->eq(
+                'uid_local',
+                $queryBuilder->createNamedParameter($secretUid, Connection::PARAM_INT),
+            ))
+            ->orderBy('sorting', 'ASC')
+            ->executeQuery()
+            ->fetchAllAssociative();
+
+        $groups = [];
+        foreach ($rows as $row) {
+            $groups[] = (int) $row['uid_foreign'];
+        }
+
+        return $groups;
     }
 
     private function readColumn(int $uid, string $column): string

--- a/Tests/Unit/Domain/Model/SecretTest.php
+++ b/Tests/Unit/Domain/Model/SecretTest.php
@@ -497,7 +497,9 @@ final class SecretTest extends TestCase
             'encryption_version' => 1,
             'value_checksum' => 'sha256hash',
             'owner_uid' => 5,
-            'allowed_groups' => '1,2,3',
+            // MM-backed column: the value is the relation COUNT, and the UIDs
+            // are passed separately by the repository from the MM table.
+            'allowed_groups' => 3,
             'context' => 'payment',
             'version' => 3,
             'expires_at' => 1735689600,
@@ -514,7 +516,7 @@ final class SecretTest extends TestCase
             'last_read_at' => 1704153600,
         ];
 
-        $secret = Secret::fromDatabaseRow($row);
+        $secret = Secret::fromDatabaseRow($row, [1, 2, 3]);
 
         self::assertSame(42, $secret->getUid());
         self::assertSame(1, $secret->getScopePid());
@@ -817,7 +819,7 @@ final class SecretTest extends TestCase
             'encryption_algorithm' => 'xchacha20poly1305',
             'value_checksum' => 'cs',
             'owner_uid' => 5,
-            'allowed_groups' => '7,8,9',
+            'allowed_groups' => 3,
             'context' => 'payment',
             'frontend_accessible' => 1,
             'version' => 3,
@@ -835,7 +837,7 @@ final class SecretTest extends TestCase
             'last_read_at' => 1704153600,
         ];
 
-        $secret = Secret::fromDatabaseRow($row);
+        $secret = Secret::fromDatabaseRow($row, [7, 8, 9]);
 
         self::assertSame(42, $secret->getUid());
         self::assertSame(1, $secret->getScopePid());
@@ -1039,30 +1041,65 @@ final class SecretTest extends TestCase
         self::assertTrue($secret->isHidden());
     }
 
+    /**
+     * The row columns hold the MM relation COUNT, never the related UIDs.
+     * Interpreting "3 groups are allowed" as "group 3 is allowed" would
+     * forge an ACL out of a counter, so the columns must be ignored
+     * entirely when the caller passes no MM-loaded groups.
+     */
     #[Test]
-    public function fromDatabaseRowAllowedGroupsFiltersZeroValues(): void
+    public function fromDatabaseRowIgnoresTheRelationCountColumns(): void
     {
         $secret = Secret::fromDatabaseRow([
             'uid' => 1,
             'identifier' => 't',
-            'allowed_groups' => '1,0,2,0,3',
-        ]);
-
-        // Zeros must be filtered out — without array_filter() they would remain.
-        self::assertNotContains(0, $secret->getAllowedGroups());
-        self::assertSame([1, 2, 3], array_values($secret->getAllowedGroups()));
-    }
-
-    #[Test]
-    public function fromDatabaseRowAllowedGroupsAllZeroReturnsEmpty(): void
-    {
-        $secret = Secret::fromDatabaseRow([
-            'uid' => 1,
-            'identifier' => 't',
-            'allowed_groups' => '0,0,0',
+            'allowed_groups' => 3,
+            'write_groups' => 2,
         ]);
 
         self::assertSame([], $secret->getAllowedGroups());
+        self::assertSame([], $secret->getWriteGroups());
+    }
+
+    /**
+     * The same holds for a count that happens to look like a UID list — a
+     * legacy row still carrying comma-separated values must not resurrect
+     * the removed CSV fallback.
+     */
+    #[Test]
+    public function fromDatabaseRowIgnoresACommaSeparatedGroupsColumn(): void
+    {
+        $secret = Secret::fromDatabaseRow([
+            'uid' => 1,
+            'identifier' => 't',
+            'allowed_groups' => '1,2,3',
+            'write_groups' => '4,5',
+        ]);
+
+        self::assertSame([], $secret->getAllowedGroups());
+        self::assertSame([], $secret->getWriteGroups());
+    }
+
+    /**
+     * The MM-loaded lists win over whatever the columns say — they are the
+     * only source of the effective ACL.
+     */
+    #[Test]
+    public function fromDatabaseRowTakesGroupsSolelyFromTheMmArguments(): void
+    {
+        $secret = Secret::fromDatabaseRow(
+            [
+                'uid' => 1,
+                'identifier' => 't',
+                'allowed_groups' => 99,
+                'write_groups' => 98,
+            ],
+            [4, 5],
+            [6],
+        );
+
+        self::assertSame([4, 5], $secret->getAllowedGroups());
+        self::assertSame([6], $secret->getWriteGroups());
     }
 
     // ---------------------------------------------------------------
@@ -1099,7 +1136,9 @@ final class SecretTest extends TestCase
         self::assertSame('dek', $row['encrypted_dek']);
         self::assertSame('checksum', $row['value_checksum']);
         self::assertSame(5, $row['owner_uid']);
-        self::assertSame('1,2', $row['allowed_groups']);
+        // MM-backed column: the relation count, matching what DataHandler
+        // writes — the UIDs themselves go to the MM table.
+        self::assertSame(2, $row['allowed_groups']);
         self::assertSame('testing', $row['context']);
         self::assertSame(2, $row['version']);
         self::assertSame('{"key":"value"}', $row['metadata']);
@@ -1210,7 +1249,7 @@ final class SecretTest extends TestCase
         self::assertSame(1, $row['encryption_version']);
         self::assertSame('cs', $row['value_checksum']);
         self::assertSame(2, $row['owner_uid']);
-        self::assertSame('3,4', $row['allowed_groups']);
+        self::assertSame(2, $row['allowed_groups']);
         self::assertSame('ctx', $row['context']);
         self::assertSame(1, $row['frontend_accessible']);
         self::assertSame(5, $row['version']);
@@ -1226,14 +1265,25 @@ final class SecretTest extends TestCase
     }
 
     #[Test]
-    public function toDatabaseRowSerialisesEmptyAllowedGroupsAsEmptyString(): void
+    public function toDatabaseRowSerialisesGroupTiersAsRelationCounts(): void
+    {
+        $secret = new Secret(identifier: 't', allowedGroups: [3, 4, 5], writeGroups: [9]);
+
+        $row = $secret->toDatabaseRow();
+
+        self::assertSame(3, $row['allowed_groups']);
+        self::assertSame(1, $row['write_groups']);
+    }
+
+    #[Test]
+    public function toDatabaseRowSerialisesEmptyGroupTiersAsZero(): void
     {
         $secret = new Secret(identifier: 't');
 
         $row = $secret->toDatabaseRow();
 
-        // implode(',', []) === ''
-        self::assertSame('', $row['allowed_groups']);
+        self::assertSame(0, $row['allowed_groups']);
+        self::assertSame(0, $row['write_groups']);
     }
 
     #[Test]

--- a/Tests/Unit/Hook/SecretTcaHookTest.php
+++ b/Tests/Unit/Hook/SecretTcaHookTest.php
@@ -9,10 +9,13 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Hook;
 
+use Closure;
+use Doctrine\DBAL\Result;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
 use Netresearch\NrVault\Hook\SecretTcaHook;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
@@ -20,12 +23,28 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use ReflectionClass;
+use RuntimeException;
+use Throwable;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Schema\TcaSchema;
+use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 #[CoversClass(SecretTcaHook::class)]
 #[AllowMockObjectsWithoutExpectations]
 final class SecretTcaHookTest extends TestCase
 {
+    private const TABLE = 'tx_nrvault_secret';
+
+    private const READ_GROUPS_MM = 'tx_nrvault_secret_begroups_mm';
+
+    private const WRITE_GROUPS_MM = 'tx_nrvault_secret_writegroups_mm';
+
     private VaultServiceInterface&MockObject $vaultService;
 
     private AuditLogServiceInterface&MockObject $auditService;
@@ -399,5 +418,1020 @@ final class SecretTcaHookTest extends TestCase
         $this->auditService->expects($this->never())->method('log');
 
         $this->hook->processCmdmap_preProcess('move', 'tx_nrvault_secret', 1);
+    }
+
+    #[Test]
+    public function snapshotMmRelationsSkipsANewRecordWithoutTouchingTheDatabase(): void
+    {
+        $calls = [];
+        $hook = $this->hookWith($this->queryBuilderPool([], $calls));
+
+        self::assertSame([], $this->invokePrivate($hook, 'snapshotMmRelations', [0, ['allowed_groups']]));
+        self::assertSame([], $calls, 'a record without a uid must not be read');
+    }
+
+    #[Test]
+    public function snapshotMmRelationsYieldsNothingWithoutAConnectionPool(): void
+    {
+        // $this->hook is built without the optional ConnectionPool — the
+        // rollback degrades to logging, so nothing may be snapshotted.
+        self::assertSame(
+            [],
+            $this->invokePrivate($this->hook, 'snapshotMmRelations', [5, ['allowed_groups', 'write_groups']]),
+        );
+    }
+
+    #[Test]
+    public function snapshotMmRelationsOnlyReadsTheTiersTheSaveSubmits(): void
+    {
+        $calls = [];
+        $pool = $this->queryBuilderPool([self::READ_GROUPS_MM => []], $calls);
+
+        $snapshot = $this->invokePrivate(
+            $this->hookWith($pool),
+            'snapshotMmRelations',
+            [5, ['allowed_groups', 'title']],
+        );
+
+        self::assertIsArray($snapshot);
+        self::assertSame([self::READ_GROUPS_MM], array_keys($snapshot));
+        self::assertContains(['from', self::READ_GROUPS_MM], $calls);
+    }
+
+    #[Test]
+    public function snapshotMmRelationsReadsTheRecordsRowsInSortingOrder(): void
+    {
+        $calls = [];
+        $pool = $this->queryBuilderPool([self::READ_GROUPS_MM => []], $calls);
+
+        $this->invokePrivate($this->hookWith($pool), 'snapshotMmRelations', [5, ['allowed_groups']]);
+
+        // `sorting` is part of the identity of the restored state: the same
+        // groups in a different order are a different record.
+        self::assertContains(['select', ['uid_foreign', 'sorting', 'sorting_foreign']], $calls);
+        self::assertContains(['orderBy', 'sorting', 'ASC'], $calls);
+        self::assertContains(['createNamedParameter', 5, Connection::PARAM_INT], $calls);
+    }
+
+    #[Test]
+    public function snapshotMmRelationsOmitsATierWhoseReadFails(): void
+    {
+        $calls = [];
+        $pool = $this->queryBuilderPool([
+            self::READ_GROUPS_MM => new RuntimeException('mm read failed'),
+            self::WRITE_GROUPS_MM => [['uid_foreign' => 3, 'sorting' => 1, 'sorting_foreign' => 0]],
+        ], $calls);
+
+        $snapshot = $this->invokePrivate(
+            $this->hookWith($pool),
+            'snapshotMmRelations',
+            [5, ['allowed_groups', 'write_groups']],
+        );
+
+        self::assertIsArray($snapshot);
+        // Absent, NOT an empty list: an empty entry would be "restored" by
+        // deleting the tier's real relations.
+        self::assertArrayNotHasKey(self::READ_GROUPS_MM, $snapshot);
+        self::assertSame(
+            [['uid_foreign' => 3, 'sorting' => 1, 'sorting_foreign' => 0]],
+            $snapshot[self::WRITE_GROUPS_MM],
+        );
+    }
+
+    #[Test]
+    public function snapshotMmRelationsCoercesNonNumericRowValuesToZero(): void
+    {
+        $calls = [];
+        $pool = $this->queryBuilderPool([
+            self::READ_GROUPS_MM => [['uid_foreign' => '7', 'sorting' => null, 'sorting_foreign' => 'x']],
+        ], $calls);
+
+        $snapshot = $this->invokePrivate($this->hookWith($pool), 'snapshotMmRelations', [5, ['allowed_groups']]);
+
+        self::assertIsArray($snapshot);
+        self::assertSame(
+            [['uid_foreign' => 7, 'sorting' => 0, 'sorting_foreign' => 0]],
+            $snapshot[self::READ_GROUPS_MM],
+        );
+    }
+
+    #[Test]
+    public function restoreMmRelationsRefusesARecordWithoutAUid(): void
+    {
+        $calls = [];
+        $pool = $this->poolWith([self::READ_GROUPS_MM => $this->recordingConnection($calls)]);
+
+        $restored = $this->invokePrivate(
+            $this->hookWith($pool),
+            'restoreMmRelations',
+            [0, [self::READ_GROUPS_MM => []]],
+        );
+
+        self::assertFalse($restored);
+        self::assertSame([], $calls);
+    }
+
+    #[Test]
+    public function restoreMmRelationsRefusesWithoutAConnectionPool(): void
+    {
+        self::assertFalse(
+            $this->invokePrivate($this->hook, 'restoreMmRelations', [5, [self::READ_GROUPS_MM => []]]),
+        );
+    }
+
+    #[Test]
+    public function restoreMmRelationsReplacesATierInsideOneTransaction(): void
+    {
+        $calls = [];
+        $pool = $this->poolWith([self::READ_GROUPS_MM => $this->recordingConnection($calls)]);
+
+        $restored = $this->invokePrivate($this->hookWith($pool), 'restoreMmRelations', [5, [
+            self::READ_GROUPS_MM => [
+                ['uid_foreign' => 3, 'sorting' => 1, 'sorting_foreign' => 0],
+                ['uid_foreign' => 9, 'sorting' => 2, 'sorting_foreign' => 0],
+            ],
+        ]]);
+
+        self::assertTrue($restored);
+        // Order matters twice over: the delete must precede the inserts, and
+        // both must sit inside the transaction — a failed insert after a
+        // committed delete would leave the tier empty.
+        self::assertSame([
+            ['transactional'],
+            ['delete', self::READ_GROUPS_MM, ['uid_local' => 5]],
+            ['insert', self::READ_GROUPS_MM, ['uid_local' => 5, 'uid_foreign' => 3, 'sorting' => 1, 'sorting_foreign' => 0]],
+            ['insert', self::READ_GROUPS_MM, ['uid_local' => 5, 'uid_foreign' => 9, 'sorting' => 2, 'sorting_foreign' => 0]],
+        ], $calls);
+    }
+
+    #[Test]
+    public function restoreMmRelationsHonoursAnEmptyTierByDeletingWhatTheChangeAdded(): void
+    {
+        $calls = [];
+        $pool = $this->poolWith([self::WRITE_GROUPS_MM => $this->recordingConnection($calls)]);
+
+        $restored = $this->invokePrivate(
+            $this->hookWith($pool),
+            'restoreMmRelations',
+            [5, [self::WRITE_GROUPS_MM => []]],
+        );
+
+        self::assertTrue($restored);
+        self::assertSame([
+            ['transactional'],
+            ['delete', self::WRITE_GROUPS_MM, ['uid_local' => 5]],
+        ], $calls);
+    }
+
+    #[Test]
+    public function restoreMmRelationsReportsFailureYetStillRestoresTheOtherTier(): void
+    {
+        $failingCalls = [];
+        $healthyCalls = [];
+        $pool = $this->poolWith([
+            self::READ_GROUPS_MM => $this->recordingConnection(
+                $failingCalls,
+                transactionFailure: new RuntimeException('transaction rolled back'),
+            ),
+            self::WRITE_GROUPS_MM => $this->recordingConnection($healthyCalls),
+        ]);
+
+        $restored = $this->invokePrivate($this->hookWith($pool), 'restoreMmRelations', [5, [
+            self::READ_GROUPS_MM => [['uid_foreign' => 3, 'sorting' => 1, 'sorting_foreign' => 0]],
+            self::WRITE_GROUPS_MM => [['uid_foreign' => 4, 'sorting' => 1, 'sorting_foreign' => 0]],
+        ]]);
+
+        self::assertFalse($restored);
+        // The rolled-back tier keeps its current rows — no half-write leaked.
+        self::assertSame([['transactional']], $failingCalls);
+        self::assertSame([
+            ['transactional'],
+            ['delete', self::WRITE_GROUPS_MM, ['uid_local' => 5]],
+            ['insert', self::WRITE_GROUPS_MM, ['uid_local' => 5, 'uid_foreign' => 4, 'sorting' => 1, 'sorting_foreign' => 0]],
+        ], $healthyCalls);
+    }
+
+    #[Test]
+    public function purgeMmRelationsRefusesARecordWithoutAUid(): void
+    {
+        $calls = [];
+        $pool = $this->poolWith([self::READ_GROUPS_MM => $this->recordingConnection($calls)]);
+
+        self::assertFalse($this->invokePrivate($this->hookWith($pool), 'purgeMmRelations', [0]));
+        self::assertSame([], $calls);
+    }
+
+    #[Test]
+    public function purgeMmRelationsRefusesWithoutAConnectionPool(): void
+    {
+        self::assertFalse($this->invokePrivate($this->hook, 'purgeMmRelations', [5]));
+    }
+
+    #[Test]
+    public function purgeMmRelationsDeletesTheRecordsRowsInBothTiers(): void
+    {
+        $calls = [];
+        $connection = $this->recordingConnection($calls);
+        $pool = $this->poolWith([
+            self::READ_GROUPS_MM => $connection,
+            self::WRITE_GROUPS_MM => $connection,
+        ]);
+
+        self::assertTrue($this->invokePrivate($this->hookWith($pool), 'purgeMmRelations', [5]));
+        self::assertSame([
+            ['delete', self::READ_GROUPS_MM, ['uid_local' => 5]],
+            ['delete', self::WRITE_GROUPS_MM, ['uid_local' => 5]],
+        ], $calls);
+    }
+
+    #[Test]
+    public function purgeMmRelationsReportsFailureYetStillPurgesTheOtherTier(): void
+    {
+        $failingCalls = [];
+        $healthyCalls = [];
+        $pool = $this->poolWith([
+            self::READ_GROUPS_MM => $this->recordingConnection(
+                $failingCalls,
+                writeFailure: new RuntimeException('delete refused'),
+            ),
+            self::WRITE_GROUPS_MM => $this->recordingConnection($healthyCalls),
+        ]);
+
+        self::assertFalse($this->invokePrivate($this->hookWith($pool), 'purgeMmRelations', [5]));
+        self::assertSame([['delete', self::WRITE_GROUPS_MM, ['uid_local' => 5]]], $healthyCalls);
+    }
+
+    #[Test]
+    public function revertRowRefusesARecordWithoutAUid(): void
+    {
+        $calls = [];
+        $pool = $this->poolWith([self::TABLE => $this->recordingConnection($calls)]);
+
+        self::assertFalse($this->invokePrivate($this->hookWith($pool), 'revertRow', [0, null]));
+        self::assertSame([], $calls);
+    }
+
+    #[Test]
+    public function revertRowRefusesWithoutAConnectionPool(): void
+    {
+        self::assertFalse($this->invokePrivate($this->hook, 'revertRow', [5, null]));
+    }
+
+    #[Test]
+    public function revertRowRemovesTheRecordWhenNoOriginalValuesWereCaptured(): void
+    {
+        $calls = [];
+        $pool = $this->poolWith([self::TABLE => $this->recordingConnection($calls)]);
+
+        self::assertTrue($this->invokePrivate($this->hookWith($pool), 'revertRow', [5, null]));
+        self::assertSame([['delete', self::TABLE, ['uid' => 5]]], $calls);
+    }
+
+    #[Test]
+    public function revertRowRefusesAnEmptyValueMapWithoutWriting(): void
+    {
+        $calls = [];
+        $pool = $this->poolWith([self::TABLE => $this->recordingConnection($calls)]);
+
+        // An empty map is not "restore nothing" — it is a failed capture, and
+        // writing it would delete every column value.
+        self::assertFalse($this->invokePrivate($this->hookWith($pool), 'revertRow', [5, []]));
+        self::assertSame([], $calls);
+    }
+
+    #[Test]
+    public function revertRowRestoresTheCapturedColumnValues(): void
+    {
+        $calls = [];
+        $pool = $this->poolWith([self::TABLE => $this->recordingConnection($calls)]);
+
+        $reverted = $this->invokePrivate(
+            $this->hookWith($pool),
+            'revertRow',
+            [5, ['owner_uid' => 12, 'frontend_accessible' => 0]],
+        );
+
+        self::assertTrue($reverted);
+        self::assertSame(
+            [['update', self::TABLE, ['owner_uid' => 12, 'frontend_accessible' => 0], ['uid' => 5]]],
+            $calls,
+        );
+    }
+
+    #[Test]
+    public function revertRowReportsFailureWhenTheWriteThrows(): void
+    {
+        $calls = [];
+        $pool = $this->poolWith([
+            self::TABLE => $this->recordingConnection($calls, writeFailure: new RuntimeException('write refused')),
+        ]);
+
+        self::assertFalse($this->invokePrivate($this->hookWith($pool), 'revertRow', [5, ['owner_uid' => 12]]));
+    }
+
+    #[Test]
+    public function metadataAuditFailureReportsTheChangeAsRevertedWhenRowAndRelationsAreRestored(): void
+    {
+        $this->auditService->method('log')->willThrowException(new RuntimeException('audit sink down'));
+
+        $calls = [];
+        $connection = $this->recordingConnection($calls);
+        $pool = $this->poolWith([
+            self::TABLE => $connection,
+            self::READ_GROUPS_MM => $connection,
+            self::WRITE_GROUPS_MM => $connection,
+        ]);
+
+        $messages = [];
+        $this->invokePrivate($this->hookWith($pool), 'auditMetadataUpdateOrCompensate', [
+            'api/token',
+            5,
+            ['allowed_groups', 'write_groups'],
+            ['allowed_groups' => 1, 'write_groups' => 0],
+            [
+                self::READ_GROUPS_MM => [['uid_foreign' => 3, 'sorting' => 1, 'sorting_foreign' => 0]],
+                self::WRITE_GROUPS_MM => [],
+            ],
+            $this->capturingDataHandler($messages),
+        ]);
+
+        self::assertCount(1, $messages);
+        self::assertStringContainsString('audit sink down', $messages[0]);
+        self::assertStringContainsString('was reverted (no mutation may persist without an audit entry).', $messages[0]);
+    }
+
+    #[Test]
+    public function metadataAuditFailureIsNotRevertibleWhenAChangedAclTierIsMissingFromTheSnapshot(): void
+    {
+        $this->auditService->method('log')->willThrowException(new RuntimeException('audit sink down'));
+
+        $calls = [];
+        $pool = $this->poolWith([self::TABLE => $this->recordingConnection($calls)]);
+
+        $messages = [];
+        $this->invokePrivate($this->hookWith($pool), 'auditMetadataUpdateOrCompensate', [
+            'api/token',
+            5,
+            ['allowed_groups'],
+            ['allowed_groups' => 1],
+            // Snapshot read failed for the changed tier: no entry at all.
+            [],
+            $this->capturingDataHandler($messages),
+        ]);
+
+        self::assertCount(1, $messages);
+        self::assertStringContainsString('NOT revertible; manual reconciliation required.', $messages[0]);
+        // The row half DID succeed — proving the verdict comes from the
+        // missing relation snapshot, not from a failed row revert.
+        self::assertSame(
+            [['update', self::TABLE, ['allowed_groups' => 1], ['uid' => 5]]],
+            $calls,
+        );
+    }
+
+    #[Test]
+    public function metadataAuditFailureIsNotRevertibleWhenARelationTierCannotBeRestored(): void
+    {
+        $this->auditService->method('log')->willThrowException(new RuntimeException('audit sink down'));
+
+        $rowCalls = [];
+        $pool = $this->poolWith([
+            self::TABLE => $this->recordingConnection($rowCalls),
+            self::READ_GROUPS_MM => $this->recordingConnection(
+                $rowCalls,
+                transactionFailure: new RuntimeException('transaction rolled back'),
+            ),
+        ]);
+
+        $messages = [];
+        $this->invokePrivate($this->hookWith($pool), 'auditMetadataUpdateOrCompensate', [
+            'api/token',
+            5,
+            ['allowed_groups'],
+            ['allowed_groups' => 1],
+            [self::READ_GROUPS_MM => [['uid_foreign' => 3, 'sorting' => 1, 'sorting_foreign' => 0]]],
+            $this->capturingDataHandler($messages),
+        ]);
+
+        self::assertCount(1, $messages);
+        self::assertStringContainsString('NOT revertible; manual reconciliation required.', $messages[0]);
+    }
+
+    #[Test]
+    public function afterAllOperationsPurgesTheRelationsOfARevertedCreationSilently(): void
+    {
+        $calls = [];
+        $connection = $this->recordingConnection($calls);
+        $hook = $this->hookWith($this->poolWith([
+            self::READ_GROUPS_MM => $connection,
+            self::WRITE_GROUPS_MM => $connection,
+        ]));
+        $this->queueRevertedCreation($hook, 5);
+
+        $messages = [];
+        $hook->processDatamap_afterAllOperations($this->capturingDataHandler($messages));
+
+        self::assertSame([
+            ['delete', self::READ_GROUPS_MM, ['uid_local' => 5]],
+            ['delete', self::WRITE_GROUPS_MM, ['uid_local' => 5]],
+        ], $calls);
+        self::assertSame([], $messages);
+    }
+
+    #[Test]
+    public function afterAllOperationsLogsAnUnpurgeableRevertedCreationOnce(): void
+    {
+        $calls = [];
+        $hook = $this->hookWith($this->poolWith([
+            self::READ_GROUPS_MM => $this->recordingConnection($calls, writeFailure: new RuntimeException('delete refused')),
+            self::WRITE_GROUPS_MM => $this->recordingConnection($calls),
+        ]));
+        $this->queueRevertedCreation($hook, 5);
+
+        $messages = [];
+        $hook->processDatamap_afterAllOperations($this->capturingDataHandler($messages));
+
+        self::assertCount(1, $messages);
+        self::assertStringContainsString('could not be purged; manual reconciliation required.', $messages[0]);
+
+        // The queue is consumed: a second run of a DI-shared instance must not
+        // re-log the same uid.
+        $secondRun = [];
+        $hook->processDatamap_afterAllOperations($this->capturingDataHandler($secondRun));
+        self::assertSame([], $secondRun);
+    }
+
+    #[Test]
+    public function creationAuditFailureRevertsTheRowAndQueuesItsRelationsForPurging(): void
+    {
+        $this->auditService->method('log')->willThrowException(new RuntimeException('audit sink down'));
+
+        $calls = [];
+        $connection = $this->recordingConnection($calls);
+        $hook = $this->hookWith($this->poolWith([
+            self::TABLE => $connection,
+            self::READ_GROUPS_MM => $connection,
+            self::WRITE_GROUPS_MM => $connection,
+        ]));
+
+        $messages = [];
+        $this->invokePrivate($hook, 'auditRecordCreationOrCompensate', [
+            'api/token',
+            5,
+            ['identifier' => 'api/token'],
+            $this->capturingDataHandler($messages),
+        ]);
+
+        self::assertCount(1, $messages);
+        self::assertStringContainsString('was reverted', $messages[0]);
+
+        // DataHandler writes the record's MM rows only after this hook has
+        // run, so the purge is queued rather than performed here.
+        self::assertSame([5 => true], $this->readPrivate($hook, 'revertedCreations'));
+
+        $purgeMessages = [];
+        $hook->processDatamap_afterAllOperations($this->capturingDataHandler($purgeMessages));
+        self::assertSame([], $purgeMessages);
+        self::assertSame([
+            ['delete', self::TABLE, ['uid' => 5]],
+            ['delete', self::READ_GROUPS_MM, ['uid_local' => 5]],
+            ['delete', self::WRITE_GROUPS_MM, ['uid_local' => 5]],
+        ], $calls);
+    }
+
+    #[Test]
+    public function creationAuditFailureQueuesNoPurgeWhenTheRowSurvives(): void
+    {
+        $this->auditService->method('log')->willThrowException(new RuntimeException('audit sink down'));
+
+        $calls = [];
+        $pool = $this->poolWith([
+            self::TABLE => $this->recordingConnection($calls, writeFailure: new RuntimeException('delete refused')),
+        ]);
+        $hook = $this->hookWith($pool);
+
+        $messages = [];
+        $this->invokePrivate($hook, 'auditRecordCreationOrCompensate', [
+            'api/token',
+            5,
+            ['identifier' => 'api/token'],
+            $this->capturingDataHandler($messages),
+        ]);
+
+        self::assertCount(1, $messages);
+        self::assertStringContainsString('NOT revertible', $messages[0]);
+
+        // The record still exists, so its relations rightfully belong to it
+        // and nothing is queued for purging.
+        self::assertSame([], $this->readPrivate($hook, 'revertedCreations'));
+
+        $purgeMessages = [];
+        $hook->processDatamap_afterAllOperations($this->capturingDataHandler($purgeMessages));
+        self::assertSame([], $purgeMessages);
+        self::assertSame([], $calls);
+    }
+
+    #[Test]
+    public function preProcessSnapshotsTheRelationsOfEverySubmittedAclTier(): void
+    {
+        $this->stubBackendRecords([['allowed_groups' => 2]]);
+
+        $queryCalls = [];
+        $hook = $this->hookWith($this->queryBuilderPool([
+            self::READ_GROUPS_MM => [['uid_foreign' => 3, 'sorting' => 1, 'sorting_foreign' => 0]],
+        ], $queryCalls));
+
+        $fieldArray = ['allowed_groups' => '3,4'];
+        $dataHandler = $this->createMock(DataHandler::class);
+        $hook->processDatamap_preProcessFieldArray($fieldArray, self::TABLE, 5, $dataHandler);
+
+        // DataHandler replaces the MM rows during checkValue(), i.e. before
+        // afterDatabaseOperations() — only a snapshot taken here can restore
+        // the pre-change ACL.
+        self::assertSame(
+            [self::READ_GROUPS_MM => [['uid_foreign' => 3, 'sorting' => 1, 'sorting_foreign' => 0]]],
+            $this->readPrivate($hook, 'originalMmRelations')['5'] ?? null,
+        );
+    }
+
+    #[Test]
+    public function preProcessDropsAnMmBackedAclChangeSubmittedByANonOwner(): void
+    {
+        $this->stubBackendRecords([['owner_uid' => 99, 'frontend_accessible' => 0, 'scope_pid' => 0]]);
+
+        $hook = $this->hookForNonAdmin(7);
+
+        $fieldArray = ['allowed_groups' => '3,4'];
+        $messages = [];
+        $hook->processDatamap_preProcessFieldArray($fieldArray, self::TABLE, 5, $this->capturingDataHandler($messages));
+
+        // Dropped, not reverted: the row column holds only the relation count,
+        // so leaving it out makes DataHandler keep the existing MM rows.
+        self::assertSame([], $fieldArray);
+        self::assertCount(1, $messages);
+        self::assertStringContainsString('can only be changed by an administrator', $messages[0]);
+    }
+
+    #[Test]
+    public function preProcessRevertsAScalarAclChangeSubmittedByANonOwner(): void
+    {
+        // Two reads: the ACL gate, then the pre-change metadata capture.
+        $this->stubBackendRecords([
+            ['owner_uid' => 99, 'frontend_accessible' => 0, 'scope_pid' => 0],
+            ['owner_uid' => 99],
+        ]);
+
+        $hook = $this->hookForNonAdmin(7);
+
+        $fieldArray = ['owner_uid' => 'be_users_7'];
+        $messages = [];
+        $hook->processDatamap_preProcessFieldArray($fieldArray, self::TABLE, 5, $this->capturingDataHandler($messages));
+
+        self::assertSame(['owner_uid' => 99], $fieldArray);
+        self::assertCount(1, $messages);
+    }
+
+    #[Test]
+    public function preProcessLeavesAnUnchangedScalarAclColumnAlone(): void
+    {
+        // An ordinary save by a non-owner resubmits the stored owner in group
+        // notation — that is not tampering and must not be logged as such.
+        $this->stubBackendRecords([
+            ['owner_uid' => 99, 'frontend_accessible' => 0, 'scope_pid' => 0],
+            ['owner_uid' => 99],
+        ]);
+
+        $hook = $this->hookForNonAdmin(7);
+
+        $fieldArray = ['owner_uid' => 'be_users_99'];
+        $messages = [];
+        $hook->processDatamap_preProcessFieldArray($fieldArray, self::TABLE, 5, $this->capturingDataHandler($messages));
+
+        self::assertSame(99, $fieldArray['owner_uid']);
+        self::assertSame([], $messages);
+    }
+
+    #[Test]
+    public function preProcessLetsTheOwnerWithTheManagePolicyGrantChangeTheAcl(): void
+    {
+        $this->stubBackendRecords([
+            ['owner_uid' => 7, 'frontend_accessible' => 0, 'scope_pid' => 0],
+            ['allowed_groups' => 1],
+        ]);
+
+        $queryCalls = [];
+        $hook = $this->hookForNonAdmin(7, canManagePolicy: true, connectionPool: $this->queryBuilderPool(
+            [self::READ_GROUPS_MM => []],
+            $queryCalls,
+        ));
+
+        $fieldArray = ['allowed_groups' => '3,4'];
+        $messages = [];
+        $hook->processDatamap_preProcessFieldArray($fieldArray, self::TABLE, 5, $this->capturingDataHandler($messages));
+
+        self::assertSame(['allowed_groups' => '3,4'], $fieldArray);
+        self::assertSame([], $messages);
+    }
+
+    #[Test]
+    public function afterDatabaseOperationsAuditsAMetadataOnlyChange(): void
+    {
+        $this->stubBackendRecords([['identifier' => 'api/token', 'owner_uid' => 1, 'allowed_groups' => 1, 'scope_pid' => 0]]);
+
+        $this->auditService
+            ->expects(self::once())
+            ->method('log')
+            ->with('api/token', 'metadata_update', true, null, 'FormEngine edit: allowed_groups, frontend_accessible');
+
+        $this->hook->processDatamap_afterDatabaseOperations(
+            'update',
+            self::TABLE,
+            5,
+            ['allowed_groups' => 2, 'frontend_accessible' => 1],
+            $this->createMock(DataHandler::class),
+        );
+    }
+
+    #[Test]
+    public function afterDatabaseOperationsSkipsTheAuditWhenNoColumnWasSubmitted(): void
+    {
+        $this->stubBackendRecords([['identifier' => 'api/token']]);
+
+        $this->auditService->expects(self::never())->method('log');
+
+        $this->hook->processDatamap_afterDatabaseOperations(
+            'update',
+            self::TABLE,
+            5,
+            [],
+            $this->createMock(DataHandler::class),
+        );
+    }
+
+    #[Test]
+    public function afterDatabaseOperationsStopsWhenTheRecordIsGone(): void
+    {
+        $this->stubBackendRecords([false]);
+
+        $this->auditService->expects(self::never())->method('log');
+
+        $this->hook->processDatamap_afterDatabaseOperations(
+            'update',
+            self::TABLE,
+            5,
+            ['allowed_groups' => 2],
+            $this->createMock(DataHandler::class),
+        );
+    }
+
+    #[Test]
+    public function afterDatabaseOperationsCompensatesAFailedMetadataAuditWithTheCapturedState(): void
+    {
+        // One read for the pre-change capture, one for the post-write lookup.
+        $this->stubBackendRecords([
+            ['allowed_groups' => 1],
+            ['identifier' => 'api/token', 'owner_uid' => 1, 'allowed_groups' => 2, 'scope_pid' => 0],
+        ]);
+        $this->auditService->method('log')->willThrowException(new RuntimeException('audit sink down'));
+
+        $writes = [];
+        $reads = [];
+        $connection = $this->recordingConnection($writes);
+        $pool = self::createStub(ConnectionPool::class);
+        $pool->method('getConnectionForTable')->willReturn($connection);
+        $pool->method('getQueryBuilderForTable')->willReturnCallback($this->queryBuilderFactory(
+            [self::READ_GROUPS_MM => [['uid_foreign' => 3, 'sorting' => 1, 'sorting_foreign' => 0]]],
+            $reads,
+        ));
+        $hook = $this->hookWith($pool);
+
+        $fieldArray = ['allowed_groups' => '3,4'];
+        $dataHandler = $this->createMock(DataHandler::class);
+        $hook->processDatamap_preProcessFieldArray($fieldArray, self::TABLE, 5, $dataHandler);
+
+        $messages = [];
+        $hook->processDatamap_afterDatabaseOperations(
+            'update',
+            self::TABLE,
+            5,
+            $fieldArray,
+            $this->capturingDataHandler($messages),
+        );
+
+        self::assertCount(1, $messages);
+        self::assertStringContainsString('was reverted', $messages[0]);
+        // Both halves of the rollback ran: the row columns AND the MM rows the
+        // widened ACL replaced.
+        self::assertSame([
+            ['update', self::TABLE, ['allowed_groups' => 1], ['uid' => 5]],
+            ['transactional'],
+            ['delete', self::READ_GROUPS_MM, ['uid_local' => 5]],
+            ['insert', self::READ_GROUPS_MM, ['uid_local' => 5, 'uid_foreign' => 3, 'sorting' => 1, 'sorting_foreign' => 0]],
+        ], $writes);
+    }
+
+    /**
+     * Build the hook with the optional ConnectionPool wired, leaving the
+     * services from setUp() in place.
+     */
+    private function hookWith(ConnectionPool $connectionPool): SecretTcaHook
+    {
+        return new SecretTcaHook(
+            $this->vaultService,
+            $this->auditService,
+            $this->accessControlService,
+            $this->secretRepository,
+            $connectionPool,
+        );
+    }
+
+    /**
+     * @param list<mixed> $arguments
+     */
+    private function invokePrivate(SecretTcaHook $hook, string $method, array $arguments): mixed
+    {
+        return (new ReflectionClass($hook))->getMethod($method)->invokeArgs($hook, $arguments);
+    }
+
+    /**
+     * Queue $uid as a creation this hook rolled back, the state
+     * processDatamap_afterAllOperations() acts on.
+     */
+    private function queueRevertedCreation(SecretTcaHook $hook, int $uid): void
+    {
+        $property = (new ReflectionClass($hook))->getProperty('revertedCreations');
+        $property->setValue($hook, [$uid => true]);
+    }
+
+    /**
+     * A connection that appends every write to $calls, so a test can assert
+     * what was written and in which order — not merely that something was.
+     *
+     * @param list<array<int, mixed>> $calls
+     */
+    private function recordingConnection(
+        array &$calls,
+        ?Throwable $transactionFailure = null,
+        ?Throwable $writeFailure = null,
+    ): Connection&MockObject {
+        $connection = $this->createMock(Connection::class);
+
+        $connection->method('transactional')->willReturnCallback(
+            static function (Closure $callback) use (&$calls, $transactionFailure): mixed {
+                $calls[] = ['transactional'];
+                if ($transactionFailure instanceof Throwable) {
+                    throw $transactionFailure;
+                }
+
+                return $callback();
+            },
+        );
+
+        $connection->method('delete')->willReturnCallback(
+            static function (string $table, array $identifier) use (&$calls, $writeFailure): int {
+                if ($writeFailure instanceof Throwable) {
+                    throw $writeFailure;
+                }
+                $calls[] = ['delete', $table, $identifier];
+
+                return 1;
+            },
+        );
+
+        $connection->method('insert')->willReturnCallback(
+            static function (string $table, array $data) use (&$calls, $writeFailure): int {
+                if ($writeFailure instanceof Throwable) {
+                    throw $writeFailure;
+                }
+                $calls[] = ['insert', $table, $data];
+
+                return 1;
+            },
+        );
+
+        $connection->method('update')->willReturnCallback(
+            static function (string $table, array $data, array $identifier) use (&$calls, $writeFailure): int {
+                if ($writeFailure instanceof Throwable) {
+                    throw $writeFailure;
+                }
+                $calls[] = ['update', $table, $data, $identifier];
+
+                return 1;
+            },
+        );
+
+        return $connection;
+    }
+
+    /**
+     * @param array<string, Connection> $connections table => connection; a request for any
+     *                                               other table fails the test
+     */
+    private function poolWith(array $connections): ConnectionPool
+    {
+        $pool = self::createStub(ConnectionPool::class);
+        $pool->method('getConnectionForTable')->willReturnCallback(
+            static function (string $table) use ($connections): Connection {
+                self::assertArrayHasKey($table, $connections, 'unexpected connection request for ' . $table);
+
+                return $connections[$table];
+            },
+        );
+
+        return $pool;
+    }
+
+    /**
+     * A pool whose query builders return the configured rows per table (or
+     * raise the configured failure), recording the query shape into $calls.
+     *
+     * @param array<string, list<array<string, mixed>>|Throwable> $outcomes
+     * @param list<array<int, mixed>> $calls
+     */
+    private function queryBuilderPool(array $outcomes, array &$calls): ConnectionPool
+    {
+        $pool = self::createStub(ConnectionPool::class);
+        $pool->method('getQueryBuilderForTable')->willReturnCallback($this->queryBuilderFactory($outcomes, $calls));
+
+        return $pool;
+    }
+
+    /**
+     * The `getQueryBuilderForTable()` implementation behind
+     * {@see queryBuilderPool()}, reusable where the pool also has to serve
+     * connections.
+     *
+     * @param array<string, list<array<string, mixed>>|Throwable> $outcomes
+     * @param list<array<int, mixed>> $calls
+     *
+     * @return Closure(string): QueryBuilder
+     */
+    private function queryBuilderFactory(array $outcomes, array &$calls): Closure
+    {
+        return function (string $table) use ($outcomes, &$calls): QueryBuilder {
+            self::assertArrayHasKey($table, $outcomes, 'unexpected query builder request for ' . $table);
+            $outcome = $outcomes[$table];
+
+            $result = self::createStub(Result::class);
+            if (!$outcome instanceof Throwable) {
+                $result->method('fetchAllAssociative')->willReturn($outcome);
+            }
+
+            $expression = self::createStub(ExpressionBuilder::class);
+            $expression->method('eq')->willReturn('uid_local = :p');
+
+            $queryBuilder = $this->createMock(QueryBuilder::class);
+            $queryBuilder->method('expr')->willReturn($expression);
+            $queryBuilder->method('where')->willReturnSelf();
+            $queryBuilder->method('createNamedParameter')->willReturnCallback(
+                static function (mixed $value, mixed $type) use (&$calls): string {
+                    $calls[] = ['createNamedParameter', $value, $type];
+
+                    return ':p';
+                },
+            );
+            $queryBuilder->method('select')->willReturnCallback(
+                static function (string ...$fields) use ($queryBuilder, &$calls): QueryBuilder {
+                    $calls[] = ['select', $fields];
+
+                    return $queryBuilder;
+                },
+            );
+            $queryBuilder->method('from')->willReturnCallback(
+                static function (string $from) use ($queryBuilder, &$calls): QueryBuilder {
+                    $calls[] = ['from', $from];
+
+                    return $queryBuilder;
+                },
+            );
+            $queryBuilder->method('orderBy')->willReturnCallback(
+                static function (string $fieldName, ?string $order) use ($queryBuilder, &$calls): QueryBuilder {
+                    $calls[] = ['orderBy', $fieldName, $order];
+
+                    return $queryBuilder;
+                },
+            );
+            $queryBuilder->method('executeQuery')->willReturnCallback(
+                static function () use ($outcome, $result): Result {
+                    if ($outcome instanceof Throwable) {
+                        throw $outcome;
+                    }
+
+                    return $result;
+                },
+            );
+
+            return $queryBuilder;
+        };
+    }
+
+    /**
+     * Make the next `BackendUtility::getRecord()` calls resolve to the given
+     * rows (`false` = record gone). Each row consumes one instance from the
+     * `GeneralUtility::makeInstance()` stack, so the count must match the
+     * number of reads the exercised path performs — the testing framework
+     * fails the test on leftovers.
+     *
+     * @param list<array<string, mixed>|false> $rows
+     */
+    private function stubBackendRecords(array $rows): void
+    {
+        foreach ($rows as $row) {
+            // Twice per read: BackendUtility::getRecord() resolves the schema
+            // itself, and the DeletedRestriction it adds resolves another one
+            // in its constructor.
+            for ($i = 0; $i < 2; $i++) {
+                $schemaFactory = $this->createMock(TcaSchemaFactory::class);
+                $schemaFactory->method('has')->willReturn(true);
+                $schemaFactory->method('get')->willReturn($this->createMock(TcaSchema::class));
+                GeneralUtility::addInstance(TcaSchemaFactory::class, $schemaFactory);
+            }
+
+            $result = self::createStub(Result::class);
+            $result->method('fetchAssociative')->willReturn($row);
+
+            $expression = self::createStub(ExpressionBuilder::class);
+            $expression->method('eq')->willReturn('uid = :p');
+
+            $queryBuilder = $this->createMock(QueryBuilder::class);
+            $queryBuilder->method('getRestrictions')
+                ->willReturn(self::createStub(QueryRestrictionContainerInterface::class));
+            $queryBuilder->method('expr')->willReturn($expression);
+            $queryBuilder->method('createNamedParameter')->willReturn(':p');
+            $queryBuilder->method('select')->willReturnSelf();
+            $queryBuilder->method('from')->willReturnSelf();
+            $queryBuilder->method('where')->willReturnSelf();
+            $queryBuilder->method('executeQuery')->willReturn($result);
+
+            $pool = self::createStub(ConnectionPool::class);
+            $pool->method('getQueryBuilderForTable')->willReturn($queryBuilder);
+            GeneralUtility::addInstance(ConnectionPool::class, $pool);
+        }
+    }
+
+    /**
+     * A hook whose actor is a plain backend user — setUp() defaults to an
+     * admin, which short-circuits the privileged-column policy.
+     */
+    private function hookForNonAdmin(
+        int $actorUid,
+        bool $canManagePolicy = false,
+        ?ConnectionPool $connectionPool = null,
+    ): SecretTcaHook {
+        $accessControl = $this->createMock(AccessControlServiceInterface::class);
+        $accessControl->method('isCurrentActorAdmin')->willReturn(false);
+        $accessControl->method('getCurrentActorUid')->willReturn($actorUid);
+        $accessControl->method('isGranted')->willReturnCallback(
+            static function (VaultPermission $permission) use ($canManagePolicy): bool {
+                self::assertSame(VaultPermission::SecretManagePolicy, $permission);
+
+                return $canManagePolicy;
+            },
+        );
+
+        return new SecretTcaHook(
+            $this->vaultService,
+            $this->auditService,
+            $accessControl,
+            $this->secretRepository,
+            $connectionPool,
+        );
+    }
+
+    /**
+     * @return array<array-key, mixed>
+     */
+    private function readPrivate(SecretTcaHook $hook, string $property): array
+    {
+        $value = (new ReflectionClass($hook))->getProperty($property)->getValue($hook);
+        self::assertIsArray($value);
+
+        return $value;
+    }
+
+    /**
+     * A DataHandler whose log() messages are collected for assertion.
+     *
+     * @param list<string> $messages
+     */
+    private function capturingDataHandler(array &$messages): DataHandler&MockObject
+    {
+        $dataHandler = $this->createMock(DataHandler::class);
+        $dataHandler->method('log')->willReturnCallback(
+            static function (
+                string $table,
+                int $recordUid,
+                int $action,
+                ?int $recordPid,
+                int $error,
+                string $details,
+            ) use (&$messages): int {
+                $messages[] = $details;
+
+                return 0;
+            },
+        );
+
+        return $dataHandler;
     }
 }

--- a/Tests/Unit/Hook/SecretTcaHookTest.php
+++ b/Tests/Unit/Hook/SecretTcaHookTest.php
@@ -31,9 +31,6 @@ use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 use TYPO3\CMS\Core\Database\Query\Restriction\QueryRestrictionContainerInterface;
 use TYPO3\CMS\Core\DataHandling\DataHandler;
-use TYPO3\CMS\Core\Schema\TcaSchema;
-use TYPO3\CMS\Core\Schema\TcaSchemaFactory;
-use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 #[CoversClass(SecretTcaHook::class)]
 #[AllowMockObjectsWithoutExpectations]
@@ -55,6 +52,20 @@ final class SecretTcaHookTest extends TestCase
 
     private SecretTcaHook $hook;
 
+    /**
+     * Rows the hook's record reads resolve to, consumed in order.
+     *
+     * @var list<array<string, mixed>|false>
+     */
+    private array $backendRecords = [];
+
+    /**
+     * The shape of every record read performed so far.
+     *
+     * @var list<array<int, mixed>>
+     */
+    private array $recordReads = [];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -75,6 +86,15 @@ final class SecretTcaHookTest extends TestCase
             $this->accessControlService,
             $this->secretRepository,
         );
+    }
+
+    protected function tearDown(): void
+    {
+        // A path that performs fewer reads than the test queued would
+        // otherwise pass silently.
+        self::assertSame([], $this->backendRecords, 'queued record reads left unconsumed');
+
+        parent::tearDown();
     }
 
     #[Test]
@@ -959,7 +979,7 @@ final class SecretTcaHookTest extends TestCase
     {
         $this->stubBackendRecords([['owner_uid' => 99, 'frontend_accessible' => 0, 'scope_pid' => 0]]);
 
-        $hook = $this->hookForNonAdmin(7);
+        $hook = $this->hookForNonAdmin(7, connectionPool: $this->recordPool());
 
         $fieldArray = ['allowed_groups' => '3,4'];
         $messages = [];
@@ -981,7 +1001,7 @@ final class SecretTcaHookTest extends TestCase
             ['owner_uid' => 99],
         ]);
 
-        $hook = $this->hookForNonAdmin(7);
+        $hook = $this->hookForNonAdmin(7, connectionPool: $this->recordPool());
 
         $fieldArray = ['owner_uid' => 'be_users_7'];
         $messages = [];
@@ -1001,7 +1021,7 @@ final class SecretTcaHookTest extends TestCase
             ['owner_uid' => 99],
         ]);
 
-        $hook = $this->hookForNonAdmin(7);
+        $hook = $this->hookForNonAdmin(7, connectionPool: $this->recordPool());
 
         $fieldArray = ['owner_uid' => 'be_users_99'];
         $messages = [];
@@ -1043,7 +1063,7 @@ final class SecretTcaHookTest extends TestCase
             ->method('log')
             ->with('api/token', 'metadata_update', true, null, 'FormEngine edit: allowed_groups, frontend_accessible');
 
-        $this->hook->processDatamap_afterDatabaseOperations(
+        $this->hookWith($this->recordPool())->processDatamap_afterDatabaseOperations(
             'update',
             self::TABLE,
             5,
@@ -1059,7 +1079,7 @@ final class SecretTcaHookTest extends TestCase
 
         $this->auditService->expects(self::never())->method('log');
 
-        $this->hook->processDatamap_afterDatabaseOperations(
+        $this->hookWith($this->recordPool())->processDatamap_afterDatabaseOperations(
             'update',
             self::TABLE,
             5,
@@ -1075,13 +1095,39 @@ final class SecretTcaHookTest extends TestCase
 
         $this->auditService->expects(self::never())->method('log');
 
-        $this->hook->processDatamap_afterDatabaseOperations(
+        $this->hookWith($this->recordPool())->processDatamap_afterDatabaseOperations(
             'update',
             self::TABLE,
             5,
             ['allowed_groups' => 2],
             $this->createMock(DataHandler::class),
         );
+    }
+
+    #[Test]
+    public function recordReadsSelectTheRequestedColumnsOfOneLiveRecord(): void
+    {
+        $this->stubBackendRecords([['identifier' => 'api/token']]);
+
+        $this->hookWith($this->recordPool())->processDatamap_afterDatabaseOperations(
+            'update',
+            self::TABLE,
+            5,
+            [],
+            $this->createMock(DataHandler::class),
+        );
+
+        // BackendUtility::getRecord() semantics, spelled out so they hold on
+        // every supported core version: all restrictions dropped, soft-deleted
+        // rows excluded by an explicit predicate, one uid, bound as integers.
+        self::assertSame([
+            ['removeAll'],
+            ['select', ['identifier', 'owner_uid', 'allowed_groups', 'scope_pid']],
+            ['from', self::TABLE],
+            ['createNamedParameter', 5, Connection::PARAM_INT],
+            ['createNamedParameter', 0, Connection::PARAM_INT],
+            ['where', ['uid = 5', 'deleted = 0']],
+        ], $this->recordReads);
     }
 
     #[Test]
@@ -1269,6 +1315,13 @@ final class SecretTcaHookTest extends TestCase
     private function queryBuilderFactory(array $outcomes, array &$calls): Closure
     {
         return function (string $table) use ($outcomes, &$calls): QueryBuilder {
+            // The secret table is only ever queried by the hook's record read;
+            // the MM tables these outcomes describe are queried by the
+            // relation snapshot.
+            if ($table === self::TABLE) {
+                return $this->recordQueryBuilder();
+            }
+
             self::assertArrayHasKey($table, $outcomes, 'unexpected query builder request for ' . $table);
             $outcome = $outcomes[$table];
 
@@ -1326,47 +1379,100 @@ final class SecretTcaHookTest extends TestCase
     }
 
     /**
-     * Make the next `BackendUtility::getRecord()` calls resolve to the given
-     * rows (`false` = record gone). Each row consumes one instance from the
-     * `GeneralUtility::makeInstance()` stack, so the count must match the
-     * number of reads the exercised path performs — the testing framework
-     * fails the test on leftovers.
+     * Queue the rows the hook's record reads resolve to, in the order the
+     * exercised path performs them (`false` = record gone). The queue is
+     * served through the hook's injected ConnectionPool, so the stub is
+     * independent of which TYPO3 version's `BackendUtility` internals are
+     * installed. tearDown() fails a test that queues more reads than the
+     * path performs.
      *
      * @param list<array<string, mixed>|false> $rows
      */
     private function stubBackendRecords(array $rows): void
     {
-        foreach ($rows as $row) {
-            // Twice per read: BackendUtility::getRecord() resolves the schema
-            // itself, and the DeletedRestriction it adds resolves another one
-            // in its constructor.
-            for ($i = 0; $i < 2; $i++) {
-                $schemaFactory = $this->createMock(TcaSchemaFactory::class);
-                $schemaFactory->method('has')->willReturn(true);
-                $schemaFactory->method('get')->willReturn($this->createMock(TcaSchema::class));
-                GeneralUtility::addInstance(TcaSchemaFactory::class, $schemaFactory);
-            }
+        $this->backendRecords = [...$this->backendRecords, ...$rows];
+    }
 
-            $result = self::createStub(Result::class);
-            $result->method('fetchAssociative')->willReturn($row);
+    /**
+     * A pool that serves nothing but the hook's record reads.
+     */
+    private function recordPool(): ConnectionPool
+    {
+        $pool = self::createStub(ConnectionPool::class);
+        $pool->method('getQueryBuilderForTable')->willReturnCallback(
+            function (string $table): QueryBuilder {
+                self::assertSame(self::TABLE, $table, 'unexpected query builder request for ' . $table);
 
-            $expression = self::createStub(ExpressionBuilder::class);
-            $expression->method('eq')->willReturn('uid = :p');
+                return $this->recordQueryBuilder();
+            },
+        );
 
-            $queryBuilder = $this->createMock(QueryBuilder::class);
-            $queryBuilder->method('getRestrictions')
-                ->willReturn(self::createStub(QueryRestrictionContainerInterface::class));
-            $queryBuilder->method('expr')->willReturn($expression);
-            $queryBuilder->method('createNamedParameter')->willReturn(':p');
-            $queryBuilder->method('select')->willReturnSelf();
-            $queryBuilder->method('from')->willReturnSelf();
-            $queryBuilder->method('where')->willReturnSelf();
-            $queryBuilder->method('executeQuery')->willReturn($result);
+        return $pool;
+    }
 
-            $pool = self::createStub(ConnectionPool::class);
-            $pool->method('getQueryBuilderForTable')->willReturn($queryBuilder);
-            GeneralUtility::addInstance(ConnectionPool::class, $pool);
-        }
+    /**
+     * A query builder for the secret table answering with the next row
+     * {@see stubBackendRecords()} queued, recording the query shape into
+     * $recordReads so a test can pin the read itself, not merely its result.
+     */
+    private function recordQueryBuilder(): QueryBuilder
+    {
+        self::assertNotSame([], $this->backendRecords, 'unexpected record read on ' . self::TABLE);
+        $row = array_shift($this->backendRecords);
+
+        $result = self::createStub(Result::class);
+        $result->method('fetchAssociative')->willReturn($row);
+
+        $restrictions = $this->createMock(QueryRestrictionContainerInterface::class);
+        $restrictions->method('removeAll')->willReturnCallback(
+            function () use ($restrictions): QueryRestrictionContainerInterface {
+                $this->recordReads[] = ['removeAll'];
+
+                return $restrictions;
+            },
+        );
+
+        // Render the placeholder as the bound value so the recorded
+        // predicates read as `uid = 5` / `deleted = 0`.
+        $expression = self::createStub(ExpressionBuilder::class);
+        $expression->method('eq')->willReturnCallback(
+            static fn (string $fieldName, string $value): string => $fieldName . ' = ' . $value,
+        );
+
+        $queryBuilder = $this->createMock(QueryBuilder::class);
+        $queryBuilder->method('getRestrictions')->willReturn($restrictions);
+        $queryBuilder->method('expr')->willReturn($expression);
+        $queryBuilder->method('executeQuery')->willReturn($result);
+        $queryBuilder->method('createNamedParameter')->willReturnCallback(
+            function (int $value, mixed $type): string {
+                $this->recordReads[] = ['createNamedParameter', $value, $type];
+
+                return (string) $value;
+            },
+        );
+        $queryBuilder->method('select')->willReturnCallback(
+            function (string ...$fields) use ($queryBuilder): QueryBuilder {
+                $this->recordReads[] = ['select', $fields];
+
+                return $queryBuilder;
+            },
+        );
+        $queryBuilder->method('from')->willReturnCallback(
+            function (string $from) use ($queryBuilder): QueryBuilder {
+                $this->recordReads[] = ['from', $from];
+
+                return $queryBuilder;
+            },
+        );
+        $queryBuilder->method('where')->willReturnCallback(
+            function (string ...$predicates) use ($queryBuilder): QueryBuilder {
+                $this->recordReads[] = ['where', $predicates];
+
+                return $queryBuilder;
+            },
+        );
+
+        return $queryBuilder;
     }
 
     /**


### PR DESCRIPTION
First (High) finding of the external review round 3, verified against the code before implementing: the FormEngine audit-failure rollback restored only the `tx_nrvault_secret` row — the ACL MM relations (`tx_nrvault_secret_begroups_mm`, `tx_nrvault_secret_writegroups_mm`), which are what `SecretRepository` actually loads effective groups from, kept the widened set. An authorized ACL widening whose audit write failed therefore persisted unaudited, while the restored count column actively contradicted the MM state.

## Changes

- **MM snapshot/restore:** `processDatamap_preProcessFieldArray()` captures both MM tiers (incl. sorting) whenever an ACL column is submitted — the only viable moment, since DataHandler's `writeMM()` runs inside `checkValue()`, before the audit hook. On audit-write failure the captured rows replace the current ones; a tier that legitimately had no groups is restored to empty. If a tier cannot be repaired, the DataHandler log now says **NOT revertible** instead of falsely claiming success.
- **Create-path orphans:** for `status='new'` the MM writes are deferred (`dbAnalysisStoreExec()` flushes them *after* the hook), so the audit-failure revert that deletes the fresh row used to leave orphaned MM rows against the deleted uid. A new `processDatamap_afterAllOperations()` purges them.
- **Latent ACL-parsing bug removed:** `Secret` parsed the `allowed_groups`/`write_groups` *count* columns as a CSV of group uids when the MM load was empty — count 3 would have read as "group 3 allowed". The fallback had no legitimate producer and is gone; the write side now emits the relation count consistently.

Both new functional regression tests fail with the fixes neutralised (widened tier survives / orphaned rows remain) and pass with them.

## Not in scope (follow-up PR)

During implementation a pre-existing adjacent bug surfaced: a value-bearing **create** carrying ACL groups rebuilds the entity with empty group tiers in `VaultService::store()`, zeroing the count column. This lands in the rejected-create compensation PR of this round.

## Verification

- Unit+Fuzz: 4978 tests, 18432 assertions — OK
- Functional (full suite, sqlite): 298 tests — OK (9 pre-existing skips)
- PHPStan: no errors · CGL: clean
