### PR TITLE
Move the unit tests off the deprecated expectExceptionMessage()

### DIFF
--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -115,7 +115,7 @@ final class IdentifierValidatorTest extends TestCase
     #[DataProvider('invalidIdentifierProvider')]
     public function testRejectsInvalidIdentifier(string $input, string $reason): void
     {
-        $this->expectExceptionMessage($reason);
+        $this->expectExceptionMessageToContain($reason);
         (new IdentifierValidator())->validate($input);
     }
 

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -79,6 +79,12 @@ Tests/
   `FunctionalTestCase` directly.
 - Test class name: `<SourceClass>Test`; methods use the `#[Test]` PHPUnit attribute (`PHPUnit\Framework\Attributes\Test`) or a `test` prefix — never the legacy `@test` docblock annotation.
 - Use `#[DataProvider]` (native PHPUnit 10 attribute) for parameterized cases.
+- **Expect exception messages with `$this->expectExceptionMessageToContain()`**
+  (`ExceptionMessageExpectationTrait`), never `expectExceptionMessage()` —
+  PHPUnit 13.2 soft-deprecated the latter, and its replacement
+  `expectExceptionMessageIsOrContains()` is a fatal error on the PHPUnit 11.5 /
+  12.5 the matrix resolves for PHP 8.2 / 8.3. `expectExceptionMessageMatches()`
+  stays correct where the expectation genuinely is a pattern.
 - One assertion concept per test; split by behaviour, not by line count.
 - No real HTTP / filesystem calls — mock adapters (`VaultAdapterInterface`).
 - Functional fixtures: `Tests/.../Fixtures/*.csv`, loaded via `$this->importCSVDataSet()`.
@@ -136,11 +142,12 @@ final class AuditLogServiceTest extends AbstractVaultFunctionalTestCase
 | Helper | Purpose |
 |--------|---------|
 | `Tests/Functional/AbstractVaultFunctionalTestCase.php` | Master-key lifecycle + UUID v7 helper (deduplicates ~17 functional tests) |
-| `Tests/Unit/TestCase.php` | Project base composing the two mock traits below |
+| `Tests/Unit/TestCase.php` | Project base composing the shared traits below |
 | `Tests/Unit/Traits/TcaSchemaMockTrait.php` | `mockTcaSchemaForTable()` (was duplicated 4x) |
 | `Tests/Unit/Traits/BackendUserMockTrait.php` | `createMockBackendUser()` (was duplicated 3x) |
 | `Tests/Unit/Traits/EnvironmentSandboxTrait.php` | Throwaway project layout + initialised `Environment` for tests that resolve paths via `getVarPath()` / check the `getPublicPath()` boundary (audit file sink, extension-config path defaults) |
 | `Tests/Unit/Traits/ErrorSuppressionTrait.php` | `withoutPhpDiagnostics()` — run one call with PHP diagnostics silenced, for code that handles a native failure by checking the return value (`fopen`/`mkdir` returning false) instead of using `@`, where the genuine warning would otherwise trip `failOnWarning` |
+| `Tests/Unit/Traits/ExceptionMessageExpectationTrait.php` | `expectExceptionMessageToContain()` — the substring form of the exception-message expectation. PHPUnit 13.2 soft-deprecated `expectExceptionMessage()` and its replacement `expectExceptionMessageIsOrContains()` does not exist before 13.2, while the matrix still resolves PHPUnit 11.5 on PHP 8.2 and 12.5 on PHP 8.3. Use this instead of either |
 | `Tests/Unit/Fixtures/SecretFixtureBuilder.php` | Fluent builder for `SecretDetails` / `SecretMetadata` / `Secret` DTOs (replaces ~6 hand-rolled factory methods) |
 | `Tests/Unit/Fixtures/FailingStreamWrapper.php` | Stream wrapper that stats as a healthy writable file but fails at a chosen point (`fopen` refused/throwing, `flock` refused, short write) — the audit-sink write layers a real filesystem cannot reach |
 | `Tests/Unit/Fixtures/AuditChainLockHost.php` | Host exposing `AuditChainLockTrait`'s private lock primitives so the raw-vs-savepoint lock protocol can be tested without a consumer's write path |

--- a/Tests/Unit/Audit/AuditChainLockTraitTest.php
+++ b/Tests/Unit/Audit/AuditChainLockTraitTest.php
@@ -133,7 +133,7 @@ final class AuditChainLockTraitTest extends TestCase
             ->with('SELECT RELEASE_LOCK("nr_vault_audit")');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('deadlock');
+        $this->expectExceptionMessageToContain('deadlock');
 
         $this->subject->acquire($connection, false);
     }
@@ -152,7 +152,7 @@ final class AuditChainLockTraitTest extends TestCase
         $connection->method('executeStatement')->willThrowException(new RuntimeException('gone', 1750000012));
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('original');
+        $this->expectExceptionMessageToContain('original');
 
         $this->subject->acquire($connection, false);
     }

--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -2301,7 +2301,7 @@ final class AuditLogServiceTest extends TestCase
             ->method('insert');
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('simulated DB failure');
+        $this->expectExceptionMessageToContain('simulated DB failure');
 
         try {
             $this->getSubject()->log('s', 'read', true);

--- a/Tests/Unit/Audit/Sink/JsonFileAuditSinkTest.php
+++ b/Tests/Unit/Audit/Sink/JsonFileAuditSinkTest.php
@@ -381,7 +381,7 @@ final class JsonFileAuditSinkTest extends TestCase
     public function unencodablePayloadThrowsAnEncodingFailure(): void
     {
         $this->expectException(AuditSinkException::class);
-        $this->expectExceptionMessage('could not encode the record');
+        $this->expectExceptionMessageToContain('could not encode the record');
 
         $this->createSubject()->publish(
             $this->createEntry(context: $this->deeplyNestedContext()),

--- a/Tests/Unit/Audit/Sink/WebhookAuditSinkTest.php
+++ b/Tests/Unit/Audit/Sink/WebhookAuditSinkTest.php
@@ -206,7 +206,7 @@ final class WebhookAuditSinkTest extends TestCase
         $subject = $this->createSubject(client: new RecordingClient(new Response($status)));
 
         $this->expectException(AuditSinkException::class);
-        $this->expectExceptionMessage((string) $status);
+        $this->expectExceptionMessageToContain((string) $status);
 
         $subject->publish($this->createEntry(), 'tip');
     }
@@ -231,7 +231,7 @@ final class WebhookAuditSinkTest extends TestCase
         );
 
         $this->expectException(AuditSinkException::class);
-        $this->expectExceptionMessage('transport failed');
+        $this->expectExceptionMessageToContain('transport failed');
 
         $subject->publish($this->createEntry(), 'tip');
     }
@@ -250,7 +250,7 @@ final class WebhookAuditSinkTest extends TestCase
         );
 
         $this->expectException(AuditSinkException::class);
-        $this->expectExceptionMessage('disallowed IP range');
+        $this->expectExceptionMessageToContain('disallowed IP range');
 
         $subject->publish($this->createEntry(), 'tip');
     }

--- a/Tests/Unit/Crypto/EncryptionServiceTest.php
+++ b/Tests/Unit/Crypto/EncryptionServiceTest.php
@@ -260,7 +260,7 @@ final class EncryptionServiceTest extends TestCase
         $arguments[$field] = '!!!not-base64!!!';
 
         $this->expectException(EncryptionException::class);
-        $this->expectExceptionMessage('Invalid base64 encoding');
+        $this->expectExceptionMessageToContain('Invalid base64 encoding');
 
         $this->subject->decrypt(
             $arguments['encryptedValue'],
@@ -290,7 +290,7 @@ final class EncryptionServiceTest extends TestCase
         $encrypted = $this->subject->encrypt('rewrap', 'rewrap-test');
 
         $this->expectException(EncryptionException::class);
-        $this->expectExceptionMessage('Invalid base64 encoding');
+        $this->expectExceptionMessageToContain('Invalid base64 encoding');
 
         $this->subject->reEncryptDek(
             '!!!not-base64!!!',
@@ -309,7 +309,7 @@ final class EncryptionServiceTest extends TestCase
         $encrypted = $this->subject->encrypt('rewrap', 'rewrap-test');
 
         $this->expectException(EncryptionException::class);
-        $this->expectExceptionMessage('Invalid base64 encoding');
+        $this->expectExceptionMessageToContain('Invalid base64 encoding');
 
         $this->subject->reEncryptDek(
             $encrypted->encryptedDek,
@@ -716,7 +716,7 @@ final class EncryptionServiceTest extends TestCase
         $subject = new EncryptionService($this->masterKeyProvider, $brokenConfig);
 
         $this->expectException(EncryptionException::class);
-        $this->expectExceptionMessage('Unknown encryptionAlgorithm');
+        $this->expectExceptionMessageToContain('Unknown encryptionAlgorithm');
 
         $subject->encrypt('value', 'id');
     }
@@ -764,7 +764,7 @@ final class EncryptionServiceTest extends TestCase
         $encrypted = $this->subject->encrypt('v2-no-marker', 'v2-no-marker-id');
 
         $this->expectException(EncryptionException::class);
-        $this->expectExceptionMessage('Unknown encryption algorithm marker');
+        $this->expectExceptionMessageToContain('Unknown encryption algorithm marker');
 
         $this->subject->decrypt(
             $encrypted->encryptedValue,
@@ -783,7 +783,7 @@ final class EncryptionServiceTest extends TestCase
         $encrypted = $this->subject->encrypt('v2-bad-marker', 'v2-bad-marker-id');
 
         $this->expectException(EncryptionException::class);
-        $this->expectExceptionMessage('Unknown encryption algorithm marker');
+        $this->expectExceptionMessageToContain('Unknown encryption algorithm marker');
 
         $this->subject->decrypt(
             $encrypted->encryptedValue,

--- a/Tests/Unit/Crypto/EnvironmentMasterKeyProviderTest.php
+++ b/Tests/Unit/Crypto/EnvironmentMasterKeyProviderTest.php
@@ -114,7 +114,7 @@ final class EnvironmentMasterKeyProviderTest extends TestCase
         $provider = new EnvironmentMasterKeyProvider($config);
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage('Environment variable');
+        $this->expectExceptionMessageToContain('Environment variable');
 
         $provider->getMasterKey();
     }
@@ -130,7 +130,7 @@ final class EnvironmentMasterKeyProviderTest extends TestCase
         $provider = new EnvironmentMasterKeyProvider($config);
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage('Invalid master key length');
+        $this->expectExceptionMessageToContain('Invalid master key length');
 
         $provider->getMasterKey();
     }
@@ -142,7 +142,7 @@ final class EnvironmentMasterKeyProviderTest extends TestCase
         $provider = new EnvironmentMasterKeyProvider($config);
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage('cannot be persisted');
+        $this->expectExceptionMessageToContain('cannot be persisted');
 
         $provider->storeMasterKey(random_bytes(32));
     }

--- a/Tests/Unit/Crypto/FileMasterKeyProviderTest.php
+++ b/Tests/Unit/Crypto/FileMasterKeyProviderTest.php
@@ -140,7 +140,7 @@ final class FileMasterKeyProviderTest extends TestCase
         $provider = new FileMasterKeyProvider($config);
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage('not found');
+        $this->expectExceptionMessageToContain('not found');
 
         $provider->getMasterKey();
     }
@@ -174,7 +174,7 @@ final class FileMasterKeyProviderTest extends TestCase
         $provider = new FileMasterKeyProvider($config);
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage(self::INVALID_KEY_LENGTH_MESSAGE);
+        $this->expectExceptionMessageToContain(self::INVALID_KEY_LENGTH_MESSAGE);
 
         $provider->getMasterKey();
     }
@@ -218,7 +218,7 @@ final class FileMasterKeyProviderTest extends TestCase
         $provider = new FileMasterKeyProvider($config);
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage(self::INVALID_KEY_LENGTH_MESSAGE);
+        $this->expectExceptionMessageToContain(self::INVALID_KEY_LENGTH_MESSAGE);
 
         $provider->storeMasterKey('tooshort');
     }
@@ -249,7 +249,7 @@ final class FileMasterKeyProviderTest extends TestCase
         $provider = new FileMasterKeyProvider($config);
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage('not found');
+        $this->expectExceptionMessageToContain('not found');
 
         $provider->getMasterKey();
     }
@@ -268,7 +268,7 @@ final class FileMasterKeyProviderTest extends TestCase
         $provider = new FileMasterKeyProvider($config);
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage(self::INVALID_KEY_LENGTH_MESSAGE);
+        $this->expectExceptionMessageToContain(self::INVALID_KEY_LENGTH_MESSAGE);
 
         $provider->getMasterKey();
     }
@@ -430,7 +430,7 @@ final class FileMasterKeyProviderTest extends TestCase
         $provider = new FileMasterKeyProvider($config);
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage('Master key not found at: No path configured');
+        $this->expectExceptionMessageToContain('Master key not found at: No path configured');
 
         $provider->getMasterKey();
     }

--- a/Tests/Unit/Crypto/TransitMasterKeyProviderTest.php
+++ b/Tests/Unit/Crypto/TransitMasterKeyProviderTest.php
@@ -112,7 +112,7 @@ final class TransitMasterKeyProviderTest extends TestCase
 
         $this->expectException(MasterKeyException::class);
         $this->expectExceptionCode(1703800009);
-        $this->expectExceptionMessage('Invalid master key length');
+        $this->expectExceptionMessageToContain('Invalid master key length');
 
         $provider->getMasterKey();
     }
@@ -207,7 +207,7 @@ final class TransitMasterKeyProviderTest extends TestCase
         $provider = $this->createProvider($this->createMock(ClientInterface::class));
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage('Master key not found');
+        $this->expectExceptionMessageToContain('Master key not found');
 
         $provider->getMasterKey();
     }

--- a/Tests/Unit/Crypto/Typo3MasterKeyProviderTest.php
+++ b/Tests/Unit/Crypto/Typo3MasterKeyProviderTest.php
@@ -195,7 +195,7 @@ final class Typo3MasterKeyProviderTest extends TestCase
         $provider = new Typo3MasterKeyProvider();
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage('TYPO3 encryption key is not set');
+        $this->expectExceptionMessageToContain('TYPO3 encryption key is not set');
 
         $provider->getMasterKey();
     }
@@ -206,7 +206,7 @@ final class Typo3MasterKeyProviderTest extends TestCase
         $provider = new Typo3MasterKeyProvider();
 
         $this->expectException(MasterKeyException::class);
-        $this->expectExceptionMessage('TYPO3 provider derives the key');
+        $this->expectExceptionMessageToContain('TYPO3 provider derives the key');
 
         $provider->storeMasterKey(random_bytes(32));
     }

--- a/Tests/Unit/Domain/Model/SecretTest.php
+++ b/Tests/Unit/Domain/Model/SecretTest.php
@@ -183,7 +183,7 @@ final class SecretTest extends TestCase
         string $valueNonce,
     ): void {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('encryptedValue, encryptedDek, dekNonce, valueNonce, and valueChecksum must all be set or all be empty');
+        $this->expectExceptionMessageToContain('encryptedValue, encryptedDek, dekNonce, valueNonce, and valueChecksum must all be set or all be empty');
 
         // The constructor MUST throw before returning; assertInstanceOf
         // is unreachable but uses the constructed value so Sonar's S1848
@@ -202,7 +202,7 @@ final class SecretTest extends TestCase
     public function constructorThrowsOnVersionTwoWithoutAlgorithmMarker(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('known encryptionAlgorithm marker');
+        $this->expectExceptionMessageToContain('known encryptionAlgorithm marker');
 
         self::assertInstanceOf(Secret::class, new Secret(
             identifier: 'v2-no-marker',
@@ -219,7 +219,7 @@ final class SecretTest extends TestCase
     public function constructorThrowsOnVersionTwoWithUnknownAlgorithmMarker(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('known encryptionAlgorithm marker');
+        $this->expectExceptionMessageToContain('known encryptionAlgorithm marker');
 
         self::assertInstanceOf(Secret::class, new Secret(
             identifier: 'v2-bad-marker',
@@ -239,7 +239,7 @@ final class SecretTest extends TestCase
         // Version 2 means "explicitly marked envelope" — without an envelope
         // the marker is meaningless and indicates a programming error.
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('full encryption envelope');
+        $this->expectExceptionMessageToContain('full encryption envelope');
 
         self::assertInstanceOf(Secret::class, new Secret(
             identifier: 'v2-no-envelope',
@@ -255,7 +255,7 @@ final class SecretTest extends TestCase
         // the marker (host-derived resolution) and silently diverge from
         // what the stored marker claims.
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('must not carry an encryptionAlgorithm marker');
+        $this->expectExceptionMessageToContain('must not carry an encryptionAlgorithm marker');
 
         self::assertInstanceOf(Secret::class, new Secret(
             identifier: 'v1-with-marker',

--- a/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
+++ b/Tests/Unit/Domain/Repository/SecretRepositoryTest.php
@@ -751,7 +751,7 @@ final class SecretRepositoryTest extends TestCase
             ->willThrowException(new RuntimeException('Constraint violation'));
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Constraint violation');
+        $this->expectExceptionMessageToContain('Constraint violation');
 
         $this->subject->save($secret);
     }

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -387,7 +387,7 @@ final class OAuthTokenManagerTest extends TestCase
             ->willReturn($response);
 
         $this->expectException(OAuthException::class);
-        $this->expectExceptionMessage('OAuth token request failed with status 401');
+        $this->expectExceptionMessageToContain('OAuth token request failed with status 401');
 
         $this->subject->getAccessToken($config);
     }
@@ -419,7 +419,7 @@ final class OAuthTokenManagerTest extends TestCase
             ->willReturn($response);
 
         $this->expectException(OAuthException::class);
-        $this->expectExceptionMessage('OAuth response missing access_token');
+        $this->expectExceptionMessageToContain('OAuth response missing access_token');
 
         $this->subject->getAccessToken($config);
     }
@@ -448,7 +448,7 @@ final class OAuthTokenManagerTest extends TestCase
             ->willThrowException($exception);
 
         $this->expectException(OAuthException::class);
-        $this->expectExceptionMessage('OAuth token request failed: Connection timeout');
+        $this->expectExceptionMessageToContain('OAuth token request failed: Connection timeout');
 
         $this->subject->getAccessToken($config);
     }
@@ -666,7 +666,7 @@ final class OAuthTokenManagerTest extends TestCase
             ->willReturn($response);
 
         $this->expectException(OAuthException::class);
-        $this->expectExceptionMessage('Invalid JSON response from OAuth server');
+        $this->expectExceptionMessageToContain('Invalid JSON response from OAuth server');
 
         $this->subject->getAccessToken($config);
     }

--- a/Tests/Unit/Http/VaultHttpClientTest.php
+++ b/Tests/Unit/Http/VaultHttpClientTest.php
@@ -813,7 +813,7 @@ final class VaultHttpClientTest extends TestCase
         ], json_encode([1, 2, 3]));
 
         $this->expectException(VaultException::class);
-        $this->expectExceptionMessage(self::NON_OBJECT_BODY_MESSAGE);
+        $this->expectExceptionMessageToContain(self::NON_OBJECT_BODY_MESSAGE);
 
         $authenticatedClient->sendRequest($request);
     }
@@ -848,7 +848,7 @@ final class VaultHttpClientTest extends TestCase
         ], json_encode('just-a-string'));
 
         $this->expectException(VaultException::class);
-        $this->expectExceptionMessage(self::NON_OBJECT_BODY_MESSAGE);
+        $this->expectExceptionMessageToContain(self::NON_OBJECT_BODY_MESSAGE);
 
         $authenticatedClient->sendRequest($request);
     }
@@ -884,7 +884,7 @@ final class VaultHttpClientTest extends TestCase
         ], '[]');
 
         $this->expectException(VaultException::class);
-        $this->expectExceptionMessage(self::NON_OBJECT_BODY_MESSAGE);
+        $this->expectExceptionMessageToContain(self::NON_OBJECT_BODY_MESSAGE);
 
         $authenticatedClient->sendRequest($request);
     }
@@ -921,7 +921,7 @@ final class VaultHttpClientTest extends TestCase
         ], '{"broken": ');
 
         $this->expectException(VaultException::class);
-        $this->expectExceptionMessage('request body is not valid JSON');
+        $this->expectExceptionMessageToContain('request body is not valid JSON');
 
         $authenticatedClient->sendRequest($request);
     }

--- a/Tests/Unit/Http/VaultHttpResponseTest.php
+++ b/Tests/Unit/Http/VaultHttpResponseTest.php
@@ -343,7 +343,7 @@ final class VaultHttpResponseTest extends TestCase
         $response = new VaultHttpResponse($psrResponse);
 
         $this->expectException(VaultException::class);
-        $this->expectExceptionMessage('HTTP request failed with status 404: Not Found');
+        $this->expectExceptionMessageToContain('HTTP request failed with status 404: Not Found');
 
         $response->throwIfError();
     }

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -147,7 +147,7 @@ final class VaultServiceTest extends TestCase
     public function storeRejectsEmptySecret(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('empty');
+        $this->expectExceptionMessageToContain('empty');
 
         $this->subject->store('validIdentifier', '');
     }

--- a/Tests/Unit/TestCase.php
+++ b/Tests/Unit/TestCase.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit;
 
 use Netresearch\NrVault\Tests\Unit\Traits\BackendUserMockTrait;
+use Netresearch\NrVault\Tests\Unit\Traits\ExceptionMessageExpectationTrait;
 use Netresearch\NrVault\Tests\Unit\Traits\TcaSchemaMockTrait;
 use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 
@@ -21,8 +22,8 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
  * `TestCase`) directly. The class is intentionally empty: its job is to
  *
  *  1. compose the shared helper traits (TCA schema mocks, backend-user
- *     mocks) so test authors opt in with one `extends` line rather than
- *     three `use` statements, and
+ *     mocks, exception-message expectations) so test authors opt in with
+ *     one `extends` line rather than three `use` statements, and
  *  2. serve as a convention anchor for the architecture check run by
  *     `Tests/scripts/check-test-base-class.php`.
  *
@@ -33,5 +34,6 @@ use TYPO3\TestingFramework\Core\Unit\UnitTestCase;
 abstract class TestCase extends UnitTestCase
 {
     use BackendUserMockTrait;
+    use ExceptionMessageExpectationTrait;
     use TcaSchemaMockTrait;
 }

--- a/Tests/Unit/Traits/ExceptionMessageExpectationTrait.php
+++ b/Tests/Unit/Traits/ExceptionMessageExpectationTrait.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Traits;
+
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Substring expectation for exception messages that works on every supported
+ * PHPUnit major.
+ *
+ * PHPUnit 13.2.0 soft-deprecated `expectExceptionMessage()` in favour of
+ * `expectExceptionMessageIsOrContains()`
+ * (<https://github.com/sebastianbergmann/phpunit/issues/6560>). The replacement
+ * method does NOT exist before 13.2.0, and the CI matrix still resolves PHPUnit
+ * 11.5 on PHP 8.2 and PHPUnit 12.5 on PHP 8.3, so calling it directly would be a
+ * fatal error on half the supported cells.
+ *
+ * `expectExceptionMessageMatches()` has existed unchanged since PHPUnit 8.4 and
+ * is available everywhere. Quoting the needle turns it into a literal, unanchored
+ * search — which is exactly what `str_contains()` does inside PHPUnit's
+ * `ExceptionMessageIsOrContains` constraint, on 11.5, 12.5 and 13.2 alike.
+ *
+ * Once the PHPUnit floor is >= 13.2 this trait can be reduced to a forward to
+ * `expectExceptionMessageIsOrContains()`, or deleted after inlining it.
+ *
+ * @phpstan-require-extends TestCase
+ */
+trait ExceptionMessageExpectationTrait
+{
+    /**
+     * Expect the raised exception's message to contain `$message` verbatim.
+     *
+     * Drop-in replacement for the deprecated `expectExceptionMessage()`,
+     * including its treatment of the empty needle: PHPUnit reads that not as
+     * "matches anything" but as "the message must itself be empty".
+     */
+    protected function expectExceptionMessageToContain(string $message): void
+    {
+        if ($message === '') {
+            $this->expectExceptionMessageMatches('/^$/D');
+
+            return;
+        }
+
+        $this->expectExceptionMessageMatches('/' . \preg_quote($message, '/') . '/');
+    }
+}

--- a/Tests/Unit/Traits/ExceptionMessageExpectationTrait.php
+++ b/Tests/Unit/Traits/ExceptionMessageExpectationTrait.php
@@ -49,6 +49,6 @@ trait ExceptionMessageExpectationTrait
             return;
         }
 
-        $this->expectExceptionMessageMatches('/' . \preg_quote($message, '/') . '/');
+        $this->expectExceptionMessageMatches('/' . preg_quote($message, '/') . '/');
     }
 }

--- a/Tests/Unit/Traits/ExceptionMessageExpectationTraitTest.php
+++ b/Tests/Unit/Traits/ExceptionMessageExpectationTraitTest.php
@@ -68,7 +68,7 @@ final class ExceptionMessageExpectationTraitTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageToContain($needle);
 
-        throw new RuntimeException($thrown);
+        throw new RuntimeException($thrown, 2734202747);
     }
 
     #[Test]
@@ -77,6 +77,6 @@ final class ExceptionMessageExpectationTraitTest extends TestCase
         $this->expectException(RuntimeException::class);
         $this->expectExceptionMessageToContain('');
 
-        throw new RuntimeException('');
+        throw new RuntimeException('', 1183658049);
     }
 }

--- a/Tests/Unit/Traits/ExceptionMessageExpectationTraitTest.php
+++ b/Tests/Unit/Traits/ExceptionMessageExpectationTraitTest.php
@@ -10,7 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Traits;
 
 use Netresearch\NrVault\Tests\Unit\TestCase;
-use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\CoversNothing;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use RuntimeException;
@@ -25,7 +25,7 @@ use RuntimeException;
  * expected-message regular expression. They fail loudly here if the quoting is
  * ever dropped.
  */
-#[CoversClass(ExceptionMessageExpectationTrait::class)]
+#[CoversNothing]
 final class ExceptionMessageExpectationTraitTest extends TestCase
 {
     /**

--- a/Tests/Unit/Traits/ExceptionMessageExpectationTraitTest.php
+++ b/Tests/Unit/Traits/ExceptionMessageExpectationTraitTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Traits;
+
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+use RuntimeException;
+
+/**
+ * Pins `expectExceptionMessageToContain()` to the substring semantics of the
+ * `expectExceptionMessage()` it replaces.
+ *
+ * The metacharacter cases are the ones that matter: passing the needle to
+ * `expectExceptionMessageMatches()` unquoted turns `(` into an unterminated
+ * group and `/` into a premature delimiter, which PHPUnit rejects as an invalid
+ * expected-message regular expression. They fail loudly here if the quoting is
+ * ever dropped.
+ */
+#[CoversClass(ExceptionMessageExpectationTrait::class)]
+final class ExceptionMessageExpectationTraitTest extends TestCase
+{
+    /**
+     * @return iterable<string, array{string, string}>
+     */
+    public static function messageProvider(): iterable
+    {
+        yield 'needle is a strict substring' => [
+            'Master key not found at: /var/keys/master.key',
+            'not found',
+        ];
+
+        yield 'needle is the full message' => [
+            'TYPO3 encryption key is not set',
+            'TYPO3 encryption key is not set',
+        ];
+
+        yield 'needle contains an unbalanced parenthesis' => [
+            'Unknown encryptionAlgorithm marker (xchacha20 expected',
+            'marker (xchacha20',
+        ];
+
+        yield 'needle contains a slash and a dollar sign' => [
+            'Refusing to read $GLOBALS/TYPO3_CONF_VARS as a master key',
+            '$GLOBALS/TYPO3_CONF_VARS',
+        ];
+
+        yield 'needle contains regex quantifiers and anchors' => [
+            'Identifier must match ^[a-z0-9._-]+$ but did not',
+            '^[a-z0-9._-]+$',
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('messageProvider')]
+    public function matchesTheSameMessagesAsAContainsCheck(string $thrown, string $needle): void
+    {
+        self::assertStringContainsString($needle, $thrown, 'provider is inconsistent');
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageToContain($needle);
+
+        throw new RuntimeException($thrown);
+    }
+
+    #[Test]
+    public function treatsAnEmptyNeedleAsRequiringAnEmptyMessage(): void
+    {
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessageToContain('');
+
+        throw new RuntimeException('');
+    }
+}

--- a/Tests/Unit/Utility/IdentifierValidatorTest.php
+++ b/Tests/Unit/Utility/IdentifierValidatorTest.php
@@ -51,7 +51,7 @@ final class IdentifierValidatorTest extends TestCase
     public function validateRejectsEmptyIdentifier(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('empty');
+        $this->expectExceptionMessageToContain('empty');
 
         IdentifierValidator::validate('');
     }
@@ -60,7 +60,7 @@ final class IdentifierValidatorTest extends TestCase
     public function validateRejectsTooShortIdentifier(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('at least');
+        $this->expectExceptionMessageToContain('at least');
 
         IdentifierValidator::validate('ab');
     }
@@ -69,7 +69,7 @@ final class IdentifierValidatorTest extends TestCase
     public function validateRejectsTooLongIdentifier(): void
     {
         $this->expectException(ValidationException::class);
-        $this->expectExceptionMessage('exceed');
+        $this->expectExceptionMessageToContain('exceed');
 
         IdentifierValidator::validate(str_repeat('a', 256));
     }


### PR DESCRIPTION
PHPUnit 13.2 deprecated `expectExceptionMessage()`; the suite used it at 45 call sites across 16 files. A fresh `composer install` today resolves 13.2.6, and `composer ci:test:php:phpstan` then reports 45 `method.deprecated` errors — friction for anyone installing from scratch.

## Why a straight rename would have broken the matrix

The replacement, `expectExceptionMessageIsOrContains()`, landed in **13.2.0**. The supported matrix does not run 13.2 everywhere — measured with `composer update --dry-run` in scratch directories outside the repo, one per cell:

| PHP | PHPUnit resolved | replacement available |
|---|---|---|
| 8.2 | 11.5.56 | no |
| 8.3 | 12.5.33 | no |
| 8.4 / 8.5 | 13.2.6 | yes |

**Four of eight cells run PHPUnit below 13.2** — the TYPO3 axis is irrelevant (`typo3/testing-framework` resolves to 9.6.1 throughout); the split comes from PHPUnit's own PHP floors. A rename would have fataled with "call to undefined method" on half the matrix.

## What was done instead

A trait composed into the existing test base exposes `expectExceptionMessageToContain()`, which routes to `expectExceptionMessageMatches()` with a `preg_quote`d needle — an API present across the entire supported range.

Deliberately **not** named `expectExceptionMessageIsOrContains`: on ≥13.2 that is `final protected` on `TestCase`, so a same-named trait method is a fatal "cannot override final method".

## Semantics are provably unchanged

`expectExceptionMessage()` is a **substring** match, and `ExceptionMessageIsOrContains::matches()` is byte-for-byte identical in 11.5.56, 12.5.33 and 13.2.6 — only the entry point is new. `expectExceptionMessageMatches()` runs an unanchored `preg_match`, so a quoted needle is the same literal scan; the empty-message special case (`$expected === '' → $other === ''`) is reproduced explicitly, since `preg_match('//', $x)` would otherwise invert it.

Pinned by a dedicated test covering substring, full message, an unbalanced `(`, a `$` combined with `/`, a full regex-looking string, and the empty case — **run green on all three PHPUnit lines**. The counterfactual was checked too: under 11.5.56 an unquoted migration dies with "Invalid expected exception message regular expression given", and the naive rename with "call to undefined method". No current message contains metacharacters, so the unquoted variant would have looked correct today and broken on the first one that did.

## Correction to the premise that started this

CI was **not** about to go red. The shared workflow pins `phpunit/phpunit:<13` for the PHPStan job (because `phpstan-phpunit ^2.0` does not model PHPUnit 13's mock-builder API), so static analysis runs against 11.5.56 or 12.5.33, where the annotation does not exist. This was local-install friction and a latent failure for when that pin is lifted — which the workflow's own comment states as the intent — not a currently-red gate.

The deprecation is soft: a `@deprecated` docblock on a forwarder, no runtime trigger. Tests never failed; only static analysis complained.

## Verification

- PHPStan: **no errors** (was 45) · CGL clean · architecture, `doc-cli`, self-test and evidence checks green
- Full unit suite run on **all three** resolutions: 11.5.56, 12.5.33 and 13.2.6 — 3520 tests, 12025 assertions, identical
- Functional 337 — zero failures

Follow-up worth its own ticket: that `phpunit/phpunit:<13` pin means static analysis never sees the PHPUnit version half the matrix actually runs. That gap is what let this land unnoticed, and it will hide the next one too.
