### PR TITLE
Enforce secret.create before a secret record is inserted

### DIFF
--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -27,6 +27,7 @@ use TYPO3\CMS\Core\DataHandling\DataHandler;
  * DataHandler hook for tx_nrvault_secret TCA operations.
  *
  * Handles:
+ * - Create authorization (secret.create, before the row is inserted)
  * - Identifier immutability (prevent changes after creation)
  * - Secret encryption on save (secret_input field)
  * - Audit logging for metadata changes
@@ -157,6 +158,9 @@ final class SecretTcaHook
      * Prevents identifier changes on existing records.
      *
      * @param array<string, mixed> $fieldArray
+     *
+     * @param-out array<string, mixed>|null $fieldArray `null` refuses the
+     *            record: core skips it entirely (see the create gate below)
      */
     public function processDatamap_preProcessFieldArray(// NOSONAR: TYPO3 DataHandler hook method name (fixed API contract)
         array &$fieldArray,
@@ -165,6 +169,43 @@ final class SecretTcaHook
         DataHandler $dataHandler,
     ): void {
         if ($table !== self::TABLE) {
+            return;
+        }
+
+        // Authorize the CREATION ITSELF before DataHandler inserts anything.
+        // Both create gates (canCreate + secret.create) live inside
+        // VaultService::store(), and a record saved with an empty
+        // secret_input never calls store() — secret_input is optional, so
+        // that is a plain FormEngine save, not an edge case. Without this
+        // gate such a create bypassed secret.create entirely: the row landed,
+        // owner_uid was forced to its unauthorized creator by
+        // enforcePrivilegedColumnPolicy(), and a SUCCESS `create` entry went
+        // into the tamper-evident chain for an operation nobody was allowed
+        // to perform. The identifier stayed squatted, so the next legitimate
+        // non-admin creator failed canWrite() against the row.
+        //
+        // Refusing here rather than compensating afterwards is the point: the
+        // unauthorized row never exists, so there is nothing to squat, no MM
+        // rows to purge and no audit entry to retract.
+        if (str_starts_with((string) $id, 'NEW') && !$this->isCreationGranted($fieldArray, $dataHandler)) {
+            // Invalidating the by-ref array is how a preProcessFieldArray
+            // hook aborts one record: immediately after each hook call
+            // DataHandler re-checks the argument it just passed by reference,
+            //
+            //     if (!is_array($incomingFieldArray)) { continue 2; }
+            //
+            // skipping the record before newFieldArray(), insertDB() and the
+            // deferred MM queuing. Quoted as code rather than by line number,
+            // which moves with every core patch release; the guard is present
+            // verbatim in v12.4, v13.4 and v14.3 alike.
+            //
+            // `[]` is NOT a substitute — core's guard is is_array(), and
+            // newFieldArray() would refill the TCA defaults and insert the row
+            // anyway. Assigning null to a by-ref `array` parameter is legal:
+            // PHP type-checks by-ref parameters at call time, not on
+            // assignment inside the callee.
+            $fieldArray = null;
+
             return;
         }
 
@@ -940,6 +981,99 @@ final class SecretTcaHook
         }
 
         return $purged;
+    }
+
+    /**
+     * Both create gates, evaluated before the record exists.
+     *
+     * Mirrors what VaultService::store() applies on the programmatic path —
+     * the per-actor `canCreate()` tier and the `secret.create` operation
+     * permission (separation of duties: being allowed to touch the vault at
+     * all versus being allowed to perform this KIND of operation). The hook
+     * cannot delegate to store(): the whole point of this gate is the create
+     * that never reaches store() because it carries no value.
+     *
+     * Applied to EVERY actor, admins included. Neither gate is an
+     * "is this a non-admin" question — `canCreate()` and `isGranted()` route
+     * the admin decision through AccessControlService::adminBypassActive(),
+     * the single seam the hardened profile can switch off. Short-circuiting
+     * admins here would reintroduce the bypass this extension deliberately
+     * keeps in one place.
+     *
+     * @param array<string, mixed> $fieldArray
+     *
+     * @return bool True when the creation may proceed
+     */
+    private function isCreationGranted(array $fieldArray, DataHandler $dataHandler): bool
+    {
+        if (!$this->accessControlService->canCreate()) {
+            $this->refuseCreation($fieldArray, 'Create access denied', $dataHandler);
+
+            return false;
+        }
+
+        if (!$this->accessControlService->isGranted(VaultPermission::SecretCreate)) {
+            $this->refuseCreation(
+                $fieldArray,
+                'Create denied: missing ' . VaultPermission::SecretCreate->value . ' permission',
+                $dataHandler,
+            );
+
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Record a refused creation: an `access_denied` audit entry (the same
+     * shape VaultService writes when it refuses a create) plus a DataHandler
+     * log line so FormEngine tells the editor why the save did nothing.
+     *
+     * No `create` entry is written, successful or otherwise — nothing was
+     * created. The audit write is contained: a denial whose audit entry
+     * cannot be written must still deny, so the failure is surfaced in the
+     * DataHandler log rather than allowed to abort the refusal.
+     *
+     * @param array<string, mixed> $fieldArray
+     */
+    private function refuseCreation(array $fieldArray, string $errorMessage, DataHandler $dataHandler): void
+    {
+        $identifier = \is_string($fieldArray['identifier'] ?? null) ? $fieldArray['identifier'] : '';
+
+        try {
+            // Fourth positional argument is $errorMessage, not $reason —
+            // same slot VaultService uses for its own denial entries, so the
+            // two read alike in the audit trail.
+            $this->auditService->log(
+                $identifier,
+                AuditAction::AccessDenied->value,
+                false,
+                $errorMessage,
+            );
+        } catch (Throwable $e) {
+            /** @phpstan-ignore method.internal */
+            $dataHandler->log(
+                self::TABLE,
+                0,
+                1,
+                null,
+                1,
+                'Vault audit logging of the refused secret creation failed: ' . $e->getMessage()
+                . ' — the creation was refused regardless.',
+            );
+        }
+
+        /** @phpstan-ignore method.internal */
+        $dataHandler->log(
+            self::TABLE,
+            0,
+            1,
+            null,
+            1,
+            'Vault secret creation requires the ' . VaultPermission::SecretCreate->value
+            . ' permission (' . $errorMessage . ') — the record was not created.',
+        );
     }
 
     /**

--- a/Documentation/Auditor/ControlMapping.rst
+++ b/Documentation/Auditor/ControlMapping.rst
@@ -137,10 +137,16 @@ OWASP ASVS v4: chapter 2 (Authentication), chapter 4 (Access Control).*
             ``secret.manage_policy``; ``rotate()`` requires
             ``secret.rotate``; ``delete()`` requires ``secret.delete``), so
             DataHandler/FormEngine requests and programmatic callers face the
-            same gate as the module controllers. Controllers and
-            :php:`SecretTcaHook` re-assert the permissions as
-            defense-in-depth.
-        -   :php:`VaultService::assertOperationGranted()`; route
+            same gate as the module controllers. Controllers re-assert the
+            permissions as defense-in-depth. :php:`SecretTcaHook` does so
+            too, and is the *sole* enforcement point for one case the
+            service cannot see: creating a ``tx_nrvault_secret`` record
+            without a value never calls ``store()``, so the hook asserts
+            ``secret.create`` in
+            ``processDatamap_preProcessFieldArray()`` and refuses the
+            record before it is inserted.
+        -   :php:`VaultService::assertOperationGranted()`;
+            :php:`SecretTcaHook::isCreationGranted()`; route
             configuration plus controller code
 
     *   -   No privileged short-circuit in the grant lookup

--- a/Documentation/Security/Index.rst
+++ b/Documentation/Security/Index.rst
@@ -372,6 +372,12 @@ Notes on the model:
    faces the same gates as the secrets module. Editors whose forms
    write vault-backed TCA fields need ``secret.create`` /
    ``secret.rotate`` in addition to ``secret.use``.
+   Creating a ``tx_nrvault_secret`` record asserts ``secret.create``
+   even when no value is submitted. That one case cannot go through
+   the service — no value means no ``store()`` call — so
+   :php:`SecretTcaHook` gates it in
+   ``processDatamap_preProcessFieldArray()``, refusing the record
+   before DataHandler inserts it rather than deleting it afterwards.
 -  **Technical actors** (``TechnicalActorContext::runAs()``) hold
    ``secret.use`` implicitly — headless consumption is their purpose —
    and every other operation permission only if one of their

--- a/Tests/Functional/Hook/Fixtures/be_users_create_permission.csv
+++ b/Tests/Functional/Hook/Fixtures/be_users_create_permission.csv
@@ -1,0 +1,12 @@
+"pages",,,,,,,,,,
+,"uid","pid","title","doktype","deleted","hidden","perms_userid","perms_groupid","perms_user","perms_everybody"
+,1,0,"Vault storage",254,0,0,1,30,31,31
+"be_users",,,,,,,,
+,"uid","username","admin","disable","starttime","endtime","usergroup","db_mountpoints"
+,1,"admin",1,0,0,0,"",""
+,2,"editor_without_create",0,0,0,0,"30","1"
+,4,"editor_with_create",0,0,0,0,"31","1"
+"be_groups",,,,,,
+,"uid","pid","title","tables_modify","non_exclude_fields","custom_options"
+,30,0,"vault-editors","tx_nrvault_secret","tx_nrvault_secret:owner_uid,tx_nrvault_secret:allowed_groups,tx_nrvault_secret:write_groups",""
+,31,0,"vault-creators","tx_nrvault_secret","tx_nrvault_secret:owner_uid,tx_nrvault_secret:allowed_groups,tx_nrvault_secret:write_groups","tx_nrvault:secret.create"

--- a/Tests/Functional/Hook/SecretTcaHookCreateAclTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookCreateAclTest.php
@@ -320,6 +320,16 @@ final class SecretTcaHookCreateAclTest extends AbstractVaultFunctionalTestCase
         /** @phpstan-ignore property.internal */
         $errorLog = $dataHandler->errorLog;
 
-        return implode("\n", array_map(static fn (mixed $line): string => (string) $line, $errorLog));
+        // Explicit narrowing rather than a cast: the v13 stubs type errorLog
+        // as a plain array, so its entries are mixed there and casting them
+        // fails PHPStan on that matrix leg only.
+        $lines = [];
+        foreach ($errorLog as $line) {
+            if (\is_scalar($line)) {
+                $lines[] = (string) $line;
+            }
+        }
+
+        return implode("\n", $lines);
     }
 }

--- a/Tests/Functional/Hook/SecretTcaHookCreateAclTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookCreateAclTest.php
@@ -19,22 +19,26 @@ use TYPO3\CMS\Core\DataHandling\DataHandler;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
- * The review's acceptance scenario for the FormEngine create path: a backend
- * user holding generic TABLE permissions on tx_nrvault_secret but NOT the
- * secret.create operation permission must not be able to store a secret value
- * through a direct DataHandler request — the secrets-module controller check
- * is UX, the enforcement lives in VaultService::store() behind the hook.
+ * The `secret.create` gate on the FormEngine create path.
  *
- * A refusal must leave nothing behind either. The denied create used to keep
- * its row (squatting the identifier under the denied user as owner, which
- * makes every later legitimate non-admin create of that identifier fail
- * canWrite) and to be audited as a SUCCESSFUL creation, because the hook
- * classified the outcome by "no value was stored" — which a deliberately
- * value-less create produces as well.
+ * The gap this pins: both create gates (`canCreate()` and
+ * `isGranted(secret.create)`) live inside `VaultService::store()`, and a
+ * record saved with an EMPTY value never calls store() — `secret_input` is
+ * optional and the table is not adminOnly, so that is an ordinary save. A
+ * backend user holding table rights but not `secret.create` could therefore
+ * create a vault secret record: the row landed, `owner_uid` was forced to the
+ * unauthorized creator by the privileged-column policy, and a SUCCESS `create`
+ * entry went into the tamper-evident HMAC chain for an operation nobody was
+ * allowed to perform. The identifier then stayed squatted — a later legitimate
+ * non-admin creator of the same identifier fails `canWrite()` against the
+ * existing row, not the unique key.
  *
- * The hook contract is driven directly (like SecretTcaHookDeleteAclTest):
- * core's own table-permission system would block the group-less editor before
- * the vault gate runs and mask the result under test.
+ * The gate is a pre-process refusal, not a compensating rollback: it nulls the
+ * by-ref field array in `processDatamap_preProcessFieldArray()`, which makes
+ * core skip the record entirely before `insertDB()`. These tests therefore
+ * drive the REAL DataHandler — the assertion "no row exists" is produced by
+ * core itself, and the fixture gives the denied user the table and page rights
+ * that would otherwise mask the result.
  */
 #[CoversClass(SecretTcaHook::class)]
 final class SecretTcaHookCreateAclTest extends AbstractVaultFunctionalTestCase
@@ -47,130 +51,247 @@ final class SecretTcaHookCreateAclTest extends AbstractVaultFunctionalTestCase
 
     private const WRITE_MM_TABLE = 'tx_nrvault_secret_writegroups_mm';
 
-    /** Non-admin editor (uid 2), no vault operation permissions. */
-    private const EDITOR_UID = 2;
+    /** Storage page both editors may write content to. */
+    private const STORAGE_PID = 1;
 
-    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_acl.csv';
+    /** Non-admin editor with table rights but WITHOUT secret.create. */
+    private const EDITOR_WITHOUT_CREATE = 2;
 
-    protected ?int $backendUserUid = self::EDITOR_UID;
+    /** Non-admin editor with table rights AND secret.create. */
+    private const EDITOR_WITH_CREATE = 4;
 
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_create_permission.csv';
+
+    /** Each test logs in the user it needs. */
+    protected ?int $backendUserUid = null;
+
+    /**
+     * The finding itself: no value, no store() call, and until now no gate
+     * either.
+     */
     #[Test]
-    public function editorWithoutSecretCreatePermissionCannotStoreViaDataHandler(): void
+    public function valuelessCreateWithoutSecretCreatePermissionInsertsNoRecord(): void
     {
-        $identifier = 'op_create_' . bin2hex(random_bytes(4));
+        $this->setUpBackendUser(self::EDITOR_WITHOUT_CREATE);
+        $identifier = 'valueless_' . bin2hex(random_bytes(4));
 
-        $hook = $this->get(SecretTcaHook::class);
-        self::assertInstanceOf(SecretTcaHook::class, $hook);
-
-        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
-        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
-
-        // Simulate the FormEngine create: preProcess captures the pending
-        // secret value, core writes the row, afterDatabaseOperations hands
-        // the value to VaultService::store() — which must deny.
-        $fieldArray = [
-            'pid' => 0,
+        $dataHandler = $this->processCreate([
+            'pid' => self::STORAGE_PID,
             'identifier' => $identifier,
-            'secret_input' => 'must-not-be-stored',
-        ];
-        $hook->processDatamap_preProcessFieldArray($fieldArray, self::SECRET_TABLE, 'NEW1', $dataHandler);
-
-        $connection = $this->getConnectionPool()->getConnectionForTable(self::SECRET_TABLE);
-        $connection->insert(self::SECRET_TABLE, [
-            'pid' => 0,
-            'identifier' => $identifier,
-            'owner_uid' => self::EDITOR_UID,
-            'deleted' => 0,
+            'description' => 'A record carrying no secret value at all',
         ]);
-        $newUid = (int) $connection->lastInsertId();
 
-        $dataHandler->substNEWwithIDs['NEW1'] = $newUid;
-        $hook->processDatamap_afterDatabaseOperations('new', self::SECRET_TABLE, 'NEW1', $fieldArray, $dataHandler);
-
-        // DataHandler defers a new record's MM writes until every
-        // afterDatabaseOperations() hook has run — stand in for that flush,
-        // so the deferred purge has something to clean up.
-        $this->insertMmRow(self::READ_MM_TABLE, $newUid, 10);
-        $this->insertMmRow(self::WRITE_MM_TABLE, $newUid, 20);
-
-        $hook->processDatamap_afterAllOperations($dataHandler);
-
-        // Nothing was created, so no row may survive: it would hold no secret
-        // and squat the identifier under the denied user as owner.
-        $row = $connection->select(
-            ['uid'],
-            self::SECRET_TABLE,
-            ['uid' => $newUid],
-        )->fetchAssociative();
-        self::assertFalse($row, 'The denied create must not leave a record behind.');
-
-        // ... nor its ACL relations, which DataHandler writes after the row
-        // has already been removed.
-        self::assertSame(
-            [],
-            $this->loadMmGroups(self::READ_MM_TABLE, $newUid),
-            'The denied create must leave no orphaned read-tier ACL relations.',
-        );
-        self::assertSame(
-            [],
-            $this->loadMmGroups(self::WRITE_MM_TABLE, $newUid),
-            'The denied create must leave no orphaned write-tier ACL relations.',
+        self::assertNull(
+            $this->findRecord($identifier),
+            'A creator without secret.create must not get a record — it would squat the identifier.',
         );
 
-        // The denial is recorded in the audit trail.
         self::assertSame(
             1,
             $this->countAuditEntries($identifier, AuditAction::AccessDenied->value, false),
-            'The denied create must be audited as access_denied.',
+            'The refused create must be audited as access_denied.',
         );
-
-        // And nothing else is: a success create entry would be a
-        // verifiable-looking falsehood in the tamper-evident chain, standing
-        // right next to the truthful denial.
         self::assertSame(
             0,
             $this->countAuditEntries($identifier, AuditAction::Create->value, true),
-            'A denied create must not be audited as a successful creation.',
+            'A refused create must never produce a success create entry in the HMAC chain.',
         );
 
-        // The DataHandler log carries the user-facing error.
-        /** @phpstan-ignore property.internal */
-        self::assertNotEmpty($dataHandler->errorLog, 'The denied create must surface in the DataHandler error log.');
-    }
-
-    private function insertMmRow(string $mmTable, int $secretUid, int $groupUid): void
-    {
-        $this->getConnectionPool()->getConnectionForTable($mmTable)->insert($mmTable, [
-            'uid_local' => $secretUid,
-            'uid_foreign' => $groupUid,
-            'sorting' => 0,
-            'sorting_foreign' => 0,
-        ]);
+        self::assertStringContainsString(
+            'secret.create',
+            $this->errorLogText($dataHandler),
+            'FormEngine must tell the editor which permission the save needed.',
+        );
     }
 
     /**
-     * @return list<int>
+     * The same gate catches a value-BEARING create one step earlier than
+     * VaultService::store() would: the row is never inserted, so there is
+     * nothing to revert and nothing to squat in between.
      */
-    private function loadMmGroups(string $mmTable, int $secretUid): array
+    #[Test]
+    public function valueBearingCreateWithoutSecretCreatePermissionInsertsNoRecord(): void
     {
-        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable($mmTable);
+        $this->setUpBackendUser(self::EDITOR_WITHOUT_CREATE);
+        $identifier = 'valuebearing_' . bin2hex(random_bytes(4));
+
+        $this->processCreate([
+            'pid' => self::STORAGE_PID,
+            'identifier' => $identifier,
+            'secret_input' => 'must-not-be-stored',
+        ]);
+
+        self::assertNull($this->findRecord($identifier));
+        self::assertSame(
+            1,
+            $this->countAuditEntries($identifier, AuditAction::AccessDenied->value, false),
+        );
+        self::assertSame(
+            0,
+            $this->countAuditEntries($identifier, AuditAction::Create->value, true),
+        );
+    }
+
+    /**
+     * A refused create must not leave the ACL relations DataHandler would
+     * otherwise queue for it behind either.
+     */
+    #[Test]
+    public function refusedCreateLeavesNoAclRelationRows(): void
+    {
+        $this->setUpBackendUser(self::EDITOR_WITHOUT_CREATE);
+        $identifier = 'acl_refused_' . bin2hex(random_bytes(4));
+
+        $this->processCreate([
+            'pid' => self::STORAGE_PID,
+            'identifier' => $identifier,
+            'allowed_groups' => '30,31',
+            'write_groups' => '31',
+        ]);
+
+        self::assertNull($this->findRecord($identifier));
+        self::assertSame(0, $this->countRows(self::READ_MM_TABLE), 'No read-tier ACL relations may be written.');
+        self::assertSame(0, $this->countRows(self::WRITE_MM_TABLE), 'No write-tier ACL relations may be written.');
+    }
+
+    /**
+     * The gate must not break the legitimate case it guards: a value-less
+     * record is a valid thing to create, and after this change that is the
+     * only thing RecordCreationOutcome::ValueLess can still mean — an
+     * AUTHORIZED creator who deliberately left the value empty.
+     */
+    #[Test]
+    public function creatorHoldingSecretCreateMayCreateAValuelessRecord(): void
+    {
+        $this->setUpBackendUser(self::EDITOR_WITH_CREATE);
+        $identifier = 'granted_valueless_' . bin2hex(random_bytes(4));
+
+        $dataHandler = $this->processCreate([
+            'pid' => self::STORAGE_PID,
+            'identifier' => $identifier,
+            'description' => 'Deliberately created without a value',
+        ]);
+
+        $record = $this->findRecord($identifier);
+        self::assertIsArray(
+            $record,
+            'A creator holding secret.create must still be able to create. DataHandler log: '
+            . $this->errorLogText($dataHandler),
+        );
+        // The creator owns what they created (the privileged-column policy
+        // forces this for non-admins) — the gate runs in front of it, it does
+        // not replace it.
+        self::assertSame(self::EDITOR_WITH_CREATE, (int) $record['owner_uid']);
+
+        self::assertSame(
+            1,
+            $this->countAuditEntries($identifier, AuditAction::Create->value, true),
+            'An authorized value-less create is audited as a creation.',
+        );
+        self::assertSame(
+            0,
+            $this->countAuditEntries($identifier, AuditAction::AccessDenied->value, false),
+        );
+    }
+
+    #[Test]
+    public function creatorHoldingSecretCreateMayCreateAValueBearingRecord(): void
+    {
+        $this->setUpBackendUser(self::EDITOR_WITH_CREATE);
+        $identifier = 'granted_value_' . bin2hex(random_bytes(4));
+
+        $this->processCreate([
+            'pid' => self::STORAGE_PID,
+            'identifier' => $identifier,
+            'secret_input' => 'a-real-value',
+        ]);
+
+        $record = $this->findRecord($identifier);
+        self::assertIsArray($record);
+        $encryptedValue = $record['encrypted_value'];
+        self::assertIsString($encryptedValue);
+        self::assertNotSame(
+            '',
+            $encryptedValue,
+            'The submitted value must have been encrypted and stored.',
+        );
+
+        self::assertSame(
+            1,
+            $this->countAuditEntries($identifier, AuditAction::Create->value, true),
+            'VaultService::store() audits the creation it performed.',
+        );
+        self::assertSame(
+            0,
+            $this->countAuditEntries($identifier, AuditAction::AccessDenied->value, false),
+        );
+    }
+
+    /**
+     * An admin is unaffected: the gate asks AccessControlService, which routes
+     * the admin decision through the single `adminBypassActive()` seam rather
+     * than short-circuiting on the role here.
+     */
+    #[Test]
+    public function adminIsUnaffectedByTheCreateGate(): void
+    {
+        $this->setUpBackendUser(1);
+        $identifier = 'admin_created_' . bin2hex(random_bytes(4));
+
+        $this->processCreate([
+            'pid' => self::STORAGE_PID,
+            'identifier' => $identifier,
+            'description' => 'Created by an administrator',
+        ]);
+
+        self::assertIsArray($this->findRecord($identifier));
+        self::assertSame(
+            0,
+            $this->countAuditEntries($identifier, AuditAction::AccessDenied->value, false),
+        );
+    }
+
+    /**
+     * Run one NEW-record datamap through the real DataHandler.
+     *
+     * @param array<string, mixed> $fieldArray
+     */
+    private function processCreate(array $fieldArray): DataHandler
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start([self::SECRET_TABLE => ['NEW1' => $fieldArray]], []);
+        $dataHandler->process_datamap();
+
+        return $dataHandler;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function findRecord(string $identifier): ?array
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::SECRET_TABLE);
         $queryBuilder->getRestrictions()->removeAll();
-        $rows = $queryBuilder
-            ->select('uid_foreign')
-            ->from($mmTable)
+        $row = $queryBuilder
+            ->select('uid', 'owner_uid', 'encrypted_value')
+            ->from(self::SECRET_TABLE)
             ->where($queryBuilder->expr()->eq(
-                'uid_local',
-                $queryBuilder->createNamedParameter($secretUid, Connection::PARAM_INT),
+                'identifier',
+                $queryBuilder->createNamedParameter($identifier),
             ))
             ->executeQuery()
-            ->fetchAllAssociative();
+            ->fetchAssociative();
 
-        $groups = [];
-        foreach ($rows as $row) {
-            $groups[] = (int) $row['uid_foreign'];
-        }
+        return $row === false ? null : $row;
+    }
 
-        return $groups;
+    private function countRows(string $table): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable($table);
+        $queryBuilder->getRestrictions()->removeAll();
+        $count = $queryBuilder->count('uid_local')->from($table)->executeQuery()->fetchOne();
+
+        return is_numeric($count) ? (int) $count : 0;
     }
 
     private function countAuditEntries(string $identifier, string $action, bool $success): int
@@ -192,5 +313,13 @@ final class SecretTcaHookCreateAclTest extends AbstractVaultFunctionalTestCase
             ->fetchOne();
 
         return is_numeric($count) ? (int) $count : 0;
+    }
+
+    private function errorLogText(DataHandler $dataHandler): string
+    {
+        /** @phpstan-ignore property.internal */
+        $errorLog = $dataHandler->errorLog;
+
+        return implode("\n", array_map(static fn (mixed $line): string => (string) $line, $errorLog));
     }
 }

--- a/Tests/Unit/Hook/SecretTcaHookTest.php
+++ b/Tests/Unit/Hook/SecretTcaHookTest.php
@@ -80,6 +80,14 @@ final class SecretTcaHookTest extends TestCase
         // privileged-column policy. Policy-specific tests override this.
         $this->accessControlService->method('isCurrentActorAdmin')->willReturn(true);
 
+        // ... and let that actor create. The create gate refuses a NEW record
+        // outright (the field array is nulled and core skips the record), so
+        // without these the normalisation tests below would assert against a
+        // record that never got normalised. The gate has its own tests, each
+        // building its own access-control mock.
+        $this->accessControlService->method('canCreate')->willReturn(true);
+        $this->accessControlService->method('isGranted')->willReturn(true);
+
         $this->hook = new SecretTcaHook(
             $this->vaultService,
             $this->auditService,
@@ -150,6 +158,7 @@ final class SecretTcaHookTest extends TestCase
             $dataHandler,
         );
 
+        self::assertIsArray($fieldArray);
         self::assertSame(42, $fieldArray['owner_uid']);
     }
 
@@ -168,6 +177,7 @@ final class SecretTcaHookTest extends TestCase
             $dataHandler,
         );
 
+        self::assertIsArray($fieldArray);
         self::assertSame(100, $fieldArray['scope_pid']);
     }
 
@@ -186,6 +196,7 @@ final class SecretTcaHookTest extends TestCase
             $dataHandler,
         );
 
+        self::assertIsArray($fieldArray);
         self::assertSame(15, $fieldArray['owner_uid']);
     }
 
@@ -239,6 +250,7 @@ final class SecretTcaHookTest extends TestCase
         );
 
         // Integer should pass through unchanged
+        self::assertIsArray($fieldArray);
         self::assertSame(42, $fieldArray['owner_uid']);
     }
 
@@ -258,6 +270,7 @@ final class SecretTcaHookTest extends TestCase
         );
 
         // Should remain as string without conversion (no 'pages' in value)
+        self::assertIsArray($fieldArray);
         self::assertSame('99', $fieldArray['scope_pid']);
     }
 
@@ -341,9 +354,13 @@ final class SecretTcaHookTest extends TestCase
     public function nonAdminCreatingNewRecordCannotAssignForeignOwnerUid(): void
     {
         // Fresh hook with a NON-admin actor (uid 7); setUp() defaults to admin.
+        // The actor holds secret.create — this test is about WHOSE name the
+        // created record carries, not about whether it may be created.
         $accessControl = $this->createMock(AccessControlServiceInterface::class);
         $accessControl->method('isCurrentActorAdmin')->willReturn(false);
         $accessControl->method('getCurrentActorUid')->willReturn(7);
+        $accessControl->method('canCreate')->willReturn(true);
+        $accessControl->method('isGranted')->willReturn(true);
 
         $hook = new SecretTcaHook(
             $this->vaultService,
@@ -367,6 +384,7 @@ final class SecretTcaHookTest extends TestCase
         );
 
         // owner_uid must be forced to the current backend user (7), not 42.
+        self::assertIsArray($fieldArray);
         self::assertSame(7, $fieldArray['owner_uid']);
     }
 
@@ -380,6 +398,8 @@ final class SecretTcaHookTest extends TestCase
         $accessControl = $this->createMock(AccessControlServiceInterface::class);
         $accessControl->method('isCurrentActorAdmin')->willReturn(false);
         $accessControl->method('getCurrentActorUid')->willReturn(7);
+        $accessControl->method('canCreate')->willReturn(true);
+        $accessControl->method('isGranted')->willReturn(true);
 
         $hook = new SecretTcaHook(
             $this->vaultService,
@@ -401,6 +421,7 @@ final class SecretTcaHookTest extends TestCase
             $dataHandler,
         );
 
+        self::assertIsArray($fieldArray);
         self::assertSame(7, $fieldArray['owner_uid']);
     }
 
@@ -421,7 +442,297 @@ final class SecretTcaHookTest extends TestCase
             $dataHandler,
         );
 
+        self::assertIsArray($fieldArray);
         self::assertSame(42, $fieldArray['owner_uid']);
+    }
+
+    /**
+     * The gate this suite exists for: a create whose value is empty never
+     * reaches VaultService::store(), where both create gates live, so it has
+     * to be refused before DataHandler inserts anything.
+     */
+    #[Test]
+    public function preProcessRefusesAValuelessCreateWithoutTheSecretCreatePermission(): void
+    {
+        $accessControl = $this->createMock(AccessControlServiceInterface::class);
+        $accessControl->method('isCurrentActorAdmin')->willReturn(false);
+        $accessControl->method('getCurrentActorUid')->willReturn(7);
+        $accessControl->method('canCreate')->willReturn(true);
+        $accessControl->expects($this->once())
+            ->method('isGranted')
+            ->with(VaultPermission::SecretCreate)
+            ->willReturn(false);
+
+        // No value is submitted, so store() — and with it every gate inside
+        // it — is never called. That is precisely the bypass under test.
+        $this->vaultService->expects($this->never())->method('store');
+
+        $this->auditService->expects($this->once())->method('log')->with(
+            'squatted-identifier',
+            'access_denied',
+            false,
+            'Create denied: missing secret.create permission',
+        );
+
+        $hook = new SecretTcaHook(
+            $this->vaultService,
+            $this->auditService,
+            $accessControl,
+            $this->secretRepository,
+        );
+
+        $fieldArray = ['identifier' => 'squatted-identifier', 'description' => 'no value'];
+        $messages = [];
+
+        $hook->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            self::TABLE,
+            'NEW123',
+            $this->capturingDataHandler($messages),
+        );
+
+        // Nulling the by-ref array is what makes core skip the record (its
+        // guard is is_array()); an empty array would still be inserted with
+        // TCA defaults.
+        self::assertNull($fieldArray, 'A refused create must invalidate the field array, not merely empty it.');
+        self::assertSame(
+            ['Vault secret creation requires the secret.create permission '
+                . '(Create denied: missing secret.create permission) — the record was not created.'],
+            $messages,
+        );
+    }
+
+    /**
+     * The coarser tier, checked first and audited under its own reason so an
+     * operator can tell "may not use the vault at all" from "may use it but
+     * not create".
+     */
+    #[Test]
+    public function preProcessRefusesACreateWhenCanCreateDenies(): void
+    {
+        $accessControl = $this->createMock(AccessControlServiceInterface::class);
+        $accessControl->method('isCurrentActorAdmin')->willReturn(false);
+        $accessControl->method('getCurrentActorUid')->willReturn(7);
+        $accessControl->method('canCreate')->willReturn(false);
+        // The coarse tier already refused; the operation permission is not
+        // consulted.
+        $accessControl->expects($this->never())->method('isGranted');
+
+        $this->auditService->expects($this->once())->method('log')->with(
+            'denied-identifier',
+            'access_denied',
+            false,
+            'Create access denied',
+        );
+
+        $hook = new SecretTcaHook(
+            $this->vaultService,
+            $this->auditService,
+            $accessControl,
+            $this->secretRepository,
+        );
+
+        $fieldArray = ['identifier' => 'denied-identifier'];
+        $messages = [];
+
+        $hook->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            self::TABLE,
+            'NEW1',
+            $this->capturingDataHandler($messages),
+        );
+
+        self::assertNull($fieldArray);
+        self::assertSame(
+            ['Vault secret creation requires the secret.create permission '
+                . '(Create access denied) — the record was not created.'],
+            $messages,
+        );
+    }
+
+    /**
+     * A value-BEARING create by an unauthorized actor is refused by the same
+     * gate, one step earlier than before: the row is never inserted, so it
+     * cannot squat the identifier while the compensating revert runs.
+     */
+    #[Test]
+    public function preProcessRefusesAValueBearingCreateWithoutTheSecretCreatePermission(): void
+    {
+        $accessControl = $this->createMock(AccessControlServiceInterface::class);
+        $accessControl->method('isCurrentActorAdmin')->willReturn(false);
+        $accessControl->method('getCurrentActorUid')->willReturn(7);
+        $accessControl->method('canCreate')->willReturn(true);
+        $accessControl->method('isGranted')->willReturn(false);
+
+        $this->vaultService->expects($this->never())->method('store');
+
+        $hook = new SecretTcaHook(
+            $this->vaultService,
+            $this->auditService,
+            $accessControl,
+            $this->secretRepository,
+        );
+
+        $fieldArray = [
+            'identifier' => 'value-bearing',
+            'secret_input' => 'must-not-be-stored',
+        ];
+        $messages = [];
+
+        $hook->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            self::TABLE,
+            'NEW7',
+            $this->capturingDataHandler($messages),
+        );
+
+        self::assertNull($fieldArray);
+        // The refused value must not be parked for afterDatabaseOperations to
+        // pick up — the record it belonged to will never exist.
+        self::assertSame([], $this->readPrivate($hook, 'pendingSecrets'));
+    }
+
+    /**
+     * The gate must not fire on an UPDATE: secret.create governs creation, and
+     * an existing record's edit is governed by the privileged-column policy
+     * and the metadata audit instead.
+     */
+    #[Test]
+    public function preProcessDoesNotApplyTheCreateGateToAnExistingRecord(): void
+    {
+        $accessControl = $this->createMock(AccessControlServiceInterface::class);
+        $accessControl->method('isCurrentActorAdmin')->willReturn(true);
+        // Would refuse if it were consulted — an update must not consult it.
+        $accessControl->method('canCreate')->willReturn(false);
+        $accessControl->expects($this->never())->method('isGranted');
+
+        // The update path snapshots the pre-change column values for the
+        // compensating rollback, so it needs a readable record.
+        $this->stubBackendRecords([['description' => 'stored']]);
+
+        $hook = new SecretTcaHook(
+            $this->vaultService,
+            $this->auditService,
+            $accessControl,
+            $this->secretRepository,
+            $this->recordPool(),
+        );
+
+        $fieldArray = ['description' => 'edited'];
+        $messages = [];
+
+        $hook->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            self::TABLE,
+            5,
+            $this->capturingDataHandler($messages),
+        );
+
+        self::assertSame(['description' => 'edited'], $fieldArray);
+        self::assertSame([], $messages);
+    }
+
+    /**
+     * The gate is scoped to this extension's own table — every other table's
+     * datamap must pass through untouched.
+     */
+    #[Test]
+    public function preProcessDoesNotApplyTheCreateGateToAnotherTable(): void
+    {
+        $accessControl = $this->createMock(AccessControlServiceInterface::class);
+        $accessControl->method('canCreate')->willReturn(false);
+        $accessControl->expects($this->never())->method('isGranted');
+
+        $hook = new SecretTcaHook(
+            $this->vaultService,
+            $this->auditService,
+            $accessControl,
+            $this->secretRepository,
+        );
+
+        $fieldArray = ['title' => 'a page'];
+
+        $hook->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            'pages',
+            'NEW123',
+            $this->createMock(DataHandler::class),
+        );
+
+        self::assertSame(['title' => 'a page'], $fieldArray);
+    }
+
+    /**
+     * A granted creator passes both gates and keeps a value-less record —
+     * which after this change is the only thing ValueLess can still mean.
+     */
+    #[Test]
+    public function preProcessLetsAGrantedCreatorCreateAValuelessRecord(): void
+    {
+        $hook = $this->hookForNonAdmin(7);
+
+        $this->auditService->expects($this->never())->method('log');
+
+        $fieldArray = ['identifier' => 'allowed-identifier'];
+        $messages = [];
+
+        $hook->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            self::TABLE,
+            'NEW123',
+            $this->capturingDataHandler($messages),
+        );
+
+        self::assertIsArray($fieldArray);
+        self::assertSame('allowed-identifier', $fieldArray['identifier']);
+        // ... and the creator owns what they created.
+        self::assertSame(7, $fieldArray['owner_uid']);
+        self::assertSame([], $messages);
+    }
+
+    /**
+     * A denial whose audit entry cannot be written must still deny — the
+     * refusal is the security control, the audit entry is its record. The
+     * failure is surfaced rather than swallowed.
+     */
+    #[Test]
+    public function preProcessStillRefusesTheCreateWhenTheDenialAuditWriteFails(): void
+    {
+        $accessControl = $this->createMock(AccessControlServiceInterface::class);
+        $accessControl->method('isCurrentActorAdmin')->willReturn(false);
+        $accessControl->method('getCurrentActorUid')->willReturn(7);
+        $accessControl->method('canCreate')->willReturn(true);
+        $accessControl->method('isGranted')->willReturn(false);
+
+        $this->auditService->method('log')->willThrowException(new RuntimeException('audit sink down'));
+
+        $hook = new SecretTcaHook(
+            $this->vaultService,
+            $this->auditService,
+            $accessControl,
+            $this->secretRepository,
+        );
+
+        $fieldArray = ['identifier' => 'audit-fails'];
+        $messages = [];
+
+        $hook->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            self::TABLE,
+            'NEW123',
+            $this->capturingDataHandler($messages),
+        );
+
+        self::assertNull($fieldArray, 'An unauditable denial must still deny.');
+        self::assertSame(
+            [
+                'Vault audit logging of the refused secret creation failed: audit sink down'
+                . ' — the creation was refused regardless.',
+                'Vault secret creation requires the secret.create permission '
+                . '(Create denied: missing secret.create permission) — the record was not created.',
+            ],
+            $messages,
+        );
     }
 
     #[Test]
@@ -1027,6 +1338,7 @@ final class SecretTcaHookTest extends TestCase
         $messages = [];
         $hook->processDatamap_preProcessFieldArray($fieldArray, self::TABLE, 5, $this->capturingDataHandler($messages));
 
+        self::assertIsArray($fieldArray);
         self::assertSame(99, $fieldArray['owner_uid']);
         self::assertSame([], $messages);
     }
@@ -1154,6 +1466,7 @@ final class SecretTcaHookTest extends TestCase
         $fieldArray = ['allowed_groups' => '3,4'];
         $dataHandler = $this->createMock(DataHandler::class);
         $hook->processDatamap_preProcessFieldArray($fieldArray, self::TABLE, 5, $dataHandler);
+        self::assertIsArray($fieldArray);
 
         $messages = [];
         $hook->processDatamap_afterDatabaseOperations(
@@ -1483,15 +1796,20 @@ final class SecretTcaHookTest extends TestCase
         int $actorUid,
         bool $canManagePolicy = false,
         ?ConnectionPool $connectionPool = null,
+        bool $canCreate = true,
     ): SecretTcaHook {
         $accessControl = $this->createMock(AccessControlServiceInterface::class);
         $accessControl->method('isCurrentActorAdmin')->willReturn(false);
         $accessControl->method('getCurrentActorUid')->willReturn($actorUid);
+        $accessControl->method('canCreate')->willReturn($canCreate);
+        // Each gate answers for its own permission — a path that asked for the
+        // wrong one falls to `false` and fails the test that expects it to
+        // pass, so the permission identity stays asserted.
         $accessControl->method('isGranted')->willReturnCallback(
-            static function (VaultPermission $permission) use ($canManagePolicy): bool {
-                self::assertSame(VaultPermission::SecretManagePolicy, $permission);
-
-                return $canManagePolicy;
+            static fn (VaultPermission $permission): bool => match ($permission) {
+                VaultPermission::SecretManagePolicy => $canManagePolicy,
+                VaultPermission::SecretCreate => $canCreate,
+                default => false,
             },
         );
 


### PR DESCRIPTION
Finding 2 of the external review round 4, verified: a **value-less** create bypassed `secret.create` entirely.

## The defect

`RecordCreationOutcome` correctly separates ValueLess / Stored / Rejected, and PR #263 made Rejected compensate properly. But both create gates (`canCreate()` and `isGranted(SecretCreate)`) live inside `VaultService::store()` — and ValueLess is by definition the path where `store()` is never called. `secret_input` is optional in the TCA, so a backend user with `tables_modify` on `tx_nrvault_secret` but **without** `secret.create` could deliberately leave the value empty and still create a vault record, become its owner (the hook forces `owner_uid` to the creator), reserve the identifier, and produce a **successful `create` audit entry** in the HMAC chain for an operation they were not permitted to perform. No race, no misconfiguration.

Squatting consequence: a later legitimate non-admin creator of that identifier is then blocked by `canWrite()` on the attacker-owned row.

## Fix — refuse before the row exists

The gate sits in `processDatamap_preProcessFieldArray()` and asserts both `canCreate()` and `isGranted(VaultPermission::SecretCreate)` on new records. On refusal it sets the by-ref `$fieldArray` to `null`, which triggers core's documented abort:

```php
if (!is_array($incomingFieldArray)) { continue 2; }
```

so the record is skipped before `newFieldArray()`, `insertDB()` and MM queuing — nothing is inserted, so nothing needs compensating (unlike the Rejected path, which only compensates because the identifier is not knowable until after the insert). The guard is quoted as code rather than by line number so the reference cannot rot; it is present in TYPO3 v12.4, v13.4 and v14.3, and the by-ref-null behaviour was verified empirically (PHP type-checks by-ref parameters at call time, not on assignment).

The refusal writes an `access_denied` audit entry and a DataHandler log line for FormEngine. **No success create entry is written.** An unauditable denial still denies — an audit failure is reported, it does not abort the refusal.

`RecordCreationOutcome` is untouched: the gate sits in front of it, so ValueLess now only ever means "an authorized creator deliberately created a record without a value".

## Also fixed on the way

A real defect in the new code, caught in review: `refuseCreation()`'s message was passed as `log()`'s 4th positional argument, which is `$errorMessage`, not `$reason`. Renamed and annotated at the call site.

Docs corrected: `Security/Index.rst` and `Auditor/ControlMapping.rst` described enforcement as living solely in `VaultService` with the hook as "defense-in-depth". For the value-less create the hook is the **sole** enforcement point; both now say so.

## Verification

- Unit 3453 / Fuzz 1612 / Functional 309 — zero failures
- PHPStan: no errors · CGL: clean
- The fix was validated by stashing it and re-running the new functional suite: the value-less denial case reproduces the finding end-to-end through the real DataHandler (row present with `owner_uid` set where none was expected).
