### PR TITLE
Cap the ext_emconf TYPO3 constraint at 14.3.99

### DIFF
--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -16,7 +16,7 @@ $EM_CONF[$_EXTKEY] = [
     'version' => '0.13.0',
     'constraints' => [
         'depends' => [
-            'typo3' => '13.4.0-14.99.99',
+            'typo3' => '13.4.0-14.3.99',
             'php' => '8.2.0-8.99.99',
         ],
         'conflicts' => [],


### PR DESCRIPTION
`ext_emconf.php` declared `typo3 => 13.4.0-14.99.99`. v14.3 **is** the LTS — 14.4 through 14.99 do not exist as supported releases, so the range claimed compatibility with versions that will never ship under that line. Now capped at `13.4.0-14.3.99`, matching the house convention.

## Why this does not contradict the 0.7.0 decision

The CHANGELOG for 0.7.0 deliberately kept a *coarse* range with the reasoning that "a single continuous range cannot express the `^13.4 || ^14.3` gap". That argument is about the **gap** (the unsupported 14.0–14.2 sprint releases, which a continuous range unavoidably spans) — not about the **ceiling**. Lowering the upper bound is orthogonal: the range still covers 14.0–14.2, and `composer.json` remains the authoritative constraint for a composer-based installation, exactly as that entry states.

## Verification

- Doctor unit suite (which parses this constraint via `Typo3VersionRange`): 161 tests — OK
- `VaultDoctorCommandTest` functional: 6 tests — OK
- CGL: clean

`Typo3VersionRangeTest` keeps `13.4.0-14.99.99` as its parser fixture — it exercises the parsing of an arbitrary range and is not an assertion about this extension's own constraint.
