### PR TITLE
Replace the copy/delete atomicity claim with the real guarantee

### DIFF
--- a/Documentation/Auditor/ControlMapping.rst
+++ b/Documentation/Auditor/ControlMapping.rst
@@ -193,8 +193,15 @@ OWASP ASVS v4: chapter 2 (Authentication), chapter 4 (Access Control).*
         -   :php:`DataHandlerHook` — a record delete asserts every vault
             field's delete gate before removing the first secret and is
             cancelled outright if any fails; a copy that cannot clone every
-            secret deletes the ones it made and blanks every vault field, so a
-            copy never shares the source record's secrets
+            secret deletes the ones it made and blanks every vault field. The
+            control is a preflight plus best-effort compensation, not
+            atomicity: a failure the preflight cannot predict leaves the
+            secrets already deleted unrestorable, a failed rollback delete
+            leaves an orphaned clone, and a failed blanking leaves the copy
+            still referencing the source record's identifiers. The record is
+            preserved either way, the delete and blanking residuals are named
+            to the editor, and every failure — the orphaned clone included —
+            is logged under a correlation reference
         -   :ref:`tca-integration`; :ref:`adr-018-flexform-secret-lifecycle`
 
     *   -   CLI grant narrowed to low-risk operations

--- a/Documentation/Developer/Adr/ADR-004-TcaIntegration.rst
+++ b/Documentation/Developer/Adr/ADR-004-TcaIntegration.rst
@@ -274,8 +274,9 @@ Data flow
    2. Retrieves source secrets by UUID
    3. Creates new secrets with new UUIDs for copied record
    4. On failure: the secrets already cloned are deleted again and every
-      vault field of the new record is blanked, so the copy never shares the
-      source record's secrets
+      vault field of the new record is blanked; both steps are best effort,
+      so a failed rollback delete leaves an orphaned clone and a failed
+      blanking leaves the copy referencing the source record's secrets
 
 Runtime resolution
 ------------------

--- a/Documentation/Developer/Adr/ADR-004-TcaIntegration.rst
+++ b/Documentation/Developer/Adr/ADR-004-TcaIntegration.rst
@@ -274,7 +274,7 @@ Data flow
    2. Retrieves source secrets by UUID
    3. Creates new secrets with new UUIDs for copied record
    4. On failure: the secrets already cloned are deleted again and every
-      vault field of the new record is blanked; both steps are best effort,
+      vault field of the new record is blanked; both steps are best-effort,
       so a failed rollback delete leaves an orphaned clone and a failed
       blanking leaves the copy referencing the source record's secrets
 

--- a/Documentation/Developer/TcaIntegration.rst
+++ b/Documentation/Developer/TcaIntegration.rst
@@ -394,7 +394,8 @@ Record operations
 -  **Copy**: Vault secrets are cloned to the new record under fresh
    identifiers.
 
-Records with several vault fields are handled all-or-nothing.
+Records with several vault fields are handled as one unit, with the residual
+cases named below.
 
 A **create** whose secret value is refused is compensated rather than left
 half-applied: the just-inserted ``tx_nrvault_secret`` row is removed, the
@@ -408,10 +409,17 @@ the audit write fails.
 
 A **copy** clones every field or none: if one secret cannot be cloned, the
 secrets already cloned for that copy are deleted again and *all* vault fields
-of the new record are cleared. They are never left holding the source record's
-identifiers — the copy would otherwise share the original's secrets, and
+of the new record are cleared, so the copy does not end up holding the source
+record's identifiers — it would otherwise share the original's secrets, and
 rotating or deleting one record would silently change the other. The editor
 gets an error message and re-enters the values.
+
+Both halves of that rollback are best effort. If a rollback delete fails, the
+clone it should have removed survives as an orphan that nothing references any
+more; the failure is logged for the administrator rather than shown to the
+editor. If the blanking write fails, the copy keeps the source record's
+identifiers and does share its secrets — the editor's error message says so
+explicitly, and the record needs manual review.
 
 A **delete** checks the delete permission of every vault field *before*
 removing the first secret, because a vault delete cannot be undone. If any

--- a/Documentation/Developer/TcaIntegration.rst
+++ b/Documentation/Developer/TcaIntegration.rst
@@ -409,12 +409,12 @@ the audit write fails.
 
 A **copy** clones every field or none: if one secret cannot be cloned, the
 secrets already cloned for that copy are deleted again and *all* vault fields
-of the new record are cleared, so the copy does not end up holding the source
+of the new record are cleared, so the copy should not end up holding the source
 record's identifiers — it would otherwise share the original's secrets, and
 rotating or deleting one record would silently change the other. The editor
 gets an error message and re-enters the values.
 
-Both halves of that rollback are best effort. If a rollback delete fails, the
+Both halves of that rollback are best-effort. If a rollback delete fails, the
 clone it should have removed survives as an orphan that nothing references any
 more; the failure is logged for the administrator rather than shown to the
 editor. If the blanking write fails, the copy keeps the source record's


### PR DESCRIPTION
Finding 5 of the external review round 4, verified against the code: the docs claimed atomicity for multi-field record copy/delete where the code's real guarantee is **preflight plus best-effort compensation**. The code is honest — its own log messages name the residuals — but three passages said "never".

## Corrected

| Passage | Was | Now |
|---|---|---|
| `Auditor/ControlMapping.rst` | "so a copy never shares the source record's secrets" | states the control as preflight + best-effort compensation and names all three residuals |
| `Developer/TcaIntegration.rst` | "They are never left holding the source record's identifiers." | qualified against the blanking-failure path |
| `Developer/Adr/ADR-004` | same "never" | same qualification |
| `Developer/TcaIntegration.rst:397` | "handled all-or-nothing" (unqualified umbrella, contradicted by its own lines 421-427) | "handled as one unit, with the residual cases below" |

Also documented for the first time: **copy-rollback deletes are best-effort** — `abandonCopiedSecrets()` catches a per-field compensation failure, reports it and continues, so an orphaned clone can survive.

The residuals, all traceable in code: a failure the preflight cannot predict leaves already-deleted secrets unrestorable (`DataHandlerHook.php:301-319`); a failed rollback delete leaves an orphaned clone (`:539-550`); a failed blanking leaves the copy still referencing the source identifiers (`blankVaultFields()` returning false, `:596-602`, surfaced by the caller at `:573-574`). The record is preserved in every case and each failure is logged under a correlation reference (`VaultFailureReporter`).

Untouched because already accurate: ADR-018's blanking-failure clause (its wording was reused), `Api.rst:99-103`, and the delete residual at `TcaIntegration.rst:421-427`.

## Verification

- `make docs`: 71/71 rendered, no new warnings or unresolved references
- Docs only — no code changed
