### PR TITLE
Grade the CLI allowlist and the stored audit epoch honestly

### DIFF
--- a/Classes/Audit/Anchor/ChainTipAnchorService.php
+++ b/Classes/Audit/Anchor/ChainTipAnchorService.php
@@ -136,6 +136,7 @@ final readonly class ChainTipAnchorService implements ChainTipAnchorServiceInter
             currentSequence: $currentSequence,
             anchor: $anchor,
             warnings: $chainResult->warnings,
+            epochCounts: $chainResult->epochCounts,
         );
 
         $this->dispatchFindings($report);

--- a/Classes/Audit/AuditIntegrityReport.php
+++ b/Classes/Audit/AuditIntegrityReport.php
@@ -35,6 +35,14 @@ final readonly class AuditIntegrityReport
      * @param int $currentSequence Highest audit uid at verification time
      * @param ChainTipAnchor|null $anchor Anchor compared against (null = none available)
      * @param array<int, string> $warnings Non-fatal chain notes, keyed by uid
+     * @param array<int, int> $epochCounts Rows per `hmac_key_epoch` across the full
+     *                                     chain, keyed by epoch. Carried through from
+     *                                     the chain pass, which counts them for free
+     *                                     while walking. A valid chain whose lowest
+     *                                     epoch is below the configured one is not a
+     *                                     finding — nothing was tampered with — but it
+     *                                     is the state a stalled HMAC migration leaves
+     *                                     behind, so the verifier reports it.
      */
     public function __construct(
         public array $findings,
@@ -42,6 +50,7 @@ final readonly class AuditIntegrityReport
         public int $currentSequence,
         public ?ChainTipAnchor $anchor = null,
         public array $warnings = [],
+        public array $epochCounts = [],
     ) {}
 
     /**
@@ -110,6 +119,9 @@ final readonly class AuditIntegrityReport
      *     reasonCodes: list<string>,
      *     findings: list<array{reason: string, tamperEvidence: bool, detail: string, timestamp: int, context: array<string, bool|int|string>}>,
      *     warnings: array<int, string>,
+     *     epochCounts: array<int, int>,
+     *     minEpoch: int|null,
+     *     maxEpoch: int|null,
      * }
      */
     public function toArray(): array
@@ -126,6 +138,28 @@ final readonly class AuditIntegrityReport
                 $this->findings,
             ),
             'warnings' => $this->warnings,
+            'epochCounts' => $this->epochCounts,
+            'minEpoch' => $this->getMinEpoch(),
+            'maxEpoch' => $this->getMaxEpoch(),
         ];
+    }
+
+    /**
+     * Lowest `hmac_key_epoch` in the chain, or null when it is empty.
+     *
+     * The number that decides what the OLDEST evidence is protected by:
+     * raising `auditHmacEpoch` only changes how new rows are signed.
+     */
+    public function getMinEpoch(): ?int
+    {
+        return $this->epochCounts === [] ? null : min(array_keys($this->epochCounts));
+    }
+
+    /**
+     * Highest `hmac_key_epoch` in the chain, or null when it is empty.
+     */
+    public function getMaxEpoch(): ?int
+    {
+        return $this->epochCounts === [] ? null : max(array_keys($this->epochCounts));
     }
 }

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -305,6 +305,15 @@ final readonly class AuditLogService implements AuditLogServiceInterface
         // Highest epoch observed across the chain (the "high-water mark"). Stays
         // -1 for an empty chain so the epoch-floor check below is skipped.
         $maxEpoch = -1;
+        // Rows per `hmac_key_epoch` across the scanned range. Free here: the
+        // walk already visits every row and already reads the epoch to pick the
+        // hash algorithm, so this is one increment on a value in hand. It is
+        // what makes the difference between "the chain is valid" and "the whole
+        // chain is signed at the configured epoch" visible — a chain of
+        // epoch-1 rows verifies perfectly while leaving `success` and the
+        // attribution fields outside the MAC.
+        /** @var array<int, int> $epochCounts */
+        $epochCounts = [];
         // When the caller specified $fromUid, treat $fromUid-1 as the
         // previous UID so a leading gap (first row > $fromUid) is still
         // detected. Otherwise start at -1 meaning "no prior row yet".
@@ -394,6 +403,7 @@ final readonly class AuditLogService implements AuditLogServiceInterface
                 if ($epoch > $maxEpoch) {
                     $maxEpoch = $epoch;
                 }
+                $epochCounts[$epoch] = ($epochCounts[$epoch] ?? 0) + 1;
 
                 // Epoch-aware hash dispatch:
                 //   0 → legacy SHA-256 (identity fields only)
@@ -465,9 +475,13 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             $anchorStatus = $this->verifyAnchor($connection, $errors, $warnings);
         }
 
+        // Ascending epoch order, so the reported distribution reads as the
+        // migration timeline it is rather than in row-arrival order.
+        ksort($epochCounts);
+
         return $errors === []
-            ? HashChainVerificationResult::valid($warnings, $missingUids, $missingUidCount, $anchorStatus)
-            : HashChainVerificationResult::invalid($errors, $warnings, $missingUids, $missingUidCount, $anchorStatus);
+            ? HashChainVerificationResult::valid($warnings, $missingUids, $missingUidCount, $anchorStatus, $epochCounts)
+            : HashChainVerificationResult::invalid($errors, $warnings, $missingUids, $missingUidCount, $anchorStatus, $epochCounts);
     }
 
     public function verifyChainForReseal(): ?HashChainVerificationResult

--- a/Classes/Audit/HashChainVerificationResult.php
+++ b/Classes/Audit/HashChainVerificationResult.php
@@ -36,6 +36,16 @@ final readonly class HashChainVerificationResult
      *                                             detects tail truncation and full wipes
      *                                             that the walk alone cannot see. Only
      *                                             evaluated on a full-chain pass.
+     * @param array<int, int> $epochCounts How many rows in the verified range carry each
+     *                                     `hmac_key_epoch`, keyed by epoch and sorted
+     *                                     ascending. Free: the walk already visits every
+     *                                     row and already reads the epoch to pick the hash
+     *                                     algorithm. Empty for an empty range. Reported by
+     *                                     `vault:audit-verify`, where "the chain is valid"
+     *                                     and "every row is signed at the configured epoch"
+     *                                     are separate questions — a chain of epoch-1 rows
+     *                                     verifies perfectly and is still missing the MAC
+     *                                     over `success` and the attribution fields.
      */
     public function __construct(
         public bool $valid,
@@ -44,6 +54,7 @@ final readonly class HashChainVerificationResult
         public array $missingUids = [],
         public int $missingUidCount = 0,
         public AuditChainAnchorStatus $anchorStatus = AuditChainAnchorStatus::NotChecked,
+        public array $epochCounts = [],
     ) {}
 
     /**
@@ -53,12 +64,14 @@ final readonly class HashChainVerificationResult
      * @param list<int> $missingUids UID values missing from the chain (may be empty)
      * @param int $missingUidCount Total number of missing UIDs detected
      * @param AuditChainAnchorStatus $anchorStatus Outcome of the tip-anchor check
+     * @param array<int, int> $epochCounts Row count per `hmac_key_epoch` in the range
      */
     public static function valid(
         array $warnings = [],
         array $missingUids = [],
         int $missingUidCount = 0,
         AuditChainAnchorStatus $anchorStatus = AuditChainAnchorStatus::NotChecked,
+        array $epochCounts = [],
     ): self {
         return new self(
             valid: true,
@@ -67,6 +80,7 @@ final readonly class HashChainVerificationResult
             missingUids: $missingUids,
             missingUidCount: $missingUidCount > 0 ? $missingUidCount : \count($missingUids),
             anchorStatus: $anchorStatus,
+            epochCounts: $epochCounts,
         );
     }
 
@@ -78,6 +92,7 @@ final readonly class HashChainVerificationResult
      * @param list<int> $missingUids UID values missing from the chain
      * @param int $missingUidCount Total number of missing UIDs detected
      * @param AuditChainAnchorStatus $anchorStatus Outcome of the tip-anchor check
+     * @param array<int, int> $epochCounts Row count per `hmac_key_epoch` in the range
      */
     public static function invalid(
         array $errors,
@@ -85,6 +100,7 @@ final readonly class HashChainVerificationResult
         array $missingUids = [],
         int $missingUidCount = 0,
         AuditChainAnchorStatus $anchorStatus = AuditChainAnchorStatus::NotChecked,
+        array $epochCounts = [],
     ): self {
         return new self(
             valid: false,
@@ -93,6 +109,7 @@ final readonly class HashChainVerificationResult
             missingUids: $missingUids,
             missingUidCount: $missingUidCount > 0 ? $missingUidCount : \count($missingUids),
             anchorStatus: $anchorStatus,
+            epochCounts: $epochCounts,
         );
     }
 
@@ -129,9 +146,46 @@ final readonly class HashChainVerificationResult
     }
 
     /**
+     * Lowest `hmac_key_epoch` any row in the verified range carries, or null
+     * for an empty range.
+     *
+     * The number an operator actually has to act on: raising `auditHmacEpoch`
+     * changes what NEW rows are signed with and nothing else, so this is the
+     * protection level the OLDEST evidence still rests on.
+     */
+    public function getMinEpoch(): ?int
+    {
+        // min()/max() over the keys rather than array_key_first()/_last(), so a
+        // caller that hands in an unordered map still gets the right answer —
+        // the getters must not depend on how the producer happened to insert.
+        return $this->epochCounts === [] ? null : min(array_keys($this->epochCounts));
+    }
+
+    /**
+     * Highest `hmac_key_epoch` in the verified range, or null for an empty
+     * range.
+     *
+     * The high-water mark the chain-wide downgrade floor is compared against
+     * on a full-chain pass, exposed so a caller can see the value behind that
+     * verdict instead of only its outcome.
+     */
+    public function getMaxEpoch(): ?int
+    {
+        return $this->epochCounts === [] ? null : max(array_keys($this->epochCounts));
+    }
+
+    /**
+     * Whether the range mixes epochs, i.e. a migration covered part of it.
+     */
+    public function hasMixedEpochs(): bool
+    {
+        return \count($this->epochCounts) > 1;
+    }
+
+    /**
      * Convert to array for JSON serialization.
      *
-     * @return array{valid: bool, errors: array<int, string>, warnings: array<int, string>, missingUids: list<int>, missingUidCount: int, anchorStatus: string}
+     * @return array{valid: bool, errors: array<int, string>, warnings: array<int, string>, missingUids: list<int>, missingUidCount: int, anchorStatus: string, epochCounts: array<int, int>, minEpoch: int|null, maxEpoch: int|null}
      */
     public function toArray(): array
     {
@@ -142,6 +196,9 @@ final readonly class HashChainVerificationResult
             'missingUids' => $this->missingUids,
             'missingUidCount' => $this->missingUidCount,
             'anchorStatus' => $this->anchorStatus->value,
+            'epochCounts' => $this->epochCounts,
+            'minEpoch' => $this->getMinEpoch(),
+            'maxEpoch' => $this->getMaxEpoch(),
         ];
     }
 }

--- a/Classes/Command/VaultAuditVerifyCommand.php
+++ b/Classes/Command/VaultAuditVerifyCommand.php
@@ -187,6 +187,7 @@ final class VaultAuditVerifyCommand extends Command
                     gmdate('Y-m-d H:i:s', $anchor->timestamp),
                 )
                 : 'none available'],
+            ['Stored HMAC epochs' => $this->formatEpochDistribution($report)],
             ['Enabled sinks' => $this->formatSinkList()],
         );
 
@@ -235,6 +236,36 @@ final class VaultAuditVerifyCommand extends Command
             . 'exiting successfully because --tamper-only was given.',
             $codes,
         ));
+    }
+
+    /**
+     * How the stored rows are distributed across HMAC epochs.
+     *
+     * Reported unconditionally, including on a clean run: "the chain is valid"
+     * and "the whole chain is signed at the configured epoch" are different
+     * statements, and only this one answers the second. A chain left at epoch 1
+     * by a stalled migration verifies perfectly while leaving `success` and the
+     * attribution fields outside the MAC — there is no error to raise, and an
+     * operator still has to see it. The counts come from the walk this command
+     * already performs, so nothing extra is read.
+     */
+    private function formatEpochDistribution(AuditIntegrityReport $report): string
+    {
+        if ($report->epochCounts === []) {
+            return '(chain empty)';
+        }
+
+        $parts = [];
+        foreach ($report->epochCounts as $epoch => $count) {
+            $parts[] = \sprintf('epoch %d: %d row(s)', $epoch, $count);
+        }
+
+        return \sprintf(
+            '%s — lowest %d, highest %d',
+            implode(', ', $parts),
+            (int) $report->getMinEpoch(),
+            (int) $report->getMaxEpoch(),
+        );
     }
 
     private function formatSinkList(): string

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -38,8 +38,9 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
     /**
      * Operation permissions the unattributed CLI actor may hold when
      * `allowCliAccess` is on. High-risk operations (secret.reveal,
-     * secret.delete, audit.export, master_key.rotate, vault.configure) are
-     * deliberately absent — they must be opted into explicitly.
+     * secret.delete, secret.manage_policy, audit.view, audit.export,
+     * master_key.rotate, vault.configure) are deliberately absent — they must
+     * be opted into explicitly.
      */
     public const DEFAULT_CLI_ALLOWED_OPERATIONS = 'secret.use,secret.create,secret.rotate';
 

--- a/Classes/Service/Doctor/Check/AuditCheck.php
+++ b/Classes/Service/Doctor/Check/AuditCheck.php
@@ -357,6 +357,11 @@ final readonly class AuditCheck implements ReadinessCheckInterface
             'fromUid' => $fromUid,
             'toUid' => $currentSequence,
             'errorCount' => $result->getErrorCount(),
+            // Computed by every verification pass and discarded until now. The
+            // warnings are epoch boundaries — non-fatal by design, and the
+            // signal that a migration touched part of this range, which is
+            // context a CI gate wants next to a green errorCount.
+            'warningCount' => $result->getWarningCount(),
             'missingUidCount' => $result->missingUidCount,
         ];
 
@@ -431,24 +436,56 @@ final readonly class AuditCheck implements ReadinessCheckInterface
      * {@see \Netresearch\NrVault\Upgrades\AuditHmacMigrationWizard} run, not
      * hypotheticals, and reporting them as equivalent to 3 is what let a
      * half-migrated installation read as clean. The shipped default is 3.
+     *
+     * ## The setting is not the evidence
+     *
+     * `auditHmacEpoch` decides how the NEXT row is signed. It says nothing
+     * about the rows already stored, and the two come apart on exactly the
+     * installation this check exists for: raise the setting to 3 without
+     * running `vault:audit-migrate-hmac` and every historical row keeps its
+     * epoch-1 or epoch-2 signature while the control reports the full payload.
+     * Nothing else caught it — {@see AuditLogServiceInterface::verifyHashChain()}
+     * compares the chain HIGH-WATER epoch against the floor and only on a
+     * full-chain pass, which {@see self::checkHashChain()} never requests
+     * because it always passes a `$fromUid`. So the stored minimum is read
+     * here, and the pass text no longer asserts anything about stored rows it
+     * has not looked at.
      */
     private function checkHmacEpoch(): Finding
     {
         $id = 'audit.hmac_epoch';
         $epoch = $this->configuration->getAuditHmacEpoch();
+        $storedMinEpoch = $this->fetchStoredMinEpoch();
         $details = [
             'auditHmacEpoch' => $epoch,
             'auditAnchorRequired' => $this->configuration->isAuditAnchorRequired(),
+            // -1, not null: `details` is a flat scalar map that the backend
+            // status panel and a CI gate both read, and "no rows" needs a value
+            // they can compare rather than a missing key.
+            'storedMinEpoch' => $storedMinEpoch ?? -1,
         ];
 
         if ($epoch >= 3) {
+            if ($storedMinEpoch !== null && $storedMinEpoch < $epoch) {
+                return $this->unmigratedStoredRowsFinding($id, $epoch, $storedMinEpoch, $details);
+            }
+
             return Finding::pass(
                 id: $id,
                 summary: \sprintf(
-                    'Audit chain HMAC epoch is %d: rows are HMAC-signed over the full forensic '
-                    . 'payload including the epoch selector and the attribution fields, the '
-                    . 'epoch-downgrade floor is armed, and the in-DB tip anchor is active.',
+                    'Audit chain HMAC epoch is configured as %d, so rows are HMAC-signed over the '
+                    . 'full forensic payload including the epoch selector and the attribution '
+                    . 'fields, the epoch-downgrade floor is armed, and the in-DB tip anchor is '
+                    . 'active. %s',
                     $epoch,
+                    $storedMinEpoch === null
+                        ? 'The audit log is empty, so there is no stored row to confirm that against '
+                            . 'yet.'
+                        : \sprintf(
+                            'The oldest stored row is at epoch %d, so the stored rows carry that '
+                            . 'payload too — full-range confirmation is vault:audit-verify.',
+                            $storedMinEpoch,
+                        ),
                 ),
                 docsUrl: DocsLink::AUDIT_HMAC_EPOCH,
                 details: $details,
@@ -476,6 +513,108 @@ final readonly class AuditCheck implements ReadinessCheckInterface
                 . 'vendor/bin/typo3 vault:audit-migrate-hmac (or the install-tool "Migrate audit hash '
                 . 'chain" wizard), then arm the anchor with vendor/bin/typo3 vault:audit '
                 . '--reset-anchor.',
+            docsUrl: DocsLink::AUDIT_HMAC_EPOCH,
+            details: $details,
+        );
+    }
+
+    /**
+     * The lowest `hmac_key_epoch` any stored audit row carries, or null when the
+     * table is empty.
+     *
+     * ## Why the oldest row, and not a GROUP BY
+     *
+     * `hmac_key_epoch` has no index (see `ext_tables.sql`), so `MIN()` or a
+     * `GROUP BY` over it is a full clustered-index scan that drags the `text`
+     * columns along — precisely the cost this checkset avoids, because it also
+     * runs on every render of the backend status panel. One PRIMARY-ordered row
+     * is O(1) instead.
+     *
+     * It answers the same question because a legitimate chain is epoch-monotonic
+     * in uid: {@see AuditLogServiceInterface::verifyHashChain()} walks
+     * `ORDER BY uid ASC` and records a DECREASE between adjacent rows as an
+     * ERROR (an increase is only a warning, because a partial migration
+     * legitimately leaves older rows behind). On any chain that verifies, the
+     * epoch sequence is therefore non-decreasing and the oldest row holds the
+     * minimum.
+     *
+     * The caveat, stated rather than assumed: on a chain that does NOT verify,
+     * the oldest row can overstate the minimum. That chain is already failing —
+     * `audit.hash_chain` for the tail, `vault:audit-verify` for the full range,
+     * and the latter now also reports the complete per-epoch distribution. This
+     * control is not the one that catches a downgrade; it catches the
+     * configuration that was raised without migrating.
+     */
+    private function fetchStoredMinEpoch(): ?int
+    {
+        $value = $this->connectionPool
+            ->getConnectionForTable(AuditLogService::TABLE_NAME)
+            ->createQueryBuilder()
+            ->select('hmac_key_epoch')
+            ->from(AuditLogService::TABLE_NAME)
+            ->orderBy('uid', 'ASC')
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchOne();
+
+        // fetchOne() returns false on an empty result set.
+        return is_numeric($value) ? (int) $value : null;
+    }
+
+    /**
+     * The setting says 3, the stored rows do not.
+     *
+     * A warning rather than a critical: nothing was tampered with and the chain
+     * still verifies — the rows are keyed, just under a narrower payload. What
+     * is broken is the claim, and the claim is what a deployment gate reads.
+     *
+     * Naming the cause correctly matters for the remediation. An INTERRUPTED
+     * migration does not produce this state silently: both migration paths
+     * rewrite row by row without a transaction, so a half-finished run leaves
+     * newer rows at the old epoch behind older migrated ones — a DECREASE, which
+     * `verifyHashChain()` already records as an error. The state that arrives
+     * without any signal is the other one: `auditHmacEpoch` raised in the
+     * extension configuration and the migration never run at all.
+     *
+     * @param array<string, bool|int|string> $details
+     */
+    private function unmigratedStoredRowsFinding(
+        string $id,
+        int $epoch,
+        int $storedMinEpoch,
+        array $details,
+    ): Finding {
+        return Finding::warning(
+            id: $id,
+            summary: \sprintf(
+                'Audit chain HMAC epoch is configured as %d, but the oldest stored audit row is at '
+                . 'epoch %d: the setting was raised without re-signing the existing entries.',
+                $epoch,
+                $storedMinEpoch,
+            ),
+            risk: \sprintf(
+                'The configuration governs how the NEXT row is signed; it does not reach back over '
+                . 'the ones already stored. Every historical row still carries its epoch-%d '
+                . 'signature, so %s. The chain verifies either way — these rows are keyed, just '
+                . 'under a narrower payload — which is why nothing else reports it: the '
+                . 'epoch-downgrade floor in verifyHashChain() compares the chain HIGH-WATER epoch '
+                . 'against the configured one, and a single row at the current epoch already '
+                . 'satisfies that.',
+                $storedMinEpoch,
+                $storedMinEpoch <= 1
+                    ? 'the outcome column "success" is outside the MAC on them — a recorded denial '
+                        . 'can be flipped into a recorded grant — along with the forensic columns '
+                        . 'and the attribution fields the audit list presents as "who did this"'
+                    : 'the algorithm selector hmac_key_epoch and the attribution fields '
+                        . 'actor_type, actor_username, actor_role and request_id are outside the '
+                        . 'MAC on them, so blame can be reassigned on any of those rows without '
+                        . 'breaking the chain',
+            ),
+            remediation: 'Re-sign the stored entries with vendor/bin/typo3 vault:audit-migrate-hmac '
+                . '(or the install-tool "Migrate audit hash chain" wizard) — raising '
+                . '"auditHmacEpoch" alone only changes new writes. Run vendor/bin/typo3 '
+                . 'vault:audit-verify afterwards: it reports the full per-epoch distribution, so '
+                . 'the migration can be confirmed rather than assumed.',
             docsUrl: DocsLink::AUDIT_HMAC_EPOCH,
             details: $details,
         );

--- a/Classes/Service/Doctor/Check/AuditCheck.php
+++ b/Classes/Service/Doctor/Check/AuditCheck.php
@@ -571,10 +571,14 @@ final readonly class AuditCheck implements ReadinessCheckInterface
      * Naming the cause correctly matters for the remediation. An INTERRUPTED
      * migration does not produce this state silently: both migration paths
      * rewrite row by row without a transaction, so a half-finished run leaves
-     * newer rows at the old epoch behind older migrated ones — a DECREASE, which
-     * `verifyHashChain()` already records as an error. The state that arrives
-     * without any signal is the other one: `auditHmacEpoch` raised in the
-     * extension configuration and the migration never run at all.
+     * newer rows at the old epoch behind older migrated ones — a DECREASE. A
+     * FULL `vault:audit-verify` pass records that as an error; this check does
+     * not see it, because the migration rewrites oldest-first (so the probe
+     * below reads the NEW epoch) and `checkHashChain()` only covers the newest
+     * CHAIN_TAIL_SIZE rows. Past that many rows, a stalled migration reads
+     * green here. The state that arrives without any signal at all is the
+     * other one: `auditHmacEpoch` raised in the extension configuration and
+     * the migration never run.
      *
      * @param array<string, bool|int|string> $details
      */

--- a/Classes/Service/Doctor/Check/CliAccessCheck.php
+++ b/Classes/Service/Doctor/Check/CliAccessCheck.php
@@ -185,9 +185,24 @@ final readonly class CliAccessCheck implements ReadinessCheckInterface
     /**
      * Which operations does the unattributed CLI actor actually hold?
      *
-     * The allowlist defaults to store/rotate/use. Every high-risk operation
-     * present is called out; unknown tokens are reported too — a typo in the
-     * list silently revokes the grant the operator believes is configured.
+     * The allowlist defaults to `secret.use,secret.create,secret.rotate`. Every
+     * high-risk operation present is called out; unknown tokens are reported too
+     * — a typo in the list silently revokes the grant the operator believes is
+     * configured.
+     *
+     * "High-risk" is the set that hands a shell more than the deployment step
+     * the switch exists for. Two of them are less obvious than the rest and were
+     * missing here while being listed as `$known`, so an allowlist containing
+     * them read as a clean pass:
+     *
+     *  - `secret.manage_policy` edits `allowed_groups` / `write_groups`, i.e.
+     *    the permission that governs the permissions
+     *    ({@see VaultPermission::SecretManagePolicy}). A shell holding it can
+     *    widen its own per-secret reach and the widening looks like ordinary
+     *    configuration afterwards.
+     *  - `audit.view` reads the trail rather than the secrets, but the trail
+     *    maps the credential topology ({@see VaultPermission::AuditView}) and
+     *    the hardened deployment guide already treats it as an explicit opt-in.
      */
     private function checkAllowedOperations(): Finding
     {
@@ -198,7 +213,15 @@ final readonly class CliAccessCheck implements ReadinessCheckInterface
             static fn (VaultPermission $permission): string => $permission->value,
             VaultPermission::cases(),
         );
-        $highRisk = ['secret.reveal', 'secret.delete', 'audit.export', 'master_key.rotate', 'vault.configure'];
+        $highRisk = [
+            'secret.reveal',
+            'secret.delete',
+            'secret.manage_policy',
+            'audit.view',
+            'audit.export',
+            'master_key.rotate',
+            'vault.configure',
+        ];
 
         $unknown = array_values(array_diff($operations, $known));
         $risky = array_values(array_intersect($operations, $highRisk));
@@ -212,8 +235,17 @@ final readonly class CliAccessCheck implements ReadinessCheckInterface
         if ($risky === [] && $unknown === []) {
             return Finding::pass(
                 id: $id,
+                // Not "low-risk": the remaining defaults are not harmless
+                // writes. secret.create makes the CLI actor the OWNER of what
+                // it creates, which is privilege-widening, and secret.rotate
+                // substitutes a credential the operator's own systems then
+                // use. The pass says the list holds nothing that needs an
+                // explicit opt-in — not that its contents are inert.
                 summary: \sprintf(
-                    'The CLI operation allowlist is scoped to %d low-risk operation(s): %s.',
+                    'The CLI operation allowlist holds no operation that needs an explicit opt-in: '
+                    . '%d automation operation(s) (%s). That is a scoped grant, not a harmless one — '
+                    . 'everything listed is available to anyone with a shell on this host, under an '
+                    . 'actor the audit trail cannot name.',
                     \count($operations),
                     implode(', ', $operations),
                 ),
@@ -235,11 +267,21 @@ final readonly class CliAccessCheck implements ReadinessCheckInterface
             summary: 'The "cliAllowedOperations" list ' . implode(' and ', $summaryParts) . '.',
             risk: 'High-risk operations let anyone with a shell reveal plaintext, delete secrets, walk '
                 . 'off with the audit history or rewrite every key envelope — without a named actor in '
-                . 'the audit trail. Unknown values do nothing: the grant the operator believes is '
+                . 'the audit trail. "secret.manage_policy" is the widest of them in the long run: it '
+                . 'edits allowed_groups and write_groups, so it is the permission that governs the '
+                . 'permissions — a shell can widen its own per-secret reach to secrets the current ACLs '
+                . 'do not admit it to, and the widened tiers read as ordinary configuration afterwards. '
+                . '"audit.view" grants no secret access at all, but the trail it opens names who touched '
+                . 'which identifier when: it maps the credential topology, and it is also where the '
+                . 'shell\'s own activity is recorded, so it is reconnaissance handed to the actor the '
+                . 'log exists to catch. Unknown values do nothing: the grant the operator believes is '
                 . 'configured is silently absent.',
             remediation: 'Remove the high-risk operations from "cliAllowedOperations" (use a named '
                 . 'technical actor for those workflows) and fix any typo — valid values are the '
-                . 'tx_nrvault permission identifiers, e.g. secret.use, secret.create, secret.rotate.',
+                . 'tx_nrvault permission identifiers, e.g. secret.use, secret.create, secret.rotate. '
+                . 'Where a scheduled control genuinely needs one — vault:audit-verify asserts '
+                . 'audit.view, the orphan cleanup asserts secret.delete — grant it to a named backend '
+                . 'group and run the job as a technical actor instead of widening this list.',
             docsUrl: DocsLink::ACCESS_CONTROL,
             details: $details,
         );

--- a/Documentation/Auditor/ControlMapping.rst
+++ b/Documentation/Auditor/ControlMapping.rst
@@ -210,11 +210,11 @@ OWASP ASVS v4: chapter 2 (Authentication), chapter 4 (Access Control).*
             is logged under a correlation reference
         -   :ref:`tca-integration`; :ref:`adr-018-flexform-secret-lifecycle`
 
-    *   -   CLI grant narrowed to low-risk operations
+    *   -   CLI grant narrowed to automation operations
         -   ``cliAllowedOperations`` defaults to
             ``secret.use,secret.create,secret.rotate``; reveal, delete,
-            audit export, master-key rotation and vault configuration must
-            be added explicitly
+            policy management, audit viewing, audit export, master-key
+            rotation and vault configuration must be added explicitly
         -   ``vault:doctor`` finding ``cli.allowed_operations``
 
 .. _auditor-control-mapping-logging:

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -398,6 +398,15 @@ CLI access
    1 or 2, so treat that warning as "the migration did not finish", not as a
    pending nice-to-have.
 
+   The setting is not the evidence. It decides how the *next* row is signed and
+   says nothing about the rows already stored, so raising it to 3 without
+   running the migration leaves every historical row at its old epoch while the
+   configuration reads as fully protected. ``audit.hmac_epoch`` therefore also
+   **warns** when the oldest stored row is below the configured epoch, naming
+   both numbers and exposing the stored minimum as ``details.storedMinEpoch``.
+   :bash:`vault:audit-verify` reports the full per-epoch distribution, so the
+   migration can be confirmed rather than assumed.
+
 .. confval:: auditAnchorRequired
    :name: ext-nrvault-auditAnchorRequired
    :type: boolean

--- a/Documentation/Configuration/Index.rst
+++ b/Documentation/Configuration/Index.rst
@@ -215,24 +215,29 @@ CLI access
    :confval:`allowCliAccess <ext-nrvault-allowCliAccess>` is on.
    The default covers deployment automation (store, rotate, consume).
    High-risk operations — ``secret.reveal`` (:bash:`vault:retrieve`
-   printing plaintext), ``secret.delete``, ``audit.export``,
-   ``master_key.rotate`` (:bash:`vault:rotate-master-key`),
-   ``vault.configure`` — are **excluded by default** and must be added
-   explicitly where a workflow genuinely needs them. Prefer a named
+   printing plaintext), ``secret.delete``, ``secret.manage_policy``,
+   ``audit.view``, ``audit.export``, ``master_key.rotate``
+   (:bash:`vault:rotate-master-key`), ``vault.configure`` — are
+   **excluded by default** and must be added explicitly where a workflow
+   genuinely needs them. Prefer a named
    technical actor (``TechnicalActorContext::runAs()``) over widening
    this list: the audit trail then names the responsible identity.
    Note that the scheduled orphan cleanup deletes secrets and therefore
    needs ``secret.delete`` when it runs as the bare CLI actor.
 
-   All five change what a CLI command can do: ``secret.reveal``
+   Five of the seven change what a CLI command can do: ``secret.reveal``
    (:bash:`vault:retrieve`), ``secret.delete`` (:bash:`vault:delete`),
    ``master_key.rotate`` (:bash:`vault:rotate-master-key`), ``audit.export``
    (:bash:`vault:audit --export`) and ``vault.configure``
    (:bash:`vault:audit-anchor` and :bash:`vault:audit --reset-anchor`).
-   ``audit.view`` is excluded as well, and it now covers three commands —
-   :bash:`vault:audit` for plain listing, :bash:`vault:audit --verify` and
-   :bash:`vault:audit-verify` — so reading or verifying the audit log from an
-   unattributed shell needs it added here too.
+   ``audit.view`` covers three more — :bash:`vault:audit` for plain
+   listing, :bash:`vault:audit --verify` and :bash:`vault:audit-verify` —
+   so reading or verifying the audit log from an unattributed shell needs
+   it added here. ``secret.manage_policy`` gates the **backend** policy
+   edit rather than a command, and it is listed because it is the widest
+   entry over time: it edits ``allowed_groups`` and ``write_groups``, so a
+   shell holding it can widen its own per-secret reach and the widened
+   tiers read as ordinary configuration afterwards.
 
    The scheduler is a different actor and is not affected by this allowlist:
    :bash:`scheduler:run` authenticates the ``_cli_`` administrator, so the

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -1297,19 +1297,29 @@ cli.allowed_operations
    Emitted only when CLI access is on. Reports which operations
    :confval:`ext-nrvault-cliAllowedOperations` actually grants the unattributed
    CLI actor. Warning when the list contains a high-risk operation
-   (``secret.reveal``, ``secret.delete``, ``audit.export``,
-   ``master_key.rotate``, ``vault.configure``) or an unknown value. Unknown
+   (``secret.reveal``, ``secret.delete``, ``secret.manage_policy``,
+   ``audit.view``, ``audit.export``, ``master_key.rotate``,
+   ``vault.configure``) or an unknown value. Unknown
    values are called out because they are silently inert — a typo revokes the
    grant the operator believes is configured rather than failing loudly.
 
-   Of the five high-risk entries, three currently change what a CLI command
+   Of the seven high-risk entries, four currently change what a CLI command
    can do: ``secret.reveal`` (``vault:retrieve``), ``secret.delete``
-   (``vault:delete`` and the orphan cleanup) and ``master_key.rotate``
-   (``vault:rotate-master-key``). ``audit.export`` and ``vault.configure``
+   (``vault:delete`` and the orphan cleanup), ``master_key.rotate``
+   (``vault:rotate-master-key``) and ``audit.view`` (``vault:audit``,
+   ``vault:audit --verify``, ``vault:audit-verify``). ``secret.manage_policy``,
+   ``audit.export`` and ``vault.configure``
    gate the corresponding **backend** actions; ``vault:audit --export``
    asserts no operation permission of its own. They are still called out
    here, because the allowlist is the record of what the CLI actor has been
    granted, not only of what it can currently reach.
+
+   The pass wording is deliberately not "low-risk operation(s)". What remains
+   after the seven are excluded is the deployment-automation default, and it
+   is not inert either: ``secret.create`` makes the CLI actor the *owner* of
+   what it creates, and ``secret.rotate`` substitutes a credential the
+   operator's own systems then use. The pass states that nothing in the list
+   needs an explicit opt-in — not that the list is harmless.
 
 cli.frontend_placeholder_legacy
    :confval:`ext-nrvault-frontendPlaceholderLegacyCli`. Pass when off — the

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -1193,6 +1193,11 @@ audit.hash_chain
    tail verifies", never "the chain is intact". :ref:`command-audit-verify` is
    the authoritative full-range verifier and belongs on a schedule.
 
+   ``details`` carries ``errorCount``, ``warningCount`` and
+   ``missingUidCount``. The warnings are epoch boundaries — non-fatal by
+   design, and the sign that a migration covered only part of the verified
+   range, which is context a CI gate wants beside a green ``errorCount``.
+
 audit.hmac_epoch
    :confval:`ext-nrvault-auditHmacEpoch` is at least 3 — the shipped default,
    and the only epoch whose HMAC spans the whole audit row. Three-way, because
@@ -1225,6 +1230,42 @@ audit.hmac_epoch
    partial :ref:`command-audit-migrate-hmac` run (or its install-tool wizard)
    leaves an installation exactly there, which is why the remediation says to
    check that the migration completed rather than only raising the setting.
+
+   **Warning** when the setting is at 3 or above but the STORED rows are not.
+   :confval:`ext-nrvault-auditHmacEpoch` decides how the *next* row is signed;
+   it does not reach back over the ones already written. Raise it without
+   running :ref:`command-audit-migrate-hmac` and every historical row keeps its
+   narrower signature while the configuration reads as fully protected — the
+   chain still verifies, because those rows are keyed, just under a smaller
+   payload. Nothing else catches it: the epoch-downgrade floor in
+   ``verifyHashChain()`` compares the chain HIGH-WATER epoch against the
+   configured one, so a single row at the current epoch satisfies it, and it
+   only runs on a full-range pass, which ``audit.hash_chain`` never requests.
+
+   The check reads the ``hmac_key_epoch`` of the OLDEST row — one
+   PRIMARY-ordered row, because that column carries no index and a ``GROUP BY``
+   over it would be a full scan on a control that also renders the backend
+   status panel. That equals the stored minimum on any chain that verifies: a
+   *decrease* between adjacent uids is already recorded as an error, so a
+   legitimate chain is epoch-monotonic. The value is reported as
+   ``details.storedMinEpoch`` (``-1`` when the audit log is empty) for a CI
+   gate, and the pass text now states the configured epoch and — where there
+   was a stored row to check it against — the stored minimum it confirmed,
+   rather than asserting a property of rows it never looked at.
+
+   The interrupted-migration case is *not* the silent one. Both migration paths
+   rewrite row by row without a transaction, so a half-finished run leaves
+   newer rows behind older migrated ones — a decrease, which is already an
+   error. The state that arrives without any signal is the setting raised while
+   the migration was never run.
+
+   :ref:`command-audit-verify` reports the FULL distribution rather than only
+   the minimum: its walk already reads every row's epoch to pick the hash
+   algorithm, so the per-epoch counts cost nothing. They appear as
+   ``Stored HMAC epochs`` in the text report and as ``epochCounts`` /
+   ``minEpoch`` / ``maxEpoch`` in the JSON body — on a clean run too, because
+   "the chain is valid" and "the whole chain is signed at the configured epoch"
+   are different statements and only the second is answered there.
 
 audit.db_anchor
    The IN-DATABASE tip anchor in ``sys_registry`` — a different control from

--- a/Documentation/Operations/HardenedDeployment.rst
+++ b/Documentation/Operations/HardenedDeployment.rst
@@ -173,11 +173,14 @@ ownership and group tiers still apply — see
     separately by :confval:`ext-nrvault-cliAllowedOperations`, which defaults
     to ``secret.use,secret.create,secret.rotate``. Keep it at or below that,
     and scope ``cliAccessGroups`` as well. Of the high-risk entries,
-    ``secret.reveal``, ``secret.delete`` and ``master_key.rotate`` directly
-    hand ``vault:retrieve``, ``vault:delete`` and ``vault:rotate-master-key``
+    ``secret.reveal``, ``secret.delete``, ``master_key.rotate`` and
+    ``audit.view`` directly hand ``vault:retrieve``, ``vault:delete``,
+    ``vault:rotate-master-key`` and ``vault:audit`` / ``vault:audit-verify``
     to anyone with a shell on the host, under an actor the audit trail cannot
-    name; ``audit.export`` and ``vault.configure`` gate the corresponding
-    backend actions. Prefer a named technical actor —
+    name; ``secret.manage_policy``, ``audit.export`` and ``vault.configure``
+    gate the corresponding backend actions — ``secret.manage_policy`` is
+    listed because it edits ``allowed_groups`` / ``write_groups``, so it is
+    the entry that lets a grant widen itself. Prefer a named technical actor —
     :ref:`developer-technical-actor-context` — for those workflows.
     ``vault:doctor`` reports the list as ``cli.allowed_operations``.
 

--- a/Documentation/Operations/IncidentResponse.rst
+++ b/Documentation/Operations/IncidentResponse.rst
@@ -111,8 +111,9 @@ remove over-broad grants (an editor holding ``secret.reveal`` who only needs
 ``secret.use`` is the common finding); withdraw the admin override and pin it
 (:ref:`security-disable-admin-override`); switch off ``allowCliAccess`` if it
 was enabled for a one-off and never turned back off, and where it must stay on,
-narrow :confval:`ext-nrvault-cliAllowedOperations` back to the low-risk default
-— a pipeline that was granted ``secret.reveal`` or ``master_key.rotate`` for one
+narrow :confval:`ext-nrvault-cliAllowedOperations` back to the automation
+default — a pipeline that was granted ``secret.reveal``, ``master_key.rotate``
+or ``secret.manage_policy`` for one
 task and kept it is the same class of finding as the over-broad editor grant;
 consider the hardened profile (:ref:`security-profiles-migration`).
 

--- a/Tests/Functional/Audit/AuditLogServiceTest.php
+++ b/Tests/Functional/Audit/AuditLogServiceTest.php
@@ -557,7 +557,7 @@ final class AuditLogServiceTest extends AbstractVaultFunctionalTestCase
         // free counter against it proves the walk agrees with the database,
         // without pinning the epoch the test environment happens to run at.
         $expected = array_map(
-            'intval',
+            intval(...),
             $this->getConnectionPool()
                 ->getConnectionForTable('tx_nrvault_audit_log')
                 ->createQueryBuilder()

--- a/Tests/Functional/Audit/AuditLogServiceTest.php
+++ b/Tests/Functional/Audit/AuditLogServiceTest.php
@@ -525,5 +525,95 @@ final class AuditLogServiceTest extends AbstractVaultFunctionalTestCase
             $result->isValid(),
             'A uniform relabel to keyless epoch-0 on an HMAC-configured install must be rejected',
         );
+        // The distribution names what the verdict only implies: every row is
+        // now keyless. This is the report an operator acts on — "invalid" alone
+        // does not say the algorithm selector was rewritten wholesale.
+        self::assertSame([0 => \count($rows)], $result->epochCounts);
+        self::assertSame(0, $result->getMinEpoch());
+        self::assertSame(0, $result->getMaxEpoch());
+        self::assertFalse($result->hasMixedEpochs());
+    }
+
+    /**
+     * The chain walk already reads every row's `hmac_key_epoch` to pick the hash
+     * algorithm, so counting them is free — and it is the only thing that
+     * separates "the chain is valid" from "every stored row is signed at the
+     * configured epoch". A chain left at epoch 1 by a stalled migration
+     * verifies perfectly while leaving `success` outside the MAC.
+     */
+    #[Test]
+    public function verifyHashChainReportsHowManyRowsCarryEachEpoch(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $vaultService = $this->get(VaultServiceInterface::class);
+
+        $identifier = $this->generateUuidV7();
+        $vaultService->store($identifier, 'epoch-distribution-value');
+        $vaultService->retrieve($identifier);
+        $vaultService->delete($identifier, 'cleanup');
+
+        // The authoritative answer, read the expensive way the check itself
+        // must not: an unindexed GROUP BY over the whole table. Comparing the
+        // free counter against it proves the walk agrees with the database,
+        // without pinning the epoch the test environment happens to run at.
+        $expected = array_map(
+            'intval',
+            $this->getConnectionPool()
+                ->getConnectionForTable('tx_nrvault_audit_log')
+                ->createQueryBuilder()
+                ->select('hmac_key_epoch')
+                ->addSelectLiteral('COUNT(uid) AS row_count')
+                ->from('tx_nrvault_audit_log')
+                ->groupBy('hmac_key_epoch')
+                ->orderBy('hmac_key_epoch', 'ASC')
+                ->executeQuery()
+                ->fetchAllKeyValue(),
+        );
+
+        $result = $auditService->verifyHashChain();
+
+        self::assertTrue($result->isValid(), 'Precondition: the chain must verify');
+        self::assertNotSame([], $expected, 'Precondition: the chain must not be empty');
+        self::assertSame($expected, $result->epochCounts);
+        self::assertSame(array_sum($expected), array_sum($result->epochCounts));
+        self::assertSame(min(array_keys($expected)), $result->getMinEpoch());
+        self::assertSame(max(array_keys($expected)), $result->getMaxEpoch());
+        self::assertSame(\count($expected) > 1, $result->hasMixedEpochs());
+    }
+
+    /**
+     * A bounded range reports the epochs of the rows it actually scanned, not of
+     * the whole table — `AuditCheck` verifies only the tail, so a distribution
+     * that silently widened to the full chain would misreport what was covered.
+     */
+    #[Test]
+    public function verifyHashChainCountsOnlyTheScannedRange(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $vaultService = $this->get(VaultServiceInterface::class);
+
+        $identifier = $this->generateUuidV7();
+        $vaultService->store($identifier, 'bounded-range-value');
+        $vaultService->retrieve($identifier);
+        $vaultService->retrieve($identifier);
+        $vaultService->delete($identifier, 'cleanup');
+
+        $tip = $this->getConnectionPool()
+            ->getConnectionForTable('tx_nrvault_audit_log')
+            ->createQueryBuilder()
+            ->select('uid', 'hmac_key_epoch')
+            ->from('tx_nrvault_audit_log')
+            ->orderBy('uid', 'DESC')
+            ->setMaxResults(1)
+            ->executeQuery()
+            ->fetchAssociative();
+
+        self::assertIsArray($tip, 'Precondition: the chain must not be empty');
+
+        $maxUid = (int) $tip['uid'];
+        $result = $auditService->verifyHashChain($maxUid, $maxUid);
+
+        // Exactly the one row the range covers — not the whole table.
+        self::assertSame([(int) $tip['hmac_key_epoch'] => 1], $result->epochCounts);
     }
 }

--- a/Tests/Unit/Audit/AuditIntegrityReportTest.php
+++ b/Tests/Unit/Audit/AuditIntegrityReportTest.php
@@ -150,6 +150,44 @@ final class AuditIntegrityReportTest extends TestCase
     }
 
     /**
+     * A valid chain and a fully migrated chain are different statements. The
+     * report carries the per-epoch distribution the walk counted for free, so a
+     * monitor reading the JSON can tell a stalled `vault:audit-migrate-hmac` run
+     * from a healthy installation — neither raises a finding.
+     */
+    #[Test]
+    public function arrayFormCarriesTheEpochDistributionAndItsBounds(): void
+    {
+        $report = new AuditIntegrityReport(
+            findings: [],
+            chainValid: true,
+            currentSequence: 945,
+            epochCounts: [1 => 45, 3 => 900],
+        );
+
+        $array = $report->toArray();
+
+        self::assertTrue($array['valid']);
+        self::assertSame([1 => 45, 3 => 900], $array['epochCounts']);
+        self::assertSame(1, $array['minEpoch']);
+        self::assertSame(3, $array['maxEpoch']);
+    }
+
+    /**
+     * Null, not 0 — epoch 0 is a real state ("keyless") and must not be how an
+     * empty chain reports itself.
+     */
+    #[Test]
+    public function anEmptyChainReportsNoEpochBounds(): void
+    {
+        $report = new AuditIntegrityReport(findings: [], chainValid: true, currentSequence: 0);
+
+        self::assertSame([], $report->epochCounts);
+        self::assertNull($report->getMinEpoch());
+        self::assertNull($report->getMaxEpoch());
+    }
+
+    /**
      * The JSON output is a machine interface for monitoring, so it must stay
      * serialisable and carry every finding.
      */

--- a/Tests/Unit/Audit/HashChainVerificationResultTest.php
+++ b/Tests/Unit/Audit/HashChainVerificationResultTest.php
@@ -127,6 +127,9 @@ final class HashChainVerificationResultTest extends TestCase
             'missingUids' => [],
             'missingUidCount' => 0,
             'anchorStatus' => 'notChecked',
+            'epochCounts' => [],
+            'minEpoch' => null,
+            'maxEpoch' => null,
         ], $subject->toArray());
     }
 
@@ -143,21 +146,110 @@ final class HashChainVerificationResultTest extends TestCase
             'missingUids' => [],
             'missingUidCount' => 0,
             'anchorStatus' => 'notChecked',
+            'epochCounts' => [],
+            'minEpoch' => null,
+            'maxEpoch' => null,
         ], $subject->toArray());
     }
 
     #[Test]
-    public function toArrayContainsExactlySixKeys(): void
+    public function toArrayContainsExactlyNineKeys(): void
     {
         $subject = HashChainVerificationResult::valid();
 
         // Schema: valid, errors, warnings, missingUids, missingUidCount,
-        // anchorStatus. missingUidCount was added alongside the enumeration cap
-        // so large gaps (mass purges) do not explode the missingUids array —
-        // callers can still detect the gap scale without holding N entries.
-        // anchorStatus reports the tip-anchor check, which is what detects a
-        // tail truncation or a full wipe the row walk cannot see.
-        self::assertCount(6, $subject->toArray());
+        // anchorStatus, epochCounts, minEpoch, maxEpoch. missingUidCount was
+        // added alongside the enumeration cap so large gaps (mass purges) do not
+        // explode the missingUids array — callers can still detect the gap scale
+        // without holding N entries. anchorStatus reports the tip-anchor check,
+        // which is what detects a tail truncation or a full wipe the row walk
+        // cannot see. epochCounts and its two derived bounds answer the question
+        // `valid` cannot: whether every stored row is signed at the configured
+        // epoch, or only the newest ones are.
+        self::assertCount(9, $subject->toArray());
+    }
+
+    /**
+     * The distribution is what separates "the chain is valid" from "the whole
+     * chain is signed at the configured epoch". A chain left at epoch 1 by a
+     * stalled migration verifies perfectly and still leaves `success` and the
+     * attribution fields outside the MAC.
+     */
+    #[Test]
+    public function theEpochDistributionExposesItsBoundsAndWhetherItIsMixed(): void
+    {
+        $subject = HashChainVerificationResult::valid(
+            epochCounts: [1 => 40, 2 => 5, 3 => 900],
+        );
+
+        self::assertSame([1 => 40, 2 => 5, 3 => 900], $subject->epochCounts);
+        self::assertSame(1, $subject->getMinEpoch());
+        self::assertSame(3, $subject->getMaxEpoch());
+        self::assertTrue($subject->hasMixedEpochs());
+    }
+
+    /**
+     * A fully migrated chain is one epoch across the board — min equals max and
+     * nothing is mixed, so a caller can act on the bounds alone.
+     */
+    #[Test]
+    public function aSingleEpochChainIsNotReportedAsMixed(): void
+    {
+        $subject = HashChainVerificationResult::valid(epochCounts: [3 => 120]);
+
+        self::assertSame(3, $subject->getMinEpoch());
+        self::assertSame(3, $subject->getMaxEpoch());
+        self::assertFalse($subject->hasMixedEpochs());
+    }
+
+    /**
+     * An empty range has no epoch at all — null, never 0, which is a real epoch
+     * meaning "keyless" and the opposite of "nothing to say".
+     */
+    #[Test]
+    public function anEmptyRangeReportsNoEpochBoundsRatherThanZero(): void
+    {
+        $subject = HashChainVerificationResult::valid();
+
+        self::assertSame([], $subject->epochCounts);
+        self::assertNull($subject->getMinEpoch());
+        self::assertNull($subject->getMaxEpoch());
+        self::assertFalse($subject->hasMixedEpochs());
+    }
+
+    /**
+     * The bounds are derived from the keys, not from insertion order, so a
+     * caller that hands in an unordered map still gets the right answer.
+     */
+    #[Test]
+    public function theEpochBoundsDoNotDependOnInsertionOrder(): void
+    {
+        $subject = HashChainVerificationResult::invalid(
+            [7 => 'Entry hash mismatch - possible tampering'],
+            epochCounts: [3 => 10, 0 => 2, 2 => 4],
+        );
+
+        self::assertSame(0, $subject->getMinEpoch());
+        self::assertSame(3, $subject->getMaxEpoch());
+    }
+
+    /**
+     * An invalid chain still reports its distribution — a downgraded chain is
+     * exactly the case where an operator needs to see which epochs are present.
+     */
+    #[Test]
+    public function theInvalidFactoryCarriesTheDistributionThroughToArray(): void
+    {
+        $subject = HashChainVerificationResult::invalid(
+            [0 => 'HMAC key epoch downgrade detected'],
+            epochCounts: [0 => 900],
+        );
+
+        $array = $subject->toArray();
+
+        self::assertSame([0 => 900], $array['epochCounts']);
+        self::assertSame(0, $array['minEpoch']);
+        self::assertSame(0, $array['maxEpoch']);
     }
 
     #[Test]

--- a/Tests/Unit/Command/VaultAuditVerifyCommandTest.php
+++ b/Tests/Unit/Command/VaultAuditVerifyCommandTest.php
@@ -170,6 +170,77 @@ final class VaultAuditVerifyCommandTest extends TestCase
     }
 
     /**
+     * The distribution is reported on a CLEAN run, not only on a failure: a
+     * chain left at epoch 1 by a stalled migration verifies perfectly and still
+     * leaves `success` and the attribution fields outside the MAC. There is no
+     * finding to raise and an operator still has to see it, so the text report
+     * carries the per-epoch counts the walk already produced.
+     */
+    #[Test]
+    public function theTextReportNamesTheStoredEpochDistributionOnACleanChain(): void
+    {
+        $this->anchorService->method('verify')->willReturn(new AuditIntegrityReport(
+            findings: [],
+            chainValid: true,
+            currentSequence: 945,
+            epochCounts: [1 => 45, 3 => 900],
+        ));
+
+        self::assertSame(Command::SUCCESS, $this->commandTester->execute([]));
+
+        $display = $this->normalizedDisplay();
+
+        self::assertStringContainsString('Stored HMAC epochs', $display);
+        self::assertStringContainsString('epoch 1: 45 row(s)', $display);
+        self::assertStringContainsString('epoch 3: 900 row(s)', $display);
+        self::assertStringContainsString('lowest 1, highest 3', $display);
+    }
+
+    /**
+     * An empty chain has no epoch to report, and must not be rendered as
+     * "epoch 0" — that is a real state meaning keyless.
+     */
+    #[Test]
+    public function theTextReportSaysTheChainIsEmptyRatherThanReportingEpochZero(): void
+    {
+        $this->anchorService->method('verify')->willReturn(
+            new AuditIntegrityReport(findings: [], chainValid: true, currentSequence: 0),
+        );
+
+        $this->commandTester->execute([]);
+
+        $display = $this->normalizedDisplay();
+
+        self::assertStringContainsString('Stored HMAC epochs (chain empty)', $display);
+        self::assertStringNotContainsString('epoch 0', $display);
+    }
+
+    /**
+     * The JSON body is the monitoring interface — the same distribution has to
+     * be machine-readable, not only printed.
+     */
+    #[Test]
+    public function theJsonReportCarriesTheStoredEpochDistribution(): void
+    {
+        $this->anchorService->method('verify')->willReturn(new AuditIntegrityReport(
+            findings: [],
+            chainValid: true,
+            currentSequence: 945,
+            epochCounts: [1 => 45, 3 => 900],
+        ));
+
+        $this->commandTester->execute(['--format' => 'json']);
+
+        $payload = json_decode($this->commandTester->getDisplay(), true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertIsArray($payload);
+        self::assertTrue($payload['valid']);
+        self::assertSame(['1' => 45, '3' => 900], $payload['epochCounts']);
+        self::assertSame(1, $payload['minEpoch']);
+        self::assertSame(3, $payload['maxEpoch']);
+    }
+
+    /**
      * @return list<VaultPermission>
      */
     private function allPermissionsExcept(VaultPermission $excluded): array

--- a/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/AuditCheckTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
 
+use Doctrine\DBAL\Result;
 use Netresearch\NrVault\Audit\Anchor\AnchorReaderInterface;
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchor;
 use Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface;
@@ -33,6 +34,7 @@ use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\CMS\Core\Database\Connection;
 use TYPO3\CMS\Core\Database\ConnectionPool;
+use TYPO3\CMS\Core\Database\Query\QueryBuilder;
 
 #[CoversClass(AuditCheck::class)]
 final class AuditCheckTest extends TestCase
@@ -441,6 +443,200 @@ final class AuditCheckTest extends TestCase
         );
 
         self::assertTrue($finding->isPass(), $finding->summary);
+    }
+
+    /**
+     * The bug: `auditHmacEpoch` decides how the NEXT row is signed, and the pass
+     * asserted "rows are HMAC-signed over the full forensic payload" — a claim
+     * about STORED rows that nothing verified. Raise the setting to 3 without
+     * running `vault:audit-migrate-hmac` and the historical rows keep their
+     * epoch-1 signature while the gate reads green.
+     *
+     * @param int $storedMinEpoch Epoch of the oldest stored row
+     */
+    #[Test]
+    #[DataProvider('storedEpochBelowConfiguredProvider')]
+    public function storedRowsBelowTheConfiguredEpochWarn(int $storedMinEpoch): void
+    {
+        foreach (SecurityProfile::cases() as $profile) {
+            $finding = $this->assertFindingSeverity(
+                FindingSeverity::Warning,
+                $this->check(epoch: 3, storedMinEpoch: $storedMinEpoch)->run($this->doctorContext($profile)),
+                'audit.hmac_epoch',
+            );
+
+            // Both numbers, so the operator sees the gap rather than a verdict.
+            self::assertStringContainsString('configured as 3', $finding->summary);
+            self::assertStringContainsString(
+                \sprintf('oldest stored audit row is at epoch %d', $storedMinEpoch),
+                $finding->summary,
+            );
+            self::assertSame(3, $finding->details['auditHmacEpoch']);
+            self::assertSame($storedMinEpoch, $finding->details['storedMinEpoch']);
+        }
+    }
+
+    /**
+     * @return iterable<string, array{int}>
+     */
+    public static function storedEpochBelowConfiguredProvider(): iterable
+    {
+        yield 'keyless rows never migrated' => [0];
+        yield 'identity-only rows' => [1];
+        yield 'forensic rows without the epoch selector' => [2];
+    }
+
+    /**
+     * The risk text has to name what is unsigned on the rows that were left
+     * behind, and that differs by how far the chain got: below epoch 2 the
+     * outcome column itself is forgeable, at epoch 2 only the selector and the
+     * attribution fields are.
+     */
+    #[Test]
+    public function theUnmigratedRowsRiskNamesTheColumnsThatEpochLeavesUnsigned(): void
+    {
+        $stalledEarly = $this->findingById(
+            $this->check(epoch: 3, storedMinEpoch: 1)->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.hmac_epoch',
+        );
+        $stalledLate = $this->findingById(
+            $this->check(epoch: 3, storedMinEpoch: 2)->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.hmac_epoch',
+        );
+
+        self::assertStringContainsString('"success"', $stalledEarly->risk);
+        self::assertStringNotContainsString('"success"', $stalledLate->risk);
+        self::assertStringContainsString('actor_username', $stalledLate->risk);
+        self::assertNotSame($stalledEarly->risk, $stalledLate->risk);
+    }
+
+    /**
+     * The remediation must send the operator to the migration, not to the
+     * setting they already raised — and to the verifier that can confirm it,
+     * because this control only ever sees the oldest row.
+     */
+    #[Test]
+    public function theUnmigratedRowsRemediationNamesTheMigrationAndTheVerifier(): void
+    {
+        $finding = $this->findingById(
+            $this->check(epoch: 3, storedMinEpoch: 1)->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.hmac_epoch',
+        );
+
+        self::assertStringContainsString('vault:audit-migrate-hmac', $finding->remediation);
+        self::assertStringContainsString('vault:audit-verify', $finding->remediation);
+        self::assertStringContainsString('only changes new writes', $finding->remediation);
+    }
+
+    /**
+     * The boundary: equal is migrated, one below is not. Pinned so a `<=` cannot
+     * turn a fully migrated chain into a permanent warning.
+     */
+    #[Test]
+    public function aStoredEpochAtOrAboveTheConfiguredOnePasses(): void
+    {
+        foreach ([3, 4] as $storedMinEpoch) {
+            $finding = $this->findingById(
+                $this->check(epoch: 3, storedMinEpoch: $storedMinEpoch)->run(
+                    $this->doctorContext(SecurityProfile::Hardened),
+                ),
+                'audit.hmac_epoch',
+            );
+
+            self::assertTrue($finding->isPass(), $finding->summary);
+            self::assertSame($storedMinEpoch, $finding->details['storedMinEpoch']);
+            // The pass now states what was actually verified: the configuration
+            // AND the stored minimum it confirmed against.
+            self::assertStringContainsString('configured as 3', $finding->summary);
+            self::assertStringContainsString(
+                \sprintf('oldest stored row is at epoch %d', $storedMinEpoch),
+                $finding->summary,
+            );
+            self::assertStringContainsString('vault:audit-verify', $finding->summary);
+        }
+    }
+
+    /**
+     * An empty audit log has no stored row to contradict the configuration, so
+     * it passes — but the summary must not claim a confirmation it could not
+     * make, and `details` needs a comparable value rather than a missing key.
+     */
+    #[Test]
+    public function anEmptyAuditLogPassesWithoutClaimingStoredRowsWereChecked(): void
+    {
+        $finding = $this->findingById(
+            $this->check(epoch: 3, emptyAuditLog: true)->run($this->doctorContext(SecurityProfile::Hardened)),
+            'audit.hmac_epoch',
+        );
+
+        self::assertTrue($finding->isPass(), $finding->summary);
+        self::assertSame(-1, $finding->details['storedMinEpoch']);
+        self::assertStringContainsString('audit log is empty', $finding->summary);
+        self::assertStringNotContainsString('oldest stored row', $finding->summary);
+    }
+
+    /**
+     * The cost guarantee, pinned. `hmac_key_epoch` carries no index (see
+     * `ext_tables.sql`), so `MIN()` or a `GROUP BY` over it is a full
+     * clustered-index scan dragging the `text` columns along — on a checkset
+     * that also renders the backend status panel. The probe must stay a single
+     * PRIMARY-ordered row, which is only correct because a chain that verifies
+     * is epoch-monotonic in uid: `verifyHashChain()` records a DECREASE between
+     * adjacent rows as an ERROR.
+     */
+    #[Test]
+    public function theStoredEpochProbeReadsOneRowOrderedByThePrimaryKey(): void
+    {
+        $calls = [];
+        $queryBuilder = $this->epochQueryBuilder(3, $calls);
+
+        $this->check(epoch: 3, epochQueryBuilder: $queryBuilder)
+            ->run($this->doctorContext(SecurityProfile::Standard));
+
+        self::assertSame(['hmac_key_epoch'], $calls['select'] ?? null);
+        // from() carries an optional alias, so only the table is asserted.
+        self::assertSame(AuditLogService::TABLE_NAME, $calls['from'][0] ?? null);
+        self::assertSame(['uid', 'ASC'], $calls['orderBy'] ?? null);
+        self::assertSame([1], $calls['setMaxResults'] ?? null);
+    }
+
+    /**
+     * A chain still below the configured epoch at 1 or 2 keeps the partial-
+     * signature warning, but the stored minimum has to reach `details` there
+     * too — a CI gate reads one key, not one branch.
+     */
+    #[Test]
+    #[DataProvider('partiallySignedEpochProvider')]
+    public function theStoredMinimumIsReportedAtEveryConfiguredEpoch(int $epoch): void
+    {
+        $finding = $this->findingById(
+            $this->check(epoch: $epoch, storedMinEpoch: 0)->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.hmac_epoch',
+        );
+
+        self::assertSame(0, $finding->details['storedMinEpoch']);
+    }
+
+    /**
+     * The chain pass computes a warning count on every run and discarded it —
+     * `getWarningCount()` had no caller under `Classes/Service/Doctor/`. The
+     * warnings are epoch boundaries: non-fatal, and exactly the context a CI
+     * gate wants beside a green `errorCount`.
+     */
+    #[Test]
+    public function theChainCheckReportsTheWarningCountItAlreadyComputes(): void
+    {
+        $finding = $this->findingById(
+            $this->check(chainResult: HashChainVerificationResult::valid([
+                1200 => 'HMAC key epoch boundary: 1 -> 2',
+                1800 => 'HMAC key epoch boundary: 2 -> 3',
+            ]))->run($this->doctorContext(SecurityProfile::Standard)),
+            'audit.hash_chain',
+        );
+
+        self::assertTrue($finding->isPass(), $finding->summary);
+        self::assertSame(2, $finding->details['warningCount']);
+        self::assertSame(0, $finding->details['errorCount']);
     }
 
     /**
@@ -918,6 +1114,13 @@ final class AuditCheckTest extends TestCase
      *                                                    the real store does
      * @param bool $sharesConnection Whether `sys_registry` resolves to the audit
      *                               connection
+     * @param int|null $storedMinEpoch `hmac_key_epoch` of the OLDEST stored audit
+     *                                 row; null models a fully migrated chain by
+     *                                 deriving it from `$epoch`, so a test that
+     *                                 only changes the configuration is not
+     *                                 silently also asserting a drifted chain
+     * @param bool $emptyAuditLog No audit row exists at all, so the epoch probe
+     *                            has nothing to read
      */
     private function check(
         bool $auditReads = true,
@@ -934,6 +1137,9 @@ final class AuditCheckTest extends TestCase
         bool $anchorRequired = false,
         ?AuditChainAnchorStatus $dbAnchorStatus = null,
         bool $sharesConnection = true,
+        ?int $storedMinEpoch = null,
+        bool $emptyAuditLog = false,
+        ?QueryBuilder $epochQueryBuilder = null,
     ): AuditCheck {
         $configuration = self::createStub(ExtensionConfigurationInterface::class);
         $configuration->method('isAuditReadsEnabled')->willReturn($auditReads);
@@ -983,7 +1189,7 @@ final class AuditCheckTest extends TestCase
             $anchorService,
             $anchorReader,
             $this->anchorStore($epoch, $dbAnchorStatus, $sharesConnection),
-            $this->connectionPool(),
+            $this->connectionPool($emptyAuditLog ? null : ($storedMinEpoch ?? $epoch), $epochQueryBuilder),
             $deliveryState,
         );
     }
@@ -1019,12 +1225,58 @@ final class AuditCheckTest extends TestCase
         return $store;
     }
 
-    private function connectionPool(): ConnectionPool
+    /**
+     * The audit connection, wired so the stored-epoch probe reads
+     * `$storedMinEpoch` from the oldest row — null models an empty table, where
+     * `fetchOne()` returns false.
+     *
+     * The probe must stay a single PRIMARY-ordered row: `hmac_key_epoch` has no
+     * index, so a `MIN()`/`GROUP BY` would be a full scan on a control that also
+     * renders the backend status panel. The expectations below pin that shape.
+     */
+    private function connectionPool(?int $storedMinEpoch, ?QueryBuilder $queryBuilder = null): ConnectionPool
     {
+        $connection = self::createStub(Connection::class);
+        $connection->method('createQueryBuilder')->willReturn(
+            $queryBuilder ?? $this->epochQueryBuilder($storedMinEpoch),
+        );
+
         $pool = self::createStub(ConnectionPool::class);
-        $pool->method('getConnectionForTable')->willReturn(self::createStub(Connection::class));
+        $pool->method('getConnectionForTable')->willReturn($connection);
 
         return $pool;
+    }
+
+    /**
+     * A query builder that answers the stored-epoch probe with `$storedMinEpoch`
+     * — null models an empty table, where `fetchOne()` returns false.
+     *
+     * @param array<string, mixed>|null $calls Filled with the builder calls the
+     *                                         probe made, so a test can assert
+     *                                         the query SHAPE rather than only
+     *                                         its answer
+     */
+    private function epochQueryBuilder(?int $storedMinEpoch, ?array &$calls = null): QueryBuilder
+    {
+        $result = self::createStub(Result::class);
+        $result->method('fetchOne')->willReturn($storedMinEpoch ?? false);
+
+        $queryBuilder = self::createStub(QueryBuilder::class);
+        $record = static function (string $method) use (&$queryBuilder, &$calls): callable {
+            return static function (mixed ...$arguments) use ($method, &$queryBuilder, &$calls): QueryBuilder {
+                $calls[$method] = $arguments;
+
+                return $queryBuilder;
+            };
+        };
+
+        $queryBuilder->method('select')->willReturnCallback($record('select'));
+        $queryBuilder->method('from')->willReturnCallback($record('from'));
+        $queryBuilder->method('orderBy')->willReturnCallback($record('orderBy'));
+        $queryBuilder->method('setMaxResults')->willReturnCallback($record('setMaxResults'));
+        $queryBuilder->method('executeQuery')->willReturn($result);
+
+        return $queryBuilder;
     }
 
     /**

--- a/Tests/Unit/Service/Doctor/Check/CliAccessCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/CliAccessCheckTest.php
@@ -11,6 +11,7 @@ namespace Netresearch\NrVault\Tests\Unit\Service\Doctor\Check;
 
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Configuration\SecurityProfile;
+use Netresearch\NrVault\Security\VaultPermission;
 use Netresearch\NrVault\Service\Doctor\Check\CliAccessCheck;
 use Netresearch\NrVault\Service\Doctor\FindingSeverity;
 use Netresearch\NrVault\Tests\Unit\TestCase;
@@ -101,6 +102,31 @@ final class CliAccessCheckTest extends TestCase
         );
 
         self::assertTrue($finding->isPass());
+        self::assertSame('', $finding->details['highRisk']);
+        self::assertSame('secret.use,secret.create,secret.rotate', $finding->details['cliAllowedOperations']);
+    }
+
+    /**
+     * The pass must not call the remainder "low-risk". `secret.create` makes the
+     * CLI actor the owner of what it creates and `secret.rotate` substitutes a
+     * credential live consumers already hold — the enum says so itself. The pass
+     * asserts "nothing here needs an explicit opt-in", not "this is harmless".
+     */
+    #[Test]
+    public function theOperationAllowlistPassDoesNotCallTheDefaultsLowRisk(): void
+    {
+        $finding = $this->findingById(
+            $this->check(true, [42])->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.allowed_operations',
+        );
+
+        self::assertStringNotContainsStringIgnoringCase('low-risk', $finding->summary);
+        self::assertStringContainsString('explicit opt-in', $finding->summary);
+        self::assertStringContainsString('the audit trail cannot name', $finding->summary);
+        // Every configured operation stays named in the summary, so the report
+        // shows the grant rather than only its size.
+        self::assertStringContainsString('secret.use, secret.create, secret.rotate', $finding->summary);
+        self::assertStringContainsString('3 automation operation(s)', $finding->summary);
     }
 
     #[Test]
@@ -114,6 +140,138 @@ final class CliAccessCheckTest extends TestCase
         );
 
         self::assertSame('secret.reveal,master_key.rotate', $finding->details['highRisk']);
+    }
+
+    /**
+     * The bug this covers: both permissions are in `VaultPermission::cases()`, so
+     * they never counted as unknown either — an allowlist containing them
+     * satisfied `$risky === [] && $unknown === []` and reported a clean pass.
+     *
+     * @param list<string> $operations Configured `cliAllowedOperations`
+     * @param string $expectedHighRisk Expected `details['highRisk']`
+     */
+    #[Test]
+    #[DataProvider('optInOperationProvider')]
+    public function anOperationThatNeedsAnExplicitOptInIsAWarning(
+        array $operations,
+        string $expectedHighRisk,
+    ): void {
+        $finding = $this->assertFindingSeverity(
+            FindingSeverity::Warning,
+            $this->check(true, [42], $operations)->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.allowed_operations',
+        );
+
+        self::assertSame($expectedHighRisk, $finding->details['highRisk']);
+        self::assertSame('', $finding->details['unknown']);
+        self::assertStringContainsString('grants high-risk operation(s) ' . str_replace(',', ', ', $expectedHighRisk), $finding->summary);
+    }
+
+    /**
+     * @return iterable<string, array{list<string>, string}>
+     */
+    public static function optInOperationProvider(): iterable
+    {
+        yield 'manage_policy alone' => [
+            ['secret.use', 'secret.manage_policy'],
+            'secret.manage_policy',
+        ];
+        yield 'audit.view alone' => [
+            ['secret.use', 'audit.view'],
+            'audit.view',
+        ];
+        yield 'both, reported in configured order' => [
+            ['secret.use', 'audit.view', 'secret.manage_policy'],
+            'audit.view,secret.manage_policy',
+        ];
+        yield 'both alongside a previously listed one' => [
+            ['secret.manage_policy', 'audit.view', 'secret.delete'],
+            'secret.manage_policy,audit.view,secret.delete',
+        ];
+    }
+
+    /**
+     * An operator cannot act on "this is high-risk" — the risk text has to say
+     * what each of the two newly named permissions actually opens.
+     */
+    #[Test]
+    public function theRiskTextExplainsWhyPolicyManagementAndAuditViewingAreHighRisk(): void
+    {
+        $finding = $this->findingById(
+            $this->check(true, [42], ['secret.manage_policy', 'audit.view'])
+                ->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.allowed_operations',
+        );
+
+        // manage_policy: the permission that governs the permissions.
+        self::assertStringContainsString('allowed_groups', $finding->risk);
+        self::assertStringContainsString('write_groups', $finding->risk);
+        self::assertStringContainsString('widen its own per-secret reach', $finding->risk);
+        // audit.view: no secret access, but the credential topology.
+        self::assertStringContainsString('credential topology', $finding->risk);
+        self::assertStringContainsString('reconnaissance', $finding->risk);
+    }
+
+    /**
+     * The narrower route out is a named grant plus a technical actor, not a
+     * wider allowlist — and the two controls that legitimately want these
+     * permissions have to be named, or the remediation reads as "never grant
+     * them" for workflows that genuinely need them.
+     */
+    #[Test]
+    public function theOperationRemediationNamesTheTechnicalActorRouteForScheduledControls(): void
+    {
+        $finding = $this->findingById(
+            $this->check(true, [42], ['audit.view'])->run($this->doctorContext(SecurityProfile::Standard)),
+            'cli.allowed_operations',
+        );
+
+        self::assertStringContainsString('vault:audit-verify', $finding->remediation);
+        self::assertStringContainsString('orphan cleanup', $finding->remediation);
+        self::assertStringContainsString('technical actor', $finding->remediation);
+    }
+
+    /**
+     * Guards the pairing the bug came from: a permission may be high-risk or
+     * merely known, never neither by accident. Every high-risk token the check
+     * carries must be a real `VaultPermission` case (otherwise it is dead
+     * configuration that can never match), and the two permissions this change
+     * adds must actually be classified.
+     */
+    #[Test]
+    public function everyHighRiskTokenIsARealPermissionAndTheTwoNewOnesAreClassified(): void
+    {
+        $known = array_map(
+            static fn (VaultPermission $permission): string => $permission->value,
+            VaultPermission::cases(),
+        );
+
+        $reported = [];
+        foreach ($known as $permission) {
+            $finding = $this->findingById(
+                $this->check(true, [42], [$permission])->run($this->doctorContext(SecurityProfile::Standard)),
+                'cli.allowed_operations',
+            );
+
+            self::assertSame('', $finding->details['unknown'], $permission . ' must be a known value');
+            if ($finding->details['highRisk'] !== '') {
+                self::assertSame($permission, $finding->details['highRisk']);
+                $reported[] = $permission;
+            }
+        }
+
+        self::assertSame(
+            [
+                'secret.reveal',
+                'secret.delete',
+                'secret.manage_policy',
+                'audit.view',
+                'audit.export',
+                'master_key.rotate',
+                'vault.configure',
+            ],
+            $reported,
+        );
     }
 
     #[Test]

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -39,7 +39,7 @@ allowCliAccess = 0
 # cat=Security; type=string; label=CLI Access Groups: Comma-separated list of backend user group IDs allowed CLI access
 cliAccessGroups =
 
-# cat=Security; type=string; label=CLI Allowed Operations: Comma-separated operation permissions the unattributed CLI actor may hold when "allowCliAccess" is on. High-risk operations (secret.reveal, secret.delete, audit.export, master_key.rotate, vault.configure) are excluded by default - add them explicitly only where the deployment genuinely needs them, or prefer a named technical actor (TechnicalActorContext::runAs()).
+# cat=Security; type=string; label=CLI Allowed Operations: Comma-separated operation permissions the unattributed CLI actor may hold when "allowCliAccess" is on. High-risk operations (secret.reveal, secret.delete, secret.manage_policy, audit.view, audit.export, master_key.rotate, vault.configure) are excluded by default - add them explicitly only where the deployment genuinely needs them, or prefer a named technical actor (TechnicalActorContext::runAs()).
 cliAllowedOperations = secret.use,secret.create,secret.rotate
 
 # cat=Security; type=int+; label=Audit Log Retention (days): Number of days to keep audit log entries (0 = forever)


### PR DESCRIPTION
Two wrong-verdict bugs in `vault:doctor` — the runtime was correct in both cases, the readiness report was not.

## `cli.allowed_operations` called two privileged permissions harmless

The high-risk list held `secret.reveal`, `secret.delete`, `audit.export`, `master_key.rotate`, `vault.configure` — but not `secret.manage_policy` or `audit.view`, and both are in the *known* list, so they were not flagged as unknown either. An allowlist containing both read as a clean **Pass**.

The extension's own enum contradicts that: `manage_policy` is "the permission that governs the permissions" (it edits `allowed_groups`/`write_groups`, so a shell can widen its own per-secret reach, and the widened tiers read as ordinary configuration afterwards); `audit.view` grants no secret access but "maps out the credential topology" — and it is where the shell's own activity is recorded, so it is reconnaissance handed to the actor the log exists to catch. `HardenedDeployment.rst` already treated `audit.view` as opt-in, so the doctor was contradicting the documentation as well as the enum.

The pass summary called the remainder "low-risk operation(s)" — untrue even for the defaults, since the enum calls `secret.create` "a privilege-widening operation, not a harmless write". It now states what is actually true for any contents: no operation needing an explicit opt-in, N automation operations, *"a scoped grant, not a harmless one — everything listed is available to anyone with a shell on this host, under an actor the audit trail cannot name."* The remediation names the technical-actor route for the two scheduled controls that legitimately need these, so it does not read as "never grant them".

The five-item list was mirrored in **seven** places; all are updated, otherwise the docs would now contradict the code.

## `audit.hmac_epoch` graded the configuration, not the rows

The check read only `getAuditHmacEpoch()` and never queried the audit table, yet its `>= 3` pass text asserted "rows are HMAC-signed over the full forensic payload" — a claim about stored rows that was never verified. Meanwhile the epoch floor in `verifyHashChain()` compares the chain's **high-water** epoch against the floor and only on a full-chain pass, a rise is merely a warning, and the doctor always passes a bounded `$fromUid` — so the floor and the anchor evaluation are skipped by construction and warnings are never read. An installation could read green while older rows still lacked a signed `success` (epoch 1) or signed attribution and algorithm selector (epoch 2).

**Checked with one row, not an aggregate.** `hmac_key_epoch` has no index, so a `GROUP BY` would be a full clustered-index scan including the text columns — the cost this checkset explicitly avoids, as it also renders the backend status panel. Since an epoch *decrease* is already an error, a chain that verifies is epoch-non-decreasing in `uid`, so the oldest row holds the stored minimum: one `ORDER BY uid ASC LIMIT 1` read. The monotonicity argument was verified against the source rather than assumed, and the caveat is stated in the code: on a chain that does *not* verify the oldest row can overstate the minimum — but that chain is already failing `audit.hash_chain`.

Below the configured epoch → Warning naming both numbers, with `details.storedMinEpoch` for CI (`-1` on an empty log, so a gate sees a comparable value rather than a missing key). The remediation carries the correct causal note: an interrupted migration produces a *decrease*, which is already an error; the silent case is raising the setting **without** running the migration.

The full distribution went where it is free: `verifyHashChain()` already walks every row, so an epoch→count map costs one increment. `vault:audit-verify` now reports `Stored HMAC epochs` in text and JSON, and `audit.hash_chain` finally surfaces the `warningCount` it was computing and discarding.

## Verification

- Unit 3543 · Fuzz 1612 · Functional 339 — zero failures · CGL clean · docs render 72 documents
- PHPStan reports 45 errors — **pre-existing and unrelated**: baselined by stashing the change on the unmodified tree, identical 45, all `expectExceptionMessage()` deprecations from PHPUnit 13.2 in test files this branch never touches. Being handled separately.

Functional assertions deliberately compare the free counter against an authoritative `GROUP BY`, rather than hardcoding an epoch — the test class pins `auditHmacEpoch => 1`, so a hardcoded 3 would have been environment-dependent.
