### PR TITLE
Refuse the record commands a vault secret cannot honour

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -1849,7 +1849,7 @@ parameters:
 		-
 			rawMessage: 'Call to an undefined method TYPO3\CMS\Core\Database\Query\QueryBuilder::method().'
 			identifier: method.notFound
-			count: 14
+			count: 15
 			path: ../Tests/Unit/Domain/Repository/SecretRepositoryTest.php
 
 		-
@@ -1861,7 +1861,7 @@ parameters:
 		-
 			rawMessage: 'Cannot call method willReturnOnConsecutiveCalls() on mixed.'
 			identifier: method.nonObject
-			count: 2
+			count: 3
 			path: ../Tests/Unit/Domain/Repository/SecretRepositoryTest.php
 
 		-
@@ -1879,7 +1879,7 @@ parameters:
 		-
 			rawMessage: 'Dynamic call to static method PHPUnit\Framework\TestCase::createStub().'
 			identifier: staticMethod.dynamicCall
-			count: 64
+			count: 68
 			path: ../Tests/Unit/Domain/Repository/SecretRepositoryTest.php
 
 		-

--- a/Classes/Command/VaultDeleteCommand.php
+++ b/Classes/Command/VaultDeleteCommand.php
@@ -90,7 +90,11 @@ final class VaultDeleteCommand extends Command
         // Confirm unless --force
         if (!$input->getOption('force')) {
             $confirmed = $io->confirm(
-                \sprintf('Are you sure you want to delete secret "%s"? This action cannot be undone.', $identifier),
+                \sprintf(
+                    'Are you sure you want to delete secret "%s"? The vault cannot restore it. '
+                    . 'The encrypted row is retained in the database until it is removed there.',
+                    $identifier,
+                ),
                 false,
             );
 

--- a/Classes/Domain/Repository/SecretRepository.php
+++ b/Classes/Domain/Repository/SecretRepository.php
@@ -13,6 +13,7 @@ use Netresearch\NrVault\Domain\Dto\SecretFilters;
 use Netresearch\NrVault\Domain\Model\Secret;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 
 /**
  * Repository for secret entities.
@@ -59,6 +60,47 @@ final readonly class SecretRepository implements SecretRepositoryInterface
     public function findByUid(int $uid): ?Secret
     {
         $queryBuilder = $this->getConnection()->createQueryBuilder();
+        $row = $queryBuilder
+            ->select('*')
+            ->from(self::TABLE_NAME)
+            ->where(
+                $queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)),
+                $queryBuilder->expr()->eq('deleted', 0),
+            )
+            ->executeQuery()
+            ->fetchAssociative();
+
+        if ($row === false) {
+            return null;
+        }
+
+        return Secret::fromDatabaseRow(
+            $row,
+            $this->loadGroupsForSecret($uid),
+            $this->loadGroupsForSecret($uid, self::MM_WRITE_TABLE_NAME),
+        );
+    }
+
+    /**
+     * Resolve a secret by UID INCLUDING one that is disabled.
+     *
+     * The counterpart of {@see findByUid()} for the write-path guards that
+     * must judge a record they are about to change or remove. Everything
+     * else, the plaintext read path above all, keeps using `findByUid()`.
+     *
+     * That split is the whole point, so exactly one restriction is lifted and
+     * named: `HiddenRestriction`, the one TCA's `enablecolumns.disabled`
+     * mapping binds to the `hidden` column. `removeAll()` is deliberately NOT
+     * used — it would also discard `DeletedRestriction`, and a lookup that
+     * hands back soft-deleted rows would turn an `undelete` guard into the
+     * thing that resurrects them. `findByUid()` is left untouched for the
+     * same reason: widening it would switch the control off rather than work
+     * around it.
+     */
+    public function findByUidIncludingDisabled(int $uid): ?Secret
+    {
+        $queryBuilder = $this->getConnection()->createQueryBuilder();
+        $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
         $row = $queryBuilder
             ->select('*')
             ->from(self::TABLE_NAME)

--- a/Classes/Domain/Repository/SecretRepositoryInterface.php
+++ b/Classes/Domain/Repository/SecretRepositoryInterface.php
@@ -21,6 +21,21 @@ interface SecretRepositoryInterface
 
     public function findByUid(int $uid): ?Secret;
 
+    /**
+     * Resolve a secret by UID INCLUDING one that is disabled (`hidden = 1`),
+     * which {@see findByUid()} deliberately cannot see.
+     *
+     * Reserved for the write-path guards that must judge a record they are
+     * about to change or remove — `SecretTcaHook` resolves its DataHandler
+     * target through this method, because a guard blind to a disabled record
+     * does not refuse the operation, it lets core perform it ungated.
+     * Soft-deleted records stay invisible here; only the enable columns are
+     * given up. Never use this on a path that returns plaintext: disabling a
+     * secret revokes access precisely because the enable-column restriction
+     * removes it from the read path's query.
+     */
+    public function findByUidIncludingDisabled(int $uid): ?Secret;
+
     public function exists(string $identifier): bool;
 
     /**

--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -598,6 +598,13 @@ final class SecretTcaHook
      * The extra $value/$dataHandler parameters are supplied by core
      * (DataHandler passes six positional args); they are optional so the
      * pre-existing three-argument unit-test calls still bind.
+     *
+     * The target is resolved through the disabled-visible lookup. The
+     * restricted one skips a disabled secret, and skipping here does not
+     * refuse the delete — it hands the command back to core, which
+     * soft-deletes the row with no per-secret ACL, no `secret.delete` and no
+     * audit entry. Disabling a secret must not be the way to strip it of its
+     * guard.
      */
     public function processCmdmap_preProcess(// NOSONAR: TYPO3 DataHandler hook method name (fixed API contract)
         string $command,
@@ -621,7 +628,7 @@ final class SecretTcaHook
         }
 
         $uid = is_numeric($id) ? (int) $id : 0;
-        $secret = $this->secretRepository->findByUid($uid);
+        $secret = $this->secretRepository->findByUidIncludingDisabled($uid);
         if (!$secret instanceof Secret) {
             return;
         }
@@ -1194,8 +1201,22 @@ final class SecretTcaHook
      *
      * A creation is not gated here: it has no existing secret to authorize
      * against, and its own gates (`canCreate()`, `secret.create`) live on
-     * the VaultService path. A datamap for a uid with no secret row is left
-     * to core, which refuses a nonexistent record on its own.
+     * the VaultService path.
+     *
+     * The record is resolved through the disabled-visible lookup, for the
+     * same reason as the delete gate: the restricted one cannot see a
+     * disabled secret, and a gate that cannot see its subject does not refuse
+     * the write — it lets core perform it without ever consulting
+     * `canWrite()`. Disabling a secret must not be the way to strip it of its
+     * guard.
+     *
+     * With that lookup in place, an unresolved uid no longer means "possibly
+     * a disabled secret". It means no row for this uid — left to core, which
+     * refuses a nonexistent record on its own — or a soft-deleted one, whose
+     * columns no read path reaches and which this table's refused `undelete`
+     * keeps that way. Passing those through stays what it was: the vault
+     * declining to answer for a record it no longer holds, not a grant over
+     * one it does.
      */
     private function isUpdateAuthorized(string|int $id, DataHandler $dataHandler): bool
     {
@@ -1204,7 +1225,7 @@ final class SecretTcaHook
         }
 
         $uid = is_numeric($id) ? (int) $id : 0;
-        $secret = $this->secretRepository->findByUid($uid);
+        $secret = $this->secretRepository->findByUidIncludingDisabled($uid);
         if (!$secret instanceof Secret) {
             return true;
         }

--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -32,6 +32,9 @@ use TYPO3\CMS\Core\DataHandling\DataHandler;
  * - Identifier immutability (prevent changes after creation)
  * - Secret encryption on save (secret_input field)
  * - Audit logging for metadata changes
+ * - Delete authorization (the vault delete ACL, performed through VaultService)
+ * - Refusal of the cmdmap commands this table does not support (see
+ *   REFUSED_COMMANDS: undelete, copy, move)
  * - FormEngine integration with VaultService
  */
 final class SecretTcaHook
@@ -122,6 +125,64 @@ final class SecretTcaHook
     ];
 
     /**
+     * Cmdmap commands refused outright for this table, mapped to the reason
+     * the editor is shown. Core supports nine; the other six need no entry:
+     *
+     *  - `delete` is performed THROUGH VaultService further down, gates,
+     *    audit entry and compensating rollback included.
+     *  - `localize` and `copyToLanguage` both call DataHandler::localize(),
+     *    which refuses a table whose schema is not language-aware
+     *    ("Localization failed; languageField and transOrigPointerField must
+     *    be defined"). The TCA declares neither, by design — a secret has no
+     *    translations.
+     *  - `inlineLocalizeSynchronize` acts on the children of an inline field;
+     *    this table has none, and the command returns early for a language id
+     *    of 0.
+     *  - `discard` returns unless the schema is workspace-aware AND the actor
+     *    is in a workspace; `version` logs "Versioning is not supported for
+     *    this table". The TCA sets no `versioningWS`.
+     *
+     * That leaves three, refused here:
+     *
+     *  - `undelete` restored a soft-deleted secret with no vault check of any
+     *    kind. Core's undeleteRecord() asks checkModifyAccessList() and
+     *    checkRecordEditAccess(), and skips the page-permission branch
+     *    entirely for a record at pid 0 — which every vault secret is
+     *    (`rootLevel => -1`, and the module creates them there). Because the
+     *    vault delete is a SOFT delete — SecretRepository::delete() writes
+     *    only `deleted`/`tstamp` — the ciphertext, the wrapped DEK,
+     *    `frontend_accessible`, `hidden` and both MM ACL tiers survive it and
+     *    come back with the row. The vault has no restore operation, and the
+     *    product tells the editor it cannot give a deleted secret back, so
+     *    the TCA path must not quietly offer one.
+     *  - `copy` cannot produce a working secret. The crypto columns
+     *    (`encrypted_value`, `encrypted_dek`, both nonces, `value_checksum`)
+     *    have no TCA definition, and DataHandler::fillInFieldArray() only
+     *    processes fields the schema knows — so the clone is value-less. What
+     *    it does carry is the ORIGINAL identifier, and
+     *    SecretRepository::findByIdentifier() has no ORDER BY: the empty
+     *    clone can win the lookup and make retrieve() fail for every
+     *    consumer of a secret that is still perfectly intact.
+     *  - `move` is the only command that can take a secret off the root level
+     *    and into the page tree. A record on a page is deleted by
+     *    DataHandler::deleteSpecificPage(), which calls deleteRecord()
+     *    directly — that path never reaches this hook, so the per-secret ACL
+     *    and the audit entry are both skipped. `pid` carries no vault meaning
+     *    (the ACL scope is the separate `scope_pid` column), so the move buys
+     *    nothing and costs the record its protection.
+     *
+     * @var array<string, string>
+     */
+    private const REFUSED_COMMANDS = [
+        'undelete' => 'A deleted vault secret cannot be restored: the vault has no restore operation, '
+            . 'and its delete is documented as not reversible.',
+        'copy' => 'A vault secret cannot be copied: the copy would carry no encrypted value and would '
+            . 'claim the original identifier, shadowing it.',
+        'move' => 'A vault secret cannot be moved: it belongs on the root level, where no page '
+            . 'operation can delete it unaudited.',
+    ];
+
+    /**
      * Pending secrets to store after database operations.
      *
      * @var array<string, mixed> Map of temporary ID => secret value
@@ -129,17 +190,21 @@ final class SecretTcaHook
     private array $pendingSecrets = [];
 
     /**
-     * Record UIDs whose delete command was fully handled in
-     * processCmdmap_preProcess() — either performed through
-     * VaultService::delete() (ACL, operation permission and compensated audit
-     * included) or refused. Both outcomes must make core skip its own
-     * deleteAction in processCmdmap(). Entries are consumed (unset) when the
-     * cancel is applied so a DI-shared hook instance cannot leak a stale
-     * entry across DataHandler runs.
+     * Commands fully handled in processCmdmap_preProcess(), keyed
+     * "<command>:<uid>" — a `delete` performed through VaultService (ACL,
+     * operation permission and compensated audit included) or refused by it,
+     * and every command in REFUSED_COMMANDS. All of those must make core skip
+     * its own branch of the cmdmap switch in processCmdmap(). Entries are
+     * consumed (unset) when the cancel is applied so a DI-shared hook
+     * instance cannot leak a stale entry across DataHandler runs.
      *
-     * @var array<int, true>
+     * Keyed by command as well as uid because one cmdmap may legitimately
+     * carry several commands for the same record; a uid-only key would let
+     * the first of them cancel the second.
+     *
+     * @var array<string, true>
      */
-    private array $handledDeletions = [];
+    private array $handledCommands = [];
 
     /**
      * Original values of the real columns a datamap UPDATE submits, captured
@@ -519,8 +584,10 @@ final class SecretTcaHook
     }
 
     /**
-     * Called before a command (here: delete) is processed. Enforces the vault
-     * delete ACL (F5 / CWE-862) and records the audit entry.
+     * Called before a command is processed. Refuses the commands this table
+     * does not support at all (see REFUSED_COMMANDS) and enforces the vault
+     * delete ACL (F5 / CWE-862) on the one it does, recording the audit entry
+     * either way.
      *
      * DataHandler's own table permissions are NOT the vault ACL, so the gate
      * lives here — mirroring VaultService::delete()'s canDelete() check (the
@@ -539,7 +606,17 @@ final class SecretTcaHook
         mixed $value = null,
         ?DataHandler $dataHandler = null,
     ): void {
-        if ($table !== self::TABLE || $command !== 'delete') {
+        if ($table !== self::TABLE) {
+            return;
+        }
+
+        if (\array_key_exists($command, self::REFUSED_COMMANDS)) {
+            $this->refuseCommand($command, $id, $dataHandler);
+
+            return;
+        }
+
+        if ($command !== 'delete') {
             return;
         }
 
@@ -556,7 +633,7 @@ final class SecretTcaHook
         // exactly as on the programmatic path. Core's own deleteAction is
         // skipped in processCmdmap() in every outcome: on success the service
         // already soft-deleted the record, on refusal it must survive.
-        $this->handledDeletions[$uid] = true;
+        $this->handledCommands[$command . ':' . $uid] = true;
 
         try {
             $this->vaultService->delete($secret->getIdentifier(), 'Deleted via FormEngine');
@@ -587,10 +664,11 @@ final class SecretTcaHook
     }
 
     /**
-     * Makes core skip its own deleteAction() for every delete command the
-     * hook handled in processCmdmap_preProcess() — a successful service
-     * delete already soft-deleted the record, a refused one must leave it
-     * untouched. (DataHandler runs this hook before the command switch.)
+     * Makes core skip its own branch of the cmdmap switch for every command
+     * the hook handled in processCmdmap_preProcess() — a successful service
+     * delete already soft-deleted the record, a refused delete must leave it
+     * untouched, and a refused command must not be carried out at all.
+     * (DataHandler runs this hook before the command switch.)
      *
      * The flag is consumed so a DI-shared hook instance cannot leak a stale
      * entry into a later DataHandler run (same discipline as
@@ -605,15 +683,59 @@ final class SecretTcaHook
         DataHandler $dataHandler,
         mixed $pasteUpdate,
     ): void {
-        if ($table !== self::TABLE || $command !== 'delete') {
+        if ($table !== self::TABLE) {
             return;
         }
 
         $uid = is_numeric($id) ? (int) $id : 0;
-        if (($this->handledDeletions[$uid] ?? false) === true) {
-            unset($this->handledDeletions[$uid]);
+        $key = $command . ':' . $uid;
+        if (($this->handledCommands[$key] ?? false) === true) {
+            unset($this->handledCommands[$key]);
             $commandIsProcessed = true;
         }
+    }
+
+    /**
+     * Refuse a command this table does not support: cancel it, tell the
+     * editor why, and record the refusal in the tamper-evident chain.
+     *
+     * The refusal is unconditional — it is a property of the command on this
+     * table, not of the actor or of the row. An admin exemption would make
+     * "a vault delete cannot be undone" mean "unless an administrator says
+     * otherwise", and the chain auditors read would carry a restore the vault
+     * never performed. An operator who genuinely must resurrect a row still
+     * can, at the database, where the change is visible as one.
+     *
+     * The record read includes soft-deleted rows: an `undelete` target is by
+     * definition deleted, so the default read would find nothing and the
+     * denial would land in the chain without the identifier it is about.
+     * An unreadable row still gets refused — only its audit entry is
+     * necessarily anonymous, and the DataHandler log carries the uid.
+     */
+    private function refuseCommand(string $command, string|int $id, ?DataHandler $dataHandler): void
+    {
+        $uid = is_numeric($id) ? (int) $id : 0;
+
+        // Flagged before anything can fail, and for uid 0 as well: the
+        // cancellation is what makes the refusal real, so it must not depend
+        // on the record read or the audit write below succeeding.
+        $this->handledCommands[$command . ':' . $uid] = true;
+
+        $record = $this->readRecord($uid, ['identifier'], true);
+        $identifier = \is_string($record['identifier'] ?? null) ? $record['identifier'] : '';
+        if ($identifier !== '') {
+            $this->auditDenial($identifier, 'Command refused: ' . $command);
+        }
+
+        /** @phpstan-ignore method.internal */
+        $dataHandler?->log(
+            self::TABLE,
+            $uid,
+            2,
+            null,
+            1,
+            self::REFUSED_COMMANDS[$command],
+        );
     }
 
     /**
@@ -838,18 +960,22 @@ final class SecretTcaHook
      * Without a ConnectionPool (construction without DI) the static call is
      * kept so those callers keep working unchanged.
      *
+     * $includeDeleted drops that predicate, for the one caller that needs a
+     * soft-deleted row: refuseCommand() has to name the identifier of an
+     * `undelete` target, which is deleted by definition.
+     *
      * @param list<string> $columns
      *
      * @return array<string, mixed>|null
      */
-    private function readRecord(int $uid, array $columns): ?array
+    private function readRecord(int $uid, array $columns, bool $includeDeleted = false): ?array
     {
         if ($uid < 1) {
             return null;
         }
 
         if (!$this->connectionPool instanceof ConnectionPool) {
-            $record = BackendUtility::getRecord(self::TABLE, $uid, implode(',', $columns));
+            $record = BackendUtility::getRecord(self::TABLE, $uid, implode(',', $columns), '', !$includeDeleted);
             if ($record === null) {
                 return null;
             }
@@ -868,19 +994,28 @@ final class SecretTcaHook
         $queryBuilder = $this->connectionPool->getQueryBuilderForTable(self::TABLE);
         $queryBuilder->getRestrictions()->removeAll();
 
-        $row = $queryBuilder
+        // Built after select()/from() so the parameter binding keeps the
+        // order the read has always had — the shape unit tests pin it.
+        $query = $queryBuilder
             ->select(...$columns)
-            ->from(self::TABLE)
-            ->where(
-                $queryBuilder->expr()->eq(
-                    'uid',
-                    $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT),
-                ),
-                $queryBuilder->expr()->eq(
-                    'deleted',
-                    $queryBuilder->createNamedParameter(0, Connection::PARAM_INT),
-                ),
-            )
+            ->from(self::TABLE);
+
+        $predicates = [
+            $queryBuilder->expr()->eq(
+                'uid',
+                $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT),
+            ),
+        ];
+
+        if (!$includeDeleted) {
+            $predicates[] = $queryBuilder->expr()->eq(
+                'deleted',
+                $queryBuilder->createNamedParameter(0, Connection::PARAM_INT),
+            );
+        }
+
+        $row = $query
+            ->where(...$predicates)
             ->executeQuery()
             ->fetchAssociative();
 

--- a/Documentation/Developer/TcaIntegration.rst
+++ b/Documentation/Developer/TcaIntegration.rst
@@ -422,9 +422,13 @@ identifiers and does share its secrets — the editor's error message says so
 explicitly, and the record needs manual review.
 
 A **delete** checks the delete permission of every vault field *before*
-removing the first secret, because a vault delete cannot be undone. If any
-field is denied, no secret is removed and the record delete is cancelled. A
-field pointing at a secret that no longer exists does not block the delete.
+removing the first secret, because the vault will not give a deleted secret
+back: the delete is a soft delete, so the encrypted row is retained, but the
+vault has no restore operation and the backend refuses TYPO3's ``undelete``
+command on ``tx_nrvault_secret`` (see
+:ref:`usage-record-operations-refused`). If any field is denied, no secret is
+removed and the record delete is cancelled. A field pointing at a secret that
+no longer exists does not block the delete.
 
 The preflight cannot cover a failure it is unable to predict — an audit write
 that fails, a vault outage, a permission revoked between the check and the

--- a/Documentation/Operations/Decommissioning.rst
+++ b/Documentation/Operations/Decommissioning.rst
@@ -26,10 +26,18 @@ Secret disposal
     There is no hard-delete path in the extension. Do not read "deleted" as
     "gone".
 
-That is the right default for a live system: it keeps the operation auditable
-and reversible, and the row is unreadable to anyone without the master key
-anyway. It is the wrong assumption when decommissioning. For actual disposal
-you have two options, and they compose:
+That is the right default for a live system: it keeps the operation auditable,
+and the row is unreadable to anyone without the master key anyway. It does
+**not** make the delete reversible. The vault has no restore operation, and
+the backend refuses TYPO3's ``undelete`` command on ``tx_nrvault_secret`` — a
+restore would hand back the ciphertext, the wrapped DEK, ``frontend_accessible``
+and both ACL tiers with no vault check at all, and nothing in the audit chain
+would say it happened. Recovering a deleted secret means acting on the database
+directly, deliberately and visibly. See
+:ref:`usage-record-operations-refused`.
+
+The soft delete is the wrong assumption when decommissioning. For actual
+disposal you have two options, and they compose:
 
 **Crypto-erasure (recommended).** Destroy the master key and every secret in
 the vault becomes permanently unreadable in one step — including soft-deleted

--- a/Documentation/Usage/Index.rst
+++ b/Documentation/Usage/Index.rst
@@ -75,8 +75,53 @@ Creating secrets
     a copy never quietly shares the original's secrets. Deleting a record
     checks every vault field's delete permission *before* removing the first
     secret, and cancels the record delete outright if the cleanup fails —
-    a vault delete cannot be undone, so the record is kept rather than
-    orphaning a secret.
+    the vault will not give a deleted secret back, so the record is kept
+    rather than orphaning a secret.
+
+.. _usage-record-operations-refused:
+
+What the backend will not do to a secret record
+-----------------------------------------------
+
+TYPO3's record commands are not all meaningful for a vault secret, and three
+of them are refused outright. Each refusal cancels the command, tells you why
+in the backend, and records an ``access_denied`` entry in the audit chain.
+The refusals apply to everyone, administrators included: they express what the
+product guarantees about a secret, not who is trusted with it.
+
+..  list-table::
+    :header-rows: 1
+    :widths: 15 85
+
+    *   -   Command
+        -   Why it is refused
+    *   -   Restore (``undelete``)
+        -   The vault has no restore operation. A delete is a *soft* delete —
+            the row keeps its ciphertext, its wrapped DEK,
+            ``frontend_accessible`` and both ACL tiers — so a restore would
+            hand the working secret straight back, and TYPO3's own restore
+            applies no vault check to do it. Recovering a deleted secret is a
+            deliberate database operation, not a button. See
+            :ref:`operations-decommissioning-secrets`.
+    *   -   Copy
+        -   A copied secret would carry no value: the encrypted columns are not
+            part of the record's editable fields, so the copy is created empty.
+            It would, however, claim the original's identifier and can shadow
+            it — breaking a secret that was never touched.
+    *   -   Move
+        -   Secrets live on the root level of the page tree. A secret moved
+            onto a page is deleted along with that page, through a code path
+            that applies no vault permission check and writes no audit entry.
+            The page a secret sits on grants nothing — the access scope is the
+            record's own :guilabel:`Scope page` field.
+
+..  note::
+
+    **"Deleted" means unreachable, not erased.** The encrypted row is retained
+    in the database until it is removed there or the master key is destroyed.
+    That is deliberate — it keeps the delete auditable — but do not read a
+    deleted secret as a disposed one. :ref:`operations-decommissioning` covers
+    actual disposal.
 
 .. _usage-viewing-secrets:
 

--- a/Resources/Private/Language/locallang_js.xlf
+++ b/Resources/Private/Language/locallang_js.xlf
@@ -48,7 +48,7 @@
         <source>Delete Secret</source>
       </trans-unit>
       <trans-unit id="nrvault.delete.confirm">
-        <source>Are you sure you want to delete the secret "{0}"? This action cannot be undone.</source>
+        <source>Are you sure you want to delete the secret "{0}"? The vault cannot restore it. The encrypted record is retained in the database until it is removed there.</source>
       </trans-unit>
 
       <!-- Reveal modal -->
@@ -132,7 +132,7 @@
 
       <!-- Clear secret (TCA form element) -->
       <trans-unit id="nrvault.clear.confirm">
-        <source>Are you sure you want to clear this secret? This action cannot be undone.</source>
+        <source>Are you sure you want to clear this secret? Saving the record deletes it, and the vault cannot restore it.</source>
       </trans-unit>
 
       <!-- Hash chain verification (vault-backend.js) -->

--- a/Resources/Public/JavaScript/SecretsList.js
+++ b/Resources/Public/JavaScript/SecretsList.js
@@ -80,7 +80,8 @@ class SecretsList {
             lang('nrvault.delete.title', 'Delete Secret'),
             lang(
                 'nrvault.delete.confirm',
-                'Are you sure you want to delete the secret "{0}"? This action cannot be undone.',
+                'Are you sure you want to delete the secret "{0}"? The vault cannot restore it. '
+                + 'The encrypted record is retained in the database until it is removed there.',
                 this.escapeHtml(identifier),
             ),
             Severity.warning,

--- a/Resources/Public/JavaScript/vault-secret-element.js
+++ b/Resources/Public/JavaScript/vault-secret-element.js
@@ -269,7 +269,11 @@ class VaultSecretElement {
 
         Modal.confirm(
             lang('nrvault.delete.title', 'Delete Secret'),
-            lang('nrvault.clear.confirm', 'Are you sure you want to clear this secret? This action cannot be undone.'),
+            lang(
+                'nrvault.clear.confirm',
+                'Are you sure you want to clear this secret? Saving the record deletes it, '
+                + 'and the vault cannot restore it.',
+            ),
             Severity.warning,
             [
                 {

--- a/Tests/Functional/Domain/Repository/SecretRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/SecretRepositoryTest.php
@@ -96,6 +96,50 @@ final class SecretRepositoryTest extends FunctionalTestCase
         self::assertNull($result);
     }
 
+    /**
+     * The control this pair implements: `hidden` is TCA's `disabled` enable
+     * column, so every restriction-honouring query drops the record. Pinning
+     * the blind side is the point — a later "fix" that widened `findByUid()`
+     * itself would switch the control off wholesale, and this test is what
+     * says so.
+     */
+    #[Test]
+    public function findByUidDoesNotSeeADisabledSecret(): void
+    {
+        $uid = $this->saveDisabledSecret('disabled_uid_secret');
+
+        self::assertNull($this->subject->findByUid($uid));
+    }
+
+    #[Test]
+    public function findByUidIncludingDisabledSeesADisabledSecret(): void
+    {
+        $uid = $this->saveDisabledSecret('disabled_uid_secret_visible');
+
+        $retrieved = $this->subject->findByUidIncludingDisabled($uid);
+
+        self::assertNotNull($retrieved);
+        self::assertSame('disabled_uid_secret_visible', $retrieved->getIdentifier());
+    }
+
+    /**
+     * Only `HiddenRestriction` is lifted. A soft-deleted record must stay
+     * invisible to the widened lookup too — the write-path guards built on it
+     * decide `undelete` among other things, and a lookup that resurrected
+     * deleted rows would answer that question with the wrong record.
+     */
+    #[Test]
+    public function findByUidIncludingDisabledDoesNotSeeADeletedSecret(): void
+    {
+        $saved = $this->subject->save($this->newSecret('deleted_uid_secret'));
+        $uid = $saved->getUid();
+        self::assertNotNull($uid);
+
+        $this->subject->delete($saved);
+
+        self::assertNull($this->subject->findByUidIncludingDisabled($uid));
+    }
+
     #[Test]
     public function existsReturnsTrueForExistingSecret(): void
     {
@@ -189,6 +233,18 @@ final class SecretRepositoryTest extends FunctionalTestCase
     }
 
     /**
+     * Persist a disabled secret and return its UID.
+     */
+    private function saveDisabledSecret(string $identifier): int
+    {
+        $saved = $this->subject->save($this->newSecret($identifier, hidden: true));
+        $uid = $saved->getUid();
+        self::assertNotNull($uid);
+
+        return $uid;
+    }
+
+    /**
      * Build a Secret with sensible defaults for repository round-trip tests.
      */
     private function newSecret(
@@ -196,6 +252,7 @@ final class SecretRepositoryTest extends FunctionalTestCase
         string $encryptedValue = 'encrypted',
         string $context = '',
         int $version = 1,
+        bool $hidden = false,
     ): Secret {
         return new Secret(
             identifier: $identifier,
@@ -207,6 +264,7 @@ final class SecretRepositoryTest extends FunctionalTestCase
             context: $context,
             version: $version,
             cruserId: 1,
+            hidden: $hidden,
         );
     }
 }

--- a/Tests/Functional/Hook/Fixtures/be_users_disabled_secret.csv
+++ b/Tests/Functional/Hook/Fixtures/be_users_disabled_secret.csv
@@ -1,0 +1,11 @@
+"pages",,,,,,,,,
+,"uid","pid","title","doktype","perms_userid","perms_groupid","perms_user","perms_group","perms_everybody"
+,1,0,"Vault secrets",1,1,30,31,31,0
+"be_groups",,,,,
+,"uid","pid","title","tables_modify","custom_options"
+,30,0,"vault-record-editors","tx_nrvault_secret",""
+,21,0,"vault-deleters","tx_nrvault_secret","tx_nrvault:secret.delete"
+"be_users",,,,,,,,,,
+,"uid","pid","username","password","admin","disable","starttime","endtime","usergroup","db_mountpoints"
+,2,0,"editor","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0,"30","1"
+,3,0,"owner_with_delete","$2y$12$B5rDqbWz6yWWxnXeANxeAOkBJJDJnWx6kQ9b5l3/0dLLX/rOKpC5e",0,0,0,0,"30,21","1"

--- a/Tests/Functional/Hook/SecretTcaHookCommandRefusalTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookCommandRefusalTest.php
@@ -1,0 +1,280 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Hook;
+
+use Netresearch\NrVault\Audit\AuditAction;
+use Netresearch\NrVault\Hook\SecretTcaHook;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for the cmdmap commands SecretTcaHook refuses outright on
+ * tx_nrvault_secret.
+ *
+ * The sharpest of the three is `undelete`: core's undeleteRecord() applies
+ * checkModifyAccessList() and checkRecordEditAccess(), and skips its
+ * page-permission branch entirely for a record at pid 0 — which every vault
+ * secret is. Because a vault delete is a SOFT delete, the ciphertext, the
+ * wrapped DEK, `frontend_accessible` and both MM ACL tiers survive it, so the
+ * restore handed the secret back intact after zero vault checks. `copy` and
+ * `move` are refused for the reasons given in SecretTcaHook::REFUSED_COMMANDS.
+ *
+ * The refusal is a PRODUCT rule, not a permission tier: an admin gets the same
+ * answer as an editor, because "a vault delete cannot be undone" must not mean
+ * "unless an administrator says otherwise".
+ */
+#[CoversClass(SecretTcaHook::class)]
+final class SecretTcaHookCommandRefusalTest extends AbstractVaultFunctionalTestCase
+{
+    private const SECRET_TABLE = 'tx_nrvault_secret';
+
+    private const AUDIT_TABLE = 'tx_nrvault_audit_log';
+
+    /** Admin backend user (uid 1 in the fixture). */
+    private const ADMIN_UID = 1;
+
+    /** Non-admin editor (uid 2 in the fixture), no operation permissions. */
+    private const EDITOR_UID = 2;
+
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_acl.csv';
+
+    /** Log in explicitly per test — different actors per scenario. */
+    protected ?int $backendUserUid = null;
+
+    /**
+     * @return iterable<string, array{0: int}>
+     */
+    public static function actorProvider(): iterable
+    {
+        yield 'non-admin editor' => [self::EDITOR_UID];
+        yield 'administrator' => [self::ADMIN_UID];
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function refusedCommandProvider(): iterable
+    {
+        yield 'undelete' => ['undelete'];
+        yield 'copy' => ['copy'];
+        yield 'move' => ['move'];
+    }
+
+    #[Test]
+    #[DataProvider('actorProvider')]
+    public function undeleteLeavesTheSecretDeletedAndRecordsTheRefusal(int $actorUid): void
+    {
+        $this->setUpBackendUser($actorUid);
+        [$uid, $identifier] = $this->seedSecret(self::ADMIN_UID, deleted: true);
+
+        $messages = [];
+        $commandIsProcessed = $this->runCommandHook('undelete', $uid, $messages);
+
+        self::assertTrue(
+            $commandIsProcessed,
+            'The refusal must cancel the command so core skips its own undeleteRecord().',
+        );
+        self::assertSame(1, $this->readDeletedFlag($uid), 'The secret must stay soft-deleted.');
+        self::assertSame(
+            1,
+            $this->countAudit($identifier, AuditAction::AccessDenied->value, 0),
+            'The refused restore must be recorded in the tamper-evident chain.',
+        );
+        // DataHandler prefixes every errorLog entry with "[<type>.<action>]: ",
+        // so the reason is asserted as the tail rather than the whole entry.
+        self::assertCount(1, $messages, 'The backend user must be told why the restore did nothing.');
+        self::assertStringEndsWith(
+            'A deleted vault secret cannot be restored: the vault has no restore operation, '
+            . 'and its delete is documented as not reversible.',
+            $messages[0],
+        );
+    }
+
+    /**
+     * The refusal must not depend on the row being readable through the
+     * ordinary (soft-delete-filtering) path, which is exactly the state an
+     * undelete target is in.
+     */
+    #[Test]
+    #[DataProvider('refusedCommandProvider')]
+    public function everyRefusedCommandIsCancelledAndAudited(string $command): void
+    {
+        $this->setUpBackendUser(self::ADMIN_UID);
+        [$uid, $identifier] = $this->seedSecret(self::ADMIN_UID, deleted: $command === 'undelete');
+
+        $messages = [];
+        $commandIsProcessed = $this->runCommandHook($command, $uid, $messages);
+
+        self::assertTrue($commandIsProcessed, $command . ' must be cancelled');
+        self::assertCount(1, $messages, $command . ' must explain itself once');
+        self::assertSame(
+            1,
+            $this->countAudit($identifier, AuditAction::AccessDenied->value, 0),
+            'The refused ' . $command . ' must be recorded in the tamper-evident chain.',
+        );
+    }
+
+    /**
+     * The whole chain, not the hook contract in isolation: a real
+     * DataHandler::process_cmdmap() run as an ADMIN, who clears every core
+     * check undeleteRecord() applies (checkModifyAccessList,
+     * checkRecordEditAccess) and for whom the page-permission branch is
+     * skipped anyway because the record sits at pid 0. Without the refusal
+     * this restores the secret; with it, the row stays deleted.
+     */
+    #[Test]
+    public function processCmdmapDoesNotRestoreADeletedSecret(): void
+    {
+        $this->setUpBackendUser(self::ADMIN_UID);
+        [$uid, $identifier] = $this->seedSecret(self::ADMIN_UID, deleted: true);
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->start([], [self::SECRET_TABLE => [$uid => ['undelete' => 1]]], $GLOBALS['BE_USER']);
+        $dataHandler->process_cmdmap();
+
+        self::assertSame(1, $this->readDeletedFlag($uid), 'The secret must not be restored.');
+        self::assertSame(
+            1,
+            $this->countAudit($identifier, AuditAction::AccessDenied->value, 0),
+            'The refused restore must be recorded in the tamper-evident chain.',
+        );
+    }
+
+    /**
+     * The commands core already refuses for this table (no languageField, no
+     * versioningWS) are deliberately NOT intercepted — blocking them would
+     * add a gate with nothing behind it and hide that fact from the next
+     * reader.
+     */
+    #[Test]
+    public function aCommandCoreAlreadyRefusesIsLeftToCore(): void
+    {
+        $this->setUpBackendUser(self::ADMIN_UID);
+        [$uid, $identifier] = $this->seedSecret(self::ADMIN_UID);
+
+        $messages = [];
+        $commandIsProcessed = $this->runCommandHook('localize', $uid, $messages);
+
+        self::assertFalse($commandIsProcessed, 'localize must be left to core');
+        self::assertSame([], $messages);
+        self::assertSame(0, $this->countAudit($identifier, AuditAction::AccessDenied->value, 0));
+    }
+
+    /**
+     * The refusal must not have cost the one command this table does support:
+     * an authorized delete still runs through VaultService and soft-deletes
+     * the record.
+     */
+    #[Test]
+    public function theDeletePathIsUnchanged(): void
+    {
+        $this->setUpBackendUser(self::ADMIN_UID);
+        [$uid, $identifier] = $this->seedSecret(self::EDITOR_UID);
+
+        $messages = [];
+        $commandIsProcessed = $this->runCommandHook('delete', $uid, $messages);
+
+        self::assertTrue($commandIsProcessed, 'The service-performed delete must cancel core deleteAction.');
+        self::assertSame(1, $this->readDeletedFlag($uid), 'The record must be soft-deleted by the service.');
+        self::assertSame(
+            1,
+            $this->countAudit($identifier, AuditAction::Delete->value, 1),
+            'The authorized delete must record a successful delete audit entry.',
+        );
+        self::assertSame([], $messages, 'A successful delete has nothing to report to the editor.');
+    }
+
+    /**
+     * Drive the hook contract directly (preProcess decision + processCmdmap
+     * cancellation) so the vault gate is isolated from core DataHandler's own
+     * table-permission system — which would otherwise block a permission-less
+     * non-admin and mask the result.
+     *
+     * @param list<string> $messages Collected DataHandler error details
+     */
+    private function runCommandHook(string $command, int $uid, array &$messages): bool
+    {
+        $hook = $this->get(SecretTcaHook::class);
+        self::assertInstanceOf(SecretTcaHook::class, $hook);
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+
+        $hook->processCmdmap_preProcess($command, self::SECRET_TABLE, $uid, null, $dataHandler);
+
+        $commandIsProcessed = false;
+        $hook->processCmdmap($command, self::SECRET_TABLE, $uid, '', $commandIsProcessed, $dataHandler, false);
+
+        // $errorLog is core-internal, but it is the only place a
+        // DataHandler::log() call the hook made is observable — and what the
+        // editor is told is exactly what this test is about.
+        /** @phpstan-ignore property.internal */
+        foreach ($dataHandler->errorLog as $entry) {
+            $messages[] = (string) $entry;
+        }
+
+        return $commandIsProcessed;
+    }
+
+    /**
+     * @return array{0: int, 1: string} [secret uid, identifier]
+     */
+    private function seedSecret(int $ownerUid, bool $deleted = false): array
+    {
+        $identifier = 'cmd_refusal_' . bin2hex(random_bytes(4));
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::SECRET_TABLE);
+        $connection->insert(self::SECRET_TABLE, [
+            'pid' => 0,
+            'identifier' => $identifier,
+            'owner_uid' => $ownerUid,
+            'frontend_accessible' => 0,
+            'deleted' => $deleted ? 1 : 0,
+        ]);
+
+        return [(int) $connection->lastInsertId(), $identifier];
+    }
+
+    private function readDeletedFlag(int $uid): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::SECRET_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $deleted = $queryBuilder
+            ->select('deleted')
+            ->from(self::SECRET_TABLE)
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)))
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($deleted) ? (int) $deleted : -1;
+    }
+
+    private function countAudit(string $identifier, string $action, int $success): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::AUDIT_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $count = $queryBuilder
+            ->count('uid')
+            ->from(self::AUDIT_TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('secret_identifier', $queryBuilder->createNamedParameter($identifier)),
+                $queryBuilder->expr()->eq('action', $queryBuilder->createNamedParameter($action)),
+                $queryBuilder->expr()->eq('success', $queryBuilder->createNamedParameter($success, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($count) ? (int) $count : 0;
+    }
+}

--- a/Tests/Functional/Hook/SecretTcaHookCommandRefusalTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookCommandRefusalTest.php
@@ -221,8 +221,14 @@ final class SecretTcaHookCommandRefusalTest extends AbstractVaultFunctionalTestC
         // DataHandler::log() call the hook made is observable — and what the
         // editor is told is exactly what this test is about.
         /** @phpstan-ignore property.internal */
-        foreach ($dataHandler->errorLog as $entry) {
-            $messages[] = (string) $entry;
+        $errorLog = $dataHandler->errorLog;
+
+        // Explicit narrowing rather than a cast: the v13 stubs type errorLog
+        // as a plain array, so its entries are mixed on that matrix leg only.
+        foreach ($errorLog as $entry) {
+            if (\is_scalar($entry)) {
+                $messages[] = (string) $entry;
+            }
         }
 
         return $commandIsProcessed;

--- a/Tests/Functional/Hook/SecretTcaHookDisabledSecretTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookDisabledSecretTest.php
@@ -1,0 +1,254 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Hook;
+
+use Netresearch\NrVault\Audit\AuditAction;
+use Netresearch\NrVault\Hook\SecretTcaHook;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for SecretTcaHook against a DISABLED secret
+ * (`hidden = 1`, TCA's `disabled` enable column).
+ *
+ * The hook resolved its DataHandler target through the restriction-honouring
+ * lookup, which drops such a record. A guard that cannot see its subject does
+ * not refuse the operation — it returns early and hands the record back to
+ * core, which then carried out the delete with no per-secret ACL, no
+ * `secret.delete` permission and no audit entry. Disabling a secret must not
+ * be the way to strip it of its guard, so both gates now resolve through the
+ * disabled-visible lookup.
+ *
+ * ## Why these tests drive the real DataHandler
+ *
+ * The sibling suites call the hook methods directly to isolate the vault ACL
+ * from core's table permissions. That is exactly wrong here: the finding is
+ * that the hook DOES NOTHING, and a direct call cannot show what core does
+ * next. The actors therefore hold real table-modify and page rights, so
+ * `process_cmdmap()` reaches core's own `deleteAction()` whenever the hook
+ * declines the command — which is what makes the unguarded delete visible.
+ */
+#[CoversClass(SecretTcaHook::class)]
+final class SecretTcaHookDisabledSecretTest extends AbstractVaultFunctionalTestCase
+{
+    private const SECRET_TABLE = 'tx_nrvault_secret';
+
+    private const AUDIT_TABLE = 'tx_nrvault_audit_log';
+
+    /** Page the secrets live on; both actors may edit and delete here. */
+    private const PAGE_UID = 1;
+
+    /**
+     * Non-admin editor with table-modify rights and nothing else: not the
+     * owner, in neither tier, holding no operation permission.
+     */
+    private const EDITOR_UID = 2;
+
+    /** Non-admin whose group grants tx_nrvault:secret.delete. */
+    private const DELETER_UID = 3;
+
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_disabled_secret.csv';
+
+    /** Logged in per test — the scenarios need different actors. */
+    protected ?int $backendUserUid = null;
+
+    /**
+     * The finding itself: before the fix core soft-deleted the row unasked,
+     * without the per-secret ACL and without an audit entry.
+     */
+    #[Test]
+    public function anUnauthorizedDeleteOfADisabledSecretDoesNotLand(): void
+    {
+        $this->setUpBackendUser(self::EDITOR_UID);
+        [$uid, $identifier] = $this->seedDisabledSecret(self::DELETER_UID);
+
+        $this->submitDeleteCommand($uid);
+
+        self::assertSame(
+            0,
+            $this->readDeletedFlag($uid),
+            'A disabled secret must not be deleted by an actor the vault never authorized.',
+        );
+        self::assertSame(
+            0,
+            $this->countAudit($identifier, AuditAction::Delete->value, 1),
+            'No successful delete audit entry may exist for a delete that was never authorized.',
+        );
+    }
+
+    /**
+     * The atomicity the finding broke, asserted as the equivalence it is: a
+     * disabled secret is soft-deleted if and only if the vault audited the
+     * delete. Both sides false is the branch's current outcome — the vault
+     * service still resolves its own target through the restricted lookup, so
+     * the delete fails closed and the record survives. Both sides true is the
+     * outcome once that lookup is widened as well. What must never occur, and
+     * what happened before this fix, is a deleted row with no audit entry.
+     */
+    #[Test]
+    public function aDisabledSecretIsNeverDeletedWithoutBeingAudited(): void
+    {
+        $this->setUpBackendUser(self::DELETER_UID);
+        [$uid, $identifier] = $this->seedDisabledSecret(self::DELETER_UID);
+
+        $this->submitDeleteCommand($uid);
+
+        self::assertSame(
+            $this->countAudit($identifier, AuditAction::Delete->value, 1) === 1,
+            $this->readDeletedFlag($uid) === 1,
+            'Deleting a disabled secret and auditing that delete are all-or-nothing.',
+        );
+    }
+
+    /**
+     * `undelete` is refused unconditionally on this table, and being disabled
+     * must not change that: the refusal reads its target through the
+     * deleted-visible read, so the record it names is found either way.
+     */
+    #[Test]
+    public function undeleteOfADisabledSecretIsStillRefused(): void
+    {
+        $this->setUpBackendUser(self::DELETER_UID);
+        [$uid, $identifier] = $this->seedDisabledSecret(self::DELETER_UID, deleted: true);
+
+        $hook = $this->get(SecretTcaHook::class);
+        self::assertInstanceOf(SecretTcaHook::class, $hook);
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+
+        $hook->processCmdmap_preProcess('undelete', self::SECRET_TABLE, $uid, dataHandler: $dataHandler);
+
+        $commandIsProcessed = false;
+        $hook->processCmdmap('undelete', self::SECRET_TABLE, $uid, '', $commandIsProcessed, $dataHandler, false);
+
+        self::assertTrue($commandIsProcessed, 'core must skip its own undelete branch');
+        self::assertSame(1, $this->readDeletedFlag($uid), 'The refused undelete must leave the record deleted.');
+        self::assertSame(
+            1,
+            $this->countAudit($identifier, AuditAction::AccessDenied->value, 0),
+            'The refusal must be recorded under the identifier it is about.',
+        );
+    }
+
+    /**
+     * The milder second site: the per-secret write tier is asserted on every
+     * FormEngine edit, and it too resolved its subject through the restricted
+     * lookup — so a non-owner could rewrite a disabled secret's columns
+     * without canWrite() ever being consulted.
+     */
+    #[Test]
+    public function aNonOwnerCannotEditADisabledSecret(): void
+    {
+        $this->setUpBackendUser(self::EDITOR_UID);
+        [$uid, $identifier] = $this->seedDisabledSecret(self::DELETER_UID);
+
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+        $dataHandler->start(
+            [self::SECRET_TABLE => [$uid => ['description' => 'rewritten by someone else']]],
+            [],
+        );
+        $dataHandler->process_datamap();
+
+        self::assertSame(
+            'seeded description',
+            $this->readDescription($uid),
+            'A disabled secret must keep its description against an actor without write access.',
+        );
+        self::assertSame(
+            1,
+            $this->countAudit($identifier, AuditAction::AccessDenied->value, 0),
+            'The refused edit must be recorded as access_denied.',
+        );
+    }
+
+    /**
+     * Run the delete as FormEngine would, through the whole DataHandler —
+     * core's own permission checks included, so that a hook which declines
+     * the command really does leave core to perform it.
+     */
+    private function submitDeleteCommand(int $uid): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+        $dataHandler->start([], [self::SECRET_TABLE => [$uid => ['delete' => 1]]]);
+        $dataHandler->process_cmdmap();
+    }
+
+    /**
+     * @return array{int, string} The new secret UID and its identifier
+     */
+    private function seedDisabledSecret(int $ownerUid, bool $deleted = false): array
+    {
+        $identifier = 'disabled_' . bin2hex(random_bytes(4));
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::SECRET_TABLE);
+        $connection->insert(self::SECRET_TABLE, [
+            'pid' => self::PAGE_UID,
+            'identifier' => $identifier,
+            'description' => 'seeded description',
+            'owner_uid' => $ownerUid,
+            'frontend_accessible' => 0,
+            'hidden' => 1,
+            'deleted' => $deleted ? 1 : 0,
+        ]);
+
+        return [(int) $connection->lastInsertId(), $identifier];
+    }
+
+    private function readDeletedFlag(int $uid): int
+    {
+        $deleted = $this->readColumn($uid, 'deleted');
+
+        return is_numeric($deleted) ? (int) $deleted : -1;
+    }
+
+    private function readDescription(int $uid): string
+    {
+        $description = $this->readColumn($uid, 'description');
+
+        return \is_string($description) ? $description : '';
+    }
+
+    private function readColumn(int $uid, string $column): mixed
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::SECRET_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return $queryBuilder
+            ->select($column)
+            ->from(self::SECRET_TABLE)
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)))
+            ->executeQuery()
+            ->fetchOne();
+    }
+
+    private function countAudit(string $identifier, string $action, int $success): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::AUDIT_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $count = $queryBuilder
+            ->count('uid')
+            ->from(self::AUDIT_TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('secret_identifier', $queryBuilder->createNamedParameter($identifier)),
+                $queryBuilder->expr()->eq('action', $queryBuilder->createNamedParameter($action)),
+                $queryBuilder->expr()->eq('success', $queryBuilder->createNamedParameter($success, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($count) ? (int) $count : 0;
+    }
+}

--- a/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
@@ -23,6 +23,8 @@ use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
 use TYPO3\CMS\Core\Database\Query\Expression\ExpressionBuilder;
 use TYPO3\CMS\Core\Database\Query\QueryBuilder;
+use TYPO3\CMS\Core\Database\Query\Restriction\DefaultRestrictionContainer;
+use TYPO3\CMS\Core\Database\Query\Restriction\HiddenRestriction;
 
 /**
  * Unit tests for {@see SecretRepository}.
@@ -141,6 +143,109 @@ final class SecretRepositoryTest extends TestCase
 
         self::assertInstanceOf(Secret::class, $secret);
         self::assertSame(42, $secret->getUid());
+    }
+
+    /**
+     * The widened lookup lifts exactly ONE restriction, by type:
+     * `HiddenRestriction`, the one bound to TCA's `enablecolumns.disabled`
+     * mapping. `removeAll()` would additionally discard `DeletedRestriction`,
+     * turning a guard that decides `undelete` into the thing that resurrects
+     * soft-deleted rows — so it must never be called.
+     */
+    #[Test]
+    public function findByUidIncludingDisabledLiftsOnlyTheHiddenRestriction(): void
+    {
+        $predicates = [];
+        $restrictions = $this->wireIncludingDisabledLookup($this->createMissingRowResult(), $predicates);
+
+        $restrictions
+            ->expects(self::once())
+            ->method('removeByType')
+            ->with(HiddenRestriction::class)
+            ->willReturnSelf();
+
+        $restrictions
+            ->expects(self::never())
+            ->method('removeAll');
+
+        $this->subject->findByUidIncludingDisabled(7);
+    }
+
+    /**
+     * The `deleted = 0` predicate stays in the WHERE clause. It is the second
+     * half of the control above: even with the restriction container widened,
+     * a soft-deleted row must not come back.
+     */
+    #[Test]
+    public function findByUidIncludingDisabledKeepsTheDeletedPredicate(): void
+    {
+        $predicates = [];
+        $restrictions = $this->wireIncludingDisabledLookup($this->createMissingRowResult(), $predicates);
+
+        $restrictions
+            ->expects(self::atMost(1))
+            ->method('removeByType')
+            ->willReturnSelf();
+
+        $this->subject->findByUidIncludingDisabled(7);
+
+        self::assertContains(
+            ['deleted', 0],
+            $predicates,
+            'findByUidIncludingDisabled() must keep the explicit deleted = 0 predicate',
+        );
+    }
+
+    #[Test]
+    public function findByUidIncludingDisabledReturnsNullWhenNotFound(): void
+    {
+        $this->setupQueryBuilderForSelect($this->createMissingRowResult());
+
+        self::assertNull($this->subject->findByUidIncludingDisabled(999));
+    }
+
+    #[Test]
+    public function findByUidIncludingDisabledReturnsSecretWhenFound(): void
+    {
+        $secretRow = $this->createSecretRow('disabled-uid-test', 42);
+        $secretRow['hidden'] = 1;
+        $result = $this->createStub(Result::class);
+        $result->method('fetchAssociative')->willReturn($secretRow);
+
+        // Read tier + write tier MM lookups follow the secret-row fetch.
+        $readGroupResult = $this->createStub(Result::class);
+        $readGroupResult->method('fetchAllAssociative')->willReturn([]);
+        $writeGroupResult = $this->createStub(Result::class);
+        $writeGroupResult->method('fetchAllAssociative')->willReturn([]);
+
+        $this->setupQueryBuilderForSelect($result);
+        $this->queryBuilder->method('executeQuery')
+            ->willReturnOnConsecutiveCalls($result, $readGroupResult, $writeGroupResult);
+
+        $secret = $this->subject->findByUidIncludingDisabled(42);
+
+        self::assertInstanceOf(Secret::class, $secret);
+        self::assertSame(42, $secret->getUid());
+        self::assertTrue($secret->isHidden(), 'the disabled row is returned as the disabled record it is');
+    }
+
+    /**
+     * Guard against the widening leaking sideways: the restricted finders
+     * must never reach for the restriction container at all. Widening one of
+     * them would switch the control off instead of working around it.
+     */
+    #[Test]
+    public function theRestrictedFindersLiftNoRestriction(): void
+    {
+        $queryBuilder = $this->useStrictQueryBuilderMock();
+        $queryBuilder
+            ->expects(self::never())
+            ->method('getRestrictions');
+
+        $this->setupQueryBuilderForSelect($this->createMissingRowResult());
+
+        self::assertNull($this->subject->findByUid(999), 'findByUid() stays fully restricted');
+        self::assertNull($this->subject->findByIdentifier('nonexistent'), 'findByIdentifier() stays fully restricted');
     }
 
     #[Test]
@@ -1011,6 +1116,58 @@ final class SecretRepositoryTest extends TestCase
         $qb->method('executeQuery')->willReturn($result);
 
         return $qb;
+    }
+
+    /**
+     * A Result whose row fetch misses — the shared "not found" shape.
+     */
+    private function createMissingRowResult(): Result
+    {
+        $result = $this->createStub(Result::class);
+        $result->method('fetchAssociative')->willReturn(false);
+
+        return $result;
+    }
+
+    /**
+     * Wire the strict QueryBuilder/ExpressionBuilder pair for a
+     * `findByUidIncludingDisabled()` call and hand back the restriction
+     * container the repository reaches for, so the caller can pin what is
+     * lifted. Every `expr()->eq()` predicate the query builds is appended to
+     * `$predicates` as `[field, value]`, so the caller can pin what is kept.
+     *
+     * @param array<int, array{0: string, 1: mixed}> $predicates
+     *
+     * @return DefaultRestrictionContainer&MockObject
+     */
+    private function wireIncludingDisabledLookup(Result $result, array &$predicates): DefaultRestrictionContainer
+    {
+        [$queryBuilder, $expressionBuilder] = $this->useStrictQueryBuilderAndExpressionBuilderMocks();
+
+        $restrictions = $this->createMock(DefaultRestrictionContainer::class);
+
+        $queryBuilder
+            ->expects(self::once())
+            ->method('getRestrictions')
+            ->willReturn($restrictions);
+        $queryBuilder->method('select')->willReturnSelf();
+        $queryBuilder->method('from')->willReturnSelf();
+        $queryBuilder->method('where')->willReturnSelf();
+        $queryBuilder->method('createNamedParameter')->willReturn('?');
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        $expressionBuilder
+            ->expects(self::atLeastOnce())
+            ->method('eq')
+            ->willReturnCallback(
+                static function (string $fieldName, mixed $value) use (&$predicates): string {
+                    $predicates[] = [$fieldName, $value];
+
+                    return $fieldName . ' = ?';
+                },
+            );
+
+        return $restrictions;
     }
 
     private function setupQueryBuilderForSelect(Result $result): void

--- a/Tests/Unit/Hook/SecretTcaHookTest.php
+++ b/Tests/Unit/Hook/SecretTcaHookTest.php
@@ -250,7 +250,7 @@ final class SecretTcaHookTest extends TestCase
     {
         // A resolvable secret, so the test proves the command is dropped by
         // the command filter rather than by an empty repository lookup.
-        $this->secretRepository->method('findByUid')->willReturn(
+        $this->secretRepository->method('findByUidIncludingDisabled')->willReturn(
             SecretFixtureBuilder::create('api/token')->withUid(1)->buildSecret(),
         );
         $this->vaultService->expects($this->never())->method('delete');
@@ -276,7 +276,7 @@ final class SecretTcaHookTest extends TestCase
     #[Test]
     public function cmdmapPreProcessStillRoutesDeleteThroughTheVaultService(): void
     {
-        $this->secretRepository->method('findByUid')->willReturn(
+        $this->secretRepository->method('findByUidIncludingDisabled')->willReturn(
             SecretFixtureBuilder::create('api/token')->withUid(1)->buildSecret(),
         );
         $this->vaultService->expects($this->once())->method('delete')->with('api/token', 'Deleted via FormEngine');
@@ -824,7 +824,7 @@ final class SecretTcaHookTest extends TestCase
         );
         // The vault is never asked whether the actor may do this — the
         // refusal is a product rule, not a permission tier.
-        $this->secretRepository->expects($this->never())->method('findByUid');
+        $this->secretRepository->expects($this->never())->method('findByUidIncludingDisabled');
         $this->vaultService->expects($this->never())->method('delete');
 
         $hook = $this->hookWith($this->recordPool());

--- a/Tests/Unit/Hook/SecretTcaHookTest.php
+++ b/Tests/Unit/Hook/SecretTcaHookTest.php
@@ -17,6 +17,7 @@ use Netresearch\NrVault\Hook\SecretTcaHook;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Tests\Unit\Fixtures\SecretFixtureBuilder;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
 use PHPUnit\Framework\Attributes\CoversClass;
@@ -236,12 +237,69 @@ final class SecretTcaHookTest extends TestCase
         $this->hook->processCmdmap_preProcess('delete', 'other_table', 1);
     }
 
+    /**
+     * The commands core cannot carry out on this table anyway — it has no
+     * languageField and no versioningWS, so localize()/versionizeRecord()
+     * refuse before touching anything — are left alone deliberately, so the
+     * refusal list stays the short list of commands that would otherwise do
+     * real damage.
+     */
     #[Test]
-    public function cmdmapPreProcessIgnoresNonDeleteCommands(): void
+    #[DataProvider('inertCommandProvider')]
+    public function cmdmapPreProcessLeavesTheCommandsCoreAlreadyRefusesAlone(string $command): void
     {
+        // A resolvable secret, so the test proves the command is dropped by
+        // the command filter rather than by an empty repository lookup.
+        $this->secretRepository->method('findByUid')->willReturn(
+            SecretFixtureBuilder::create('api/token')->withUid(1)->buildSecret(),
+        );
+        $this->vaultService->expects($this->never())->method('delete');
         $this->auditService->expects($this->never())->method('log');
 
-        $this->hook->processCmdmap_preProcess('copy', 'tx_nrvault_secret', 1);
+        $dataHandler = $this->createMock(DataHandler::class);
+        $dataHandler->expects($this->never())->method('log');
+
+        $this->hook->processCmdmap_preProcess($command, self::TABLE, 1, null, $dataHandler);
+
+        $commandIsProcessed = false;
+        $this->hook->processCmdmap($command, self::TABLE, 1, null, $commandIsProcessed, $dataHandler, false);
+
+        self::assertFalse($commandIsProcessed, $command . ' must be left to core');
+    }
+
+    /**
+     * The counterpart of the two tests above: `delete` is neither refused nor
+     * ignored — it is performed through VaultService, which is what carries
+     * the per-secret ACL, the operation permission and the compensated audit
+     * entry.
+     */
+    #[Test]
+    public function cmdmapPreProcessStillRoutesDeleteThroughTheVaultService(): void
+    {
+        $this->secretRepository->method('findByUid')->willReturn(
+            SecretFixtureBuilder::create('api/token')->withUid(1)->buildSecret(),
+        );
+        $this->vaultService->expects($this->once())->method('delete')->with('api/token', 'Deleted via FormEngine');
+
+        $dataHandler = $this->createMock(DataHandler::class);
+        $this->hook->processCmdmap_preProcess('delete', self::TABLE, 1, null, $dataHandler);
+
+        $commandIsProcessed = false;
+        $this->hook->processCmdmap('delete', self::TABLE, 1, null, $commandIsProcessed, $dataHandler, false);
+
+        self::assertTrue($commandIsProcessed, 'core must skip its own deleteAction()');
+    }
+
+    /**
+     * @return iterable<string, array{0: string}>
+     */
+    public static function inertCommandProvider(): iterable
+    {
+        yield 'localize' => ['localize'];
+        yield 'copyToLanguage' => ['copyToLanguage'];
+        yield 'inlineLocalizeSynchronize' => ['inlineLocalizeSynchronize'];
+        yield 'discard' => ['discard'];
+        yield 'version' => ['version'];
     }
 
     #[Test]
@@ -745,20 +803,173 @@ final class SecretTcaHookTest extends TestCase
         );
     }
 
+    /**
+     * Each refused command is cancelled, audited as a denial and explained to
+     * the editor. The reason text is asserted verbatim rather than by
+     * substring: it is the only thing the backend user ever sees, and a
+     * command that borrowed another one's message would still pass a
+     * looser check.
+     */
     #[Test]
-    public function cmdmapPreProcessIgnoresUndeleteCommand(): void
+    #[DataProvider('refusedCommandProvider')]
+    public function cmdmapPreProcessRefusesTheCommand(string $command, string $reason): void
     {
-        $this->auditService->expects($this->never())->method('log');
+        $this->stubBackendRecords([['identifier' => 'api/token']]);
 
-        $this->hook->processCmdmap_preProcess('undelete', 'tx_nrvault_secret', 1);
+        $this->auditService->expects($this->once())->method('log')->with(
+            'api/token',
+            'access_denied',
+            false,
+            'Command refused: ' . $command,
+        );
+        // The vault is never asked whether the actor may do this — the
+        // refusal is a product rule, not a permission tier.
+        $this->secretRepository->expects($this->never())->method('findByUid');
+        $this->vaultService->expects($this->never())->method('delete');
+
+        $hook = $this->hookWith($this->recordPool());
+        $messages = [];
+        $dataHandler = $this->capturingDataHandler($messages);
+
+        $hook->processCmdmap_preProcess($command, self::TABLE, 5, null, $dataHandler);
+
+        $commandIsProcessed = false;
+        $hook->processCmdmap($command, self::TABLE, 5, null, $commandIsProcessed, $dataHandler, false);
+
+        self::assertTrue($commandIsProcessed, 'core must skip its own ' . $command . ' branch');
+        self::assertSame([$reason], $messages);
     }
 
-    #[Test]
-    public function cmdmapPreProcessIgnoresMoveCommand(): void
+    /**
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function refusedCommandProvider(): iterable
     {
+        yield 'undelete' => [
+            'undelete',
+            'A deleted vault secret cannot be restored: the vault has no restore operation, '
+            . 'and its delete is documented as not reversible.',
+        ];
+        yield 'copy' => [
+            'copy',
+            'A vault secret cannot be copied: the copy would carry no encrypted value and would '
+            . 'claim the original identifier, shadowing it.',
+        ];
+        yield 'move' => [
+            'move',
+            'A vault secret cannot be moved: it belongs on the root level, where no page '
+            . 'operation can delete it unaudited.',
+        ];
+    }
+
+    /**
+     * An `undelete` target is soft-deleted by definition, so the read that
+     * fetches its identifier for the denial entry must not carry the
+     * `deleted = 0` predicate every other read in this hook does — otherwise
+     * the refusal lands in the tamper-evident chain without naming the secret
+     * it is about.
+     */
+    #[Test]
+    public function cmdmapPreProcessReadsTheUndeleteTargetIncludingSoftDeletedRows(): void
+    {
+        $this->stubBackendRecords([['identifier' => 'api/token']]);
+
+        $this->hookWith($this->recordPool())->processCmdmap_preProcess(
+            'undelete',
+            self::TABLE,
+            5,
+            null,
+            $this->createMock(DataHandler::class),
+        );
+
+        self::assertSame([
+            ['removeAll'],
+            ['select', ['identifier']],
+            ['from', self::TABLE],
+            ['createNamedParameter', 5, Connection::PARAM_INT],
+            ['where', ['uid = 5']],
+        ], $this->recordReads);
+    }
+
+    /**
+     * The cancellation is what makes the refusal real, so it must survive an
+     * unreadable row: the audit entry is the only thing that degrades.
+     */
+    #[Test]
+    public function cmdmapPreProcessRefusesEvenWhenTheRecordCannotBeRead(): void
+    {
+        $this->stubBackendRecords([false]);
         $this->auditService->expects($this->never())->method('log');
 
-        $this->hook->processCmdmap_preProcess('move', 'tx_nrvault_secret', 1);
+        $hook = $this->hookWith($this->recordPool());
+        $messages = [];
+        $dataHandler = $this->capturingDataHandler($messages);
+
+        $hook->processCmdmap_preProcess('undelete', self::TABLE, 5, null, $dataHandler);
+
+        $commandIsProcessed = false;
+        $hook->processCmdmap('undelete', self::TABLE, 5, null, $commandIsProcessed, $dataHandler, false);
+
+        self::assertTrue($commandIsProcessed, 'an unreadable row must still be refused');
+        self::assertCount(1, $messages);
+    }
+
+    /**
+     * Core hands processCmdmap_preProcess() six positional arguments, but the
+     * signature keeps the last two optional so the pre-existing three-argument
+     * call shape still binds. The refusal must survive that shape: no
+     * DataHandler means no explanation for the editor, never a crash and never
+     * a command that slips through.
+     */
+    #[Test]
+    public function cmdmapPreProcessRefusesWithoutADataHandler(): void
+    {
+        $this->stubBackendRecords([['identifier' => 'api/token']]);
+        $this->auditService->expects($this->once())->method('log');
+
+        $hook = $this->hookWith($this->recordPool());
+        $hook->processCmdmap_preProcess('undelete', self::TABLE, 5);
+
+        $commandIsProcessed = false;
+        $hook->processCmdmap(
+            'undelete',
+            self::TABLE,
+            5,
+            null,
+            $commandIsProcessed,
+            $this->createMock(DataHandler::class),
+            false,
+        );
+
+        self::assertTrue($commandIsProcessed);
+    }
+
+    /**
+     * One cmdmap may carry several commands for the same record, so the
+     * handled-command flag is keyed by command as well as uid. A uid-only key
+     * would let the refused command cancel an unrelated one.
+     */
+    #[Test]
+    public function cmdmapCancelsOnlyTheCommandItRefused(): void
+    {
+        $this->stubBackendRecords([['identifier' => 'api/token']]);
+
+        $hook = $this->hookWith($this->recordPool());
+        $dataHandler = $this->createMock(DataHandler::class);
+
+        $hook->processCmdmap_preProcess('undelete', self::TABLE, 5, null, $dataHandler);
+
+        $otherIsProcessed = false;
+        $hook->processCmdmap('localize', self::TABLE, 5, null, $otherIsProcessed, $dataHandler, false);
+        self::assertFalse($otherIsProcessed, 'a refused undelete must not cancel another command');
+
+        $sameUidOtherRecord = false;
+        $hook->processCmdmap('undelete', self::TABLE, 6, null, $sameUidOtherRecord, $dataHandler, false);
+        self::assertFalse($sameUidOtherRecord, 'a refused undelete must not cancel another record');
+
+        $undeleteIsProcessed = false;
+        $hook->processCmdmap('undelete', self::TABLE, 5, null, $undeleteIsProcessed, $dataHandler, false);
+        self::assertTrue($undeleteIsProcessed);
     }
 
     #[Test]


### PR DESCRIPTION
TYPO3's `undelete` command restored a soft-deleted vault secret with **no vault check of any kind** — no ACL, no operation permission, no audit entry.

## Why it mattered more than it looks

The vault delete is a soft delete: only `deleted = 1` is written, so ciphertext, DEK, `frontend_accessible`, `hidden` and both MM ACL tiers survive intact. Restoring the row brings all of it back, and a previously frontend-accessible secret is immediately resolvable again.

**Reachability was lower than a first read suggests.** Every vault secret lives at `pid 0` (the module creates via `edit[tx_nrvault_secret][0]='new'`, the entity emits no pid, the column defaults to 0, TCA sets `rootLevel: -1`). Core's `undeleteRecord()` gates page permissions behind `if ($recordPid > 0)` — skipped entirely at pid 0 — and `checkRecordEditAccess()` returns true for a non-admin because the TCA has no languageField, no editlock and no authMode field. So the prerequisites were: an authenticated **non-admin** backend user with `tables_modify` on the table, workspace 0, and one uid. Zero vault permissions. `SimpleDataHandlerController` passes `cmd` through with no allow-list, so it is directly issuable, and a non-deleted row answers silently — which also permits free uid enumeration.

Core does write `sys_log`/`sys_history`, so the restore was invisible to the **vault** chain specifically — the one auditors are pointed at.

## Refused: `undelete`, `copy`, `move`

Each is marked handled so core never reaches its cmdmap branch, writes an `access_denied` audit entry and emits a DataHandler error naming the reason.

**`copy`** — not an authorization bypass (the clone goes through `process_datamap()`, so the create gate applies), but damaging: the crypto columns have no TCA definition and `fillInFieldArray()` only processes known fields, so the clone is **always value-less** while carrying the original's `identifier` — and `findByIdentifier()` has no `ORDER BY`, so the empty clone can win the lookup and break an intact secret.

**`move`** — the only command that takes a secret off root level into the page tree, where `deleteSpecificPage()` removes records by pid through a path that reaches neither the vault ACL nor the audit log. `pid` carries no vault meaning (scope lives in `scope_pid`), so a move buys nothing and costs the record its protection.

**Deliberately not blocked:** `localize`, `copyToLanguage`, `inlineLocalizeSynchronize`, `discard`, `version` — each verified inert for this schema (no language fields, no inline fields, no `versioningWS`). Gates with nothing behind them would be noise; a unit test pins that finding so it cannot drift silently.

**Admins are refused too.** This is a product rule, not a permission tier: an exemption would make "the vault cannot restore it" mean "unless an administrator says otherwise", and would put a restore into the HMAC chain that the vault never performed. The database remains available to an operator who must resurrect a row — where the change is visible as what it is.

## Documentation now says what delete actually does

The product promised "This action cannot be undone" while `Decommissioning.rst` called the soft delete "auditable and **reversible**". Both are now consistent: the confirm dialogs, the TCA field clear and `vault:delete` all say *"The vault cannot restore it. The encrypted record is retained in the database until it is removed there."*, and a new section enumerates the three refused commands.

## Verification

- Unit 3524 · Fuzz 1612 · Functional 345 — zero failures
- CGL clean · architecture check clean · `doc-cli` passes · docs render 72 documents, both new cross-references resolve
- **Fix proven load-bearing:** with the refusal disabled, the end-to-end test driving a real `process_cmdmap()` fails (`0 is not identical to 1` — core restores the secret); with it, the row stays deleted
- Mutation on `SecretTcaHook.php`: 75.4 % MSI, 0 not covered (up from 75.0 %)

Three tests that pinned the old behaviour — including one using `copy` — are inverted; they encoded the defect.
