### PR TITLE
Check the documented CLI option lists, not only the examples

### DIFF
--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -25,7 +25,7 @@ Initialize the vault by creating a master key.
 Options
 -------
 
---output, -o
+--output=PATH, -o PATH
    Path to store the master key file (default: configured path or :file:`var/vault/master.key`).
 
 --force, -f
@@ -648,13 +648,13 @@ Scan for potential plaintext secrets in database and configuration.
 Options
 -------
 
---format, -f
+--format=FORMAT, -f FORMAT
    Output format: table (default), json, or summary.
 
---exclude, -e
+--exclude=TABLES, -e TABLES
    Comma-separated list of tables to exclude (supports wildcards).
 
---severity, -s
+--severity=LEVEL, -s LEVEL
    Minimum severity to report: critical, high, medium, low (default: low).
 
 --database-only
@@ -740,10 +740,10 @@ Options
 --dry-run
    Show what would be migrated without making changes.
 
---batch-size, -b
+--batch-size=N, -b N
    Number of records to process per batch (default: 100).
 
---where, -w
+--where=SQL, -w SQL
    Additional WHERE clause to filter records (e.g., ``pid=1``).
 
 --force, -f
@@ -752,7 +752,7 @@ Options
 --clear-source
    Clear the source field after migration (set to empty string).
 
---uid-field
+--uid-field=NAME
    Name of the UID field (default: uid).
 
 .. attention::
@@ -800,13 +800,13 @@ Options
 --dry-run
    Show what would be deleted without making changes.
 
---retention-days, -r
+--retention-days=DAYS, -r DAYS
    Only delete orphans older than this many days (default: 0).
 
---table, -t
+--table=TABLE, -t TABLE
    Only check secrets for this specific table.
 
---batch-size, -b
+--batch-size=N, -b N
    Number of secrets to check per batch (default: 100).
 
 .. _command-cleanup-orphans-example:
@@ -947,12 +947,12 @@ Options
 --status, -s
    Show the current state. This is the default when no action is given.
 
---reason, -r
+--reason=TEXT, -r TEXT
    Justification recorded in the audit log and shown in the backend warning
    banner. Mandatory for ``--activate`` and ``--deactivate``; an empty or
    whitespace-only value is rejected.
 
---minutes, -m
+--minutes=N, -m N
    Window length in minutes (default: 15). Values are clamped to the range
    1..60 rather than rejected.
 

--- a/Tests/scripts/check-cli-docs-selftest.php
+++ b/Tests/scripts/check-cli-docs-selftest.php
@@ -29,19 +29,17 @@ declare(strict_types=1);
  */
 
 /**
- * Runs the pass-2 checks of check-cli-docs.php against synthetic fixtures.
+ * The authoritative signature every pass-2 fixture is checked against:
+ *   --value=VALUE          (value, no short form)
+ *   --file=VALUE, -f VALUE (value, short form -f)
+ *   --force, -o            (flag, short form -o — deliberately NOT -f, so a
+ *                           copy-paste shortcut is a detectable mistake)
  *
- * parseDocumentedOptions(), validateDocumentedOptions() and
- * validateOptionCoverage() are declared by the guard that `require`s this file.
+ * @return array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}>
  */
-function checkCliDocsSelfTest(): int
+function cliDocsSelfTestCommands(): array
 {
-    // The authoritative signature the fixtures are checked against:
-    //   --value=VALUE          (value, no short form)
-    //   --file=VALUE, -f VALUE (value, short form -f)
-    //   --force, -o            (flag, short form -o — deliberately NOT -f, so a
-    //                           copy-paste shortcut is a detectable mistake)
-    $commands = [
+    return [
         'vault:demo' => [
             'options' => [
                 'value' => ['short' => null, 'value' => true],
@@ -51,17 +49,25 @@ function checkCliDocsSelfTest(): int
             'args' => 1,
         ],
     ];
+}
 
-    $globalOptions = ['help', 'quiet', 'verbose', 'no-interaction'];
-
-    // Every fixture is a complete, correct Options list with ONE mutation, so a
-    // failure names the mutation rather than the fixture's other noise.
+/**
+ * The pass-2 fixtures, one per rule of validateDocumentedOptions().
+ *
+ * Every fixture is a complete, correct Options list with ONE mutation, so a
+ * failure names the mutation rather than the fixture's other noise. `expect` is
+ * the substring the resulting violation must contain, or null when the fixture
+ * must produce no violation at all.
+ *
+ * @return list<array{label: string, rst: string, expect: ?string}>
+ */
+function cliDocsSelfTestOptionCases(): array
+{
     $section = static fn (string $terms): string => "vault:demo\n==========\n\nOptions\n-------\n\n" . $terms;
 
     $correct = "--value=SECRET\n   The value.\n\n--file=PATH, -f PATH\n   A file.\n\n--force, -o\n   Skip the prompt.\n";
 
-    /** @var list<array{label: string, rst: string, expect: ?string}> $cases */
-    $cases = [
+    return [
         [
             'label' => 'clean list passes',
             'rst' => $section($correct),
@@ -134,70 +140,27 @@ function checkCliDocsSelfTest(): int
             'expect' => null,
         ],
     ];
+}
 
-    $failures = 0;
-
-    foreach ($cases as $case) {
-        $result = validateDocumentedOptions(
-            $commands,
-            parseDocumentedOptions($case['rst']),
-            $globalOptions,
-            'fixture.rst',
-        );
-        $violations = $result['violations'];
-
-        $expected = $case['expect'];
-        if ($expected === null) {
-            if ($violations === []) {
-                echo "  PASS  {$case['label']}\n";
-
-                continue;
-            }
-            ++$failures;
-            echo "  FAIL  {$case['label']}: expected no violation, got:\n";
-            foreach ($violations as $violation) {
-                echo "          {$violation}\n";
-            }
-
-            continue;
-        }
-
-        $matched = null;
-        foreach ($violations as $violation) {
-            if (str_contains($violation, $expected)) {
-                $matched = $violation;
-
-                break;
-            }
-        }
-
-        if ($matched !== null) {
-            echo "  PASS  {$case['label']}\n          {$matched}\n";
-
-            continue;
-        }
-
-        ++$failures;
-        echo "  FAIL  {$case['label']}: no violation contained \"{$expected}\"; got:\n";
-        foreach ($violations === [] ? ['(none)'] : $violations as $violation) {
-            echo "          {$violation}\n";
-        }
-    }
-
-    // Repo-wide coverage: the rule that stops "delete the Options list" from
-    // being a way to silence the per-list checks.
-    /** @var list<array{label: string, covered: list<string>, commands: array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}>, expect: ?string}> $coverageCases */
-    $coverageCases = [
+/**
+ * Repo-wide coverage fixtures: the rule that stops "delete the Options list"
+ * from being a way to silence the per-list checks.
+ *
+ * @return list<array{label: string, covered: list<string>, commands: array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}>, expect: ?string}>
+ */
+function cliDocsSelfTestCoverageCases(): array
+{
+    return [
         [
             'label' => 'a documented command satisfies coverage',
             'covered' => ['vault:demo'],
-            'commands' => $commands,
+            'commands' => cliDocsSelfTestCommands(),
             'expect' => null,
         ],
         [
             'label' => 'a command documented nowhere is caught',
             'covered' => [],
-            'commands' => $commands,
+            'commands' => cliDocsSelfTestCommands(),
             'expect' => "no Options list documents 'vault:demo'",
         ],
         [
@@ -207,30 +170,98 @@ function checkCliDocsSelfTest(): int
             'expect' => null,
         ],
     ];
+}
 
-    foreach ($coverageCases as $case) {
-        $violations = validateOptionCoverage($case['commands'], $case['covered']);
-        $expected = $case['expect'];
+/**
+ * Report one self-check and say whether it behaved as specified.
+ *
+ * With $expected null the case must produce no violation at all; otherwise some
+ * violation must contain $expected. The matched violation is echoed alongside
+ * the PASS, so a green run still shows WHAT was caught — a self-check that only
+ * prints "PASS" proves nothing about the message a reader would get.
+ *
+ * @param list<string> $violations
+ *
+ * @return bool true when the case behaved as specified
+ */
+function reportCliDocsSelfTestCase(string $label, ?string $expected, array $violations): bool
+{
+    if ($expected === null) {
+        if ($violations === []) {
+            echo "  PASS  {$label}\n";
 
-        if ($expected === null && $violations === []) {
-            echo "  PASS  {$case['label']}\n";
-
-            continue;
+            return true;
         }
-        if ($expected !== null && $violations !== [] && str_contains($violations[0], $expected)) {
-            echo "  PASS  {$case['label']}\n          {$violations[0]}\n";
 
-            continue;
-        }
+        echo "  FAIL  {$label}: expected no violation, got:\n";
+        echoCliDocsSelfTestViolations($violations);
 
-        ++$failures;
-        echo "  FAIL  {$case['label']}: expected " . ($expected ?? '(no violation)') . ", got:\n";
-        foreach ($violations === [] ? ['(none)'] : $violations as $violation) {
-            echo "          {$violation}\n";
+        return false;
+    }
+
+    foreach ($violations as $violation) {
+        if (str_contains($violation, $expected)) {
+            echo "  PASS  {$label}\n          {$violation}\n";
+
+            return true;
         }
     }
 
-    $total = count($cases) + count($coverageCases);
+    echo "  FAIL  {$label}: no violation contained \"{$expected}\"; got:\n";
+    echoCliDocsSelfTestViolations($violations);
+
+    return false;
+}
+
+/**
+ * @param list<string> $violations
+ */
+function echoCliDocsSelfTestViolations(array $violations): void
+{
+    foreach ($violations === [] ? ['(none)'] : $violations as $violation) {
+        echo "          {$violation}\n";
+    }
+}
+
+/**
+ * Runs the pass-2 checks of check-cli-docs.php against synthetic fixtures.
+ *
+ * parseDocumentedOptions(), validateDocumentedOptions() and
+ * validateOptionCoverage() are declared by the guard that `require_once`s this
+ * file.
+ */
+function checkCliDocsSelfTest(): int
+{
+    $commands = cliDocsSelfTestCommands();
+    $globalOptions = ['help', 'quiet', 'verbose', 'no-interaction'];
+
+    $optionCases = cliDocsSelfTestOptionCases();
+    $coverageCases = cliDocsSelfTestCoverageCases();
+
+    $failures = 0;
+
+    foreach ($optionCases as $case) {
+        $result = validateDocumentedOptions(
+            $commands,
+            parseDocumentedOptions($case['rst']),
+            $globalOptions,
+            'fixture.rst',
+        );
+
+        if (!reportCliDocsSelfTestCase($case['label'], $case['expect'], $result['violations'])) {
+            ++$failures;
+        }
+    }
+
+    foreach ($coverageCases as $case) {
+        $violations = validateOptionCoverage($case['commands'], $case['covered']);
+
+        if (!reportCliDocsSelfTestCase($case['label'], $case['expect'], $violations)) {
+            ++$failures;
+        }
+    }
+
+    $total = count($optionCases) + count($coverageCases);
     if ($failures > 0) {
         fwrite(STDERR, "\nERROR: {$failures} of {$total} CLI-docs guard self-check(s) failed.\n");
         fwrite(STDERR, "The guard no longer catches the drift it exists to catch.\n");

--- a/Tests/scripts/check-cli-docs-selftest.php
+++ b/Tests/scripts/check-cli-docs-selftest.php
@@ -1,0 +1,244 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+/*
+ * Fixture-driven self-check for check-cli-docs.php.
+ *
+ * A guard that never fails is indistinguishable from one that has nothing to
+ * check, and that is exactly what happened here: the previous guard passed
+ * while Documentation/Developer/Commands.rst documented three options that do
+ * not exist. So each check gets a fixture that it MUST reject, plus a clean
+ * fixture it must accept — the guard is only trusted once it has been seen
+ * failing on demand.
+ *
+ * The guard is a standalone static scan with no autoloader (it runs in
+ * pre-commit hooks and on fresh checkouts where .Build/ is empty), so it cannot
+ * be reached from the PHPUnit suites in Tests/Unit. This file follows the
+ * pattern already established by Build/Scripts/collect-evidence-selftest.php:
+ * `require`d by `--self-test` and wired into `composer ci` as its own script.
+ *
+ * The fixtures below are synthetic — they describe a `vault:demo` command that
+ * does not exist — so the self-check keeps working when the real commands
+ * change, and a real-docs failure is never confused with a guard failure.
+ */
+
+/**
+ * Runs the pass-2 checks of check-cli-docs.php against synthetic fixtures.
+ *
+ * parseDocumentedOptions(), validateDocumentedOptions() and
+ * validateOptionCoverage() are declared by the guard that `require`s this file.
+ */
+function checkCliDocsSelfTest(): int
+{
+    // The authoritative signature the fixtures are checked against:
+    //   --value=VALUE          (value, no short form)
+    //   --file=VALUE, -f VALUE (value, short form -f)
+    //   --force, -o            (flag, short form -o — deliberately NOT -f, so a
+    //                           copy-paste shortcut is a detectable mistake)
+    $commands = [
+        'vault:demo' => [
+            'options' => [
+                'value' => ['short' => null, 'value' => true],
+                'file' => ['short' => 'f', 'value' => true],
+                'force' => ['short' => 'o', 'value' => false],
+            ],
+            'args' => 1,
+        ],
+    ];
+
+    $globalOptions = ['help', 'quiet', 'verbose', 'no-interaction'];
+
+    // Every fixture is a complete, correct Options list with ONE mutation, so a
+    // failure names the mutation rather than the fixture's other noise.
+    $section = static fn (string $terms): string => "vault:demo\n==========\n\nOptions\n-------\n\n" . $terms;
+
+    $correct = "--value=SECRET\n   The value.\n\n--file=PATH, -f PATH\n   A file.\n\n--force, -o\n   Skip the prompt.\n";
+
+    /** @var list<array{label: string, rst: string, expect: ?string}> $cases */
+    $cases = [
+        [
+            'label' => 'clean list passes',
+            'rst' => $section($correct),
+            'expect' => null,
+        ],
+        [
+            'label' => 'invented option is caught',
+            'rst' => $section($correct . "\n--expires=DATE\n   Not a real option.\n"),
+            'expect' => "documents '--expires', which the command does not declare",
+        ],
+        [
+            'label' => 'wrong short form is caught',
+            'rst' => $section(str_replace('--force, -o', '--force, -f', $correct)),
+            'expect' => "documents '--force, -f'; the real signature is '--force, -o'",
+        ],
+        [
+            'label' => 'malformed term is caught',
+            'rst' => $section(str_replace('-f PATH', '-f =PATH', $correct)),
+            'expect' => 'has a malformed option term',
+        ],
+        [
+            'label' => 'global option is rejected, not whitelisted',
+            'rst' => $section($correct . "\n--quiet, -q\n   Suppress output.\n"),
+            'expect' => "documents the global option '--quiet' as its own",
+        ],
+        [
+            'label' => 'omitted real option is caught',
+            'rst' => $section(str_replace("--file=PATH, -f PATH\n   A file.\n\n", '', $correct)),
+            'expect' => "does not document '--file=VALUE, -f VALUE'",
+        ],
+        [
+            'label' => 'value option written as a flag is caught',
+            'rst' => $section(str_replace('--value=SECRET', '--value', $correct)),
+            'expect' => "documents '--value'; the real signature is '--value=VALUE'",
+        ],
+        [
+            'label' => 'flag written as a value option is caught',
+            'rst' => $section(str_replace('--force, -o', '--force=BOOL, -o BOOL', $correct)),
+            'expect' => "documents '--force=BOOL, -o BOOL'; the real signature is '--force, -o'",
+        ],
+        [
+            'label' => 'short placeholder disagreeing with the long one is caught',
+            'rst' => $section(str_replace('-f PATH', '-f FILE', $correct)),
+            'expect' => "the real signature is '--file=PATH, -f PATH'",
+        ],
+        [
+            'label' => 'duplicate entry is caught',
+            'rst' => $section($correct . "\n--force, -o\n   Again.\n"),
+            'expect' => "documents '--force' twice",
+        ],
+        [
+            // A task-oriented page (Documentation/Usage/Index.rst) walks the
+            // same commands with examples only. It must not be forced to
+            // duplicate the reference — coverage is checked repo-wide instead.
+            'label' => 'command section without an Options list is skipped, not flagged',
+            'rst' => "vault:demo\n==========\n\nSome prose, no Options list.\n",
+            'expect' => null,
+        ],
+        [
+            'label' => 'section for a command that does not exist is caught',
+            'rst' => "vault:ghost\n===========\n\nOptions\n-------\n\n--force\n   Nope.\n",
+            'expect' => "documents unknown command 'vault:ghost'",
+        ],
+        [
+            // The guard must not read a neighbouring definition list as options:
+            // vault:doctor documents its control catalogue exactly like this.
+            'label' => 'definition list outside the Options section is ignored',
+            'rst' => $section($correct)
+                . "\nControl catalogue\n-----------------\n\n--not-an-option\n   Prose, not an option.\n",
+            'expect' => null,
+        ],
+    ];
+
+    $failures = 0;
+
+    foreach ($cases as $case) {
+        $result = validateDocumentedOptions(
+            $commands,
+            parseDocumentedOptions($case['rst']),
+            $globalOptions,
+            'fixture.rst',
+        );
+        $violations = $result['violations'];
+
+        $expected = $case['expect'];
+        if ($expected === null) {
+            if ($violations === []) {
+                echo "  PASS  {$case['label']}\n";
+
+                continue;
+            }
+            ++$failures;
+            echo "  FAIL  {$case['label']}: expected no violation, got:\n";
+            foreach ($violations as $violation) {
+                echo "          {$violation}\n";
+            }
+
+            continue;
+        }
+
+        $matched = null;
+        foreach ($violations as $violation) {
+            if (str_contains($violation, $expected)) {
+                $matched = $violation;
+
+                break;
+            }
+        }
+
+        if ($matched !== null) {
+            echo "  PASS  {$case['label']}\n          {$matched}\n";
+
+            continue;
+        }
+
+        ++$failures;
+        echo "  FAIL  {$case['label']}: no violation contained \"{$expected}\"; got:\n";
+        foreach ($violations === [] ? ['(none)'] : $violations as $violation) {
+            echo "          {$violation}\n";
+        }
+    }
+
+    // Repo-wide coverage: the rule that stops "delete the Options list" from
+    // being a way to silence the per-list checks.
+    /** @var list<array{label: string, covered: list<string>, commands: array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}>, expect: ?string}> $coverageCases */
+    $coverageCases = [
+        [
+            'label' => 'a documented command satisfies coverage',
+            'covered' => ['vault:demo'],
+            'commands' => $commands,
+            'expect' => null,
+        ],
+        [
+            'label' => 'a command documented nowhere is caught',
+            'covered' => [],
+            'commands' => $commands,
+            'expect' => "no Options list documents 'vault:demo'",
+        ],
+        [
+            'label' => 'a command without options needs no Options list',
+            'covered' => [],
+            'commands' => ['vault:bare' => ['options' => [], 'args' => 0]],
+            'expect' => null,
+        ],
+    ];
+
+    foreach ($coverageCases as $case) {
+        $violations = validateOptionCoverage($case['commands'], $case['covered']);
+        $expected = $case['expect'];
+
+        if ($expected === null && $violations === []) {
+            echo "  PASS  {$case['label']}\n";
+
+            continue;
+        }
+        if ($expected !== null && $violations !== [] && str_contains($violations[0], $expected)) {
+            echo "  PASS  {$case['label']}\n          {$violations[0]}\n";
+
+            continue;
+        }
+
+        ++$failures;
+        echo "  FAIL  {$case['label']}: expected " . ($expected ?? '(no violation)') . ", got:\n";
+        foreach ($violations === [] ? ['(none)'] : $violations as $violation) {
+            echo "          {$violation}\n";
+        }
+    }
+
+    $total = count($cases) + count($coverageCases);
+    if ($failures > 0) {
+        fwrite(STDERR, "\nERROR: {$failures} of {$total} CLI-docs guard self-check(s) failed.\n");
+        fwrite(STDERR, "The guard no longer catches the drift it exists to catch.\n");
+
+        return 1;
+    }
+
+    echo "\nOK: all {$total} CLI-docs guard self-check(s) behaved as specified.\n";
+
+    return 0;
+}

--- a/Tests/scripts/check-cli-docs.php
+++ b/Tests/scripts/check-cli-docs.php
@@ -10,9 +10,11 @@ declare(strict_types=1);
 /*
  * Documentation drift guard for the `vault:*` CLI.
  *
- * Every `vendor/bin/typo3 vault:<cmd> ...` example in README.md and the
- * Developer/Commands.rst reference is checked against the authoritative
- * command definitions in Classes/Command/*Command.php:
+ * Two independent passes over README.md and everything under Documentation/,
+ * both checked against the authoritative command definitions in
+ * Classes/Command/*Command.php.
+ *
+ * Pass 1 — shell examples. Every `vendor/bin/typo3 vault:<cmd> ...` invocation:
  *
  *   - the command name must exist (`#[AsCommand(name: 'vault:...')]`)
  *   - every `--option` used must be a real option of THAT command
@@ -20,14 +22,36 @@ declare(strict_types=1);
  *   - the number of positional arguments must not exceed the command's
  *     declared `addArgument()` count
  *
+ * Pass 2 — the per-command `Options` definition lists in the RST reference.
+ * Examples alone are not enough: the reference once documented
+ * `vault:store --description/--context/--expires` and `vault:retrieve -q`,
+ * none of which exist, while omitting `--stdin`, `--file` and `--limit` —
+ * and pass 1 stayed green throughout, because no example used the invented
+ * options. Each documented term is therefore compared against the real
+ * `addOption()` call:
+ *
+ *   - the long option must exist on that command
+ *   - the short form must be the real shortcut (present, absent, identical)
+ *   - a value-taking option must be written `--name=VALUE`, a flag must not
+ *   - the term must be well-shaped: `--name=VALUE, -x VALUE` exactly
+ *     (a `-x =VALUE` typo previously stood in nine places)
+ *   - every real option must be documented, and no option twice
+ *   - Symfony's global options are REJECTED here (see $globalOptions)
+ *
+ * Both passes are hard failures: an invented option is actively harmful (it is
+ * copied into a deployment script and fails, or silently does something else),
+ * and an omitted one is what sends a reader to guess. Neither is a warning,
+ * because a warning nobody gates on is how the drift lasted this long.
+ *
  * Like check-test-base-class.php this is a lightweight static scan (regex,
  * no autoloader) so it runs before the test suite, in pre-commit hooks, and
- * on fresh checkouts where `.Build/` may be empty.
+ * on fresh checkouts where `.Build/` may be empty. `--self-test` proves the
+ * pass-2 checks actually fail when they should; see check-cli-docs-selftest.php.
  *
  * Exit codes:
- *   0 — every documented example matches a real command signature
- *   1 — at least one example references an unknown command/option or passes
- *       too many positional arguments
+ *   0 — the documented examples and option lists match the real signatures
+ *   1 — at least one documented example or option contradicts the command
+ *       definitions (or, with --self-test, a check failed to catch its case)
  */
 
 $projectRoot = dirname(__DIR__, 2);
@@ -40,8 +64,21 @@ if (!is_dir($commandDir)) {
 
 /*
  * Options Symfony's Application and TYPO3's CommandApplication add to every
- * command. Examples may legitimately use these even though no command class
- * declares them.
+ * command.
+ *
+ * In a shell EXAMPLE these are legitimate: `vault:audit --no-interaction` is a
+ * real thing to run. In a per-command Options LIST they are not, and pass 2
+ * rejects them outright — no whitelist, no opt-out marker. Claiming a global in
+ * a command's own option list asserts the command owns it and gives it
+ * command-specific semantics, which is precisely how `-q` came to be
+ * documented as the `vault:retrieve` scripting flag: it is Symfony's global
+ * quiet switch, it suppresses the value, and the documented pipeline captured
+ * an empty string. An opt-out marker would only be a slower route back to that.
+ *
+ * A command that genuinely declares an option of the same name is unaffected:
+ * pass 2 resolves each documented term against the command's own definitions
+ * first, so `vault:init --env` (a real VALUE_NONE option) never reaches this
+ * list.
  */
 $globalOptions = [
     'help', 'quiet', 'verbose', 'version', 'ansi', 'no-ansi',
@@ -49,10 +86,16 @@ $globalOptions = [
 ];
 
 /**
- * @return array{0: array<string, array{options: array<string,true>, args: int}>, 1: list<string>}
+ * Parse every command class into name => {options, positional argument count}.
+ *
+ * Each option carries its real short form and whether it takes a value, so the
+ * documented term can be compared against the full signature rather than the
+ * name alone.
+ *
+ * @return array{0: array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}>, 1: list<string>}
  */
 $parseCommands = static function (string $commandDir): array {
-    /** @var array<string, array{options: array<string,true>, args: int}> $commands */
+    /** @var array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}> $commands */
     $commands = [];
     /** @var list<string> $errors */
     $errors = [];
@@ -78,13 +121,39 @@ $parseCommands = static function (string $commandDir): array {
         }
         $name = $nameMatch[1];
 
-        // Option names: first string literal argument of each addOption() call.
-        /** @var array<string,true> $options */
+        // addOption(name, shortcut, mode, ...): capture all three, so the
+        // documented short form and value placeholder can be verified too.
+        /** @var array<string, array{short: ?string, value: bool}> $options */
         $options = [];
-        if (preg_match_all('/->addOption\(\s*[\'"]([a-zA-Z0-9][a-zA-Z0-9-]*)[\'"]/', $contents, $optMatches)) {
-            foreach ($optMatches[1] as $opt) {
-                $options[$opt] = true;
-            }
+        preg_match_all(
+            '/->addOption\(\s*[\'"]([a-zA-Z0-9][a-zA-Z0-9-]*)[\'"]\s*,'
+            . '\s*(?:null|[\'"]([a-zA-Z0-9])[\'"])\s*,'
+            . '\s*((?:\s*InputOption::[A-Z_]+\s*\|?)+)/',
+            $contents,
+            $optMatches,
+            PREG_SET_ORDER,
+        );
+        foreach ($optMatches as $match) {
+            $options[$match[1]] = [
+                'short' => $match[2] === '' ? null : $match[2],
+                'value' => str_contains($match[3], 'VALUE_REQUIRED')
+                    || str_contains($match[3], 'VALUE_OPTIONAL'),
+            ];
+        }
+
+        // An addOption() call the regex could not read would silently drop out
+        // of the model — the option would then read as invented in the docs AND
+        // escape the completeness check. Fail loudly instead of guarding half
+        // the surface.
+        $declared = preg_match_all('/->addOption\(/', $contents);
+        if ($declared !== count($options)) {
+            $errors[] = sprintf(
+                '%s: parsed %d of %d addOption() call(s) — the guard cannot see the full signature of %s',
+                basename($file->getPathname()),
+                count($options),
+                (int) $declared,
+                $name,
+            );
         }
 
         // Positional argument count: number of addArgument() calls.
@@ -203,6 +272,274 @@ $parseExample = static function (string $cmdLine): array {
     return [$command, $options, $positional];
 };
 
+/**
+ * Extract the per-command `Options` definition lists from an RST reference page.
+ *
+ * A command section is a `vault:<name>` title with an underline; the option
+ * terms are the unindented `--…` lines inside its `Options` subsection. Scoping
+ * to that subsection matters: `vault:doctor` also carries a "Control catalogue"
+ * definition list whose terms are not options at all.
+ *
+ * Returns the command sections found (name => title line) alongside their terms,
+ * so a section that documents no options can be told apart from a command that
+ * has no section in this file.
+ *
+ * Declared as a named function rather than a closure, like the helpers in
+ * Build/Scripts/collect-evidence.php: PHPStan does not apply a docblock to a
+ * closure assigned to a variable, so the array shapes these three helpers pass
+ * around would degrade to `mixed` and take the guard's own type safety with them.
+ *
+ * @return array{sections: array<string,int>, options: array<string, list<array{int, string}>>}
+ */
+function parseDocumentedOptions(string $rst): array
+{
+    /** @var array<string,int> $sections */
+    $sections = [];
+    /** @var array<string, list<array{int, string}>> $options */
+    $options = [];
+
+    $lines = preg_split('/\R/', $rst);
+    if ($lines === false) {
+        return ['sections' => $sections, 'options' => $options];
+    }
+
+    $command = null;
+    $inOptions = false;
+    $count = count($lines);
+
+    for ($i = 0; $i < $count; ++$i) {
+        $title = trim($lines[$i]);
+        $underline = $lines[$i + 1] ?? '';
+
+        // An RST section header: a non-empty title whose next line is a run of
+        // punctuation at least as long as the title.
+        if (
+            $title !== ''
+            && preg_match('/^([=\-~^"\'`#*+]){2,}$/', $underline) === 1
+            && strlen($underline) >= strlen($title)
+        ) {
+            if (preg_match('/^(vault:[a-z][a-z0-9-]*)$/', $title, $sectionMatch) === 1) {
+                $command = $sectionMatch[1];
+                $sections[$command] = $i + 1;
+                $inOptions = false;
+            } else {
+                $inOptions = $title === 'Options';
+            }
+            ++$i;
+
+            continue;
+        }
+
+        if (!$inOptions) {
+            continue;
+        }
+        if ($command === null) {
+            continue;
+        }
+        if (preg_match('/^--\S/', $lines[$i]) !== 1) {
+            continue;
+        }
+
+        $options[$command][] = [$i + 1, rtrim($lines[$i])];
+    }
+
+    return ['sections' => $sections, 'options' => $options];
+}
+
+/**
+ * Render the canonical term for a real option, reusing the placeholder the
+ * author chose (`PATH`, `TEXT`, `N`, …) so the expectation shown in a failure
+ * is the line the author should have written, not a generic one.
+ */
+function renderOptionTerm(string $name, ?string $short, bool $takesValue, string $placeholder): string
+{
+    $term = '--' . $name . ($takesValue ? '=' . $placeholder : '');
+    if ($short !== null) {
+        $term .= ', -' . $short . ($takesValue ? ' ' . $placeholder : '');
+    }
+
+    return $term;
+}
+
+/**
+ * Check the documented option lists of one file against the real definitions.
+ *
+ * A command section without an `Options` subsection is skipped rather than
+ * flagged: Documentation/Usage/Index.rst walks through the same commands
+ * task-first, with examples and no option lists, and forcing it to duplicate
+ * the reference would be worse documentation. The list has to exist SOMEWHERE
+ * though — the commands whose list was validated here are reported back so
+ * $validateOptionCoverage can require exactly that, which also closes the
+ * "delete the section instead of fixing it" escape.
+ *
+ * @param array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}> $commands
+ * @param array{sections: array<string,int>, options: array<string, list<array{int, string}>>} $documented
+ * @param list<string> $globalOptions
+ *
+ * @return array{violations: list<string>, checked: int, covered: list<string>}
+ */
+function validateDocumentedOptions(
+    array $commands,
+    array $documented,
+    array $globalOptions,
+    string $label,
+): array {
+    /** @var list<string> $violations */
+    $violations = [];
+    /** @var list<string> $covered */
+    $covered = [];
+    $checked = 0;
+
+    foreach ($documented['sections'] as $command => $sectionLine) {
+        if (!isset($commands[$command])) {
+            $violations[] = "{$label}:{$sectionLine}: documents unknown command '{$command}'";
+
+            continue;
+        }
+
+        $real = $commands[$command]['options'];
+        $terms = $documented['options'][$command] ?? [];
+
+        if ($terms === []) {
+            continue;
+        }
+        $covered[] = $command;
+
+        /** @var array<string,int> $seen documented long name => line */
+        $seen = [];
+
+        foreach ($terms as [$lineNo, $term]) {
+            ++$checked;
+            $where = "{$label}:{$lineNo}: '{$command}'";
+
+            // --name[=PLACEHOLDER][, -x [PLACEHOLDER]] and nothing else. The
+            // placeholder may itself contain '=' (--metadata=KEY=VALUE) but may
+            // not start with one, which is what makes the `-x =VALUE` typo fail.
+            $shape = preg_match(
+                '/^--([a-z0-9][a-z0-9-]*)(?:=([^\s,=][^\s,]*))?(?:, -([a-zA-Z0-9])(?: ([^\s,=][^\s,]*))?)?$/',
+                $term,
+                $parts,
+            );
+            if ($shape !== 1) {
+                $violations[] = "{$where} has a malformed option term '{$term}'"
+                    . " (expected '--name=VALUE, -x VALUE', '--name=VALUE' or '--name')";
+
+                continue;
+            }
+
+            $name = $parts[1];
+            $placeholder = $parts[2] ?? '';
+            $short = ($parts[3] ?? '') === '' ? null : $parts[3];
+            $shortPlaceholder = $parts[4] ?? '';
+
+            if (!isset($real[$name])) {
+                if (in_array($name, $globalOptions, true)) {
+                    $violations[] = "{$where} documents the global option '--{$name}' as its own"
+                        . ' — Symfony adds it to every command, so a per-command entry claims'
+                        . ' semantics it does not have (this is how -q was documented as a'
+                        . ' scripting flag; it suppresses the output). Remove the entry.';
+
+                    continue;
+                }
+
+                $known = array_keys($real);
+                sort($known);
+                $violations[] = "{$where} documents '--{$name}', which the command does not declare"
+                    . ' (real options: --' . implode(', --', $known) . ')';
+
+                continue;
+            }
+
+            if (isset($seen[$name])) {
+                $violations[] = "{$where} documents '--{$name}' twice (also on line {$seen[$name]})";
+            }
+            $seen[$name] = $lineNo;
+
+            $expected = renderOptionTerm(
+                $name,
+                $real[$name]['short'],
+                $real[$name]['value'],
+                $placeholder === '' ? 'VALUE' : $placeholder,
+            );
+
+            $canonical = renderOptionTerm(
+                $name,
+                $short,
+                $placeholder !== '',
+                $placeholder === '' ? 'VALUE' : $placeholder,
+            );
+
+            // Compare the whole rendered term rather than each property one at a
+            // time: one comparison catches the wrong shortcut, a missing or
+            // invented shortcut, a value marker on a flag, a missing one on a
+            // value-taking option, and a short placeholder that disagrees with
+            // the long one — and it always names the exact line to write.
+            $selfConsistent = $canonical === $term && ($short === null || $shortPlaceholder === $placeholder);
+            if (!$selfConsistent || $canonical !== $expected) {
+                $violations[] = "{$where} documents '{$term}'; the real signature is '{$expected}'";
+            }
+        }
+
+        $missing = array_diff(array_keys($real), array_keys($seen));
+        foreach ($missing as $name) {
+            $violations[] = sprintf(
+                "%s:%d: '%s' does not document '%s'",
+                $label,
+                $sectionLine,
+                $command,
+                renderOptionTerm($name, $real[$name]['short'], $real[$name]['value'], 'VALUE'),
+            );
+        }
+    }
+
+    return ['violations' => $violations, 'checked' => $checked, 'covered' => $covered];
+}
+
+/**
+ * Every command that declares options must have its Options list on some page.
+ *
+ * Without this, the per-list checks are opt-in: a command whose documentation
+ * disagrees with its signature could be brought back into line by deleting the
+ * Options list rather than correcting it, and a newly added command could ship
+ * with no option reference at all.
+ *
+ * @param array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}> $commands
+ * @param list<string> $covered
+ *
+ * @return list<string>
+ */
+function validateOptionCoverage(array $commands, array $covered): array
+{
+    /** @var list<string> $violations */
+    $violations = [];
+
+    foreach ($commands as $command => $definition) {
+        if ($definition['options'] === []) {
+            continue;
+        }
+        if (in_array($command, $covered, true)) {
+            continue;
+        }
+        $violations[] = sprintf(
+            "no Options list documents '%s', which declares %d option(s): --%s",
+            $command,
+            count($definition['options']),
+            implode(', --', array_keys($definition['options'])),
+        );
+    }
+
+    return $violations;
+}
+
+// $argv is only populated when register_argc_argv is on; read it via $_SERVER
+// so the guard also behaves under an unusual CLI ini.
+$arguments = $_SERVER['argv'] ?? [];
+if (is_array($arguments) && in_array('--self-test', $arguments, true)) {
+    require __DIR__ . '/check-cli-docs-selftest.php';
+
+    exit(checkCliDocsSelfTest());
+}
+
 [$commands, $parseErrors] = $parseCommands($commandDir);
 $violations = $parseErrors;
 
@@ -230,6 +567,9 @@ if (is_dir($docDir)) {
 }
 
 $checked = 0;
+$checkedOptions = 0;
+/** @var list<string> $covered commands whose Options list was validated */
+$covered = [];
 foreach ($docFiles as $label => $path) {
     if (!is_file($path)) {
         continue;
@@ -263,7 +603,28 @@ foreach ($docFiles as $label => $path) {
             $violations[] = "{$label}:{$lineNo}: '{$command}' takes {$def['args']} positional argument(s), example passes {$positional}";
         }
     }
+
+    // Pass 2 — the per-command Options definition lists. RST only: the command
+    // sections are keyed on a `vault:<name>` title with an underline, which is
+    // the reference-page shape. A file without such a section contributes
+    // nothing and is silently skipped.
+    if (str_ends_with($path, '.rst')) {
+        $rst = file_get_contents($path);
+        if ($rst !== false) {
+            $result = validateDocumentedOptions(
+                $commands,
+                parseDocumentedOptions($rst),
+                $globalOptions,
+                $label,
+            );
+            $violations = [...$violations, ...$result['violations']];
+            $covered = [...$covered, ...$result['covered']];
+            $checkedOptions += $result['checked'];
+        }
+    }
 }
+
+$violations = [...$violations, ...validateOptionCoverage($commands, $covered)];
 
 if ($violations !== []) {
     sort($violations);
@@ -271,10 +632,11 @@ if ($violations !== []) {
     foreach ($violations as $v) {
         fwrite(STDERR, "  - {$v}\n");
     }
-    fwrite(STDERR, "\nFix the documented example(s) to match the command signature in\n");
-    fwrite(STDERR, "Classes/Command/*Command.php, or update the command definition.\n");
+    fwrite(STDERR, "\nFix the documented example(s) and Options list(s) to match the command\n");
+    fwrite(STDERR, "signature in Classes/Command/*Command.php, or update the command definition.\n");
     exit(1);
 }
 
-echo 'OK: ' . $checked . ' documented vault:* example(s) match their command signatures (' . count($commands) . " commands).\n";
+echo 'OK: ' . $checked . ' documented vault:* example(s) and ' . $checkedOptions
+    . ' documented option(s) match their command signatures (' . count($commands) . " commands).\n";
 exit(0);

--- a/Tests/scripts/check-cli-docs.php
+++ b/Tests/scripts/check-cli-docs.php
@@ -86,19 +86,14 @@ $globalOptions = [
 ];
 
 /**
- * Parse every command class into name => {options, positional argument count}.
+ * The PHP files below $commandDir, in the iterator's order.
  *
- * Each option carries its real short form and whether it takes a value, so the
- * documented term can be compared against the full signature rather than the
- * name alone.
- *
- * @return array{0: array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}>, 1: list<string>}
+ * @return list<string>
  */
-$parseCommands = static function (string $commandDir): array {
-    /** @var array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}> $commands */
-    $commands = [];
-    /** @var list<string> $errors */
-    $errors = [];
+function commandClassFiles(string $commandDir): array
+{
+    /** @var list<string> $paths */
+    $paths = [];
 
     /** @var SplFileInfo $file */
     foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($commandDir, RecursiveDirectoryIterator::SKIP_DOTS)) as $file) {
@@ -108,7 +103,62 @@ $parseCommands = static function (string $commandDir): array {
         if ($file->getExtension() !== 'php') {
             continue;
         }
-        $contents = file_get_contents($file->getPathname());
+        $paths[] = $file->getPathname();
+    }
+
+    return $paths;
+}
+
+/**
+ * Parse the `addOption(name, shortcut, mode, ...)` calls of one command class.
+ *
+ * All three are captured, so the documented short form and value placeholder
+ * can be verified too — not just the option name.
+ *
+ * @return array<string, array{short: ?string, value: bool}>
+ */
+function parseCommandOptions(string $contents): array
+{
+    /** @var array<string, array{short: ?string, value: bool}> $options */
+    $options = [];
+
+    preg_match_all(
+        '/->addOption\(\s*[\'"]([a-zA-Z0-9][a-zA-Z0-9-]*)[\'"]\s*,'
+        . '\s*(?:null|[\'"]([a-zA-Z0-9])[\'"])\s*,'
+        . '\s*((?:\s*InputOption::[A-Z_]+\s*\|?)+)/',
+        $contents,
+        $optMatches,
+        PREG_SET_ORDER,
+    );
+    foreach ($optMatches as $match) {
+        $options[$match[1]] = [
+            'short' => $match[2] === '' ? null : $match[2],
+            'value' => str_contains($match[3], 'VALUE_REQUIRED')
+                || str_contains($match[3], 'VALUE_OPTIONAL'),
+        ];
+    }
+
+    return $options;
+}
+
+/**
+ * Parse every command class into name => {options, positional argument count}.
+ *
+ * Each option carries its real short form and whether it takes a value, so the
+ * documented term can be compared against the full signature rather than the
+ * name alone.
+ *
+ * @return array{0: array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}>, 1: list<string>}
+ */
+function parseCommandDefinitions(string $commandDir): array
+{
+    /** @var array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}> $commands */
+    $commands = [];
+    /** @var list<string> $errors */
+    $errors = [];
+
+    foreach (commandClassFiles($commandDir) as $path) {
+        $contents = file_get_contents($path);
         if ($contents === false) {
             continue;
         }
@@ -121,25 +171,7 @@ $parseCommands = static function (string $commandDir): array {
         }
         $name = $nameMatch[1];
 
-        // addOption(name, shortcut, mode, ...): capture all three, so the
-        // documented short form and value placeholder can be verified too.
-        /** @var array<string, array{short: ?string, value: bool}> $options */
-        $options = [];
-        preg_match_all(
-            '/->addOption\(\s*[\'"]([a-zA-Z0-9][a-zA-Z0-9-]*)[\'"]\s*,'
-            . '\s*(?:null|[\'"]([a-zA-Z0-9])[\'"])\s*,'
-            . '\s*((?:\s*InputOption::[A-Z_]+\s*\|?)+)/',
-            $contents,
-            $optMatches,
-            PREG_SET_ORDER,
-        );
-        foreach ($optMatches as $match) {
-            $options[$match[1]] = [
-                'short' => $match[2] === '' ? null : $match[2],
-                'value' => str_contains($match[3], 'VALUE_REQUIRED')
-                    || str_contains($match[3], 'VALUE_OPTIONAL'),
-            ];
-        }
+        $options = parseCommandOptions($contents);
 
         // An addOption() call the regex could not read would silently drop out
         // of the model — the option would then read as invented in the docs AND
@@ -149,7 +181,7 @@ $parseCommands = static function (string $commandDir): array {
         if ($declared !== count($options)) {
             $errors[] = sprintf(
                 '%s: parsed %d of %d addOption() call(s) — the guard cannot see the full signature of %s',
-                basename($file->getPathname()),
+                basename($path),
                 count($options),
                 (int) $declared,
                 $name,
@@ -167,7 +199,7 @@ $parseCommands = static function (string $commandDir): array {
     }
 
     return [$commands, $errors];
-};
+}
 
 /**
  * Extract `vendor/bin/typo3 vault:* ...` example invocations from a doc file.
@@ -273,6 +305,17 @@ $parseExample = static function (string $cmdLine): array {
 };
 
 /**
+ * True when $title/$underline form an RST section header: a non-empty title
+ * whose next line is a run of punctuation at least as long as the title.
+ */
+function isRstSectionHeader(string $title, string $underline): bool
+{
+    return $title !== ''
+        && preg_match('/^([=\-~^"\'`#*+]){2,}$/', $underline) === 1
+        && strlen($underline) >= strlen($title);
+}
+
+/**
  * Extract the per-command `Options` definition lists from an RST reference page.
  *
  * A command section is a `vault:<name>` title with an underline; the option
@@ -307,28 +350,29 @@ function parseDocumentedOptions(string $rst): array
     $inOptions = false;
     $count = count($lines);
 
-    for ($i = 0; $i < $count; ++$i) {
-        $title = trim($lines[$i]);
-        $underline = $lines[$i + 1] ?? '';
+    // An explicit cursor rather than a `for` counter: a header consumes TWO
+    // lines (title + underline), and advancing a loop counter from inside the
+    // body is exactly the kind of hidden control flow this guard should not have.
+    $cursor = 0;
+    while ($cursor < $count) {
+        $line = $lines[$cursor];
+        $lineNo = $cursor + 1;
+        $title = trim($line);
 
-        // An RST section header: a non-empty title whose next line is a run of
-        // punctuation at least as long as the title.
-        if (
-            $title !== ''
-            && preg_match('/^([=\-~^"\'`#*+]){2,}$/', $underline) === 1
-            && strlen($underline) >= strlen($title)
-        ) {
+        if (isRstSectionHeader($title, $lines[$cursor + 1] ?? '')) {
             if (preg_match('/^(vault:[a-z][a-z0-9-]*)$/', $title, $sectionMatch) === 1) {
                 $command = $sectionMatch[1];
-                $sections[$command] = $i + 1;
+                $sections[$command] = $lineNo;
                 $inOptions = false;
             } else {
                 $inOptions = $title === 'Options';
             }
-            ++$i;
+            $cursor += 2;
 
             continue;
         }
+
+        ++$cursor;
 
         if (!$inOptions) {
             continue;
@@ -336,11 +380,11 @@ function parseDocumentedOptions(string $rst): array
         if ($command === null) {
             continue;
         }
-        if (preg_match('/^--\S/', $lines[$i]) !== 1) {
+        if (preg_match('/^--\S/', $line) !== 1) {
             continue;
         }
 
-        $options[$command][] = [$i + 1, rtrim($lines[$i])];
+        $options[$command][] = [$lineNo, rtrim($line)];
     }
 
     return ['sections' => $sections, 'options' => $options];
@@ -362,6 +406,189 @@ function renderOptionTerm(string $name, ?string $short, bool $takesValue, string
 }
 
 /**
+ * Split one documented term into its four parts, or null when it is malformed.
+ *
+ * Shape rule: `--name[=PLACEHOLDER][, -x [PLACEHOLDER]]` and nothing else. The
+ * placeholder may itself contain '=' (--metadata=KEY=VALUE) but may not start
+ * with one, which is what makes the `-x =VALUE` typo fail.
+ *
+ * @return array{name: string, placeholder: string, short: ?string, shortPlaceholder: string}|null
+ */
+function parseOptionTerm(string $term): ?array
+{
+    $shape = preg_match(
+        '/^--([a-z0-9][a-z0-9-]*)(?:=([^\s,=][^\s,]*))?(?:, -([a-zA-Z0-9])(?: ([^\s,=][^\s,]*))?)?$/',
+        $term,
+        $parts,
+    );
+    if ($shape !== 1) {
+        return null;
+    }
+
+    $short = $parts[3] ?? '';
+
+    return [
+        'name' => $parts[1],
+        'placeholder' => $parts[2] ?? '',
+        'short' => $short === '' ? null : $short,
+        'shortPlaceholder' => $parts[4] ?? '',
+    ];
+}
+
+/**
+ * Rule: a documented long option must be declared by THAT command.
+ *
+ * A Symfony global gets its own message, because "remove the entry" is the fix,
+ * whereas "the command does not declare it" would read as an invitation to add
+ * the option to the command.
+ *
+ * @param array<string, array{short: ?string, value: bool}> $real
+ * @param list<string> $globalOptions
+ */
+function violationForUndeclaredOption(string $where, string $name, array $real, array $globalOptions): ?string
+{
+    if (isset($real[$name])) {
+        return null;
+    }
+
+    if (in_array($name, $globalOptions, true)) {
+        return "{$where} documents the global option '--{$name}' as its own"
+            . ' — Symfony adds it to every command, so a per-command entry claims'
+            . ' semantics it does not have (this is how -q was documented as a'
+            . ' scripting flag; it suppresses the output). Remove the entry.';
+    }
+
+    $known = array_keys($real);
+    sort($known);
+
+    return "{$where} documents '--{$name}', which the command does not declare"
+        . ' (real options: --' . implode(', --', $known) . ')';
+}
+
+/**
+ * Rule: the documented term must render exactly like the real signature.
+ *
+ * Comparing the whole rendered term rather than each property one at a time:
+ * one comparison catches the wrong shortcut, a missing or invented shortcut, a
+ * value marker on a flag, a missing one on a value-taking option, and a short
+ * placeholder that disagrees with the long one — and it always names the exact
+ * line to write.
+ *
+ * @param array{name: string, placeholder: string, short: ?string, shortPlaceholder: string} $parsed
+ * @param array{short: ?string, value: bool} $real
+ */
+function violationForSignatureMismatch(string $where, string $term, array $parsed, array $real): ?string
+{
+    $placeholder = $parsed['placeholder'] === '' ? 'VALUE' : $parsed['placeholder'];
+
+    $expected = renderOptionTerm($parsed['name'], $real['short'], $real['value'], $placeholder);
+    $canonical = renderOptionTerm($parsed['name'], $parsed['short'], $parsed['placeholder'] !== '', $placeholder);
+
+    $selfConsistent = $canonical === $term
+        && ($parsed['short'] === null || $parsed['shortPlaceholder'] === $parsed['placeholder']);
+
+    if ($selfConsistent && $canonical === $expected) {
+        return null;
+    }
+
+    return "{$where} documents '{$term}'; the real signature is '{$expected}'";
+}
+
+/**
+ * Rule: every option the command declares must appear in the list.
+ *
+ * @param array<string, array{short: ?string, value: bool}> $real
+ * @param array<string,int> $seen documented long name => line
+ *
+ * @return list<string>
+ */
+function violationsForUndocumentedOptions(
+    string $label,
+    int $sectionLine,
+    string $command,
+    array $real,
+    array $seen,
+): array {
+    /** @var list<string> $violations */
+    $violations = [];
+
+    foreach (array_diff(array_keys($real), array_keys($seen)) as $name) {
+        $violations[] = sprintf(
+            "%s:%d: '%s' does not document '%s'",
+            $label,
+            $sectionLine,
+            $command,
+            renderOptionTerm($name, $real[$name]['short'], $real[$name]['value'], 'VALUE'),
+        );
+    }
+
+    return $violations;
+}
+
+/**
+ * Run every per-term rule over ONE command's Options list, then the
+ * completeness rule over the list as a whole.
+ *
+ * @param array<string, array{short: ?string, value: bool}> $real
+ * @param list<array{int, string}> $terms
+ * @param list<string> $globalOptions
+ *
+ * @return array{violations: list<string>, checked: int}
+ */
+function validateCommandOptionList(
+    string $label,
+    string $command,
+    int $sectionLine,
+    array $real,
+    array $terms,
+    array $globalOptions,
+): array {
+    /** @var list<string> $violations */
+    $violations = [];
+    /** @var array<string,int> $seen documented long name => line */
+    $seen = [];
+
+    foreach ($terms as [$lineNo, $term]) {
+        $where = "{$label}:{$lineNo}: '{$command}'";
+
+        $parsed = parseOptionTerm($term);
+        if ($parsed === null) {
+            $violations[] = "{$where} has a malformed option term '{$term}'"
+                . " (expected '--name=VALUE, -x VALUE', '--name=VALUE' or '--name')";
+
+            continue;
+        }
+
+        $name = $parsed['name'];
+
+        $undeclared = violationForUndeclaredOption($where, $name, $real, $globalOptions);
+        if ($undeclared !== null) {
+            $violations[] = $undeclared;
+
+            continue;
+        }
+
+        if (isset($seen[$name])) {
+            $violations[] = "{$where} documents '--{$name}' twice (also on line {$seen[$name]})";
+        }
+        $seen[$name] = $lineNo;
+
+        $mismatch = violationForSignatureMismatch($where, $term, $parsed, $real[$name]);
+        if ($mismatch !== null) {
+            $violations[] = $mismatch;
+        }
+    }
+
+    return [
+        'violations' => [
+            ...$violations,
+            ...violationsForUndocumentedOptions($label, $sectionLine, $command, $real, $seen),
+        ],
+        'checked' => count($terms),
+    ];
+}
+
+/**
  * Check the documented option lists of one file against the real definitions.
  *
  * A command section without an `Options` subsection is skipped rather than
@@ -369,7 +596,7 @@ function renderOptionTerm(string $name, ?string $short, bool $takesValue, string
  * task-first, with examples and no option lists, and forcing it to duplicate
  * the reference would be worse documentation. The list has to exist SOMEWHERE
  * though — the commands whose list was validated here are reported back so
- * $validateOptionCoverage can require exactly that, which also closes the
+ * validateOptionCoverage() can require exactly that, which also closes the
  * "delete the section instead of fixing it" escape.
  *
  * @param array<string, array{options: array<string, array{short: ?string, value: bool}>, args: int}> $commands
@@ -397,99 +624,22 @@ function validateDocumentedOptions(
             continue;
         }
 
-        $real = $commands[$command]['options'];
         $terms = $documented['options'][$command] ?? [];
-
         if ($terms === []) {
             continue;
         }
         $covered[] = $command;
 
-        /** @var array<string,int> $seen documented long name => line */
-        $seen = [];
-
-        foreach ($terms as [$lineNo, $term]) {
-            ++$checked;
-            $where = "{$label}:{$lineNo}: '{$command}'";
-
-            // --name[=PLACEHOLDER][, -x [PLACEHOLDER]] and nothing else. The
-            // placeholder may itself contain '=' (--metadata=KEY=VALUE) but may
-            // not start with one, which is what makes the `-x =VALUE` typo fail.
-            $shape = preg_match(
-                '/^--([a-z0-9][a-z0-9-]*)(?:=([^\s,=][^\s,]*))?(?:, -([a-zA-Z0-9])(?: ([^\s,=][^\s,]*))?)?$/',
-                $term,
-                $parts,
-            );
-            if ($shape !== 1) {
-                $violations[] = "{$where} has a malformed option term '{$term}'"
-                    . " (expected '--name=VALUE, -x VALUE', '--name=VALUE' or '--name')";
-
-                continue;
-            }
-
-            $name = $parts[1];
-            $placeholder = $parts[2] ?? '';
-            $short = ($parts[3] ?? '') === '' ? null : $parts[3];
-            $shortPlaceholder = $parts[4] ?? '';
-
-            if (!isset($real[$name])) {
-                if (in_array($name, $globalOptions, true)) {
-                    $violations[] = "{$where} documents the global option '--{$name}' as its own"
-                        . ' — Symfony adds it to every command, so a per-command entry claims'
-                        . ' semantics it does not have (this is how -q was documented as a'
-                        . ' scripting flag; it suppresses the output). Remove the entry.';
-
-                    continue;
-                }
-
-                $known = array_keys($real);
-                sort($known);
-                $violations[] = "{$where} documents '--{$name}', which the command does not declare"
-                    . ' (real options: --' . implode(', --', $known) . ')';
-
-                continue;
-            }
-
-            if (isset($seen[$name])) {
-                $violations[] = "{$where} documents '--{$name}' twice (also on line {$seen[$name]})";
-            }
-            $seen[$name] = $lineNo;
-
-            $expected = renderOptionTerm(
-                $name,
-                $real[$name]['short'],
-                $real[$name]['value'],
-                $placeholder === '' ? 'VALUE' : $placeholder,
-            );
-
-            $canonical = renderOptionTerm(
-                $name,
-                $short,
-                $placeholder !== '',
-                $placeholder === '' ? 'VALUE' : $placeholder,
-            );
-
-            // Compare the whole rendered term rather than each property one at a
-            // time: one comparison catches the wrong shortcut, a missing or
-            // invented shortcut, a value marker on a flag, a missing one on a
-            // value-taking option, and a short placeholder that disagrees with
-            // the long one — and it always names the exact line to write.
-            $selfConsistent = $canonical === $term && ($short === null || $shortPlaceholder === $placeholder);
-            if (!$selfConsistent || $canonical !== $expected) {
-                $violations[] = "{$where} documents '{$term}'; the real signature is '{$expected}'";
-            }
-        }
-
-        $missing = array_diff(array_keys($real), array_keys($seen));
-        foreach ($missing as $name) {
-            $violations[] = sprintf(
-                "%s:%d: '%s' does not document '%s'",
-                $label,
-                $sectionLine,
-                $command,
-                renderOptionTerm($name, $real[$name]['short'], $real[$name]['value'], 'VALUE'),
-            );
-        }
+        $result = validateCommandOptionList(
+            $label,
+            $command,
+            $sectionLine,
+            $commands[$command]['options'],
+            $terms,
+            $globalOptions,
+        );
+        $violations = [...$violations, ...$result['violations']];
+        $checked += $result['checked'];
     }
 
     return ['violations' => $violations, 'checked' => $checked, 'covered' => $covered];
@@ -535,12 +685,12 @@ function validateOptionCoverage(array $commands, array $covered): array
 // so the guard also behaves under an unusual CLI ini.
 $arguments = $_SERVER['argv'] ?? [];
 if (is_array($arguments) && in_array('--self-test', $arguments, true)) {
-    require __DIR__ . '/check-cli-docs-selftest.php';
+    require_once __DIR__ . '/check-cli-docs-selftest.php';
 
     exit(checkCliDocsSelfTest());
 }
 
-[$commands, $parseErrors] = $parseCommands($commandDir);
+[$commands, $parseErrors] = parseCommandDefinitions($commandDir);
 $violations = $parseErrors;
 
 // Scan README plus every doc under Documentation/ so a vault:* example

--- a/composer.json
+++ b/composer.json
@@ -91,6 +91,7 @@
             "@ci:test:php:phpstan",
             "@ci:test:php:arch",
             "@ci:test:php:doc-cli",
+            "@ci:test:php:doc-cli:self-test",
             "@ci:test:evidence",
             "@ci:test:php:cgl"
         ],
@@ -99,6 +100,7 @@
         "ci:test:evidence": "@php Build/Scripts/collect-evidence.php --self-test",
         "ci:test:php:arch": "@php Tests/scripts/check-test-base-class.php",
         "ci:test:php:doc-cli": "@php Tests/scripts/check-cli-docs.php",
+        "ci:test:php:doc-cli:self-test": "@php Tests/scripts/check-cli-docs.php --self-test",
         "ci:cgl": "php-cs-fixer fix",
         "ci:test:php:cgl": "php-cs-fixer fix --dry-run --diff",
         "ci:test:php:coverage": "@php -d pcov.enabled=0 -d xdebug.mode=coverage .Build/bin/phpunit -c Build/phpunit.xml --testsuite Unit --path-coverage --coverage-clover=.Build/coverage/clover.xml --coverage-html=.Build/coverage/html --coverage-text",


### PR DESCRIPTION
The documentation audit found `Documentation/Developer/Commands.rst` documenting options that **do not exist** (`vault:store --description/--context/--expires`, `vault:retrieve --quiet`) and omitting real ones (`--stdin`, `--file`, `--limit`). The scripting example built on the fictional `-q` returned an empty string, because `-q` is Symfony's global quiet flag and suppresses the value.

The guard passed the whole time: it validated only the **shell examples**, never the per-command **Options definition lists**, and it whitelisted `quiet`. The docs have since been corrected — this closes the hole that let it happen.

## What the guard now checks

A second pass parses each command's Options list and compares every term against the real `addOption(name, shortcut, mode, …)`:

- the long option must exist **on that command**; the short form must be the real shortcut (present, absent, and identical)
- a value-taking option must be written `--name=VALUE`; a flag must not carry one; the term must be shaped `--name=VALUE, -x VALUE` (this rejects the `-x =VALUE` form that appeared nine times)
- the short placeholder must match the long one; no option documented twice; **no real option omitted**
- repo-wide: every command declaring options must have an Options list somewhere

Plus guard integrity: if the parser finds fewer `addOption(` calls than the file contains, the run fails — otherwise an unparsed option would read as invented *and* slip past the completeness check.

## Decisions worth noting

- **Completeness is a hard error, not a warning.** The audit found both invented and omitted options; a warning would leave half the finding unguarded, and an ungated warning is how this survived. It was free — all 65 real options were already documented.
- **Globals are rejected, not whitelisted, with no opt-out marker.** The old whitelist is precisely why `-q` shipped: it accepted it silently. A marker would just be a slower route back to the same bug. Real options resolve first, so a genuine collision like `vault:init --env` is unaffected.
- **Self-test instead of PHPUnit**, mirroring the existing `collect-evidence.php --self-test` pattern — the guard runs pre-commit where `.Build/` may be empty and no autoloader is available.

## Proof it catches what it missed

16 self-checks, including the three required cases (invented option, wrong shortcut, malformed term), plus a run against the real file with the audit's original findings temporarily re-injected — each was caught with an actionable message naming the command, the option and the real signature.

## Found and fixed on the current docs

12 further real violations, all one class: value-taking options written as bare flags (`--severity, -s`, `--reason, -r`, `--uid-field`, …) while siblings correctly used `--limit=N, -l N`.

## Verification

- `ci:test:php:doc-cli`: 206 examples + **65 options** across 17 commands — OK
- `ci:test:php:doc-cli:self-test`: all 16 self-checks behaved as specified
- `composer ci` exit 0 · PHPStan no errors · CGL clean · Rector dry-run clean
