### PR TITLE
Answer each audit operation with the same permission everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,26 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- **`vault:audit` now asserts an operation permission (breaking).** The command
-  gated nothing at all, while the same four capabilities were gated in the
-  backend module all along: anyone who could invoke it could read the audit log
-  — who touched which secret when, which maps out the credential topology —
-  carry an unchained copy of it off with `--export`, or clear the
-  tamper-evidence tip anchor. Listing and console output now assert
-  `audit.view`, `--export` asserts `audit.export`, and `--verify` /
-  `--reset-anchor` assert `vault.configure`, because they act on the chain's
-  integrity state rather than reading its contents. A refusal exits 1 before
-  any query, file write or anchor change happens, and writes no `access_denied`
-  entry — the same shape as every other operation-permission gate
-  (`vault:retrieve`, `vault:rotate-master-key`, the backend modules).
+- **Every audit CLI entry point now asserts an operation permission
+  (breaking).** `vault:audit`, `vault:audit-verify` and `vault:audit-anchor`
+  gated nothing at all, while the same capabilities were gated in the backend
+  module all along: anyone who could invoke them could read the audit log — who
+  touched which secret when, which maps out the credential topology — carry an
+  unchained copy of it off with `--export`, clear the tamper-evidence tip
+  anchor, or re-attest a truncated chain to the external sinks. The permission
+  now follows the operation's effect, so the same operation answers to the same
+  permission through every entry point:
+
+  | Operation | Permission | Entry points |
+  |---|---|---|
+  | Read audit entries | `audit.view` | audit module, `vault:audit` |
+  | Verify the chain | `audit.view` | audit module, `vault:audit --verify`, `vault:audit-verify`, `AuditVerifyTask` |
+  | Export to a file | `audit.export` | audit module, `vault:audit --export` |
+  | Publish the chain tip | `vault.configure` | `vault:audit-anchor`, `AuditAnchorTask` |
+  | Reset the tip anchor | `vault.configure` | `vault:audit --reset-anchor` |
+
+  Verification is a read of the chain — it recomputes and compares, it mutates
+  nothing — so it shares `audit.view` with the listing rather than taking the
+  administrative permission. Anchoring and resetting the anchor do mutate
+  tamper evidence: an actor who truncates the log and then anchors makes the
+  external sink attest the truncated chain, which is the laundering the anchor
+  exists to prevent. A refusal exits 1 before any query, file write, chain read
+  or anchor change happens, and writes no `access_denied` entry — the same
+  shape as every other operation-permission gate (`vault:retrieve`,
+  `vault:rotate-master-key`, the backend modules). In `--format=json` a refused
+  `vault:audit-verify` reports `valid: false`, so a monitor never reads it as a
+  clean chain.
 - **Migration.** All three permissions are excluded from the
-  `cliAllowedOperations` default, so `vault:audit` run from a shell now needs
-  `allowCliAccess = 1` **and** the operation added to that list. Prefer a named
-  technical actor (`TechnicalActorContext::runAs()`) holding exactly those
-  permissions: the audit trail then names the identity that read or exported
-  the log. A backend user needs the matching `tx_nrvault:<permission>` custom
-  option on one of their groups; admins are unaffected unless the admin
-  override is disabled.
+  `cliAllowedOperations` default, so any of these commands run from a shell now
+  needs `allowCliAccess = 1` **and** the operation added to that list. Prefer a
+  named technical actor (`TechnicalActorContext::runAs()`) holding exactly
+  those permissions: the audit trail then names the identity that read,
+  exported or anchored. A backend user needs the matching
+  `tx_nrvault:<permission>` custom option on one of their groups; admins are
+  unaffected unless the admin override is disabled. **Scheduled operation is
+  unaffected on a default installation** — `scheduler:run` authenticates the
+  `_cli_` administrator, who passes through the admin bypass. Under
+  `disableAdminOverride` that bypass is gone by design, so the identity running
+  the scheduler needs a group carrying `tx_nrvault:audit.view` (verify) and
+  `tx_nrvault:vault.configure` (anchor); without it both tasks fail loudly
+  rather than skipping quietly.
 
 ### Security
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`vault:audit` now asserts an operation permission (breaking).** The command
+  gated nothing at all, while the same four capabilities were gated in the
+  backend module all along: anyone who could invoke it could read the audit log
+  — who touched which secret when, which maps out the credential topology —
+  carry an unchained copy of it off with `--export`, or clear the
+  tamper-evidence tip anchor. Listing and console output now assert
+  `audit.view`, `--export` asserts `audit.export`, and `--verify` /
+  `--reset-anchor` assert `vault.configure`, because they act on the chain's
+  integrity state rather than reading its contents. A refusal exits 1 before
+  any query, file write or anchor change happens, and writes no `access_denied`
+  entry — the same shape as every other operation-permission gate
+  (`vault:retrieve`, `vault:rotate-master-key`, the backend modules).
+- **Migration.** All three permissions are excluded from the
+  `cliAllowedOperations` default, so `vault:audit` run from a shell now needs
+  `allowCliAccess = 1` **and** the operation added to that list. Prefer a named
+  technical actor (`TechnicalActorContext::runAs()`) holding exactly those
+  permissions: the audit trail then names the identity that read or exported
+  the log. A backend user needs the matching `tx_nrvault:<permission>` custom
+  option on one of their groups; admins are unaffected unless the admin
+  override is disabled.
+
 ### Security
 
 - **Truncating the audit log is no longer invisible** (ADR-034). The hash chain

--- a/Classes/Command/VaultAuditAnchorCommand.php
+++ b/Classes/Command/VaultAuditAnchorCommand.php
@@ -12,6 +12,8 @@ namespace Netresearch\NrVault\Command;
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
 use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -30,6 +32,16 @@ use Throwable;
  * `vault:audit-verify`. The anchoring interval is the blind window: an attacker
  * who resets the table can only hide entries written since the last anchor.
  *
+ * Gated on `vault.configure`, the same permission `vault:audit --reset-anchor`
+ * asserts, because publishing an anchor mutates tamper evidence: an actor who
+ * truncates the log and then anchors makes the external sink attest the
+ * truncated chain — the exact laundering the anchor exists to prevent.
+ *
+ * `--dry-run` is gated identically rather than as a read. It publishes nothing,
+ * but it prints the current chain tip, which is the value a forged anchor has
+ * to reproduce; and it is the rehearsal of an administrative operation, not a
+ * view of the audit log.
+ *
  * Usage:
  *   vendor/bin/typo3 vault:audit-anchor
  *   vendor/bin/typo3 vault:audit-anchor --dry-run
@@ -44,6 +56,7 @@ final class VaultAuditAnchorCommand extends Command
     public function __construct(
         private readonly ChainTipAnchorServiceInterface $anchorService,
         private readonly AuditSinkRegistryInterface $sinkRegistry,
+        private readonly AccessControlServiceInterface $accessControlService,
     ) {
         parent::__construct();
     }
@@ -72,6 +85,17 @@ final class VaultAuditAnchorCommand extends Command
         $formatOption = $input->getOption('format');
         $json = \is_string($formatOption) && strtolower($formatOption) === 'json';
         $dryRun = (bool) $input->getOption('dry-run');
+
+        // Before the chain tip is even read, so a refusal discloses nothing and
+        // publishes nothing.
+        if (!$this->accessControlService->isGranted(VaultPermission::VaultConfigure)) {
+            $this->fail($io, $output, $json, \sprintf(
+                'Access denied: the "%s" permission is required to publish the audit chain tip.',
+                VaultPermission::VaultConfigure->value,
+            ));
+
+            return Command::FAILURE;
+        }
 
         try {
             $anchor = $this->anchorService->capture();

--- a/Classes/Command/VaultAuditCommand.php
+++ b/Classes/Command/VaultAuditCommand.php
@@ -34,8 +34,8 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 /**
  * CLI command to query and export audit logs.
  *
- * Every mode is gated on an operation permission: listing on `audit.view`,
- * `--export` on `audit.export`, and `--verify` / `--reset-anchor` on
+ * Every mode is gated on an operation permission: listing and `--verify` on
+ * `audit.view`, `--export` on `audit.export`, and `--reset-anchor` on
  * `vault.configure`. A refusal exits non-zero before any query, file write or
  * anchor change happens.
  *
@@ -167,9 +167,13 @@ final class VaultAuditCommand extends Command
         // derivative of the secrets themselves; before this gate existed,
         // `vault:audit` was the one privileged vault command that asserted
         // nothing at all.
-        $required = $this->requiredPermission($resetAnchor, $verify, $exportFile);
+        [$required, $operation] = $this->gate($resetAnchor, $verify, $exportFile);
         if (!$this->accessControlService->isGranted($required)) {
-            $io->error($this->accessDeniedMessage($required));
+            $io->error(\sprintf(
+                'Access denied: the "%s" permission is required to %s.',
+                $required->value,
+                $operation,
+            ));
 
             return Command::FAILURE;
         }
@@ -236,42 +240,30 @@ final class VaultAuditCommand extends Command
     }
 
     /**
-     * Which permission this invocation needs.
+     * The permission this invocation needs, and the operation it guards.
      *
-     * `--verify` and `--reset-anchor` do not read audit *content* at all: they
-     * assert on the chain's integrity state and, in the reset case, clear the
-     * truncation anchor and write into the chain. That is vault
-     * administration, so they take `vault.configure` rather than the reading
-     * permissions. Export takes `audit.export` on its own — same rule as
-     * `AuditController::exportAction()`, because the exported copy leaves the
-     * tamper-evident storage behind.
+     * Resolved as one value so a refusal can never name a permission belonging
+     * to a different mode than the one it gated, and so the operator learns
+     * which grant to ask for AND what for.
+     *
+     * `--verify` recomputes and compares — it mutates nothing, so it is a read
+     * of the chain and shares `audit.view` with the listing, exactly as
+     * `AuditController::verifyChainAction()` does. `--reset-anchor` is the
+     * outlier: it clears the truncation anchor and writes into the chain, so
+     * it stays vault administration. Export takes `audit.export` on its own —
+     * same rule as `AuditController::exportAction()`, because the exported
+     * copy leaves the tamper-evident storage behind.
+     *
+     * @return array{VaultPermission, string}
      */
-    private function requiredPermission(bool $resetAnchor, bool $verify, ?string $exportFile): VaultPermission
+    private function gate(bool $resetAnchor, bool $verify, ?string $exportFile): array
     {
         return match (true) {
-            $resetAnchor, $verify => VaultPermission::VaultConfigure,
-            $exportFile !== null => VaultPermission::AuditExport,
-            default => VaultPermission::AuditView,
+            $resetAnchor => [VaultPermission::VaultConfigure, 'reset the audit chain tip anchor'],
+            $verify => [VaultPermission::AuditView, 'verify the audit hash chain'],
+            $exportFile !== null => [VaultPermission::AuditExport, 'export audit entries to a file'],
+            default => [VaultPermission::AuditView, 'read the audit log'],
         };
-    }
-
-    /**
-     * Name the missing permission AND the operation it guards, so the operator
-     * knows which grant to ask for and for what.
-     */
-    private function accessDeniedMessage(VaultPermission $permission): string
-    {
-        $operation = match ($permission) {
-            VaultPermission::VaultConfigure => 'verify or reset the audit hash chain',
-            VaultPermission::AuditExport => 'export audit entries to a file',
-            default => 'read the audit log',
-        };
-
-        return \sprintf(
-            'Access denied: the "%s" permission is required to %s.',
-            $permission->value,
-            $operation,
-        );
     }
 
     private function buildFilters(InputInterface $input): ?AuditLogFilter

--- a/Classes/Command/VaultAuditCommand.php
+++ b/Classes/Command/VaultAuditCommand.php
@@ -18,6 +18,8 @@ use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Audit\AuditLogFilter;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Exception\VaultException;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Utility\CsvFormulaSanitizer;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -31,6 +33,20 @@ use TYPO3\CMS\Core\Database\ConnectionPool;
 
 /**
  * CLI command to query and export audit logs.
+ *
+ * Every mode is gated on an operation permission: listing on `audit.view`,
+ * `--export` on `audit.export`, and `--verify` / `--reset-anchor` on
+ * `vault.configure`. A refusal exits non-zero before any query, file write or
+ * anchor change happens.
+ *
+ * A refusal deliberately writes NO `access_denied` entry. Every sibling
+ * operation-permission gate refuses the same way — `VaultRetrieveCommand`,
+ * `VaultRotateMasterKeyCommand`, `ModuleAccessGuard` — and only the
+ * *per-secret* tiers audit their denials. Auditing here would also let anyone
+ * with a shell append rows to the tamper-evident table without holding a
+ * single permission, and, worse, `--verify` / `--reset-anchor` are the tools
+ * for a chain that is already suspect: their denial path must not append to,
+ * and re-anchor, the very chain the operator is about to inspect or reset.
  */
 #[AsCommand(
     name: 'vault:audit',
@@ -50,6 +66,7 @@ final class VaultAuditCommand extends Command
         private readonly AuditLogServiceInterface $auditLogService,
         private readonly AuditChainAnchorStoreInterface $anchorStore,
         private readonly ConnectionPool $connectionPool,
+        private readonly AccessControlServiceInterface $accessControlService,
     ) {
         parent::__construct();
     }
@@ -139,12 +156,30 @@ final class VaultAuditCommand extends Command
     {
         $io = new SymfonyStyle($input, $output);
 
-        if ((bool) $input->getOption('reset-anchor')) {
+        $resetAnchor = (bool) $input->getOption('reset-anchor');
+        $verify = (bool) $input->getOption('verify');
+        $exportFile = $this->exportTarget($input);
+
+        // One gate for the whole command, resolved from the mode the
+        // invocation selects — the same mode the dispatch below uses, so no
+        // branch can reach its work through an unasserted permission. The
+        // audit log names who touched which secret when, which is a sensitive
+        // derivative of the secrets themselves; before this gate existed,
+        // `vault:audit` was the one privileged vault command that asserted
+        // nothing at all.
+        $required = $this->requiredPermission($resetAnchor, $verify, $exportFile);
+        if (!$this->accessControlService->isGranted($required)) {
+            $io->error($this->accessDeniedMessage($required));
+
+            return Command::FAILURE;
+        }
+
+        if ($resetAnchor) {
             return $this->resetAnchor($io, (bool) $input->getOption('force'));
         }
 
         // Hash chain verification
-        if ($input->getOption('verify')) {
+        if ($verify) {
             return $this->verifyHashChain($io);
         }
 
@@ -167,8 +202,7 @@ final class VaultAuditCommand extends Command
             }
 
             // Export to file
-            $exportFile = $input->getOption('export');
-            if (\is_string($exportFile) && $exportFile !== '') {
+            if ($exportFile !== null) {
                 return $this->exportToFile($io, $entries, $exportFile, $format);
             }
 
@@ -185,6 +219,59 @@ final class VaultAuditCommand extends Command
 
             return Command::FAILURE;
         }
+    }
+
+    /**
+     * The file `--export` writes to, or null when the entries stay on stdout.
+     *
+     * Resolved once and reused by both the permission gate and the dispatch:
+     * two separate readings of the option could disagree, and the one that
+     * disagreed would be an export performed under `audit.view`.
+     */
+    private function exportTarget(InputInterface $input): ?string
+    {
+        $exportFile = $input->getOption('export');
+
+        return \is_string($exportFile) && $exportFile !== '' ? $exportFile : null;
+    }
+
+    /**
+     * Which permission this invocation needs.
+     *
+     * `--verify` and `--reset-anchor` do not read audit *content* at all: they
+     * assert on the chain's integrity state and, in the reset case, clear the
+     * truncation anchor and write into the chain. That is vault
+     * administration, so they take `vault.configure` rather than the reading
+     * permissions. Export takes `audit.export` on its own — same rule as
+     * `AuditController::exportAction()`, because the exported copy leaves the
+     * tamper-evident storage behind.
+     */
+    private function requiredPermission(bool $resetAnchor, bool $verify, ?string $exportFile): VaultPermission
+    {
+        return match (true) {
+            $resetAnchor, $verify => VaultPermission::VaultConfigure,
+            $exportFile !== null => VaultPermission::AuditExport,
+            default => VaultPermission::AuditView,
+        };
+    }
+
+    /**
+     * Name the missing permission AND the operation it guards, so the operator
+     * knows which grant to ask for and for what.
+     */
+    private function accessDeniedMessage(VaultPermission $permission): string
+    {
+        $operation = match ($permission) {
+            VaultPermission::VaultConfigure => 'verify or reset the audit hash chain',
+            VaultPermission::AuditExport => 'export audit entries to a file',
+            default => 'read the audit log',
+        };
+
+        return \sprintf(
+            'Access denied: the "%s" permission is required to %s.',
+            $permission->value,
+            $operation,
+        );
     }
 
     private function buildFilters(InputInterface $input): ?AuditLogFilter

--- a/Classes/Command/VaultAuditVerifyCommand.php
+++ b/Classes/Command/VaultAuditVerifyCommand.php
@@ -14,6 +14,8 @@ use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
 use Netresearch\NrVault\Audit\AuditIntegrityAlert;
 use Netresearch\NrVault\Audit\AuditIntegrityReport;
 use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputInterface;
@@ -43,6 +45,15 @@ use Throwable;
  * {@see \Netresearch\NrVault\Event\AuditIntegrityAlertEvent}, so SIEM listeners
  * fire whether or not anyone reads this output.
  *
+ * Gated on `audit.view`: verification recomputes and compares, it mutates
+ * nothing, so it is a read of the chain — the same permission
+ * `vault:audit --verify` and `AuditController::verifyChainAction()` assert for
+ * the same operation. Without the gate this command would be the way around
+ * theirs, and it checks strictly more (the external anchor as well as the
+ * chain). A refusal exits non-zero without running any verification, and in
+ * `--format=json` it reports `valid: false` — a verifier that was not allowed
+ * to run must never read as a verifier that found nothing.
+ *
  * Usage:
  *   vendor/bin/typo3 vault:audit-verify
  *   vendor/bin/typo3 vault:audit-verify --format=json
@@ -57,6 +68,7 @@ final class VaultAuditVerifyCommand extends Command
     public function __construct(
         private readonly ChainTipAnchorServiceInterface $anchorService,
         private readonly AuditSinkRegistryInterface $sinkRegistry,
+        private readonly AccessControlServiceInterface $accessControlService,
     ) {
         parent::__construct();
     }
@@ -86,6 +98,14 @@ final class VaultAuditVerifyCommand extends Command
         $formatOption = $input->getOption('format');
         $json = \is_string($formatOption) && strtolower($formatOption) === 'json';
         $tamperOnly = (bool) $input->getOption('tamper-only');
+
+        // Before the verification runs, and before anything is written to the
+        // output a monitoring wrapper might parse.
+        if (!$this->accessControlService->isGranted(VaultPermission::AuditView)) {
+            $this->refuse($io, $output, $json);
+
+            return Command::FAILURE;
+        }
 
         try {
             $report = $this->anchorService->verify();
@@ -123,6 +143,32 @@ final class VaultAuditVerifyCommand extends Command
         $this->renderText($io, $report, $failed);
 
         return $failed ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    /**
+     * Report the refusal in the shape the caller asked for.
+     *
+     * The JSON body carries `valid: false` alongside the reason, so a monitor
+     * that only reads that field treats a refused verification as a failed one
+     * rather than as a clean chain.
+     */
+    private function refuse(SymfonyStyle $io, OutputInterface $output, bool $json): void
+    {
+        $message = \sprintf(
+            'Access denied: the "%s" permission is required to verify the audit log integrity.',
+            VaultPermission::AuditView->value,
+        );
+
+        if ($json) {
+            $output->writeln(json_encode(
+                ['valid' => false, 'error' => $message],
+                JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR,
+            ));
+
+            return;
+        }
+
+        $io->error($message);
     }
 
     private function renderText(SymfonyStyle $io, AuditIntegrityReport $report, bool $failed): void

--- a/Classes/Task/AuditAnchorTask.php
+++ b/Classes/Task/AuditAnchorTask.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Task;
 
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
@@ -30,6 +32,20 @@ use TYPO3\CMS\Scheduler\Task\AbstractTask;
  * run that reached nothing outside the database provides no reset protection, and
  * a green scheduler entry would misreport that as working tamper evidence.
  *
+ * Gated on `vault.configure`, the same permission the `vault:audit-anchor`
+ * wrapper and `vault:audit --reset-anchor` assert. Publishing an anchor mutates
+ * tamper evidence, and the permission has to follow the operation through every
+ * entry point or the gate on the others is advisory: without this one, an actor
+ * who may not run the command registers the task instead.
+ *
+ * On a default installation the gate is inert — :bash:`scheduler:run`
+ * authenticates the `_cli_` administrator, who passes through the admin bypass.
+ * It bites under `disableAdminOverride`, which is precisely the profile that
+ * withdrew "administrator implies vault operator"; there the identity running
+ * the scheduler needs a group carrying `tx_nrvault:vault.configure`. A refusal
+ * fails the task loudly rather than skipping quietly: an anchoring run that did
+ * not happen must never look like one that did.
+ *
  * Constructor arguments are nullable and lazily resolved via
  * `GeneralUtility::makeInstance()` because the scheduler unserializes task
  * objects without going through the DI container — the same pattern as
@@ -40,6 +56,7 @@ final class AuditAnchorTask extends AbstractTask
     public function __construct(
         private readonly ?ChainTipAnchorServiceInterface $anchorService = null,
         private readonly ?LogManager $logManager = null,
+        private readonly ?AccessControlServiceInterface $accessControlService = null,
     ) {
         parent::__construct();
     }
@@ -47,6 +64,14 @@ final class AuditAnchorTask extends AbstractTask
     public function execute(): bool
     {
         $logger = $this->getLogger();
+
+        if (!$this->isGranted()) {
+            $logger->error('Vault audit anchoring denied', [
+                'missingPermission' => VaultPermission::VaultConfigure->value,
+            ]);
+
+            return false;
+        }
 
         try {
             $anchorService = $this->getAnchorService();
@@ -79,6 +104,14 @@ final class AuditAnchorTask extends AbstractTask
      */
     public function getAdditionalInformation(): string
     {
+        // The sequence is chain state, so it is withheld from a viewer the
+        // operation itself would refuse. The list view still renders — an
+        // operator who cannot see the detail must still be able to reach the
+        // task to disable it.
+        if (!$this->isGranted()) {
+            return 'Publishes the audit chain tip to the external audit sinks';
+        }
+
         try {
             $anchor = $this->getAnchorService()->capture();
         } catch (Throwable) {
@@ -91,6 +124,14 @@ final class AuditAnchorTask extends AbstractTask
             'Publishes the audit chain tip to the external audit sinks (current sequence: %d)',
             $anchor->sequence,
         );
+    }
+
+    private function isGranted(): bool
+    {
+        $accessControlService = $this->accessControlService
+            ?? GeneralUtility::makeInstance(AccessControlServiceInterface::class);
+
+        return $accessControlService->isGranted(VaultPermission::VaultConfigure);
     }
 
     private function getAnchorService(): ChainTipAnchorServiceInterface

--- a/Classes/Task/AuditVerifyTask.php
+++ b/Classes/Task/AuditVerifyTask.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Task;
 
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Psr\Log\LoggerInterface;
 use Psr\Log\NullLogger;
 use Throwable;
@@ -25,6 +27,18 @@ use TYPO3\CMS\Scheduler\Task\AbstractTask;
  * {@see \Netresearch\NrVault\Event\AuditIntegrityAlertEvent} by the anchor
  * service itself, so SIEM and notification listeners fire from a scheduled run
  * exactly as they do from the CLI — nobody has to be watching the scheduler log.
+ *
+ * Gated on `audit.view`, the same permission `vault:audit-verify`,
+ * `vault:audit --verify` and `AuditController::verifyChainAction()` assert:
+ * verification recomputes and compares, it mutates nothing, so it is a read of
+ * the chain wherever it is invoked from.
+ *
+ * On a default installation the gate is inert — :bash:`scheduler:run`
+ * authenticates the `_cli_` administrator, who passes through the admin bypass.
+ * It bites under `disableAdminOverride`, where the identity running the
+ * scheduler needs a group carrying `tx_nrvault:audit.view`. A refusal fails the
+ * task, for the same reason a verification that threw does: a check that did
+ * not run must never report success.
  *
  * Configuration (TCA field on `tx_scheduler_task`):
  * - `nr_vault_tamper_only`: when set, the task only fails on tamper evidence
@@ -42,6 +56,7 @@ final class AuditVerifyTask extends AbstractTask
     public function __construct(
         private readonly ?ChainTipAnchorServiceInterface $anchorService = null,
         private readonly ?LogManager $logManager = null,
+        private readonly ?AccessControlServiceInterface $accessControlService = null,
     ) {
         parent::__construct();
     }
@@ -71,6 +86,14 @@ final class AuditVerifyTask extends AbstractTask
     public function execute(): bool
     {
         $logger = $this->getLogger();
+
+        if (!$this->isGranted()) {
+            $logger->error('Vault audit integrity verification denied', [
+                'missingPermission' => VaultPermission::AuditView->value,
+            ]);
+
+            return false;
+        }
 
         try {
             $report = $this->getAnchorService()->verify();
@@ -117,6 +140,14 @@ final class AuditVerifyTask extends AbstractTask
         return $this->tamperOnly
             ? 'Verifies the audit hash chain and external anchor (fails on tamper evidence only)'
             : 'Verifies the audit hash chain and external anchor (fails on any finding)';
+    }
+
+    private function isGranted(): bool
+    {
+        $accessControlService = $this->accessControlService
+            ?? GeneralUtility::makeInstance(AccessControlServiceInterface::class);
+
+        return $accessControlService->isGranted(VaultPermission::AuditView);
     }
 
     private function getAnchorService(): ChainTipAnchorServiceInterface

--- a/Documentation/Auditor/EvidenceCollection.rst
+++ b/Documentation/Auditor/EvidenceCollection.rst
@@ -20,8 +20,11 @@ artefact is the evidence, not the terminal.
     unattributed CLI actor holds only when ``allowCliAccess = 1`` **and** the
     operation appears in :confval:`ext-nrvault-cliAllowedOperations`:
     ``vault:retrieve`` (``secret.reveal``), ``vault:rotate-master-key``
-    (``master_key.rotate``), and ``vault:audit`` — ``audit.view`` to list,
-    ``audit.export`` for ``--export``, ``vault.configure`` for ``--verify``.
+    (``master_key.rotate``), ``vault:audit`` — ``audit.view`` to list and to
+    ``--verify``, ``audit.export`` for ``--export``, ``vault.configure`` for
+    ``--reset-anchor`` — and the two scheduler-task wrappers,
+    ``vault:audit-verify`` (``audit.view``) and ``vault:audit-anchor``
+    (``vault.configure``).
     The cleanest arrangement for an assessment is a named technical actor
     holding exactly those, so every evidence command appears in the audit trail
     under its own identity rather than as the anonymous CLI operator.

--- a/Documentation/Auditor/EvidenceCollection.rst
+++ b/Documentation/Auditor/EvidenceCollection.rst
@@ -16,11 +16,19 @@ artefact is the evidence, not the terminal.
 
 ..  note::
 
-    Two of these commands need a permission that a CLI operator only holds when
-    ``allowCliAccess = 1`` (``vault:retrieve`` and ``vault:rotate-master-key``).
-    Everything in this section works without it. If a read-only command reports
-    access denied, that is itself a finding worth recording — with an
-    ``access_denied`` audit row to match.
+    Several of these commands assert an operation permission that the
+    unattributed CLI actor holds only when ``allowCliAccess = 1`` **and** the
+    operation appears in :confval:`ext-nrvault-cliAllowedOperations`:
+    ``vault:retrieve`` (``secret.reveal``), ``vault:rotate-master-key``
+    (``master_key.rotate``), and ``vault:audit`` — ``audit.view`` to list,
+    ``audit.export`` for ``--export``, ``vault.configure`` for ``--verify``.
+    The cleanest arrangement for an assessment is a named technical actor
+    holding exactly those, so every evidence command appears in the audit trail
+    under its own identity rather than as the anonymous CLI operator.
+
+    A refusal is not evidence about the vault's contents: the command exits 1
+    before doing any work, and writes no audit row. Record it as a gap in the
+    evidence run, then re-run with the grant in place.
 
 .. _auditor-evidence-configuration:
 
@@ -271,6 +279,8 @@ Audit log export
 ..  code-block:: bash
     :caption: Period export, with the hash columns
 
+    # --export asserts audit.export, which is a permission of its own: the
+    # exported copy leaves the tamper-evident storage behind.
     vendor/bin/typo3 vault:audit \
         --since="2026-01-01" --until="2026-06-30" \
         --format=json --limit=100000 \

--- a/Documentation/Auditor/VerificationProcedures.rst
+++ b/Documentation/Auditor/VerificationProcedures.rst
@@ -24,11 +24,14 @@ Read-only evidence collection is in :ref:`auditor-evidence-collection`.
 
 ..  note::
 
-    The ``vault:audit`` queries below assert ``audit.view``, and
-    ``vault:audit --verify`` asserts ``vault.configure``. Both are excluded
-    from the :confval:`ext-nrvault-cliAllowedOperations` default, so grant them
-    to the actor running the procedure (see :ref:`auditor-evidence-collection`)
-    or read the same rows through the audit module.
+    The ``vault:audit`` queries below assert ``audit.view``, and so do
+    ``vault:audit --verify`` and ``vault:audit-verify`` — verification is a
+    read of the chain. The one procedure that publishes a baseline anchor
+    (``vault:audit-anchor``) asserts ``vault.configure`` instead, because it
+    mutates tamper evidence. Both permissions are excluded from the
+    :confval:`ext-nrvault-cliAllowedOperations` default, so grant them to the
+    actor running the procedure (see :ref:`auditor-evidence-collection`) or
+    read the same rows through the audit module.
 
 .. _auditor-verify-reveal-audited:
 

--- a/Documentation/Auditor/VerificationProcedures.rst
+++ b/Documentation/Auditor/VerificationProcedures.rst
@@ -22,6 +22,14 @@ finding rather than a matter of interpretation.
 
 Read-only evidence collection is in :ref:`auditor-evidence-collection`.
 
+..  note::
+
+    The ``vault:audit`` queries below assert ``audit.view``, and
+    ``vault:audit --verify`` asserts ``vault.configure``. Both are excluded
+    from the :confval:`ext-nrvault-cliAllowedOperations` default, so grant them
+    to the actor running the procedure (see :ref:`auditor-evidence-collection`)
+    or read the same rows through the audit module.
+
 .. _auditor-verify-reveal-audited:
 
 Procedure 1 — A reveal writes an audit row

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -224,14 +224,13 @@ CLI access
    Note that the scheduled orphan cleanup deletes secrets and therefore
    needs ``secret.delete`` when it runs as the bare CLI actor.
 
-   Three of those five change what a CLI command can do today:
-   ``secret.reveal``, ``secret.delete`` and ``master_key.rotate``.
-   ``audit.export`` and ``vault.configure`` gate the corresponding **backend**
-   actions — the audit module's export and the migration wizard —
-   and :bash:`vault:audit --export` asserts no operation permission of its
-   own. Withholding them here still matters: the list is the record of what
-   the unattributed CLI actor has been granted, and a CLI surface for either
-   would inherit it.
+   All five change what a CLI command can do: ``secret.reveal``
+   (:bash:`vault:retrieve`), ``secret.delete`` (:bash:`vault:delete`),
+   ``master_key.rotate`` (:bash:`vault:rotate-master-key`), ``audit.export``
+   (:bash:`vault:audit --export`) and ``vault.configure`` (:bash:`vault:audit
+   --verify` and :bash:`--reset-anchor`). ``audit.view``, which
+   :bash:`vault:audit` asserts for plain listing, is excluded as well — so
+   reading the audit log from an unattributed shell needs it added here too.
 
 .. confval:: frontendPlaceholderLegacyCli
    :name: ext-nrvault-frontendPlaceholderLegacyCli

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -227,10 +227,19 @@ CLI access
    All five change what a CLI command can do: ``secret.reveal``
    (:bash:`vault:retrieve`), ``secret.delete`` (:bash:`vault:delete`),
    ``master_key.rotate`` (:bash:`vault:rotate-master-key`), ``audit.export``
-   (:bash:`vault:audit --export`) and ``vault.configure`` (:bash:`vault:audit
-   --verify` and :bash:`--reset-anchor`). ``audit.view``, which
-   :bash:`vault:audit` asserts for plain listing, is excluded as well — so
-   reading the audit log from an unattributed shell needs it added here too.
+   (:bash:`vault:audit --export`) and ``vault.configure``
+   (:bash:`vault:audit-anchor` and :bash:`vault:audit --reset-anchor`).
+   ``audit.view`` is excluded as well, and it now covers three commands —
+   :bash:`vault:audit` for plain listing, :bash:`vault:audit --verify` and
+   :bash:`vault:audit-verify` — so reading or verifying the audit log from an
+   unattributed shell needs it added here too.
+
+   The scheduler is a different actor and is not affected by this allowlist:
+   :bash:`scheduler:run` authenticates the ``_cli_`` administrator, so the
+   ``AuditVerifyTask`` / ``AuditAnchorTask`` gates resolve through the admin
+   bypass instead. They bite only under ``disableAdminOverride``, where that
+   identity needs the permissions on one of its groups — see
+   :ref:`operations-hardened-deployment-step6`.
 
 .. confval:: frontendPlaceholderLegacyCli
    :name: ext-nrvault-frontendPlaceholderLegacyCli
@@ -607,12 +616,24 @@ Vault Audit Chain Anchoring
    Publishes the current chain tip (``vault:audit-anchor``). The interval is the
    blind window — entries written since the last anchor are what an attacker who
    resets the table can still hide. Hourly is a reasonable starting point.
+   Asserts ``vault.configure``, the same permission as the command.
 
 Vault Audit Integrity Verification
    Verifies the chain against the anchor (``vault:audit-verify``) and dispatches
    an integrity alert event per finding. Set *Fail on tamper evidence only*
    while sinks are still being rolled out, so a pending integration does not keep
-   the task permanently red and train operators to ignore it.
+   the task permanently red and train operators to ignore it. Asserts
+   ``audit.view``, the same permission as the command.
+
+..  note::
+
+    Both tasks run under :bash:`scheduler:run`, which authenticates the
+    ``_cli_`` administrator, so on a default installation the admin bypass
+    grants them and nothing needs configuring. Under
+    :confval:`ext-nrvault-disableAdminOverride` there is no bypass by design:
+    give the identity the scheduler runs as a group carrying
+    ``tx_nrvault:vault.configure`` and ``tx_nrvault:audit.view``, or both tasks
+    fail — loudly, but they fail.
 
 .. _configuration-master-key-providers:
 

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -364,6 +364,22 @@ Options
 --export=FILE, -e FILE
    Export results to a file (format taken from ``--format``).
 
+.. important::
+
+   Every mode of this command asserts an operation permission: listing and
+   console output assert ``audit.view``, ``--export`` asserts ``audit.export``,
+   and ``--verify`` / ``--reset-anchor`` assert ``vault.configure`` — they act
+   on the integrity state of the chain rather than reading its contents. A
+   refusal exits 1 before any work happens: nothing is queried, no export file
+   is written, and the tip anchor is left untouched.
+
+   :confval:`ext-nrvault-cliAllowedOperations` excludes all three permissions
+   by default, so for the unattributed CLI actor this command needs
+   ``allowCliAccess`` **and** the operation in that allowlist. Prefer a named
+   technical actor (:ref:`developer-technical-actor-context`) over widening the
+   allowlist — the audit trail then names the identity that read or exported
+   the log.
+
 .. _command-audit-example:
 
 Example

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -366,12 +366,17 @@ Options
 
 .. important::
 
-   Every mode of this command asserts an operation permission: listing and
-   console output assert ``audit.view``, ``--export`` asserts ``audit.export``,
-   and ``--verify`` / ``--reset-anchor`` assert ``vault.configure`` — they act
-   on the integrity state of the chain rather than reading its contents. A
-   refusal exits 1 before any work happens: nothing is queried, no export file
-   is written, and the tip anchor is left untouched.
+   Every mode of this command asserts an operation permission: listing,
+   console output and ``--verify`` assert ``audit.view``, ``--export`` asserts
+   ``audit.export``, and ``--reset-anchor`` asserts ``vault.configure``. A
+   refusal exits 1 before any work happens: nothing is queried, no chain is
+   read, no export file is written, and the tip anchor is left untouched.
+
+   ``--verify`` shares ``audit.view`` with the listing because verification
+   recomputes and compares — it mutates nothing, so it is a read of the chain,
+   and the audit module gates the same operation the same way.
+   ``--reset-anchor`` is the outlier: it clears the truncation anchor and
+   writes into the chain, which is vault administration.
 
    :confval:`ext-nrvault-cliAllowedOperations` excludes all three permissions
    by default, so for the unattributed CLI actor this command needs
@@ -444,6 +449,30 @@ Options
 --format=FORMAT, -f FORMAT
    Output format: ``text`` (default) or ``json``.
 
+.. important::
+
+   This command asserts ``vault.configure`` — the same permission
+   ``vault:audit --reset-anchor`` asserts, because both mutate tamper evidence.
+   An actor who truncates the log and then anchors makes the external sink
+   attest the truncated chain, which is the laundering the anchor exists to
+   prevent. A refusal exits 1 without reading the chain tip and without
+   publishing anything; in ``--format=json`` the body carries the reason.
+
+   ``--dry-run`` is gated identically rather than as a read: it publishes
+   nothing, but it prints the current chain tip — the value a forged anchor has
+   to reproduce — and it is the rehearsal of an administrative operation.
+
+   :confval:`ext-nrvault-cliAllowedOperations` excludes ``vault.configure`` by
+   default, so from a shell this command needs ``allowCliAccess`` **and** that
+   operation in the allowlist. **Scheduled runs are unaffected on a default
+   installation**: the *Vault Audit Chain Anchoring* task runs under
+   :bash:`scheduler:run`, which authenticates the ``_cli_`` administrator, and
+   the admin bypass grants it. Under ``disableAdminOverride`` the bypass is gone
+   by design and that identity needs a group carrying
+   ``tx_nrvault:vault.configure``; without it the task fails rather than
+   skipping quietly, because an anchoring run that did not happen must never
+   look like one that did.
+
 .. _command-audit-anchor-exit-codes:
 
 Exit codes
@@ -508,6 +537,27 @@ Options
    (``NO_EXTERNAL_SINK``, ``SINK_FAILURE``) as warnings. Useful while external
    sinks are still being rolled out, so a pending integration does not keep the
    check permanently red and train operators to ignore a real alarm.
+
+.. important::
+
+   This command asserts ``audit.view``, the same permission
+   ``vault:audit --verify`` and the audit module's *Verify chain* action
+   assert: verification recomputes and compares, it mutates nothing, so it is a
+   read of the chain wherever it is invoked from. A refusal exits 1 without
+   running any verification, and in ``--format=json`` reports ``valid: false``
+   — a verifier that was not allowed to run must never read as a verifier that
+   found nothing. ``--tamper-only`` does not soften a refusal: that is not a
+   finding about the chain.
+
+   :confval:`ext-nrvault-cliAllowedOperations` excludes ``audit.view`` by
+   default, so from a shell this command needs ``allowCliAccess`` **and** that
+   operation in the allowlist. **Scheduled runs are unaffected on a default
+   installation**: the *Vault Audit Integrity Verification* task runs under
+   :bash:`scheduler:run`, which authenticates the ``_cli_`` administrator, and
+   the admin bypass grants it. Under ``disableAdminOverride`` that identity
+   needs a group carrying ``tx_nrvault:audit.view``; without it the task fails,
+   for the same reason a verification that threw does — a check that did not
+   run must never report success.
 
 .. _command-audit-verify-reason-codes:
 

--- a/Documentation/Operations/BackupAndRestore.rst
+++ b/Documentation/Operations/BackupAndRestore.rst
@@ -154,9 +154,11 @@ Restore procedure
 
     ..  note::
 
-        Both assert ``vault.configure``, which
-        :confval:`ext-nrvault-cliAllowedOperations` excludes. On the CLI they
-        need ``allowCliAccess = 1`` **and** that operation in the allowlist, or
+        ``vault:audit-anchor`` and ``--reset-anchor`` assert
+        ``vault.configure``; ``--verify`` asserts ``audit.view``. Both
+        permissions are excluded by
+        :confval:`ext-nrvault-cliAllowedOperations`, so on the CLI these steps
+        need ``allowCliAccess = 1`` **and** the operation in the allowlist, or
         a named technical actor. Restoring the allowlist to its previous value
         is part of finishing the restore.
 

--- a/Documentation/Operations/BackupAndRestore.rst
+++ b/Documentation/Operations/BackupAndRestore.rst
@@ -152,6 +152,14 @@ Restore procedure
         vendor/bin/typo3 vault:audit --verify
         vendor/bin/typo3 vault:audit --reset-anchor
 
+    ..  note::
+
+        Both assert ``vault.configure``, which
+        :confval:`ext-nrvault-cliAllowedOperations` excludes. On the CLI they
+        need ``allowCliAccess = 1`` **and** that operation in the allowlist, or
+        a named technical actor. Restoring the allowlist to its previous value
+        is part of finishing the restore.
+
 ..  warning::
 
     Do not run a restored production database against a *fresh* master key in

--- a/Documentation/Operations/Decommissioning.rst
+++ b/Documentation/Operations/Decommissioning.rst
@@ -101,6 +101,19 @@ a verification run after key destruction proves nothing.
 
         vendor/bin/typo3 vault:audit-anchor
 
+    ..  note::
+
+        Both commands assert an operation permission (breaking change; they
+        previously asserted none): ``vault:audit-verify`` needs ``audit.view``,
+        ``vault:audit-anchor`` needs ``vault.configure``, and the export in the
+        next step needs ``audit.export``. All three are excluded from the
+        :confval:`ext-nrvault-cliAllowedOperations` default, so from a shell
+        they need ``allowCliAccess = 1`` **and** the operation in that
+        allowlist — or, better for an evidence run, a named technical actor, so
+        the record names who collected the evidence. Sort the grant out before
+        the decommissioning window: after the master key is destroyed there is
+        no second chance at this output.
+
 #.  **Export the audit log** in full, over the entire retained period, with
     the hash columns included — ``uid``, ``previous_hash``, ``entry_hash``,
     ``hmac_key_epoch``. Without them the export is a log, not evidence.

--- a/Documentation/Operations/HardenedDeployment.rst
+++ b/Documentation/Operations/HardenedDeployment.rst
@@ -228,6 +228,16 @@ Two separate jobs, doing different things (see
 Register :php:`AuditAnchorTask` and :php:`AuditVerifyTask` in
 :guilabel:`Scheduler > Add task`, or run the commands from cron.
 
+..  note::
+
+    Anchoring asserts ``vault.configure`` and verification asserts
+    ``audit.view``, at both entry points — the command and the task. The
+    scheduler form is granted through the ``_cli_`` administrator until step 6
+    withdraws that bypass; the **cron** form is not, because it runs as the
+    unattributed CLI actor and
+    :confval:`ext-nrvault-cliAllowedOperations` excludes both permissions.
+    Prefer the scheduler tasks here, and read step 6 before you choose cron.
+
 Publish the first anchor by hand now, so verification has a baseline
 immediately rather than after the first scheduled run:
 
@@ -252,11 +262,23 @@ arms itself on the next audit write; confirm it did, then require it:
 
 ..  note::
 
-    ``vault:audit --verify`` asserts ``vault.configure``; the listing form used
-    further down asserts ``audit.view``. Neither is in the
-    :confval:`ext-nrvault-cliAllowedOperations` default, and with the admin
-    override disabled an admin no longer holds them implicitly — grant them to
-    the group these checks run as, or run them as a named technical actor.
+    ``vault:audit --verify`` asserts ``audit.view``, the same permission as the
+    listing form used further down — verification is a read of the chain.
+    ``audit.view`` is not in the :confval:`ext-nrvault-cliAllowedOperations`
+    default, and with the admin override disabled an admin no longer holds it
+    implicitly — grant it to the group these checks run as, or run them as a
+    named technical actor.
+
+    The same applies to the two scheduled controls, and this is the profile
+    where it bites. :bash:`scheduler:run` authenticates the ``_cli_``
+    administrator, so on a default installation the admin bypass grants both
+    tasks; once the override is withdrawn it does not. Give the identity the
+    scheduler runs as a group carrying ``tx_nrvault:audit.view`` (*Vault Audit
+    Integrity Verification*) and ``tx_nrvault:vault.configure`` (*Vault Audit
+    Chain Anchoring*) as part of this step. Both tasks fail loudly on a refusal
+    rather than skipping quietly, so a missed grant shows up as a red scheduler
+    entry — but a red anchoring task is a blind window that grows, so treat it
+    as urgent.
 
 ..  code-block:: none
     :caption: Extension configuration — only after the anchor reports ``ok``

--- a/Documentation/Operations/HardenedDeployment.rst
+++ b/Documentation/Operations/HardenedDeployment.rst
@@ -250,6 +250,14 @@ arms itself on the next audit write; confirm it did, then require it:
 
     vendor/bin/typo3 vault:audit --verify   # "Tip anchor: ok" — not "NOT ARMED"
 
+..  note::
+
+    ``vault:audit --verify`` asserts ``vault.configure``; the listing form used
+    further down asserts ``audit.view``. Neither is in the
+    :confval:`ext-nrvault-cliAllowedOperations` default, and with the admin
+    override disabled an admin no longer holds them implicitly — grant them to
+    the group these checks run as, or run them as a named technical actor.
+
 ..  code-block:: none
     :caption: Extension configuration — only after the anchor reports ``ok``
 

--- a/Documentation/Operations/IncidentResponse.rst
+++ b/Documentation/Operations/IncidentResponse.rst
@@ -37,6 +37,17 @@ Step 1 — preserve, before you change anything
     # Snapshot the external anchor file as it stands now.
     cp <auditSinkAnchorPath> incident-anchor-before.ndjson
 
+..  important::
+
+    Every vault command in this runbook asserts an operation permission, and
+    :confval:`ext-nrvault-cliAllowedOperations` excludes all of them:
+    ``audit.view`` for reading and verifying (``vault:audit``,
+    ``vault:audit-verify``), ``audit.export`` for ``--export``, and
+    ``vault.configure`` for re-anchoring (``vault:audit-anchor``) in step 5.
+    Under time pressure this is the moment the command exits 1 — sort the grant
+    out before the incident, not during it. A named technical actor for the
+    response runbook is the clean answer: the trail then names who responded.
+
 Copy the audit rows for the affected identifiers and the suspected time window
 out of the system as well (see :ref:`auditor-evidence-collection` for the
 export). A rotation in step 3 changes ``hash_before`` / ``hash_after`` and adds
@@ -52,12 +63,10 @@ Step 2 — determine scope from the audit log
 
 ..  note::
 
-    Reading the audit log asserts ``audit.view``, and ``--export`` asserts
-    ``audit.export``; :confval:`ext-nrvault-cliAllowedOperations` excludes
-    both. Under time pressure this is the moment the command exits 1 — sort the
-    grant out before the incident (a named technical actor for the response
-    runbook is the clean answer), not during it. The audit module in the
-    backend needs the same two permissions and no CLI allowlist entry.
+    Reading the audit log asserts ``audit.view`` — the same permission the
+    verification in step 1 needs — and ``--export`` asserts ``audit.export``;
+    :confval:`ext-nrvault-cliAllowedOperations` excludes both. The audit module
+    in the backend needs the same two permissions and no CLI allowlist entry.
 
 Answer these, and write down the answers:
 

--- a/Documentation/Operations/IncidentResponse.rst
+++ b/Documentation/Operations/IncidentResponse.rst
@@ -50,6 +50,15 @@ Step 2 — determine scope from the audit log
     # Everything that happened to one identifier.
     vendor/bin/typo3 vault:audit --identifier=<identifier>
 
+..  note::
+
+    Reading the audit log asserts ``audit.view``, and ``--export`` asserts
+    ``audit.export``; :confval:`ext-nrvault-cliAllowedOperations` excludes
+    both. Under time pressure this is the moment the command exits 1 — sort the
+    grant out before the incident (a named technical actor for the response
+    runbook is the clean answer), not during it. The audit module in the
+    backend needs the same two permissions and no CLI allowlist entry.
+
 Answer these, and write down the answers:
 
 *   **Which secrets?** Only the one observed, or every secret the compromised

--- a/Documentation/Operations/KeyRotation.rst
+++ b/Documentation/Operations/KeyRotation.rst
@@ -125,6 +125,8 @@ Your own preflight, before running any of it:
 
       ..  code-block:: bash
 
+          # Asserts audit.view; on the CLI that needs allowCliAccess = 1 AND
+          # audit.view in cliAllowedOperations, or a named technical actor.
           vendor/bin/typo3 vault:audit-verify
 
 *   [ ] **A maintenance window.** Vault reads fail between the commit and the
@@ -226,10 +228,13 @@ Verification
     #    a reveal in the backend module proves the same decrypt path.
     vendor/bin/typo3 vault:retrieve <a-known-identifier>
 
-    # 3. The chain verifies under the new key, end to end.
+    # 3. The chain verifies under the new key, end to end. Needs audit.view:
+    #    on the CLI that is allowCliAccess = 1 AND audit.view in
+    #    cliAllowedOperations, or a named technical actor.
     vendor/bin/typo3 vault:audit-verify
 
-    # 4. Anchor the new tip; the old anchor's baseline is now stale.
+    # 4. Anchor the new tip; the old anchor's baseline is now stale. Needs
+    #    vault.configure, on the same terms as step 5 below.
     vendor/bin/typo3 vault:audit-anchor
 
     # 5. The in-database anchor is re-sealed by the rotation itself. Confirm

--- a/Documentation/Operations/KeyRotation.rst
+++ b/Documentation/Operations/KeyRotation.rst
@@ -235,6 +235,8 @@ Verification
     # 5. The in-database anchor is re-sealed by the rotation itself. Confirm
     #    it reads "Tip anchor: ok" — a re-key that left it UNREADABLE means
     #    the re-seal did not complete, and that is a finding, not a nuisance.
+    #    Needs vault.configure: on the CLI that is allowCliAccess = 1 AND
+    #    vault.configure in cliAllowedOperations, or a named technical actor.
     vendor/bin/typo3 vault:audit --verify
 
 Probe at least two secrets, and pick them from different encryption versions

--- a/Documentation/Operations/MonitoringAndAlerting.rst
+++ b/Documentation/Operations/MonitoringAndAlerting.rst
@@ -62,6 +62,32 @@ Alternatively, run the commands from cron:
     can still hide. Hourly is a reasonable starting point; daily is the loosest
     defensible setting for a vault under audit.
 
+..  important::
+
+    **Both entry points assert an operation permission** (breaking change; they
+    previously asserted nothing). ``vault:audit-verify`` and
+    :php:`AuditVerifyTask` assert ``audit.view`` — verification recomputes and
+    compares, so it is a read of the chain. ``vault:audit-anchor`` and
+    :php:`AuditAnchorTask` assert ``vault.configure`` — publishing an anchor
+    mutates tamper evidence, and an actor who truncates the log and then
+    anchors makes the external sink attest the truncated chain.
+
+    **Scheduler tasks are unaffected on a default installation**:
+    :bash:`scheduler:run` authenticates the ``_cli_`` administrator, who passes
+    through the admin bypass. **The cron form above is affected**: it runs as
+    the unattributed CLI actor, which holds neither permission unless
+    ``allowCliAccess = 1`` **and** the operation is listed in
+    :confval:`ext-nrvault-cliAllowedOperations`. Prefer the scheduler tasks, or
+    run the cron entries as a named technical actor
+    (:ref:`developer-technical-actor-context`) so the audit trail names the
+    identity that anchored. A refusal exits non-zero, and the JSON form of
+    ``vault:audit-verify`` reports ``valid: false`` — so an alert fires rather
+    than the check quietly reading as clean.
+
+    Under ``disableAdminOverride`` the scheduler loses the bypass too; see
+    :ref:`operations-hardened-deployment-step6` for the group grant that keeps
+    both tasks running.
+
 ``nr_vault_tamper_only``
 ------------------------
 

--- a/Documentation/Security/Index.rst
+++ b/Documentation/Security/Index.rst
@@ -343,12 +343,15 @@ Permission                          Governs
 ``tx_nrvault:secret.delete``        Deleting secrets.
 ``tx_nrvault:secret.manage_policy`` Enabling/disabling secrets and editing their
                                     ``allowed_groups`` / ``write_groups`` tiers.
-``tx_nrvault:audit.view``           Reading the audit log, its usage analytics, and verifying the
-                                    hash chain.
-``tx_nrvault:audit.export``         Downloading the audit log (JSON / CSV).
+``tx_nrvault:audit.view``           Reading the audit log and its usage analytics (audit module,
+                                    ``vault:audit``), and verifying the hash chain in the module.
+``tx_nrvault:audit.export``         Downloading the audit log (JSON / CSV), in the module and via
+                                    ``vault:audit --export``.
 ``tx_nrvault:master_key.rotate``    Rotating the master key.
-``tx_nrvault:vault.configure``      Running the migration wizard, and seeing the detailed
-                                    ``vault:doctor`` finding list in the Overview module.
+``tx_nrvault:vault.configure``      Running the migration wizard, seeing the detailed
+                                    ``vault:doctor`` finding list in the Overview module, and the
+                                    CLI chain-integrity operations ``vault:audit --verify`` and
+                                    ``--reset-anchor``.
 =================================== ==============================================================
 
 Notes on the model:

--- a/Documentation/Security/Index.rst
+++ b/Documentation/Security/Index.rst
@@ -343,18 +343,32 @@ Permission                          Governs
 ``tx_nrvault:secret.delete``        Deleting secrets.
 ``tx_nrvault:secret.manage_policy`` Enabling/disabling secrets and editing their
                                     ``allowed_groups`` / ``write_groups`` tiers.
-``tx_nrvault:audit.view``           Reading the audit log and its usage analytics (audit module,
-                                    ``vault:audit``), and verifying the hash chain in the module.
+``tx_nrvault:audit.view``           Reading the audit log and its usage analytics, and verifying
+                                    the hash chain — in the audit module, via ``vault:audit`` /
+                                    ``vault:audit --verify`` / ``vault:audit-verify``, and in the
+                                    *Vault Audit Integrity Verification* scheduler task.
 ``tx_nrvault:audit.export``         Downloading the audit log (JSON / CSV), in the module and via
                                     ``vault:audit --export``.
 ``tx_nrvault:master_key.rotate``    Rotating the master key.
 ``tx_nrvault:vault.configure``      Running the migration wizard, seeing the detailed
-                                    ``vault:doctor`` finding list in the Overview module, and the
-                                    CLI chain-integrity operations ``vault:audit --verify`` and
-                                    ``--reset-anchor``.
+                                    ``vault:doctor`` finding list in the Overview module, and
+                                    mutating the audit chain-tip anchor — ``vault:audit-anchor``,
+                                    the *Vault Audit Chain Anchoring* scheduler task, and
+                                    ``vault:audit --reset-anchor``.
 =================================== ==============================================================
 
 Notes on the model:
+
+-  **The permission follows the operation's effect, not the command it
+   happens to live in.** The same operation answers to the same permission
+   through every entry point — interactive CLI, the scheduler-task wrapper
+   command, the scheduler task class, and the backend module — so a gate on
+   one entry point cannot be walked around by reaching for another. Verifying
+   the chain is a read (it recomputes and compares, it mutates nothing) and
+   therefore takes ``audit.view`` everywhere; publishing or resetting the tip
+   anchor mutates tamper evidence and therefore takes ``vault.configure``
+   everywhere. Auditing an installation means checking the *effect*, not
+   enumerating commands.
 
 -  **``secret.use`` does not imply ``secret.reveal``**, and neither
    implies the other. A non-admin needs **both** for an end-to-end

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -506,6 +506,14 @@ View the audit log:
    # Export to JSON
    vendor/bin/typo3 vault:audit --format=json > audit.json
 
+.. important::
+
+   Listing asserts ``audit.view``, ``--export`` asserts ``audit.export``, and
+   ``--verify`` / ``--reset-anchor`` assert ``vault.configure``. On the CLI all
+   three additionally need ``allowCliAccess`` plus the operation in
+   :confval:`ext-nrvault-cliAllowedOperations`, which excludes them by default
+   — see :ref:`command-audit`.
+
 Verify the tamper-evident chain:
 
 .. code-block:: bash

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -508,9 +508,11 @@ View the audit log:
 
 .. important::
 
-   Listing asserts ``audit.view``, ``--export`` asserts ``audit.export``, and
-   ``--verify`` / ``--reset-anchor`` assert ``vault.configure``. On the CLI all
-   three additionally need ``allowCliAccess`` plus the operation in
+   Listing and ``--verify`` assert ``audit.view`` — verification recomputes and
+   compares, which is a read of the chain. ``--export`` asserts
+   ``audit.export``, and ``--reset-anchor`` asserts ``vault.configure``,
+   because it mutates tamper evidence. On the CLI all three additionally need
+   ``allowCliAccess`` plus the operation in
    :confval:`ext-nrvault-cliAllowedOperations`, which excludes them by default
    — see :ref:`command-audit`.
 

--- a/Tests/Functional/Audit/AuditChainAnchorTest.php
+++ b/Tests/Functional/Audit/AuditChainAnchorTest.php
@@ -315,7 +315,12 @@ final class AuditChainAnchorTest extends AbstractVaultFunctionalTestCase
         $this->writeEntries($subject, 4);
         $this->truncateAuditLog();
 
-        $command = new VaultAuditCommand($subject, $store, $this->get(ConnectionPool::class));
+        $command = new VaultAuditCommand(
+            $subject,
+            $store,
+            $this->get(ConnectionPool::class),
+            $this->get(AccessControlServiceInterface::class),
+        );
         $command->setName('vault:audit');
         $exitCode = (new CommandTester($command))->execute(['--reset-anchor' => true, '--force' => true]);
 

--- a/Tests/Functional/Command/Fixtures/be_users_audit_permission.csv
+++ b/Tests/Functional/Command/Fixtures/be_users_audit_permission.csv
@@ -1,0 +1,12 @@
+"be_groups",,,,
+,"uid","pid","title","custom_options"
+,41,0,"audit-viewers","tx_nrvault:audit.view"
+,42,0,"audit-exporters","tx_nrvault:audit.export"
+,43,0,"vault-configurators","tx_nrvault:vault.configure"
+"be_users",,,,,,,
+,"uid","username","password","admin","disable","starttime","endtime","usergroup"
+,1,"admin","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",1,0,0,0,""
+,2,"no_vault_permissions","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0,""
+,3,"audit_viewer","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0,"41"
+,4,"audit_exporter","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0,"42"
+,5,"vault_configurator","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0,"43"

--- a/Tests/Functional/Command/VaultAuditAnchorCommandTest.php
+++ b/Tests/Functional/Command/VaultAuditAnchorCommandTest.php
@@ -30,7 +30,16 @@ final class VaultAuditAnchorCommandTest extends AbstractVaultFunctionalTestCase
 {
     use AuditSinkSandboxTrait;
 
-    protected ?string $backendUserFixture = __DIR__ . '/../Fixtures/Users/be_users.csv';
+    /** Non-admin whose group carries no vault permission at all. */
+    private const NO_PERMISSIONS = 2;
+
+    /** Non-admin holding `audit.view` only. */
+    private const AUDIT_VIEWER = 3;
+
+    /** Non-admin holding `vault.configure` only. */
+    private const VAULT_CONFIGURATOR = 5;
+
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_audit_permission.csv';
 
     /** @var array<string, mixed> */
     protected array $extensionConfiguration = [
@@ -134,6 +143,83 @@ final class VaultAuditAnchorCommandTest extends AbstractVaultFunctionalTestCase
         // the installation — which is worth recording, not an error.
         self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
         self::assertStringContainsString('empty chain', $tester->getDisplay());
+    }
+
+    /**
+     * The gate this pins: the wrapper asserted no permission at all, so an
+     * actor who could not run `vault:audit --reset-anchor` could still re-attest
+     * the chain from here. A refusal must publish nothing — an anchor written on
+     * an unauthorized run is exactly the laundering the anchor guards against.
+     */
+    #[Test]
+    public function anchoringIsRefusedWithoutVaultConfigure(): void
+    {
+        $this->get(AuditLogServiceInterface::class)->log('anchor_cmd_secret', 'create', true);
+        $this->setUpBackendUser(self::NO_PERMISSIONS);
+
+        $tester = new CommandTester($this->get(VaultAuditAnchorCommand::class));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString(
+            'Access denied: the "vault.configure" permission is required to publish the audit chain tip.',
+            $this->normalize($tester),
+        );
+        self::assertFileDoesNotExist($this->auditSinkAnchorPath);
+    }
+
+    /**
+     * Reading the audit log is not re-attesting it to an external observer.
+     */
+    #[Test]
+    public function anchoringIsRefusedForAnActorHoldingOnlyAuditView(): void
+    {
+        $this->get(AuditLogServiceInterface::class)->log('anchor_cmd_secret', 'create', true);
+        $this->setUpBackendUser(self::AUDIT_VIEWER);
+
+        $tester = new CommandTester($this->get(VaultAuditAnchorCommand::class));
+
+        self::assertSame(Command::FAILURE, $tester->execute([]));
+        self::assertFileDoesNotExist($this->auditSinkAnchorPath);
+    }
+
+    /**
+     * `--dry-run` publishes nothing, but it prints the current chain tip — the
+     * value a forged anchor has to reproduce — so it is gated identically.
+     */
+    #[Test]
+    public function dryRunIsRefusedWithoutVaultConfigure(): void
+    {
+        $this->get(AuditLogServiceInterface::class)->log('anchor_cmd_secret', 'create', true);
+        $this->setUpBackendUser(self::AUDIT_VIEWER);
+
+        $tester = new CommandTester($this->get(VaultAuditAnchorCommand::class));
+        $exitCode = $tester->execute(['--dry-run' => true]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringNotContainsString('Chain tip', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function anchoringIsAllowedWithVaultConfigurePermission(): void
+    {
+        $this->get(AuditLogServiceInterface::class)->log('anchor_cmd_secret', 'create', true);
+        $this->setUpBackendUser(self::VAULT_CONFIGURATOR);
+
+        $tester = new CommandTester($this->get(VaultAuditAnchorCommand::class));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
+        self::assertFileExists($this->auditSinkAnchorPath);
+    }
+
+    /**
+     * SymfonyStyle wraps its error block to the terminal width; collapsing
+     * whitespace lets the assertions pin the whole refusal sentence.
+     */
+    private function normalize(CommandTester $tester): string
+    {
+        return (string) preg_replace('/\s+/', ' ', $tester->getDisplay());
     }
 
     /**

--- a/Tests/Functional/Command/VaultAuditCommandTest.php
+++ b/Tests/Functional/Command/VaultAuditCommandTest.php
@@ -1,0 +1,313 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Command;
+
+use Netresearch\NrVault\Audit\AuditAction;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Command\VaultAuditCommand;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * The operation-permission gate on `vault:audit`, end to end.
+ *
+ * The command used to assert nothing at all, while the same four capabilities
+ * were gated in the backend module (`AuditController`). These tests drive the
+ * real command through the container against real backend users whose groups
+ * carry — or do not carry — the `tx_nrvault:<permission>` custom option, so
+ * the verdict comes from `AccessControlService` reading actual group data
+ * rather than from a mock.
+ *
+ * Every refusal case asserts BOTH halves of "fail closed": a non-zero exit and
+ * the absence of the effect (no listing in the output, no export file, an
+ * untouched anchor row) — plus an unchanged audit-row count, which pins the
+ * decision that a refusal writes no `access_denied` entry here.
+ */
+#[CoversClass(VaultAuditCommand::class)]
+final class VaultAuditCommandTest extends AbstractVaultFunctionalTestCase
+{
+    private const AUDIT_TABLE = 'tx_nrvault_audit_log';
+
+    private const REGISTRY_TABLE = 'sys_registry';
+
+    private const ANCHOR_NAMESPACE = 'tx_nrvault_audit_anchor';
+
+    private const ANCHOR_KEY = 'auditChainTip';
+
+    /** Admin — holds every permission through the admin bypass. */
+    private const ADMIN = 1;
+
+    /** Non-admin whose group carries no vault permission at all. */
+    private const NO_PERMISSIONS = 2;
+
+    /** Non-admin holding `audit.view` only. */
+    private const AUDIT_VIEWER = 3;
+
+    /** Non-admin holding `audit.export` only. */
+    private const AUDIT_EXPORTER = 4;
+
+    /** Non-admin holding `vault.configure` only. */
+    private const VAULT_CONFIGURATOR = 5;
+
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_audit_permission.csv';
+
+    /** Each test logs in the actor it needs, after seeding as admin. */
+    protected ?int $backendUserUid = null;
+
+    /** @var array<string, mixed> */
+    protected array $extensionConfiguration = [
+        // Arms the in-DB tip anchor, so the --reset-anchor cases operate on a
+        // real anchor row rather than on an absent one.
+        'auditHmacEpoch' => 1,
+    ];
+
+    #[Test]
+    public function listingIsRefusedWithoutAuditViewPermission(): void
+    {
+        $identifier = $this->seedAuditEntry();
+        $this->setUpBackendUser(self::NO_PERMISSIONS);
+        $entriesBefore = $this->countAuditEntries();
+
+        $tester = $this->executeAudit([]);
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString(
+            'Access denied: the "audit.view" permission is required to read the audit log.',
+            $this->normalize($tester),
+        );
+        self::assertStringNotContainsString($identifier, $tester->getDisplay());
+        self::assertSame($entriesBefore, $this->countAuditEntries());
+    }
+
+    #[Test]
+    public function listingIsAllowedWithAuditViewPermission(): void
+    {
+        $identifier = $this->seedAuditEntry();
+        $this->setUpBackendUser(self::AUDIT_VIEWER);
+
+        $tester = $this->executeAudit(['--identifier' => $identifier]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode(), $tester->getDisplay());
+        self::assertStringContainsString($identifier, $tester->getDisplay());
+    }
+
+    #[Test]
+    public function listingIsUnchangedForAnAdmin(): void
+    {
+        $identifier = $this->seedAuditEntry();
+        $this->setUpBackendUser(self::ADMIN);
+
+        $tester = $this->executeAudit(['--identifier' => $identifier, '--format' => 'json']);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode(), $tester->getDisplay());
+        $decoded = json_decode($tester->getDisplay(), true);
+        self::assertIsArray($decoded);
+        self::assertCount(1, $decoded);
+        $entry = $decoded[0];
+        self::assertIsArray($entry);
+        self::assertSame($identifier, $entry['secretIdentifier'] ?? null);
+    }
+
+    /**
+     * `audit.view` is not `audit.export`: reading the log in the terminal and
+     * carrying an unchained copy of it off the installation are different acts.
+     */
+    #[Test]
+    public function exportIsRefusedForAnActorHoldingOnlyAuditView(): void
+    {
+        $this->seedAuditEntry();
+        $this->setUpBackendUser(self::AUDIT_VIEWER);
+        $entriesBefore = $this->countAuditEntries();
+        $exportFile = $this->instancePath . '/refused-audit-export.json';
+
+        $tester = $this->executeAudit(['--export' => $exportFile]);
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString(
+            'Access denied: the "audit.export" permission is required to export audit entries to a file.',
+            $this->normalize($tester),
+        );
+        self::assertFileDoesNotExist($exportFile);
+        self::assertSame($entriesBefore, $this->countAuditEntries());
+    }
+
+    #[Test]
+    public function exportIsAllowedWithAuditExportPermission(): void
+    {
+        $identifier = $this->seedAuditEntry();
+        $this->setUpBackendUser(self::AUDIT_EXPORTER);
+        $exportFile = $this->instancePath . '/audit-export.json';
+
+        try {
+            $tester = $this->executeAudit(['--identifier' => $identifier, '--export' => $exportFile]);
+
+            self::assertSame(Command::SUCCESS, $tester->getStatusCode(), $tester->getDisplay());
+            self::assertFileExists($exportFile);
+            self::assertStringContainsString($identifier, (string) file_get_contents($exportFile));
+        } finally {
+            if (file_exists($exportFile)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
+                unlink($exportFile);
+            }
+        }
+    }
+
+    #[Test]
+    public function verifyIsRefusedForAnActorHoldingOnlyAuditView(): void
+    {
+        $this->seedAuditEntry();
+        $this->setUpBackendUser(self::AUDIT_VIEWER);
+        $entriesBefore = $this->countAuditEntries();
+
+        $tester = $this->executeAudit(['--verify' => true]);
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString(
+            'Access denied: the "vault.configure" permission is required to verify or reset the audit hash chain.',
+            $this->normalize($tester),
+        );
+        self::assertStringNotContainsString('Hash chain', $tester->getDisplay());
+        self::assertSame($entriesBefore, $this->countAuditEntries());
+    }
+
+    #[Test]
+    public function verifyIsAllowedWithVaultConfigurePermission(): void
+    {
+        $this->seedAuditEntry();
+        $this->setUpBackendUser(self::VAULT_CONFIGURATOR);
+
+        $tester = $this->executeAudit(['--verify' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode(), $tester->getDisplay());
+        self::assertStringContainsString('Hash chain is valid', $tester->getDisplay());
+    }
+
+    #[Test]
+    public function resetAnchorIsRefusedForAnActorHoldingOnlyAuditView(): void
+    {
+        $this->seedAuditEntry();
+        $this->setUpBackendUser(self::AUDIT_VIEWER);
+
+        $anchorBefore = $this->readAnchor();
+        self::assertNotNull($anchorBefore, 'The seeded audit write must have armed the anchor.');
+        $entriesBefore = $this->countAuditEntries();
+
+        $tester = $this->executeAudit(['--reset-anchor' => true, '--force' => true]);
+
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringContainsString(
+            'Access denied: the "vault.configure" permission is required to verify or reset the audit hash chain.',
+            $this->normalize($tester),
+        );
+        self::assertSame($anchorBefore, $this->readAnchor(), 'A refused reset must leave the anchor untouched.');
+        self::assertSame($entriesBefore, $this->countAuditEntries());
+        self::assertSame(0, $this->countAuditEntries(AuditAction::AuditAnchorReset->value));
+    }
+
+    #[Test]
+    public function resetAnchorIsAllowedWithVaultConfigurePermission(): void
+    {
+        $this->seedAuditEntry();
+        $this->setUpBackendUser(self::VAULT_CONFIGURATOR);
+
+        $tester = $this->executeAudit(['--reset-anchor' => true, '--force' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode(), $tester->getDisplay());
+        self::assertStringContainsString('Tip anchor reset', $tester->getDisplay());
+        self::assertSame(
+            1,
+            $this->countAuditEntries(AuditAction::AuditAnchorReset->value),
+            'The reset must be recorded in the chain it clears the anchor of.',
+        );
+    }
+
+    /**
+     * Write one audit entry as the admin and return the identifier it names.
+     */
+    private function seedAuditEntry(): string
+    {
+        $this->setUpBackendUser(self::ADMIN);
+        $identifier = 'cmd_audit_gate_' . bin2hex(random_bytes(4));
+
+        $this->get(AuditLogServiceInterface::class)->log(
+            $identifier,
+            AuditAction::Read->value,
+            true,
+            null,
+            'Seeded by the vault:audit permission gate test',
+        );
+
+        return $identifier;
+    }
+
+    /**
+     * @param array<string, string|bool> $arguments
+     */
+    private function executeAudit(array $arguments): CommandTester
+    {
+        $tester = new CommandTester($this->get(VaultAuditCommand::class));
+        $tester->execute($arguments);
+
+        return $tester;
+    }
+
+    private function countAuditEntries(?string $action = null): int
+    {
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::AUDIT_TABLE);
+        $queryBuilder = $connection->createQueryBuilder();
+        $queryBuilder->count('uid')->from(self::AUDIT_TABLE);
+
+        if ($action !== null) {
+            $queryBuilder->where(
+                $queryBuilder->expr()->eq('action', $queryBuilder->createNamedParameter($action)),
+            );
+        }
+
+        return (int) $queryBuilder->executeQuery()->fetchOne();
+    }
+
+    /**
+     * The raw, MAC-signed anchor value, or null when no anchor row exists.
+     */
+    private function readAnchor(): ?string
+    {
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::REGISTRY_TABLE);
+        $queryBuilder = $connection->createQueryBuilder();
+        $value = $queryBuilder
+            ->select('entry_value')
+            ->from(self::REGISTRY_TABLE)
+            ->where(
+                $queryBuilder->expr()->eq(
+                    'entry_namespace',
+                    $queryBuilder->createNamedParameter(self::ANCHOR_NAMESPACE),
+                ),
+                $queryBuilder->expr()->eq(
+                    'entry_key',
+                    $queryBuilder->createNamedParameter(self::ANCHOR_KEY),
+                ),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return \is_string($value) ? $value : null;
+    }
+
+    /**
+     * SymfonyStyle wraps its error block to the terminal width; collapsing
+     * whitespace lets the assertions pin the whole refusal sentence.
+     */
+    private function normalize(CommandTester $tester): string
+    {
+        return (string) preg_replace('/\s+/', ' ', $tester->getDisplay());
+    }
+}

--- a/Tests/Functional/Command/VaultAuditCommandTest.php
+++ b/Tests/Functional/Command/VaultAuditCommandTest.php
@@ -163,33 +163,56 @@ final class VaultAuditCommandTest extends AbstractVaultFunctionalTestCase
     }
 
     #[Test]
-    public function verifyIsRefusedForAnActorHoldingOnlyAuditView(): void
+    public function verifyIsRefusedWithoutAuditViewPermission(): void
     {
         $this->seedAuditEntry();
-        $this->setUpBackendUser(self::AUDIT_VIEWER);
+        $this->setUpBackendUser(self::NO_PERMISSIONS);
         $entriesBefore = $this->countAuditEntries();
 
         $tester = $this->executeAudit(['--verify' => true]);
 
         self::assertSame(Command::FAILURE, $tester->getStatusCode());
         self::assertStringContainsString(
-            'Access denied: the "vault.configure" permission is required to verify or reset the audit hash chain.',
+            'Access denied: the "audit.view" permission is required to verify the audit hash chain.',
             $this->normalize($tester),
         );
         self::assertStringNotContainsString('Hash chain', $tester->getDisplay());
         self::assertSame($entriesBefore, $this->countAuditEntries());
     }
 
+    /**
+     * Verification recomputes and compares — it mutates nothing, so it is a
+     * read of the chain and shares `audit.view` with the listing, exactly as
+     * `AuditController::verifyChainAction()` does in the backend module. The
+     * same operation must not answer differently depending on where it is
+     * invoked from.
+     */
     #[Test]
-    public function verifyIsAllowedWithVaultConfigurePermission(): void
+    public function verifyIsAllowedWithAuditViewPermission(): void
+    {
+        $this->seedAuditEntry();
+        $this->setUpBackendUser(self::AUDIT_VIEWER);
+
+        $tester = $this->executeAudit(['--verify' => true]);
+
+        self::assertSame(Command::SUCCESS, $tester->getStatusCode(), $tester->getDisplay());
+        self::assertStringContainsString('Hash chain is valid', $tester->getDisplay());
+    }
+
+    /**
+     * The administrative permission is not a stand-in for the read: it gates
+     * `--reset-anchor`, which mutates tamper evidence, and nothing else here.
+     */
+    #[Test]
+    public function verifyIsRefusedForAnActorHoldingOnlyVaultConfigure(): void
     {
         $this->seedAuditEntry();
         $this->setUpBackendUser(self::VAULT_CONFIGURATOR);
 
         $tester = $this->executeAudit(['--verify' => true]);
 
-        self::assertSame(Command::SUCCESS, $tester->getStatusCode(), $tester->getDisplay());
-        self::assertStringContainsString('Hash chain is valid', $tester->getDisplay());
+        self::assertSame(Command::FAILURE, $tester->getStatusCode());
+        self::assertStringNotContainsString('Hash chain', $tester->getDisplay());
     }
 
     #[Test]
@@ -206,7 +229,7 @@ final class VaultAuditCommandTest extends AbstractVaultFunctionalTestCase
 
         self::assertSame(Command::FAILURE, $tester->getStatusCode());
         self::assertStringContainsString(
-            'Access denied: the "vault.configure" permission is required to verify or reset the audit hash chain.',
+            'Access denied: the "vault.configure" permission is required to reset the audit chain tip anchor.',
             $this->normalize($tester),
         );
         self::assertSame($anchorBefore, $this->readAnchor(), 'A refused reset must leave the anchor untouched.');

--- a/Tests/Functional/Command/VaultAuditVerifyCommandTest.php
+++ b/Tests/Functional/Command/VaultAuditVerifyCommandTest.php
@@ -35,7 +35,16 @@ final class VaultAuditVerifyCommandTest extends AbstractVaultFunctionalTestCase
 {
     use AuditSinkSandboxTrait;
 
-    protected ?string $backendUserFixture = __DIR__ . '/../Fixtures/Users/be_users.csv';
+    /** Non-admin whose group carries no vault permission at all. */
+    private const NO_PERMISSIONS = 2;
+
+    /** Non-admin holding `audit.view` only. */
+    private const AUDIT_VIEWER = 3;
+
+    /** Non-admin holding `vault.configure` only. */
+    private const VAULT_CONFIGURATOR = 5;
+
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_audit_permission.csv';
 
     /** @var array<string, mixed> */
     protected array $extensionConfiguration = [
@@ -190,12 +199,105 @@ final class VaultAuditVerifyCommandTest extends AbstractVaultFunctionalTestCase
         self::assertStringContainsString('file', $tester->getDisplay());
     }
 
+    /**
+     * The gate this pins: the wrapper checks strictly more than
+     * `vault:audit --verify` — the external anchor as well as the chain — while
+     * asserting nothing, which made the gate on the interactive command a
+     * formality. A refusal must run no verification and must not be mistakable
+     * for a clean result.
+     */
+    #[Test]
+    public function verificationIsRefusedWithoutAuditView(): void
+    {
+        $this->seedChain(3);
+        $this->publishAnchor();
+        $this->setUpBackendUser(self::NO_PERMISSIONS);
+
+        $tester = new CommandTester($this->get(VaultAuditVerifyCommand::class));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString(
+            'Access denied: the "audit.view" permission is required to verify the audit log integrity.',
+            $this->normalize($tester),
+        );
+        self::assertStringNotContainsString('verified', $tester->getDisplay());
+    }
+
+    /**
+     * A monitor that only reads `valid` must see a refused verification as a
+     * failed one, never as an intact chain.
+     */
+    #[Test]
+    public function refusedJsonVerificationReportsInvalid(): void
+    {
+        $this->seedChain(3);
+        $this->publishAnchor();
+        $this->setUpBackendUser(self::NO_PERMISSIONS);
+
+        $tester = new CommandTester($this->get(VaultAuditVerifyCommand::class));
+        $exitCode = $tester->execute(['--format' => 'json']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+
+        $payload = json_decode($tester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+        self::assertFalse($payload['valid']);
+        self::assertIsString($payload['error']);
+        self::assertStringContainsString('audit.view', $payload['error']);
+    }
+
+    /**
+     * `audit.view` is the whole grant: verification is a read of the chain, so
+     * an actor who may see the audit log may also check it for tampering — the
+     * same rule `AuditController::verifyChainAction()` applies in the module.
+     */
+    #[Test]
+    public function verificationIsAllowedWithAuditViewPermission(): void
+    {
+        $this->seedChain(3);
+        $this->publishAnchor();
+        $this->setUpBackendUser(self::AUDIT_VIEWER);
+
+        $tester = new CommandTester($this->get(VaultAuditVerifyCommand::class));
+        $exitCode = $tester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode, $tester->getDisplay());
+        self::assertStringContainsString('verified', $tester->getDisplay());
+    }
+
+    /**
+     * And `vault.configure` is not a stand-in for it — the administrative
+     * permission does not carry the read.
+     */
+    #[Test]
+    public function verificationIsRefusedForAnActorHoldingOnlyVaultConfigure(): void
+    {
+        $this->seedChain(3);
+        $this->publishAnchor();
+        $this->setUpBackendUser(self::VAULT_CONFIGURATOR);
+
+        $tester = new CommandTester($this->get(VaultAuditVerifyCommand::class));
+
+        self::assertSame(Command::FAILURE, $tester->execute([]));
+    }
+
     private function seedChain(int $entries): void
     {
         $auditService = $this->get(AuditLogServiceInterface::class);
         for ($i = 0; $i < $entries; $i++) {
             $auditService->log('verify_cmd_secret', 'read', true);
         }
+    }
+
+    /**
+     * SymfonyStyle wraps its error block to the terminal width; collapsing
+     * whitespace lets the assertions pin the whole refusal sentence.
+     */
+    private function normalize(CommandTester $tester): string
+    {
+        return (string) preg_replace('/\s+/', ' ', $tester->getDisplay());
     }
 
     private function publishAnchor(): void

--- a/Tests/Unit/Command/VaultAuditAnchorCommandTest.php
+++ b/Tests/Unit/Command/VaultAuditAnchorCommandTest.php
@@ -1,0 +1,199 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Command;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Command\VaultAuditAnchorCommand;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * The operation-permission gate on `vault:audit-anchor`.
+ *
+ * Publishing an anchor mutates tamper evidence: an actor who truncates the log
+ * and then anchors makes the external sink attest the truncated chain. So the
+ * command asserts `vault.configure` — the same permission `vault:audit
+ * --reset-anchor` asserts for the other half of the anchor lifecycle.
+ */
+#[CoversClass(VaultAuditAnchorCommand::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class VaultAuditAnchorCommandTest extends TestCase
+{
+    private ChainTipAnchorServiceInterface&MockObject $anchorService;
+
+    private AuditSinkRegistryInterface&MockObject $sinkRegistry;
+
+    private AccessControlServiceInterface&MockObject $accessControlService;
+
+    /** @var list<VaultPermission> */
+    private array $grantedPermissions = [];
+
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->anchorService = $this->createMock(ChainTipAnchorServiceInterface::class);
+        $this->sinkRegistry = $this->createMock(AuditSinkRegistryInterface::class);
+        $this->sinkRegistry->method('getEnabledSinkIdentifiers')->willReturn(['file']);
+
+        $this->accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        $this->grantedPermissions = VaultPermission::cases();
+        $this->accessControlService
+            ->method('isGranted')
+            ->willReturnCallback(
+                fn (VaultPermission $permission): bool => \in_array($permission, $this->grantedPermissions, true),
+            );
+
+        $this->commandTester = new CommandTester(new VaultAuditAnchorCommand(
+            $this->anchorService,
+            $this->sinkRegistry,
+            $this->accessControlService,
+        ));
+    }
+
+    #[Test]
+    public function hasCorrectName(): void
+    {
+        $command = new VaultAuditAnchorCommand(
+            $this->anchorService,
+            $this->sinkRegistry,
+            $this->accessControlService,
+        );
+
+        self::assertSame('vault:audit-anchor', $command->getName());
+    }
+
+    /**
+     * A refusal must publish nothing AND read nothing: the chain tip it would
+     * print is the value a forged anchor has to reproduce.
+     */
+    #[Test]
+    public function refusesWithoutVaultConfigureAndPublishesNothing(): void
+    {
+        $this->grantedPermissions = $this->allPermissionsExcept(VaultPermission::VaultConfigure);
+
+        $this->anchorService->expects($this->never())->method('capture');
+        $this->anchorService->expects($this->never())->method('publish');
+
+        $exitCode = $this->commandTester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString(
+            'Access denied: the "vault.configure" permission is required to publish the audit chain tip.',
+            $this->normalizedDisplay(),
+        );
+    }
+
+    /**
+     * `audit.view` reads the log; it does not re-attest the chain to an
+     * external observer.
+     */
+    #[Test]
+    public function auditViewAloneDoesNotSatisfyTheGate(): void
+    {
+        $this->grantedPermissions = [VaultPermission::AuditView];
+
+        $this->anchorService->expects($this->never())->method('publish');
+
+        self::assertSame(Command::FAILURE, $this->commandTester->execute([]));
+    }
+
+    /**
+     * `--dry-run` publishes nothing, but it is the rehearsal of an
+     * administrative operation and prints the current chain tip, so it is gated
+     * identically rather than as a read.
+     */
+    #[Test]
+    public function dryRunIsGatedTheSameWay(): void
+    {
+        $this->grantedPermissions = [VaultPermission::AuditView];
+
+        $this->anchorService->expects($this->never())->method('capture');
+
+        $exitCode = $this->commandTester->execute(['--dry-run' => true]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString(
+            'Access denied: the "vault.configure" permission is required to publish the audit chain tip.',
+            $this->normalizedDisplay(),
+        );
+    }
+
+    #[Test]
+    public function vaultConfigureAloneSatisfiesTheGate(): void
+    {
+        $this->grantedPermissions = [VaultPermission::VaultConfigure];
+
+        $this->anchorService
+            ->method('capture')
+            ->willReturn(new ChainTipAnchor(10, 'tip', 1_750_000_000, 3));
+        $this->anchorService
+            ->expects($this->once())
+            ->method('publish')
+            ->willReturn(1);
+
+        $exitCode = $this->commandTester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode, $this->commandTester->getDisplay());
+        self::assertStringNotContainsString('Access denied', $this->commandTester->getDisplay());
+    }
+
+    /**
+     * A scheduled wrapper parsing JSON must see the refusal, not an empty
+     * object it would read as "nothing to report".
+     */
+    #[Test]
+    public function jsonRefusalCarriesTheReason(): void
+    {
+        $this->grantedPermissions = [];
+
+        $exitCode = $this->commandTester->execute(['--format' => 'json']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+
+        $payload = json_decode($this->commandTester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+        self::assertIsString($payload['error']);
+        self::assertStringContainsString('vault.configure', $payload['error']);
+        self::assertArrayNotHasKey('anchor', $payload);
+    }
+
+    /**
+     * @return list<VaultPermission>
+     */
+    private function allPermissionsExcept(VaultPermission $excluded): array
+    {
+        return array_values(array_filter(
+            VaultPermission::cases(),
+            static fn (VaultPermission $permission): bool => $permission !== $excluded,
+        ));
+    }
+
+    /**
+     * SymfonyStyle word-wraps its error block to the terminal width; collapsing
+     * whitespace lets the assertions pin the whole refusal sentence.
+     */
+    private function normalizedDisplay(): string
+    {
+        return (string) preg_replace('/\s+/', ' ', $this->commandTester->getDisplay());
+    }
+}

--- a/Tests/Unit/Command/VaultAuditCommandTest.php
+++ b/Tests/Unit/Command/VaultAuditCommandTest.php
@@ -202,11 +202,16 @@ final class VaultAuditCommandTest extends TestCase
      * Holding every OTHER permission is not a substitute: the mode's own
      * permission is the one asserted.
      *
+     * This asserts the GATE lets the mode through, not that the mode then
+     * succeeds — a passing mode may still fail later on its own
+     * preconditions (a reset-anchor with no anchor to reset, say). The
+     * functional suite covers the outcomes.
+     *
      * @param array<string, string|bool> $arguments
      */
     #[Test]
     #[DataProvider('gatedModeProvider')]
-    public function allowsModeWithOnlyItsPermission(
+    public function passesTheGateWithOnlyItsPermission(
         array $arguments,
         VaultPermission $required,
         string $refusalMessage,

--- a/Tests/Unit/Command/VaultAuditCommandTest.php
+++ b/Tests/Unit/Command/VaultAuditCommandTest.php
@@ -107,15 +107,60 @@ final class VaultAuditCommandTest extends TestCase
 
         yield 'verify' => [
             ['--verify' => true],
-            VaultPermission::VaultConfigure,
-            'Access denied: the "vault.configure" permission is required to verify or reset the audit hash chain.',
+            VaultPermission::AuditView,
+            'Access denied: the "audit.view" permission is required to verify the audit hash chain.',
         ];
 
         yield 'reset-anchor' => [
             ['--reset-anchor' => true, '--force' => true],
             VaultPermission::VaultConfigure,
-            'Access denied: the "vault.configure" permission is required to verify or reset the audit hash chain.',
+            'Access denied: the "vault.configure" permission is required to reset the audit chain tip anchor.',
         ];
+    }
+
+    /**
+     * Verification recomputes and compares; it mutates nothing. The same
+     * operation therefore answers to the same permission at every entry point —
+     * `AuditController::verifyChainAction()`, `vault:audit-verify`,
+     * `AuditVerifyTask` and here — so an actor who may read the audit log in
+     * the module may also check whether it has been tampered with from a shell.
+     */
+    #[Test]
+    public function verifyIsSatisfiedByAuditViewAloneAndDoesNotAcceptVaultConfigure(): void
+    {
+        $this->grantedPermissions = [VaultPermission::VaultConfigure];
+
+        $this->auditLogService->expects($this->never())->method('verifyHashChain');
+
+        $exitCode = $this->commandTester->execute(['--verify' => true]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString(
+            'Access denied: the "audit.view" permission is required to verify the audit hash chain.',
+            $this->normalizedDisplay(),
+        );
+    }
+
+    /**
+     * The converse, and the reason `--reset-anchor` did not move with
+     * `--verify`: resetting clears the truncation anchor and writes into the
+     * chain, so it stays vault administration and `audit.view` is not enough.
+     */
+    #[Test]
+    public function resetAnchorIsNotSatisfiedByAuditView(): void
+    {
+        $this->grantedPermissions = [VaultPermission::AuditView];
+
+        $this->anchorStore->expects($this->never())->method('reset');
+        $this->auditLogService->expects($this->never())->method('log');
+
+        $exitCode = $this->commandTester->execute(['--reset-anchor' => true, '--force' => true]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString(
+            'Access denied: the "vault.configure" permission is required to reset the audit chain tip anchor.',
+            $this->normalizedDisplay(),
+        );
     }
 
     /**

--- a/Tests/Unit/Command/VaultAuditCommandTest.php
+++ b/Tests/Unit/Command/VaultAuditCommandTest.php
@@ -15,14 +15,18 @@ use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Audit\HashChainVerificationResult;
 use Netresearch\NrVault\Command\VaultAuditCommand;
 use Netresearch\NrVault\Exception\VaultException;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use org\bovigo\vfs\vfsStream;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Tester\CommandTester;
+use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 
 #[CoversClass(VaultAuditCommand::class)]
@@ -40,6 +44,16 @@ final class VaultAuditCommandTest extends TestCase
 
     private ConnectionPool&MockObject $connectionPool;
 
+    private AccessControlServiceInterface&MockObject $accessControlService;
+
+    /**
+     * Permissions the mocked actor holds. Tests that exercise the gate narrow
+     * this before executing; every other test runs fully granted.
+     *
+     * @var list<VaultPermission>
+     */
+    private array $grantedPermissions = [];
+
     private CommandTester $commandTester;
 
     protected function setUp(): void
@@ -49,8 +63,15 @@ final class VaultAuditCommandTest extends TestCase
         $this->auditLogService = $this->createMock(AuditLogServiceInterface::class);
         $this->anchorStore = $this->createMock(AuditChainAnchorStoreInterface::class);
         $this->connectionPool = $this->createMock(ConnectionPool::class);
+        $this->accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        $this->grantedPermissions = VaultPermission::cases();
+        $this->accessControlService
+            ->method('isGranted')
+            ->willReturnCallback(
+                fn (VaultPermission $permission): bool => \in_array($permission, $this->grantedPermissions, true),
+            );
 
-        $command = new VaultAuditCommand($this->auditLogService, $this->anchorStore, $this->connectionPool);
+        $command = $this->createCommand();
 
         $application = new Application();
         $application->addCommand($command);
@@ -61,9 +82,150 @@ final class VaultAuditCommandTest extends TestCase
     #[Test]
     public function hasCorrectName(): void
     {
-        $command = new VaultAuditCommand($this->auditLogService, $this->anchorStore, $this->connectionPool);
+        self::assertSame('vault:audit', $this->createCommand()->getName());
+    }
 
-        self::assertSame('vault:audit', $command->getName());
+    /**
+     * One entry per gated mode: the arguments that select it, the permission
+     * it must assert, and the exact refusal the operator gets.
+     *
+     * @return iterable<string, array{0: array<string, string|bool>, 1: VaultPermission, 2: string}>
+     */
+    public static function gatedModeProvider(): iterable
+    {
+        yield 'listing' => [
+            [],
+            VaultPermission::AuditView,
+            'Access denied: the "audit.view" permission is required to read the audit log.',
+        ];
+
+        yield 'export' => [
+            ['--export' => 'vfs://exports/audit.json'],
+            VaultPermission::AuditExport,
+            'Access denied: the "audit.export" permission is required to export audit entries to a file.',
+        ];
+
+        yield 'verify' => [
+            ['--verify' => true],
+            VaultPermission::VaultConfigure,
+            'Access denied: the "vault.configure" permission is required to verify or reset the audit hash chain.',
+        ];
+
+        yield 'reset-anchor' => [
+            ['--reset-anchor' => true, '--force' => true],
+            VaultPermission::VaultConfigure,
+            'Access denied: the "vault.configure" permission is required to verify or reset the audit hash chain.',
+        ];
+    }
+
+    /**
+     * The gap this pins: `vault:audit` asserted no permission whatsoever, so
+     * any actor that reached the command could read the credential topology,
+     * carry a copy of it off, or clear the truncation anchor.
+     *
+     * @param array<string, string|bool> $arguments
+     */
+    #[Test]
+    #[DataProvider('gatedModeProvider')]
+    public function refusesModeWithoutItsPermission(
+        array $arguments,
+        VaultPermission $required,
+        string $expectedMessage,
+    ): void {
+        $this->grantedPermissions = array_values(array_filter(
+            VaultPermission::cases(),
+            static fn (VaultPermission $permission): bool => $permission !== $required,
+        ));
+
+        // A refusal must do no work at all — not even the read that would
+        // feed the display, and not the audit write that would let an
+        // unauthorized shell append to the tamper-evident chain.
+        $this->auditLogService->expects($this->never())->method('query');
+        $this->auditLogService->expects($this->never())->method('verifyHashChain');
+        $this->auditLogService->expects($this->never())->method('log');
+        $this->anchorStore->expects($this->never())->method('reset');
+        $this->anchorStore->expects($this->never())->method('arm');
+        $this->connectionPool->expects($this->never())->method('getConnectionForTable');
+
+        $exitCode = $this->commandTester->execute($arguments);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString($expectedMessage, $this->normalizedDisplay());
+    }
+
+    /**
+     * Holding every OTHER permission is not a substitute: the mode's own
+     * permission is the one asserted.
+     *
+     * @param array<string, string|bool> $arguments
+     */
+    #[Test]
+    #[DataProvider('gatedModeProvider')]
+    public function allowsModeWithOnlyItsPermission(
+        array $arguments,
+        VaultPermission $required,
+        string $refusalMessage,
+    ): void {
+        $this->grantedPermissions = [$required];
+        vfsStream::setup('exports');
+
+        $this->auditLogService->method('query')->willReturn([]);
+        $this->auditLogService->method('verifyHashChain')->willReturn(HashChainVerificationResult::valid());
+        $this->anchorStore->method('sharesConnection')->willReturn(false);
+        $this->connectionPool->method('getConnectionForTable')->willReturn($this->createMock(Connection::class));
+
+        $this->commandTester->execute($arguments);
+
+        self::assertStringNotContainsString(
+            'Access denied',
+            $this->normalizedDisplay(),
+            \sprintf('Holding %s alone must satisfy this mode, but got: %s', $required->value, $refusalMessage),
+        );
+    }
+
+    /**
+     * The export gate is asserted before the query, so a refused export leaves
+     * no file behind — not even an empty or partial one.
+     */
+    #[Test]
+    public function refusedExportWritesNoFile(): void
+    {
+        vfsStream::setup('exports');
+        $exportFile = vfsStream::url(self::EXPORT_PATH);
+
+        $this->grantedPermissions = [VaultPermission::AuditView];
+
+        $exitCode = $this->commandTester->execute([
+            '--export' => $exportFile,
+            '--format' => 'csv',
+        ]);
+
+        self::assertSame(1, $exitCode);
+        self::assertFileDoesNotExist($exportFile);
+        self::assertStringContainsString(
+            'Access denied: the "audit.export" permission is required to export audit entries to a file.',
+            $this->normalizedDisplay(),
+        );
+    }
+
+    /**
+     * An empty `--export=` is not an export — it falls through to the console
+     * display, so it must be gated on `audit.view`, not `audit.export`.
+     */
+    #[Test]
+    public function emptyExportOptionIsGatedAsDisplay(): void
+    {
+        $this->grantedPermissions = [VaultPermission::AuditView];
+
+        $this->auditLogService
+            ->expects($this->once())
+            ->method('query')
+            ->willReturn([]);
+
+        $exitCode = $this->commandTester->execute(['--export' => '']);
+
+        self::assertSame(0, $exitCode);
+        self::assertStringNotContainsString('Access denied', $this->normalizedDisplay());
     }
 
     #[Test]
@@ -688,6 +850,27 @@ final class VaultAuditCommandTest extends TestCase
         foreach ($rows[1] as $cell) {
             self::assertStringStartsNotWith('=', (string) $cell);
         }
+    }
+
+    private function createCommand(): VaultAuditCommand
+    {
+        return new VaultAuditCommand(
+            $this->auditLogService,
+            $this->anchorStore,
+            $this->connectionPool,
+            $this->accessControlService,
+        );
+    }
+
+    /**
+     * SymfonyStyle word-wraps its error block to the terminal width, so the
+     * raw display carries line breaks in the middle of the sentence being
+     * asserted. Collapsing runs of whitespace lets the tests pin the FULL
+     * message instead of a fragment that survives the wrap.
+     */
+    private function normalizedDisplay(): string
+    {
+        return (string) preg_replace('/\s+/', ' ', $this->commandTester->getDisplay());
     }
 
     /**

--- a/Tests/Unit/Command/VaultAuditVerifyCommandTest.php
+++ b/Tests/Unit/Command/VaultAuditVerifyCommandTest.php
@@ -1,0 +1,191 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Command;
+
+use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Audit\AuditIntegrityReport;
+use Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface;
+use Netresearch\NrVault\Command\VaultAuditVerifyCommand;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+/**
+ * The operation-permission gate on `vault:audit-verify`.
+ *
+ * The wrapper checked strictly more than `vault:audit --verify` — the external
+ * anchor as well as the in-database chain — while asserting no permission at
+ * all, which made the gate on the interactive command advisory: an actor who
+ * was refused there simply called this instead. Both now answer to `audit.view`
+ * because they perform the same operation.
+ */
+#[CoversClass(VaultAuditVerifyCommand::class)]
+#[AllowMockObjectsWithoutExpectations]
+final class VaultAuditVerifyCommandTest extends TestCase
+{
+    private ChainTipAnchorServiceInterface&MockObject $anchorService;
+
+    private AuditSinkRegistryInterface&MockObject $sinkRegistry;
+
+    private AccessControlServiceInterface&MockObject $accessControlService;
+
+    /** @var list<VaultPermission> */
+    private array $grantedPermissions = [];
+
+    private CommandTester $commandTester;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->anchorService = $this->createMock(ChainTipAnchorServiceInterface::class);
+        $this->sinkRegistry = $this->createMock(AuditSinkRegistryInterface::class);
+        $this->sinkRegistry->method('getEnabledSinkIdentifiers')->willReturn(['file']);
+        $this->sinkRegistry->method('getFailureCountsBySink')->willReturn([]);
+
+        $this->accessControlService = $this->createMock(AccessControlServiceInterface::class);
+        $this->grantedPermissions = VaultPermission::cases();
+        $this->accessControlService
+            ->method('isGranted')
+            ->willReturnCallback(
+                fn (VaultPermission $permission): bool => \in_array($permission, $this->grantedPermissions, true),
+            );
+
+        $this->commandTester = new CommandTester(new VaultAuditVerifyCommand(
+            $this->anchorService,
+            $this->sinkRegistry,
+            $this->accessControlService,
+        ));
+    }
+
+    #[Test]
+    public function hasCorrectName(): void
+    {
+        $command = new VaultAuditVerifyCommand(
+            $this->anchorService,
+            $this->sinkRegistry,
+            $this->accessControlService,
+        );
+
+        self::assertSame('vault:audit-verify', $command->getName());
+    }
+
+    /**
+     * A refusal must run no verification: the report it would produce is the
+     * chain state the permission withholds.
+     */
+    #[Test]
+    public function refusesWithoutAuditViewAndVerifiesNothing(): void
+    {
+        $this->grantedPermissions = $this->allPermissionsExcept(VaultPermission::AuditView);
+
+        $this->anchorService->expects($this->never())->method('verify');
+
+        $exitCode = $this->commandTester->execute([]);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+        self::assertStringContainsString(
+            'Access denied: the "audit.view" permission is required to verify the audit log integrity.',
+            $this->normalizedDisplay(),
+        );
+    }
+
+    /**
+     * `vault.configure` is not a substitute: holding every other permission
+     * still does not buy the verification.
+     */
+    #[Test]
+    public function vaultConfigureAloneDoesNotSatisfyTheGate(): void
+    {
+        $this->grantedPermissions = [VaultPermission::VaultConfigure];
+
+        $this->anchorService->expects($this->never())->method('verify');
+
+        self::assertSame(Command::FAILURE, $this->commandTester->execute([]));
+    }
+
+    #[Test]
+    public function auditViewAloneSatisfiesTheGate(): void
+    {
+        $this->grantedPermissions = [VaultPermission::AuditView];
+
+        $this->anchorService
+            ->expects($this->once())
+            ->method('verify')
+            ->willReturn(new AuditIntegrityReport(findings: [], chainValid: true, currentSequence: 7));
+
+        $exitCode = $this->commandTester->execute([]);
+
+        self::assertSame(Command::SUCCESS, $exitCode, $this->commandTester->getDisplay());
+        self::assertStringNotContainsString('Access denied', $this->commandTester->getDisplay());
+    }
+
+    /**
+     * The command is meant to be wired into monitoring, so a consumer reading
+     * only `valid` must see a refused verification as a failed one — never as a
+     * clean chain.
+     */
+    #[Test]
+    public function jsonRefusalReportsInvalidRatherThanAnEmptyPass(): void
+    {
+        $this->grantedPermissions = [];
+
+        $exitCode = $this->commandTester->execute(['--format' => 'json']);
+
+        self::assertSame(Command::FAILURE, $exitCode);
+
+        $payload = json_decode($this->commandTester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+        self::assertFalse($payload['valid']);
+        self::assertIsString($payload['error']);
+        self::assertStringContainsString('audit.view', $payload['error']);
+    }
+
+    /**
+     * `--tamper-only` downgrades configuration findings to warnings. It must
+     * not downgrade a refusal — that is not a finding about the chain.
+     */
+    #[Test]
+    public function tamperOnlyDoesNotSoftenTheRefusal(): void
+    {
+        $this->grantedPermissions = [];
+
+        $this->anchorService->expects($this->never())->method('verify');
+
+        self::assertSame(Command::FAILURE, $this->commandTester->execute(['--tamper-only' => true]));
+    }
+
+    /**
+     * @return list<VaultPermission>
+     */
+    private function allPermissionsExcept(VaultPermission $excluded): array
+    {
+        return array_values(array_filter(
+            VaultPermission::cases(),
+            static fn (VaultPermission $permission): bool => $permission !== $excluded,
+        ));
+    }
+
+    /**
+     * SymfonyStyle word-wraps its error block to the terminal width; collapsing
+     * whitespace lets the assertions pin the whole refusal sentence.
+     */
+    private function normalizedDisplay(): string
+    {
+        return (string) preg_replace('/\s+/', ' ', $this->commandTester->getDisplay());
+    }
+}

--- a/Tests/Unit/Task/AuditAnchorTaskTest.php
+++ b/Tests/Unit/Task/AuditAnchorTaskTest.php
@@ -11,6 +11,8 @@ namespace Netresearch\NrVault\Tests\Unit\Task;
 
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Task\AuditAnchorTask;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -43,7 +45,7 @@ final class AuditAnchorTaskTest extends TestCase
         $service->method('capture')->willReturn(new ChainTipAnchor(10, 'tip', 1_750_000_000, 3));
         $service->method('publish')->willReturn(2);
 
-        self::assertTrue((new AuditAnchorTask($service))->execute());
+        self::assertTrue($this->task($service)->execute());
     }
 
     /**
@@ -58,7 +60,7 @@ final class AuditAnchorTaskTest extends TestCase
         $service->method('capture')->willReturn(new ChainTipAnchor(10, 'tip', 1_750_000_000, 3));
         $service->method('publish')->willReturn(0);
 
-        self::assertFalse((new AuditAnchorTask($service))->execute());
+        self::assertFalse($this->task($service)->execute());
     }
 
     #[Test]
@@ -67,7 +69,7 @@ final class AuditAnchorTaskTest extends TestCase
         $service = self::createStub(ChainTipAnchorServiceInterface::class);
         $service->method('capture')->willThrowException(new RuntimeException('database unavailable'));
 
-        self::assertFalse((new AuditAnchorTask($service))->execute());
+        self::assertFalse($this->task($service)->execute());
     }
 
     #[Test]
@@ -77,7 +79,7 @@ final class AuditAnchorTaskTest extends TestCase
         $service->method('capture')->willReturn(new ChainTipAnchor(10, 'tip', 1_750_000_000, 3));
         $service->method('publish')->willThrowException(new RuntimeException('sink exploded'));
 
-        self::assertFalse((new AuditAnchorTask($service))->execute());
+        self::assertFalse($this->task($service)->execute());
     }
 
     #[Test]
@@ -86,7 +88,7 @@ final class AuditAnchorTaskTest extends TestCase
         $service = self::createStub(ChainTipAnchorServiceInterface::class);
         $service->method('capture')->willReturn(new ChainTipAnchor(128, 'tip', 1_750_000_000, 3));
 
-        self::assertStringContainsString('128', (new AuditAnchorTask($service))->getAdditionalInformation());
+        self::assertStringContainsString('128', $this->task($service)->getAdditionalInformation());
     }
 
     /**
@@ -99,6 +101,53 @@ final class AuditAnchorTaskTest extends TestCase
         $service = self::createStub(ChainTipAnchorServiceInterface::class);
         $service->method('capture')->willThrowException(new RuntimeException('no master key'));
 
-        self::assertNotSame('', (new AuditAnchorTask($service))->getAdditionalInformation());
+        self::assertNotSame('', $this->task($service)->getAdditionalInformation());
+    }
+
+    /**
+     * The permission follows the operation, not the entry point: publishing an
+     * anchor asserts `vault.configure` whether it is reached through
+     * `vault:audit-anchor` or through the scheduler. Otherwise the gate on the
+     * command is advisory — an actor refused there registers the task instead.
+     */
+    #[Test]
+    public function anchoringIsRefusedWithoutVaultConfigure(): void
+    {
+        $service = $this->createMock(ChainTipAnchorServiceInterface::class);
+        $service->expects($this->never())->method('capture');
+        $service->expects($this->never())->method('publish');
+
+        $task = $this->task($service, granted: false);
+
+        self::assertFalse($task->execute(), 'a refused anchoring run must not report success');
+    }
+
+    /**
+     * The sequence is chain state; the scheduler list view must still render so
+     * an operator who cannot see it can still reach the task.
+     */
+    #[Test]
+    public function additionalInformationWithholdsTheSequenceWithoutVaultConfigure(): void
+    {
+        $service = $this->createMock(ChainTipAnchorServiceInterface::class);
+        $service->expects($this->never())->method('capture');
+
+        $information = $this->task($service, granted: false)->getAdditionalInformation();
+
+        self::assertNotSame('', $information);
+        self::assertStringNotContainsString('sequence', $information);
+    }
+
+    private function task(ChainTipAnchorServiceInterface $service, bool $granted = true): AuditAnchorTask
+    {
+        $accessControlService = self::createStub(AccessControlServiceInterface::class);
+        $accessControlService
+            ->method('isGranted')
+            ->willReturnCallback(
+                static fn (VaultPermission $permission): bool => $granted
+                    && $permission === VaultPermission::VaultConfigure,
+            );
+
+        return new AuditAnchorTask($service, null, $accessControlService);
     }
 }

--- a/Tests/Unit/Task/AuditVerifyTaskTest.php
+++ b/Tests/Unit/Task/AuditVerifyTaskTest.php
@@ -13,6 +13,8 @@ use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
 use Netresearch\NrVault\Audit\AuditIntegrityAlert;
 use Netresearch\NrVault\Audit\AuditIntegrityReason;
 use Netresearch\NrVault\Audit\AuditIntegrityReport;
+use Netresearch\NrVault\Security\AccessControlServiceInterface;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Task\AuditVerifyTask;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -110,7 +112,7 @@ final class AuditVerifyTaskTest extends TestCase
         $service = self::createStub(ChainTipAnchorServiceInterface::class);
         $service->method('verify')->willThrowException(new RuntimeException('database unavailable'));
 
-        self::assertFalse((new AuditVerifyTask($service))->execute());
+        self::assertFalse($this->task($service)->execute());
     }
 
     #[Test]
@@ -119,7 +121,7 @@ final class AuditVerifyTaskTest extends TestCase
         $service = self::createStub(ChainTipAnchorServiceInterface::class);
         $service->method('verify')->willThrowException(new RuntimeException('database unavailable'));
 
-        $task = new AuditVerifyTask($service);
+        $task = $this->task($service);
         $task->setTaskParameters(['nr_vault_tamper_only' => 1]);
 
         self::assertFalse($task->execute());
@@ -159,12 +161,58 @@ final class AuditVerifyTaskTest extends TestCase
         self::assertNotSame($strict, $task->getAdditionalInformation());
     }
 
+    /**
+     * Verification is a read of the chain, so it answers to `audit.view` from
+     * the scheduler exactly as it does from `vault:audit-verify`,
+     * `vault:audit --verify` and the backend module.
+     */
+    #[Test]
+    public function verificationIsRefusedWithoutAuditView(): void
+    {
+        $service = $this->createMock(ChainTipAnchorServiceInterface::class);
+        $service->expects($this->never())->method('verify');
+
+        self::assertFalse(
+            $this->task($service, granted: false)->execute(),
+            'a verification that was not allowed to run must not report success',
+        );
+    }
+
+    /**
+     * `--tamper-only` downgrades configuration findings to warnings. A refusal
+     * is not a finding about the chain, so it must not be downgraded with them.
+     */
+    #[Test]
+    public function refusalFailsEvenInTamperOnlyMode(): void
+    {
+        $service = $this->createMock(ChainTipAnchorServiceInterface::class);
+        $service->expects($this->never())->method('verify');
+
+        $task = $this->task($service, granted: false);
+        $task->setTaskParameters(['nr_vault_tamper_only' => 1]);
+
+        self::assertFalse($task->execute());
+    }
+
+    private function task(ChainTipAnchorServiceInterface $service, bool $granted = true): AuditVerifyTask
+    {
+        $accessControlService = self::createStub(AccessControlServiceInterface::class);
+        $accessControlService
+            ->method('isGranted')
+            ->willReturnCallback(
+                static fn (VaultPermission $permission): bool => $granted
+                    && $permission === VaultPermission::AuditView,
+            );
+
+        return new AuditVerifyTask($service, null, $accessControlService);
+    }
+
     private function createTask(AuditIntegrityReport $report): AuditVerifyTask
     {
         $service = self::createStub(ChainTipAnchorServiceInterface::class);
         $service->method('verify')->willReturn($report);
 
-        return new AuditVerifyTask($service);
+        return $this->task($service);
     }
 
     private function report(?AuditIntegrityReason $reason = null): AuditIntegrityReport


### PR DESCRIPTION
`vault:audit` asserted **no** operation permission at all — unlike every sibling command. Reviewing that fix surfaced two further problems, and the scope was widened to fix the underlying inconsistency rather than the one command.

## The principle

**The permission follows the operation's effect, not the command it happens to live in.** The same operation answers to the same permission through every entry point — interactive CLI, wrapper command, scheduler task, backend module.

| Operation | Permission | Interactive CLI | Wrapper command | Scheduler task | Backend module |
|---|---|---|---|---|---|
| Read audit entries | `audit.view` | `vault:audit` | — | — | `indexAction` |
| **Verify the chain** | `audit.view` | `--verify` | `vault:audit-verify` *(was ungated)* | `AuditVerifyTask` *(was ungated)* | `verifyChainAction` |
| Export to a file | `audit.export` | `--export` | — | — | `exportAction` |
| **Publish the chain tip** | `vault.configure` | — | `vault:audit-anchor` *(was ungated)* | `AuditAnchorTask` *(was ungated)* | — |
| Reset the tip anchor | `vault.configure` | `--reset-anchor` | — | — | — |

Verification is a **read** — that is what the backend module already said in code ("Verification is a read of the chain, so it shares audit.view with the listing"), so `--verify` moves from `vault.configure` to `audit.view` and the two interfaces stop disagreeing about the same operation. Publishing the tip is a **mutation of tamper evidence**: truncate the log, then anchor, and the external sink attests the truncated chain — the exact attack the anchor exists to prevent.

Without gating the wrappers the `--verify` gate would have been advisory: bypass by calling `vault:audit-verify`, which checks *more* (chain **and** external anchor).

## Scheduler tasks: gated, deliberately

Plain console commands run with an **unauthenticated** CLI user, so they resolve through `cliOperationGranted()` and are denied by default. `scheduler:run` differs — it calls `Bootstrap::initializeBackendAuthentication()`, materialising the `_cli_` user created with `admin = 1`, so the gate resolves through `adminBypassActive()` and returns true.

The gate is therefore **inert on a default install** and bites only under the hardened profile with `disableAdminOverride` — which is exactly where it must. Otherwise an admin deliberately not granted `vault.configure` could open Scheduler ▸ Run task and re-attest a truncated chain, making `disableAdminOverride` "disabled in name only" at this seam.

The cost is documented rather than hidden: under that profile the scheduler identity needs the corresponding group option or both tasks go red. Fail-loud beats skip-quiet here — a red scheduler entry is recoverable; an anchoring run that did not happen but looks like one that did is precisely what the anchor exists to rule out.

**`OrphanCleanupTask` is deliberately NOT gated**: its effect already answers to `secret.delete` one layer deeper in `VaultService::assertDeletePermitted()`. A task-level gate would duplicate the seam without adding a decision.

## Refusals

No `access_denied` audit entry — consistent with every other operation-permission gate, and for `--verify`/`--reset-anchor` the deciding argument is recursion: a denial entry would append a row and advance the tip anchor, i.e. mutate the state the operator is about to inspect. Refusals honour `--format`: a refused `vault:audit-verify --format=json` emits `{"valid": false, "error": …}`, because a verifier that was not allowed to run must not read as one that found nothing.

## Breaking

After this change these commands need `allowCliAccess=1` **and** the operation in `cliAllowedOperations`, or a named technical actor; backend users need the `tx_nrvault:<permission>` group option. Documented across CHANGELOG, `Commands.rst`, `Security/Index.rst`, `Usage/Index.rst`, `Configuration/Index.rst`, both Auditor chapters and six Operations runbooks — including the two that previously needed no note because they call only the wrappers. Six statements that documented the old divergence as intentional were corrected, not supplemented.

## Verification (after merging current main)

- Unit+Fuzz 5126 · Functional 337 (full) — zero failures
- PHPStan no errors · CGL clean · `make docs` renders clean
- `ci:test:php:doc-cli` — 206 examples **and 65 options** across 17 commands, i.e. the stricter guard merged in #273 accepts the changed documentation
