### PR TITLE
Report the legacy-CLI opt-in and grade the audit HMAC epochs

### DIFF
--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -602,9 +602,12 @@ final readonly class AuditLogService implements AuditLogServiceInterface
      *
      *  1. `hmac_key_epoch` — the algorithm selector itself. At epoch 0-2 the
      *     epoch was read from the row but never bound into any hash, so a
-     *     DB-write attacker could downgrade the (keyless-verifiable) algorithm
-     *     by flipping the column and re-signing without the HMAC key. Binding
-     *     the epoch makes any such re-sign mismatch the stored entry_hash.
+     *     relabel to a lower (keyless-verifiable) algorithm was caught only by
+     *     the chain-shape guards in `verifyHashChain()` — the per-row
+     *     monotonicity check and the chain-wide epoch floor — neither of which
+     *     covers the first row of a scanned range, and the floor only a
+     *     full-chain pass. Binding the epoch makes any such re-sign mismatch
+     *     the stored entry_hash on the row itself, whatever the range.
      *  2. The human-readable attribution fields `actor_type`,
      *     `actor_username`, `actor_role` and the `request_id` — surfaced in the
      *     backend audit list and CSV export but excluded from the v2 payload,

--- a/Classes/Service/Doctor/Check/AuditCheck.php
+++ b/Classes/Service/Doctor/Check/AuditCheck.php
@@ -513,17 +513,22 @@ final readonly class AuditCheck implements ReadinessCheckInterface
                 . 'includes "success" itself: a recorded denial can be flipped into a recorded grant, '
                 . 'which inverts the meaning of the entry without touching a signed byte. '
                 . 'error_message, reason, ip_address, user_agent, hash_before, hash_after and context '
-                . 'are forgeable the same way; so is the hmac_key_epoch column, so the algorithm can '
-                . 'be relabelled downwards and re-signed without the key; and so are the attribution '
-                . 'fields the backend audit list and the CSV export present as "who did this", so '
-                . 'blame can be reassigned on any row.'
+                . 'are forgeable the same way; so is the hmac_key_epoch column, which leaves the '
+                . 'algorithm selector resting on verifyHashChain()\'s chain-shape guards rather than '
+                . 'on the MAC; and so are the attribution fields the backend audit list and the CSV '
+                . 'export present as "who did this", so blame can be reassigned on any row.'
             : 'The epoch-2 payload signs the forensic columns but leaves two sets out. The '
-                . 'hmac_key_epoch column — the algorithm selector itself — is unsigned, so a '
-                . 'database-write attacker can relabel a row to a lower epoch and re-sign it under the '
-                . 'weaker algorithm; at epoch 0 that algorithm needs no key at all. The attribution '
-                . 'fields actor_type, actor_username, actor_role and request_id are unsigned too — the '
-                . 'exact fields the backend audit list and the CSV export show as the responsible '
-                . 'actor — so blame can be reassigned on any row without breaking the chain.';
+                . 'hmac_key_epoch column — the algorithm selector itself — is unsigned, so no part of '
+                . 'the row proves which algorithm signed it, and a relabel is caught only by the '
+                . 'chain-shape guards in verifyHashChain(): per-row epoch monotonicity, and a '
+                . 'chain-wide high-water floor read from this very setting. The floor runs on a '
+                . 'full-chain pass only — not on the bounded tail audit.hash_chain verifies — and the '
+                . 'monotonicity check cannot fire on the first row of whatever range is scanned. At '
+                . 'epoch 3 the selector is inside the MAC, so a relabel breaks the stored hash by '
+                . 'itself. The attribution fields actor_type, actor_username, actor_role and '
+                . 'request_id are unsigned too — the exact fields the backend audit list and the CSV '
+                . 'export show as the responsible actor — so blame can be reassigned on any row '
+                . 'without breaking the chain.';
 
         return Finding::warning(
             id: $id,

--- a/Classes/Service/Doctor/Check/AuditCheck.php
+++ b/Classes/Service/Doctor/Check/AuditCheck.php
@@ -401,22 +401,36 @@ final readonly class AuditCheck implements ReadinessCheckInterface
     }
 
     /**
-     * Is the chain keyed at all?
+     * Is the chain keyed, and does the key cover the columns that matter?
      *
-     * `auditHmacEpoch = 0` is a single integer that switches off three separate
-     * controls, and until this finding existed none of them said so:
+     * Three-way, because "keyed" and "trustworthy" are not the same state and a
+     * two-way check said they were. `AuditLogService`'s dispatch signs a
+     * different payload per epoch, so the epoch integer is what decides which
+     * columns a database-write attacker can rewrite without the HMAC key:
      *
-     *  1. rows are hashed with plain SHA-256 instead of HMAC-SHA256, so the
-     *     chain needs no key to recompute;
-     *  2. the epoch-downgrade floor in
-     *     {@see AuditLogServiceInterface::verifyHashChain()} defaults to the
-     *     CONFIGURED epoch, so at 0 no chain can fall below it;
-     *  3. {@see AuditChainAnchorStoreInterface::isEnabled()} is `epoch >= 1`, so
-     *     the in-DB tip anchor is never read, written or verified.
+     *  - **0** — no key at all. One integer switches off three separate
+     *    controls: rows are hashed with plain SHA-256 so the chain needs no key
+     *    to recompute; the epoch-downgrade floor in
+     *    {@see AuditLogServiceInterface::verifyHashChain()} defaults to the
+     *    CONFIGURED epoch, so at 0 no chain can fall below it; and
+     *    {@see AuditChainAnchorStoreInterface::isEnabled()} is `epoch >= 1`, so
+     *    the in-DB tip anchor is never read, written or verified.
+     *  - **1** — {@see AuditLogService::calculateHash()} over six identity
+     *    fields only. Every outcome and forensic column is outside the MAC,
+     *    `success` included.
+     *  - **2** — {@see AuditLogService::calculateHashV2()} adds the forensic
+     *    columns but still leaves the epoch selector and the human-readable
+     *    attribution fields unsigned.
+     *  - **3+** — {@see AuditLogService::calculateHashV3()} binds both.
      *
-     * Critical under both profiles: the standard profile does not promise an
-     * external witness, but it does promise a tamper-evident chain, and at
-     * epoch 0 there is none. The shipped default is 3.
+     * Critical at 0 under both profiles: the standard profile does not promise
+     * an external witness, but it does promise a tamper-evident chain, and at
+     * epoch 0 there is none. Warning at 1-2 rather than critical: the chain IS
+     * keyed there, so the entries cannot be rewritten wholesale — but 1 and 2
+     * are live states reachable from a stalled or partial
+     * {@see \Netresearch\NrVault\Upgrades\AuditHmacMigrationWizard} run, not
+     * hypotheticals, and reporting them as equivalent to 3 is what let a
+     * half-migrated installation read as clean. The shipped default is 3.
      */
     private function checkHmacEpoch(): Finding
     {
@@ -427,17 +441,22 @@ final readonly class AuditCheck implements ReadinessCheckInterface
             'auditAnchorRequired' => $this->configuration->isAuditAnchorRequired(),
         ];
 
-        if ($epoch >= 1) {
+        if ($epoch >= 3) {
             return Finding::pass(
                 id: $id,
                 summary: \sprintf(
-                    'Audit chain HMAC epoch is %d: rows are HMAC-signed, the epoch-downgrade floor '
-                    . 'is armed, and the in-DB tip anchor is active.',
+                    'Audit chain HMAC epoch is %d: rows are HMAC-signed over the full forensic '
+                    . 'payload including the epoch selector and the attribution fields, the '
+                    . 'epoch-downgrade floor is armed, and the in-DB tip anchor is active.',
                     $epoch,
                 ),
                 docsUrl: DocsLink::AUDIT_HMAC_EPOCH,
                 details: $details,
             );
+        }
+
+        if ($epoch >= 1) {
+            return $this->partiallySignedEpochFinding($id, $epoch, $details);
         }
 
         return Finding::critical(
@@ -457,6 +476,70 @@ final readonly class AuditCheck implements ReadinessCheckInterface
                 . 'vendor/bin/typo3 vault:audit-migrate-hmac (or the install-tool "Migrate audit hash '
                 . 'chain" wizard), then arm the anchor with vendor/bin/typo3 vault:audit '
                 . '--reset-anchor.',
+            docsUrl: DocsLink::AUDIT_HMAC_EPOCH,
+            details: $details,
+        );
+    }
+
+    /**
+     * Epoch 1 or 2 — keyed, but the MAC does not span the whole row.
+     *
+     * Named per epoch rather than with one shared "not the latest epoch" text,
+     * because the two leave a different set of columns forgeable and an operator
+     * cannot act on "upgrade for unspecified reasons". `details.unsignedFields`
+     * carries the same list in machine-readable form for a CI gate.
+     *
+     * @param array<string, bool|int|string> $details
+     */
+    private function partiallySignedEpochFinding(string $id, int $epoch, array $details): Finding
+    {
+        // The columns each epoch's payload leaves OUT of the MAC — read off
+        // AuditLogService::calculateHash() (epoch 1) and calculateHashV2()
+        // (epoch 2) against the v3 payload, which binds everything.
+        $unsigned = $epoch === 1
+            ? [
+                'success', 'error_message', 'reason', 'ip_address', 'user_agent',
+                'hash_before', 'hash_after', 'context',
+                'hmac_key_epoch', 'actor_type', 'actor_username', 'actor_role', 'request_id',
+            ]
+            : ['hmac_key_epoch', 'actor_type', 'actor_username', 'actor_role', 'request_id'];
+
+        $details['unsignedFields'] = implode(',', $unsigned);
+
+        $risk = $epoch === 1
+            ? 'The epoch-1 payload covers six identity fields only — uid, secret_identifier, action, '
+                . 'actor_uid, crdate and previous_hash. Everything else is outside the MAC, so anyone '
+                . 'with database write access can rewrite it and the chain still verifies. That '
+                . 'includes "success" itself: a recorded denial can be flipped into a recorded grant, '
+                . 'which inverts the meaning of the entry without touching a signed byte. '
+                . 'error_message, reason, ip_address, user_agent, hash_before, hash_after and context '
+                . 'are forgeable the same way; so is the hmac_key_epoch column, so the algorithm can '
+                . 'be relabelled downwards and re-signed without the key; and so are the attribution '
+                . 'fields the backend audit list and the CSV export present as "who did this", so '
+                . 'blame can be reassigned on any row.'
+            : 'The epoch-2 payload signs the forensic columns but leaves two sets out. The '
+                . 'hmac_key_epoch column — the algorithm selector itself — is unsigned, so a '
+                . 'database-write attacker can relabel a row to a lower epoch and re-sign it under the '
+                . 'weaker algorithm; at epoch 0 that algorithm needs no key at all. The attribution '
+                . 'fields actor_type, actor_username, actor_role and request_id are unsigned too — the '
+                . 'exact fields the backend audit list and the CSV export show as the responsible '
+                . 'actor — so blame can be reassigned on any row without breaking the chain.';
+
+        return Finding::warning(
+            id: $id,
+            summary: \sprintf(
+                'Audit chain HMAC epoch is %d: the chain is keyed, but %d column(s) stay outside the '
+                . 'signed payload (%s).',
+                $epoch,
+                \count($unsigned),
+                implode(', ', $unsigned),
+            ),
+            risk: $risk,
+            remediation: 'Set "auditHmacEpoch" to 3 and re-sign the existing entries with '
+                . 'vendor/bin/typo3 vault:audit-migrate-hmac (or the install-tool "Migrate audit hash '
+                . 'chain" wizard). A stalled or partial run of that migration is the usual way an '
+                . 'installation ends up here, so check that it completed rather than only raising the '
+                . 'setting.',
             docsUrl: DocsLink::AUDIT_HMAC_EPOCH,
             details: $details,
         );

--- a/Classes/Service/Doctor/Check/CliAccessCheck.php
+++ b/Classes/Service/Doctor/Check/CliAccessCheck.php
@@ -15,6 +15,7 @@ use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\Doctor\DocsLink;
 use Netresearch\NrVault\Service\Doctor\DoctorContext;
 use Netresearch\NrVault\Service\Doctor\Finding;
+use Netresearch\NrVault\Service\Doctor\FindingSeverity;
 use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
 
 /**
@@ -29,6 +30,11 @@ use Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface;
  * Off by default, so the finding here is about a deliberate opt-in that may have
  * outlived the deployment step it was added for — and about the second, easier
  * mistake: turning it on and leaving the group restriction empty.
+ *
+ * The group also carries `frontendPlaceholderLegacyCli`, the other command-line
+ * opt-in that widens what a shell reaches. It is INDEPENDENT of `allowCliAccess`
+ * — {@see \Netresearch\NrVault\Security\FrontendPlaceholderPolicy} consults only
+ * its own flag — so it is reported whether or not CLI access is granted.
  */
 final readonly class CliAccessCheck implements ReadinessCheckInterface
 {
@@ -58,6 +64,13 @@ final readonly class CliAccessCheck implements ReadinessCheckInterface
                     docsUrl: DocsLink::ACCESS_CONTROL,
                     details: ['allowCliAccess' => false],
                 ),
+                // Reported here too, not only below: the two settings are
+                // independent. FrontendPlaceholderPolicy::isLegacyContext()
+                // consults isLegacyCliEnabled() and nothing else, so the legacy
+                // bypass is fully live on an installation with allowCliAccess
+                // off — which is the default, i.e. exactly the installations
+                // this branch serves.
+                $this->checkFrontendPlaceholderLegacy($context),
             ];
         }
 
@@ -65,7 +78,70 @@ final readonly class CliAccessCheck implements ReadinessCheckInterface
             $this->checkAccessEnabled($context),
             $this->checkAccessGroups(),
             $this->checkAllowedOperations(),
+            $this->checkFrontendPlaceholderLegacy($context),
         ];
+    }
+
+    /**
+     * Does a command-line render still resolve any placeholder an editor wrote?
+     *
+     * `frontendPlaceholderLegacyCli` is not part of the `allowCliAccess` grant
+     * and is not gated by it — it selects the pre-ADR-035 CLI *mode*, in which
+     * the frontend placeholder allow-set is not enforced at all. What it
+     * re-opens is concrete: `scheduler:run` authenticates the `_cli_`
+     * administrator, so the admin bypass already grants the read, and the
+     * allow-set is the only remaining gate between an editor-authored
+     * `tt_content` field and a secret in a newsletter or export job's output.
+     *
+     * Warning under the standard profile rather than a pass: unlike
+     * `allowCliAccess` there is no workflow that needs this and cannot be served
+     * by publishing the identifier instead, so it is a genuine finding wherever
+     * it is on. Critical under hardened, where an editor-reachable resolution
+     * site is a broken promise rather than a documented trade-off.
+     */
+    private function checkFrontendPlaceholderLegacy(DoctorContext $context): Finding
+    {
+        $id = 'cli.frontend_placeholder_legacy';
+        $enabled = $this->configuration->isFrontendPlaceholderLegacyCliEnabled();
+        $details = ['frontendPlaceholderLegacyCli' => $enabled];
+
+        if (!$enabled) {
+            return Finding::pass(
+                id: $id,
+                summary: 'Command-line renders enforce the frontend placeholder allow-set.',
+                docsUrl: DocsLink::FRONTEND_PLACEHOLDER_LEGACY_CLI,
+                details: $details,
+            );
+        }
+
+        $finding = Finding::warning(
+            id: $id,
+            summary: 'Legacy CLI placeholder resolution is enabled, so command-line renders resolve '
+                . 'every frontend-accessible %vault(id)% placeholder regardless of who authored it.',
+            risk: 'The allow-set is switched off for command-line renders, which restores the exposure '
+                . 'it was added to close. "scheduler:run" authenticates the _cli_ administrator, so the '
+                . 'admin bypass grants the read whatever the per-secret tiers say, and a scheduled '
+                . 'newsletter or export job that renders editor-authored tt_content through stdWrap() '
+                . 'then substitutes any frontend-accessible secret an editor can name. Where that '
+                . 'output goes — a subscriber mail, a file, an HTTP callback — is outside the vault\'s '
+                . 'knowledge, so the setting has to be read as re-opening the path, not as narrowing '
+                . 'it to a safe one.',
+            remediation: 'Publish the identifiers the render jobs legitimately need — one '
+                . 'plugin.tx_nrvault.frontendResolvableIdentifiers line, an entry in site configuration, '
+                . 'or one FrontendPlaceholderPolicyInterface::allowIdentifier() call in the job — then '
+                . 'turn "frontendPlaceholderLegacyCli" off and pin it in config/system/additional.php '
+                . 'via $GLOBALS[TYPO3_CONF_VARS][SYS][nrVault][frontendPlaceholderLegacyCli] so a '
+                . 'backend admin cannot tick it back on.',
+            docsUrl: DocsLink::FRONTEND_PLACEHOLDER_LEGACY_CLI,
+            details: $details,
+        );
+
+        // Same observation, same wording, one severity apart — so a
+        // `--profile=hardened` dry run is comparable to the live report line
+        // for line, which is what escalatedTo() exists for.
+        return $context->isHardened()
+            ? $finding->escalatedTo(FindingSeverity::Critical)
+            : $finding;
     }
 
     /**

--- a/Classes/Service/Doctor/DocsLink.php
+++ b/Classes/Service/Doctor/DocsLink.php
@@ -46,6 +46,14 @@ final class DocsLink
 
     public const ACCESS_CONTROL = self::BASE . 'Configuration/Index.html#configuration-access-control';
 
+    /**
+     * A `confval` `:name:` rather than a `.. _label:` target — the two are the
+     * same kind of anchor (explicitly written, not derived from heading text),
+     * and the setting's own entry is where an operator reading this finding
+     * needs to land.
+     */
+    public const FRONTEND_PLACEHOLDER_LEGACY_CLI = self::BASE . 'Configuration/Index.html#ext-nrvault-frontendPlaceholderLegacyCli';
+
     public const DEPLOYMENT_GATE = self::BASE . 'Security/Index.html#security-deployment-gate';
 
     public const COMMANDS = self::BASE . 'Developer/Commands.html#developer-commands';

--- a/Documentation/Auditor/EvidenceCollection.rst
+++ b/Documentation/Auditor/EvidenceCollection.rst
@@ -60,11 +60,13 @@ The JSON body carries ``profile``, ``configuredProfile``,
 ``summary`` object (``total``, ``pass``, ``warning``, ``critical``) and a
 ``findings`` array.
 
-**``findings`` lists every control, including the ones that passed** — 23 are
+**``findings`` lists every control, including the ones that passed** — 24 are
 always emitted, plus four conditional families:
 
 *   ``cli.access_groups`` and ``cli.allowed_operations``, only when
-    ``allowCliAccess`` is on;
+    ``allowCliAccess`` is on. ``cli.frontend_placeholder_legacy`` is **not** in
+    this family despite the shared ``cli.`` prefix — it reports a setting that
+    is independent of ``allowCliAccess`` and is therefore always emitted;
 *   ``provider.key_permissions``, only for the ``file`` master-key provider;
 *   ``audit.sink_state.<sink>``, one per enabled audit sink;
 *   ``audit.sink_probe.<sink>``, one per enabled sink and only under
@@ -147,7 +149,8 @@ Finding ids worth citing directly in an assessment:
 
     *   -   CLI exposure
         -   ``cli.access``, ``cli.access_groups``,
-            ``cli.allowed_operations``
+            ``cli.allowed_operations``,
+            ``cli.frontend_placeholder_legacy``
 
     *   -   Emergency access
         -   ``breakglass.window_open``

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -378,6 +378,13 @@ CLI access
    command) to re-hash existing rows. See
    :ref:`adr-023-audit-hash-chain-hmac`.
 
+   :bash:`vault:doctor` grades the three states apart under
+   ``audit.hmac_epoch``: pass at 3 and above, **warning** at 1 and 2 naming the
+   columns that epoch leaves outside the MAC, and **critical** at 0. A stalled
+   or partially applied migration is the usual way an installation ends up at
+   1 or 2, so treat that warning as "the migration did not finish", not as a
+   pending nice-to-have.
+
 .. confval:: auditAnchorRequired
    :name: ext-nrvault-auditAnchorRequired
    :type: boolean

--- a/Documentation/Developer/Adr/ADR-035-FrontendPlaceholderAllowSet.rst
+++ b/Documentation/Developer/Adr/ADR-035-FrontendPlaceholderAllowSet.rst
@@ -423,9 +423,11 @@ Residual risk
    request, it defaults to ``0``, and it honours the
    ``$TYPO3_CONF_VARS[SYS][nrVault][frontendPlaceholderLegacyCli]`` pin, so an
    operator can put the weakening out of reach of the backend Settings module —
-   which matters here, because the flag's only effect is to open a gate.
-   ``vault:doctor`` does not report it; an operator who sets it has to remember
-   it themselves.
+   which matters here, because the flag's only effect is to open a gate. It is
+   also visible: ``vault:doctor`` reports it as ``cli.frontend_placeholder_legacy``
+   — warning under ``standard``, critical under ``hardened`` — and emits that
+   control on every run, not only when ``allowCliAccess`` is on, because the two
+   settings are independent.
 -  **A CLI render that carries no request of its own resolves nothing**, because
    A4 needs a request to be keyed on and the console application's own request
    is not automatically the renderer's. This is the fail-closed direction and

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -1220,6 +1220,28 @@ cli.allowed_operations
    here, because the allowlist is the record of what the CLI actor has been
    granted, not only of what it can currently reach.
 
+cli.frontend_placeholder_legacy
+   :confval:`ext-nrvault-frontendPlaceholderLegacyCli`. Pass when off — the
+   command line then enforces the same frontend placeholder allow-set as a web
+   request. *Warning* / **critical** (hardened) when on.
+
+   **Always emitted, unlike the two controls above.** The setting is not part
+   of the ``allowCliAccess`` grant and is not gated by it:
+   ``FrontendPlaceholderPolicy`` consults this flag and nothing else, so the
+   bypass is fully live on a default installation with CLI access off. It
+   shares the ``cli.`` prefix because it widens what a shell reaches, not
+   because it belongs to that grant.
+
+   Warning rather than pass under ``standard``, which is where it differs from
+   ``cli.access``: a deployment pipeline genuinely needs ``allowCliAccess``,
+   whereas there is no workflow that needs this flag and cannot be served by
+   publishing the identifier instead. What it re-opens is concrete —
+   :bash:`scheduler:run` authenticates the ``_cli_`` administrator, so the admin
+   bypass grants the read whatever the per-secret tiers say, and a scheduled
+   newsletter or export job rendering editor-authored ``tt_content`` through
+   ``stdWrap()`` substitutes any frontend-accessible secret an editor can name.
+   See :ref:`adr-035-frontend-placeholder-allow-set`.
+
 secrets.expired
    No stored secret is past its expiry. Warning with the count otherwise: an
    expired secret still decrypts, so the credential stays recoverable from a

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -1128,12 +1128,37 @@ audit.hash_chain
    the authoritative full-range verifier and belongs on a schedule.
 
 audit.hmac_epoch
-   :confval:`ext-nrvault-auditHmacEpoch` is at least 1. **Critical** in both
-   profiles below that: the one integer switches off three controls at once —
+   :confval:`ext-nrvault-auditHmacEpoch` is at least 3 — the shipped default,
+   and the only epoch whose HMAC spans the whole audit row. Three-way, because
+   the epoch integer selects which payload ``AuditLogService`` signs, and
+   "keyed" and "trustworthy" are not the same state:
+
+   **Critical** at 0. The one integer switches off three controls at once —
    rows are hashed with keyless SHA-256, the epoch-downgrade floor equals the
    configured epoch and so can never be undercut, and the in-DB tip anchor is
    disabled. The finding names all three, because "epoch is 0" on its own reads
-   like a version marker rather than a disabled chain. The shipped default is 3.
+   like a version marker rather than a disabled chain.
+
+   **Warning** at 1 and 2. The chain is keyed there, so entries cannot be
+   rewritten wholesale — but the MAC does not cover the whole row, and the
+   finding names the columns it leaves out (also as
+   ``details.unsignedFields``). At **epoch 1** the payload is six identity
+   fields only (uid, secret_identifier, action, actor_uid, crdate,
+   previous_hash), so ``success`` itself is forgeable: a recorded denial can be
+   flipped into a recorded grant, and ``error_message``, ``reason``,
+   ``ip_address``, ``user_agent``, ``hash_before``, ``hash_after`` and
+   ``context`` can be rewritten the same way. At **epoch 2** the forensic
+   columns are signed, but ``hmac_key_epoch`` — the algorithm selector itself —
+   is not, so a row can be relabelled to a lower epoch and re-signed under the
+   weaker algorithm without the key; neither are ``actor_type``,
+   ``actor_username``, ``actor_role`` and ``request_id``, the fields the backend
+   audit list and the CSV export present as the responsible actor, so blame can
+   be reassigned on any row.
+
+   Both intermediate epochs are live states, not hypotheticals: a stalled or
+   partial :ref:`command-audit-migrate-hmac` run (or its install-tool wizard)
+   leaves an installation exactly there, which is why the remediation says to
+   check that the migration completed rather than only raising the setting.
 
 audit.db_anchor
    The IN-DATABASE tip anchor in ``sys_registry`` — a different control from

--- a/Documentation/Operations/HardenedDeployment.rst
+++ b/Documentation/Operations/HardenedDeployment.rst
@@ -425,9 +425,11 @@ configuration is coherent; these steps say the deployment works.
       still can, the flag is not effective, and ``--status`` will show why.
 *   [ ] The audit module is reachable by a group holding ``audit.view`` and not
       by one without it.
-*   [ ] The strict CLI placeholder policy is in force: put a
-      ``%vault(id)%`` placeholder for a ``frontend_accessible`` secret into an
-      editor-editable field, run a scheduled render over it
+*   [ ] The strict CLI placeholder policy is in force: :bash:`vault:doctor`
+      reports ``cli.frontend_placeholder_legacy`` as a pass (it is critical
+      under this profile when the flag is on). Confirm it behaviourally too —
+      put a ``%vault(id)%`` placeholder for a ``frontend_accessible`` secret
+      into an editor-editable field, run a scheduled render over it
       (:bash:`scheduler:run`), and confirm the placeholder does **not**
       resolve. If it does, ``frontendPlaceholderLegacyCli`` is on — check the
       pin.

--- a/Documentation/Operations/HardenedDeployment.rst
+++ b/Documentation/Operations/HardenedDeployment.rst
@@ -427,7 +427,7 @@ configuration is coherent; these steps say the deployment works.
       by one without it.
 *   [ ] The strict CLI placeholder policy is in force: :bash:`vault:doctor`
       reports ``cli.frontend_placeholder_legacy`` as a pass (it is critical
-      under this profile when the flag is on). Confirm it behaviourally too —
+      under this profile when the flag is on). Confirm it empirically as well —
       put a ``%vault(id)%`` placeholder for a ``frontend_accessible`` secret
       into an editor-editable field, run a scheduled render over it
       (:bash:`scheduler:run`), and confirm the placeholder does **not**

--- a/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
@@ -401,19 +401,114 @@ final class AuditCheckTest extends TestCase
     }
 
     /**
-     * The lowest epoch that still keys the chain. Epoch 1 must pass, so a
-     * relaxed `>= 1` boundary in the check cannot go unnoticed.
+     * The shipped default, and the only epoch whose MAC spans the whole row —
+     * so it is the only one that may pass. Pinned at the boundary so a relaxed
+     * `>= 1` or `>= 2` cannot go unnoticed.
      */
     #[Test]
-    public function theLowestKeyedEpochPasses(): void
+    public function onlyTheFullySignedEpochPasses(): void
+    {
+        foreach ([SecurityProfile::Standard, SecurityProfile::Hardened] as $profile) {
+            $finding = $this->findingById(
+                $this->check(epoch: 3)->run($this->doctorContext($profile)),
+                'audit.hmac_epoch',
+            );
+
+            self::assertTrue($finding->isPass(), $finding->summary);
+            self::assertSame(3, $finding->details['auditHmacEpoch']);
+        }
+    }
+
+    /**
+     * A future epoch is still fully signed — the dispatch in `AuditLogService`
+     * routes everything above 2 to `calculateHashV3()`, so `> 3` must not
+     * regress into the partial-signature warning.
+     */
+    #[Test]
+    public function anEpochAboveTheDefaultPasses(): void
+    {
+        $finding = $this->findingById(
+            $this->check(epoch: 4)->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.hmac_epoch',
+        );
+
+        self::assertTrue($finding->isPass(), $finding->summary);
+    }
+
+    /**
+     * Epochs 1 and 2 key the chain but do not sign the whole row, and reporting
+     * them as equivalent to 3 is what let a stalled `vault:audit-migrate-hmac`
+     * run read as clean. Warning, not critical: the entries still cannot be
+     * rewritten wholesale without the key.
+     */
+    #[DataProvider('partiallySignedEpochProvider')]
+    #[Test]
+    public function aPartiallySignedEpochWarnsUnderBothProfiles(int $epoch): void
+    {
+        foreach ([SecurityProfile::Standard, SecurityProfile::Hardened] as $profile) {
+            $finding = $this->assertFindingSeverity(
+                FindingSeverity::Warning,
+                $this->check(epoch: $epoch)->run($this->doctorContext($profile)),
+                'audit.hmac_epoch',
+            );
+
+            self::assertSame($epoch, $finding->details['auditHmacEpoch']);
+            self::assertStringContainsString('vault:audit-migrate-hmac', $finding->remediation);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function partiallySignedEpochProvider(): iterable
+    {
+        yield 'identity fields only' => [1];
+        yield 'forensic payload without the epoch selector' => [2];
+    }
+
+    /**
+     * At epoch 1 the MAC covers six identity fields, so `success` itself is
+     * forgeable — a recorded denial can be flipped into a recorded grant. The
+     * finding has to name that concretely; "not the latest epoch" is not
+     * something an operator can weigh.
+     */
+    #[Test]
+    public function theEpochOneFindingNamesSuccessAsForgeable(): void
     {
         $finding = $this->findingById(
             $this->check(epoch: 1)->run($this->doctorContext(SecurityProfile::Standard)),
             'audit.hmac_epoch',
         );
 
-        self::assertTrue($finding->isPass(), $finding->summary);
-        self::assertSame(1, $finding->details['auditHmacEpoch']);
+        self::assertStringContainsString('success', $finding->summary);
+        self::assertStringContainsString('"success" itself', $finding->risk);
+        self::assertSame(
+            'success,error_message,reason,ip_address,user_agent,hash_before,hash_after,context,'
+            . 'hmac_key_epoch,actor_type,actor_username,actor_role,request_id',
+            $finding->details['unsignedFields'],
+        );
+    }
+
+    /**
+     * At epoch 2 the forensic columns ARE signed — naming them here would send
+     * the operator after a problem that does not exist. What is left unbound is
+     * the epoch selector and the attribution fields.
+     */
+    #[Test]
+    public function theEpochTwoFindingNamesOnlyTheStillUnboundFields(): void
+    {
+        $finding = $this->findingById(
+            $this->check(epoch: 2)->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.hmac_epoch',
+        );
+
+        self::assertSame(
+            'hmac_key_epoch,actor_type,actor_username,actor_role,request_id',
+            $finding->details['unsignedFields'],
+        );
+        self::assertStringNotContainsString('success', $finding->summary);
+        self::assertStringContainsString('hmac_key_epoch', $finding->risk);
+        self::assertStringContainsString('actor_username', $finding->risk);
     }
 
     /**

--- a/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
@@ -545,14 +545,14 @@ final class AuditCheckTest extends TestCase
             'audit.hmac_epoch',
         );
         $declaredUnsigned = explode(',', (string) $finding->details['unsignedFields']);
-        $baseline = self::hashForEpoch($epoch, self::hashRowFixture());
+        $baseline = $this->hashForEpoch($epoch, $this->hashRowFixture());
 
-        foreach (self::columnMutations() as $column => $mutatedValue) {
-            $row = self::hashRowFixture();
+        foreach ($this->columnMutations() as $column => $mutatedValue) {
+            $row = $this->hashRowFixture();
             $row[$column] = $mutatedValue;
 
             $declaredSigned = !\in_array($column, $declaredUnsigned, true);
-            $hashMoved = self::hashForEpoch($epoch, $row) !== $baseline;
+            $hashMoved = $this->hashForEpoch($epoch, $row) !== $baseline;
 
             self::assertSame(
                 $declaredSigned,
@@ -576,15 +576,15 @@ final class AuditCheckTest extends TestCase
     #[Test]
     public function theFullySignedEpochLeavesNoColumnOutsideTheMac(): void
     {
-        $baseline = self::hashForEpoch(3, self::hashRowFixture());
+        $baseline = $this->hashForEpoch(3, $this->hashRowFixture());
 
-        foreach (self::columnMutations() as $column => $mutatedValue) {
-            $row = self::hashRowFixture();
+        foreach ($this->columnMutations() as $column => $mutatedValue) {
+            $row = $this->hashRowFixture();
             $row[$column] = $mutatedValue;
 
             self::assertNotSame(
                 $baseline,
-                self::hashForEpoch(3, $row),
+                $this->hashForEpoch(3, $row),
                 \sprintf('Column "%s" is outside the epoch-3 payload.', $column),
             );
         }
@@ -814,7 +814,7 @@ final class AuditCheckTest extends TestCase
      *
      * @return array<string, int|string>
      */
-    private static function hashRowFixture(): array
+    private function hashRowFixture(): array
     {
         return [
             'uid' => 42,
@@ -839,13 +839,13 @@ final class AuditCheckTest extends TestCase
     }
 
     /**
-     * One differing value per column of {@see self::hashRowFixture()}. `success`
+     * One differing value per column of {@see $this->hashRowFixture()}. `success`
      * flips 1 -> 0 because the extractor coerces it through `bool`, so any other
      * truthy value would leave the payload unchanged and read as "unsigned".
      *
      * @return array<string, int|string>
      */
-    private static function columnMutations(): array
+    private function columnMutations(): array
     {
         return [
             'uid' => 43,
@@ -875,7 +875,7 @@ final class AuditCheckTest extends TestCase
      *
      * @param array<string, int|string> $row
      */
-    private static function hashForEpoch(int $epoch, array $row): string
+    private function hashForEpoch(int $epoch, array $row): string
     {
         return match ($epoch) {
             1 => AuditLogService::calculateHash(

--- a/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrVault\Audit\AuditChainAnchor;
 use Netresearch\NrVault\Audit\AuditChainAnchorLoad;
 use Netresearch\NrVault\Audit\AuditChainAnchorStatus;
 use Netresearch\NrVault\Audit\AuditChainAnchorStoreInterface;
+use Netresearch\NrVault\Audit\AuditLogService;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Audit\HashChainVerificationResult;
 use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
@@ -46,13 +47,20 @@ final class AuditCheckTest extends TestCase
      */
     private const CHAIN_TIP = 2500;
 
+    /** Synthetic HMAC key for the payload-drift tests — never a derived key. */
+    private const HMAC_KEY = 'unit-test-hmac-key-0123456789abcdef';
+
+    /** Stands in for the preceding entry's hash in the drift tests. */
+    private const PREVIOUS_HASH = 'previous-entry-hash';
+
     #[Test]
-    public function appliesToBothProfiles(): void
+    public function appliesToEveryProfile(): void
     {
         $check = $this->check();
 
-        self::assertTrue($check->appliesTo(SecurityProfile::Standard));
-        self::assertTrue($check->appliesTo(SecurityProfile::Hardened));
+        foreach (SecurityProfile::cases() as $profile) {
+            self::assertTrue($check->appliesTo($profile), $profile->value);
+        }
     }
 
     #[Test]
@@ -408,7 +416,7 @@ final class AuditCheckTest extends TestCase
     #[Test]
     public function onlyTheFullySignedEpochPasses(): void
     {
-        foreach ([SecurityProfile::Standard, SecurityProfile::Hardened] as $profile) {
+        foreach (SecurityProfile::cases() as $profile) {
             $finding = $this->findingById(
                 $this->check(epoch: 3)->run($this->doctorContext($profile)),
                 'audit.hmac_epoch',
@@ -445,7 +453,7 @@ final class AuditCheckTest extends TestCase
     #[Test]
     public function aPartiallySignedEpochWarnsUnderBothProfiles(int $epoch): void
     {
-        foreach ([SecurityProfile::Standard, SecurityProfile::Hardened] as $profile) {
+        foreach (SecurityProfile::cases() as $profile) {
             $finding = $this->assertFindingSeverity(
                 FindingSeverity::Warning,
                 $this->check(epoch: $epoch)->run($this->doctorContext($profile)),
@@ -512,6 +520,77 @@ final class AuditCheckTest extends TestCase
     }
 
     /**
+     * The per-epoch unsigned-column lists in `AuditCheck` are a second copy of a
+     * fact owned by `AuditLogService`'s hash builders: add a column to the v2 or
+     * v3 payload and the finding starts naming a field that is in fact signed.
+     *
+     * Guarded by a drift test rather than by a shared definition on purpose. The
+     * check needs the COMPLEMENT of each payload, so a shared constant would
+     * still be a hand-maintained second list unless the builders themselves
+     * consumed it — and making the signed payload data-driven inside a signing
+     * routine trades a reviewable literal for indirection where a bad map
+     * silently re-signs every row. This asserts the claim against the real
+     * builders instead: change one column at a time and see whether the epoch's
+     * hash actually moves.
+     *
+     * `previous_hash` is signed at every epoch but is not part of the row the
+     * builders read — it arrives as its own argument — so it has no entry here.
+     */
+    #[DataProvider('partiallySignedEpochProvider')]
+    #[Test]
+    public function theDeclaredUnsignedFieldsMatchWhatTheHashBuildersSign(int $epoch): void
+    {
+        $finding = $this->findingById(
+            $this->check(epoch: $epoch)->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.hmac_epoch',
+        );
+        $declaredUnsigned = explode(',', (string) $finding->details['unsignedFields']);
+        $baseline = self::hashForEpoch($epoch, self::hashRowFixture());
+
+        foreach (self::columnMutations() as $column => $mutatedValue) {
+            $row = self::hashRowFixture();
+            $row[$column] = $mutatedValue;
+
+            $declaredSigned = !\in_array($column, $declaredUnsigned, true);
+            $hashMoved = self::hashForEpoch($epoch, $row) !== $baseline;
+
+            self::assertSame(
+                $declaredSigned,
+                $hashMoved,
+                \sprintf(
+                    'Epoch %d declares "%s" %s, but changing it %s the entry hash.',
+                    $epoch,
+                    $column,
+                    $declaredSigned ? 'signed' : 'unsigned',
+                    $hashMoved ? 'moves' : 'leaves',
+                ),
+            );
+        }
+    }
+
+    /**
+     * The epoch-3 finding passes on the promise that nothing is left outside the
+     * MAC, so hold the v3 payload to it from the same direction: a future
+     * payload that drops a column must not keep the pass text.
+     */
+    #[Test]
+    public function theFullySignedEpochLeavesNoColumnOutsideTheMac(): void
+    {
+        $baseline = self::hashForEpoch(3, self::hashRowFixture());
+
+        foreach (self::columnMutations() as $column => $mutatedValue) {
+            $row = self::hashRowFixture();
+            $row[$column] = $mutatedValue;
+
+            self::assertNotSame(
+                $baseline,
+                self::hashForEpoch(3, $row),
+                \sprintf('Column "%s" is outside the epoch-3 payload.', $column),
+            );
+        }
+    }
+
+    /**
      * Epoch 0 switches off three controls with one integer, and the standard
      * profile promises a tamper-evident chain just as much as the hardened one —
      * so this is critical in both, not an escalation.
@@ -520,7 +599,7 @@ final class AuditCheckTest extends TestCase
     #[Test]
     public function aKeylessEpochIsCriticalUnderBothProfiles(int $epoch): void
     {
-        foreach ([SecurityProfile::Standard, SecurityProfile::Hardened] as $profile) {
+        foreach (SecurityProfile::cases() as $profile) {
             $finding = $this->assertFindingSeverity(
                 FindingSeverity::Critical,
                 $this->check(epoch: $epoch)->run($this->doctorContext($profile)),
@@ -728,6 +807,97 @@ final class AuditCheckTest extends TestCase
 
         self::assertTrue($finding->isPass(), $finding->summary);
         self::assertStringContainsString('vault:audit-verify', $finding->summary);
+    }
+
+    /**
+     * A complete audit row, as the hash builders receive it.
+     *
+     * @return array<string, int|string>
+     */
+    private static function hashRowFixture(): array
+    {
+        return [
+            'uid' => 42,
+            'secret_identifier' => 'api/deploy-token',
+            'action' => 'read',
+            'success' => 1,
+            'actor_uid' => 7,
+            'crdate' => 1_700_000_000,
+            'error_message' => '',
+            'reason' => 'scheduled rotation',
+            'ip_address' => '192.0.2.10',
+            'user_agent' => 'phpunit',
+            'hash_before' => 'hash-before',
+            'hash_after' => 'hash-after',
+            'context' => '{"source":"cli"}',
+            'hmac_key_epoch' => 3,
+            'actor_type' => 'backend',
+            'actor_username' => 'editor',
+            'actor_role' => 'maintainer',
+            'request_id' => 'request-1',
+        ];
+    }
+
+    /**
+     * One differing value per column of {@see self::hashRowFixture()}. `success`
+     * flips 1 -> 0 because the extractor coerces it through `bool`, so any other
+     * truthy value would leave the payload unchanged and read as "unsigned".
+     *
+     * @return array<string, int|string>
+     */
+    private static function columnMutations(): array
+    {
+        return [
+            'uid' => 43,
+            'secret_identifier' => 'api/other-token',
+            'action' => 'write',
+            'success' => 0,
+            'actor_uid' => 8,
+            'crdate' => 1_700_000_001,
+            'error_message' => 'permission denied',
+            'reason' => 'manual rotation',
+            'ip_address' => '192.0.2.11',
+            'user_agent' => 'curl/8.0',
+            'hash_before' => 'hash-before-forged',
+            'hash_after' => 'hash-after-forged',
+            'context' => '{"source":"backend"}',
+            'hmac_key_epoch' => 2,
+            'actor_type' => 'technical',
+            'actor_username' => 'someone-else',
+            'actor_role' => 'admin',
+            'request_id' => 'request-2',
+        ];
+    }
+
+    /**
+     * Mirror of the epoch dispatch in
+     * {@see AuditLogService::verifyHashChain()}.
+     *
+     * @param array<string, int|string> $row
+     */
+    private static function hashForEpoch(int $epoch, array $row): string
+    {
+        return match ($epoch) {
+            1 => AuditLogService::calculateHash(
+                (int) $row['uid'],
+                (string) $row['secret_identifier'],
+                (string) $row['action'],
+                (int) $row['actor_uid'],
+                (int) $row['crdate'],
+                self::PREVIOUS_HASH,
+                self::HMAC_KEY,
+            ),
+            2 => AuditLogService::calculateHashV2(
+                AuditLogService::extractV2HashRow($row),
+                self::PREVIOUS_HASH,
+                self::HMAC_KEY,
+            ),
+            default => AuditLogService::calculateHashV3(
+                AuditLogService::extractV3HashRow($row),
+                self::PREVIOUS_HASH,
+                self::HMAC_KEY,
+            ),
+        };
     }
 
     /**

--- a/Tests/Unit/Service/Doctor/Check/CliAccessCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/CliAccessCheckTest.php
@@ -16,6 +16,7 @@ use Netresearch\NrVault\Service\Doctor\FindingSeverity;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use Netresearch\NrVault\Tests\Unit\Traits\DoctorFindingTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 
 #[CoversClass(CliAccessCheck::class)]
@@ -33,16 +34,32 @@ final class CliAccessCheckTest extends TestCase
     }
 
     /**
-     * Off is the default and the safe state — and there is then no group scope to
-     * assess, so only one control is emitted rather than a vacuous pass.
+     * Off is the default and the safe state — and there is then no group scope
+     * nor operation allowlist to assess, so those two controls are dropped
+     * rather than emitted as vacuous passes. The legacy-CLI control stays,
+     * because that setting is not part of the `allowCliAccess` grant.
      */
     #[Test]
-    public function disabledCliAccessEmitsOnlyThePassingAccessControl(): void
+    public function disabledCliAccessEmitsOnlyTheAccessAndLegacyControls(): void
     {
         $findings = $this->check(false)->run($this->doctorContext(SecurityProfile::Hardened));
 
-        self::assertSame(['cli.access'], $this->findingIds($findings));
+        self::assertSame(
+            ['cli.access', 'cli.frontend_placeholder_legacy'],
+            $this->findingIds($findings),
+        );
         self::assertTrue($findings[0]->isPass());
+    }
+
+    #[Test]
+    public function enabledCliAccessEmitsAllFourControls(): void
+    {
+        $findings = $this->check(true, [42])->run($this->doctorContext(SecurityProfile::Standard));
+
+        self::assertSame(
+            ['cli.access', 'cli.access_groups', 'cli.allowed_operations', 'cli.frontend_placeholder_legacy'],
+            $this->findingIds($findings),
+        );
     }
 
     /**
@@ -153,6 +170,128 @@ final class CliAccessCheckTest extends TestCase
     }
 
     /**
+     * The default: the CLI enforces the same allow-set as a frontend request.
+     */
+    #[Test]
+    #[DataProvider('cliAccessStateProvider')]
+    public function theStrictDefaultPassesUnderBothProfiles(bool $cliAccessAllowed): void
+    {
+        foreach (SecurityProfile::cases() as $profile) {
+            $finding = $this->findingById(
+                $this->check($cliAccessAllowed, [42], legacyCli: false)->run($this->doctorContext($profile)),
+                'cli.frontend_placeholder_legacy',
+            );
+
+            self::assertTrue($finding->isPass(), $profile->value . ' must pass with the flag off');
+            self::assertFalse($finding->details['frontendPlaceholderLegacyCli']);
+        }
+    }
+
+    /**
+     * The trap this control exists for: `frontendPlaceholderLegacyCli` is NOT
+     * gated by `allowCliAccess`. `FrontendPlaceholderPolicy::isLegacyContext()`
+     * consults only its own flag, so the bypass is fully live on a default
+     * installation with CLI access off — and a finding appended to the
+     * "CLI access is on" branch alone would be skipped on exactly those
+     * installations.
+     */
+    #[Test]
+    #[DataProvider('cliAccessStateProvider')]
+    public function theLegacyOptInIsAWarningUnderTheStandardProfileRegardlessOfCliAccess(
+        bool $cliAccessAllowed,
+    ): void {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check($cliAccessAllowed, [42], legacyCli: true)
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.frontend_placeholder_legacy',
+        );
+
+        self::assertTrue($finding->details['frontendPlaceholderLegacyCli']);
+        // The concrete path, not a generic "less strict" phrasing: scheduler:run
+        // authenticates the _cli_ admin, so the admin bypass already grants the
+        // read and this allow-set is the only remaining gate.
+        self::assertStringContainsString('scheduler:run', $finding->risk);
+        self::assertStringContainsString('_cli_', $finding->risk);
+    }
+
+    #[Test]
+    #[DataProvider('cliAccessStateProvider')]
+    public function theLegacyOptInIsCriticalUnderTheHardenedProfileRegardlessOfCliAccess(
+        bool $cliAccessAllowed,
+    ): void {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Critical,
+            $this->check($cliAccessAllowed, [42], legacyCli: true)
+                ->run($this->doctorContext(SecurityProfile::Hardened)),
+            'cli.frontend_placeholder_legacy',
+        );
+
+        self::assertTrue($finding->details['frontendPlaceholderLegacyCli']);
+    }
+
+    /**
+     * Escalating must keep every text field, so a `--profile=hardened` dry run
+     * is comparable to the live report line for line.
+     */
+    #[Test]
+    public function theHardenedEscalationKeepsTheStandardWording(): void
+    {
+        $standard = $this->findingById(
+            $this->check(false, legacyCli: true)->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.frontend_placeholder_legacy',
+        );
+        $hardened = $this->findingById(
+            $this->check(false, legacyCli: true)->run($this->doctorContext(SecurityProfile::Hardened)),
+            'cli.frontend_placeholder_legacy',
+        );
+
+        self::assertSame($standard->summary, $hardened->summary);
+        self::assertSame($standard->risk, $hardened->risk);
+        self::assertSame($standard->remediation, $hardened->remediation);
+        self::assertSame($standard->docsUrl, $hardened->docsUrl);
+        self::assertNotSame($standard->severity, $hardened->severity);
+    }
+
+    /**
+     * The remediation has to name the narrower fix (publish the identifier) and
+     * the pin, not just "turn it off" — an operator who only flips the setting
+     * leaves it flippable from the backend Settings module.
+     */
+    #[Test]
+    public function theLegacyRemediationNamesThePublishingRouteAndThePin(): void
+    {
+        $finding = $this->findingById(
+            $this->check(false, legacyCli: true)->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.frontend_placeholder_legacy',
+        );
+
+        self::assertStringContainsString('frontendResolvableIdentifiers', $finding->remediation);
+        self::assertStringContainsString('allowIdentifier()', $finding->remediation);
+        self::assertStringContainsString('additional.php', $finding->remediation);
+    }
+
+    #[Test]
+    public function theLegacyFindingLinksToTheSettingsOwnConfval(): void
+    {
+        $finding = $this->findingById(
+            $this->check(false, legacyCli: true)->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.frontend_placeholder_legacy',
+        );
+
+        self::assertStringContainsString('ext-nrvault-frontendPlaceholderLegacyCli', $finding->docsUrl);
+    }
+
+    /**
+     * @return iterable<string, array{bool}>
+     */
+    public static function cliAccessStateProvider(): iterable
+    {
+        yield 'allowCliAccess off (the default branch)' => [false];
+        yield 'allowCliAccess on' => [true];
+    }
+
+    /**
      * @param list<int> $groups
      * @param list<string> $operations
      */
@@ -160,11 +299,13 @@ final class CliAccessCheckTest extends TestCase
         bool $allowed,
         array $groups = [],
         array $operations = ['secret.use', 'secret.create', 'secret.rotate'],
+        bool $legacyCli = false,
     ): CliAccessCheck {
         $configuration = self::createStub(ExtensionConfigurationInterface::class);
         $configuration->method('isCliAccessAllowed')->willReturn($allowed);
         $configuration->method('getCliAccessGroups')->willReturn($groups);
         $configuration->method('getCliAllowedOperations')->willReturn($operations);
+        $configuration->method('isFrontendPlaceholderLegacyCliEnabled')->willReturn($legacyCli);
 
         return new CliAccessCheck($configuration);
     }

--- a/Tests/Unit/Service/Doctor/Check/EnvironmentCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/EnvironmentCheckTest.php
@@ -120,7 +120,7 @@ final class EnvironmentCheckTest extends TestCase
     #[Test]
     public function anUnsetLockSslIsAWarningUnderEitherProfile(): void
     {
-        foreach ([SecurityProfile::Standard, SecurityProfile::Hardened] as $profile) {
+        foreach (SecurityProfile::cases() as $profile) {
             $this->assertFindingSeverity(
                 FindingSeverity::Warning,
                 (new EnvironmentCheck())->run($this->doctorContext($profile)),

--- a/Tests/Unit/Service/Doctor/Check/SinkProbeCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/SinkProbeCheckTest.php
@@ -63,7 +63,7 @@ final class SinkProbeCheckTest extends TestCase
         // collector unreachable => the ACTIVE check must report critical.
         $sink = new ProbeSpySink('webhook', throwOnAnchor: new RuntimeException('connection refused'));
 
-        foreach ([SecurityProfile::Standard, SecurityProfile::Hardened] as $profile) {
+        foreach (SecurityProfile::cases() as $profile) {
             $finding = $this->assertFindingSeverity(
                 FindingSeverity::Critical,
                 $this->check([$sink])->run($this->context(activeProbes: true, profile: $profile)),


### PR DESCRIPTION
Findings 3 and 4 of the external review round 4, both verified against the code before implementing. Two independent gaps where `vault:doctor` stayed silent about a configuration that weakens a control it otherwise reports as healthy.

## `cli.frontend_placeholder_legacy` (new control)

`frontendPlaceholderLegacyCli` re-opens the scheduler-render exposure — `scheduler:run` authenticates the `_cli_` admin, so the ADR-035 allow-set is the only remaining gate between editor-authored content and a secret in a newsletter or export job — and doctor never mentioned it. ADR-035 even documented the gap ("an operator who sets it has to remember it themselves"); that sentence is now replaced by the control id and mapping.

Mapping: off → pass; on + standard → **warning**; on + hardened → **critical**. Standard warns rather than passes, deliberately unlike `cli.access`: a deployment pipeline genuinely needs `allowCliAccess`, but no workflow needs this flag that publishing the identifier would not also serve.

**The trap this had to avoid:** `CliAccessCheck::run()` early-returns when `allowCliAccess` is off — and the two settings are independent (`FrontendPlaceholderPolicy::isLegacyContext()` consults only the legacy flag). A finding appended to the late return would have been skipped on exactly the default installs where the bypass is fully live. The new check is emitted from **both** return paths, and the tests run every severity assertion at `allowCliAccess` false *and* true, so the omission would fail rather than pass silently.

## `audit.hmac_epoch` — epochs 1 and 2 graded apart from 3

The check passed on `epoch >= 1` with text claiming rows are HMAC-signed and the anchor active — each clause individually true at epoch 1, which is what made it misleading. Now three-way: critical at 0 (unchanged), **warning at 1–2**, pass only at ≥ 3.

- **Epoch 1** leaves 13 columns outside the signed payload. Named consequence: **`success` itself is forgeable** — a recorded denial can be flipped into a recorded grant without touching a signed byte.
- **Epoch 2** leaves 5: the epoch selector plus the attribution fields the backend list and CSV export show as "who did this", so blame can be reassigned and a row relabelled to a weaker epoch. The message deliberately does *not* name the forensic columns — they are signed at 2, and naming them would send operators after a non-problem (pinned by a test).

Warning, not critical: the chain *is* keyed, so entries cannot be rewritten wholesale. Epochs 1/2 are live states, not hypothetical — the HMAC migration wizard's own tests exercise them as stalled/partial migrations, which the remediation text now names as the usual cause.

## Verification

- Unit 3461 / Fuzz 1612 / Functional 304 — all OK
- PHPStan: no errors · CGL: clean · docs render 71/71 (only pre-existing warnings)
- Docs updated: `Commands.rst` control list, `Configuration/Index.rst`, `Auditor/EvidenceCollection.rst` (always-emitted count 23 → 24, with a note that the new id is *not* in the `allowCliAccess`-conditional family despite its `cli.` prefix), `HardenedDeployment.rst`, ADR-035.
