### PR TITLE
Refuse a datamap write whose target the vault cannot resolve

### DIFF
--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -28,7 +28,9 @@ use TYPO3\CMS\Core\DataHandling\DataHandler;
  *
  * Handles:
  * - Create authorization (secret.create, before the row is inserted)
- * - Update authorization (the per-secret write ACL, before anything is written)
+ * - Update authorization (the per-secret write ACL, before anything is written),
+ *   refusing outright a datamap whose target the vault cannot resolve — a
+ *   soft-deleted secret or none at all (see refuseUnresolvableTarget())
  * - Identifier immutability (prevent changes after creation)
  * - Secret encryption on save (secret_input field)
  * - Audit logging for metadata changes
@@ -343,7 +345,17 @@ final class SecretTcaHook
         // The VaultService coercion (resolveOwnerUid/resolveFrontendAccessible)
         // only runs on the programmatic store($options) path; the FormEngine
         // path writes the raw columns directly, so the gate must live here.
-        $this->enforcePrivilegedColumnPolicy($fieldArray, $id, $dataHandler);
+        //
+        // Normally the policy filters the record and it proceeds; it refuses
+        // the record outright only when the target could not be resolved at
+        // all, which the ACL gate above should already have caught — the two
+        // resolve through different reads, so this closes the case where they
+        // disagree rather than trusting one of them for both.
+        if (!$this->enforcePrivilegedColumnPolicy($fieldArray, $id, $dataHandler)) {
+            $fieldArray = null;
+
+            return;
+        }
 
         // For existing records, prevent identifier changes
         if (!str_starts_with((string) $id, 'NEW') && isset($fieldArray['identifier'])) {
@@ -1211,12 +1223,10 @@ final class SecretTcaHook
      * guard.
      *
      * With that lookup in place, an unresolved uid no longer means "possibly
-     * a disabled secret". It means no row for this uid — left to core, which
-     * refuses a nonexistent record on its own — or a soft-deleted one, whose
-     * columns no read path reaches and which this table's refused `undelete`
-     * keeps that way. Passing those through stays what it was: the vault
-     * declining to answer for a record it no longer holds, not a grant over
-     * one it does.
+     * a disabled secret" — it means the vault holds no live record for this
+     * uid, and the write is refused rather than waved through
+     * (see refuseUnresolvableTarget() for what the two remaining causes are
+     * and why both are refused).
      */
     private function isUpdateAuthorized(string|int $id, DataHandler $dataHandler): bool
     {
@@ -1227,7 +1237,9 @@ final class SecretTcaHook
         $uid = is_numeric($id) ? (int) $id : 0;
         $secret = $this->secretRepository->findByUidIncludingDisabled($uid);
         if (!$secret instanceof Secret) {
-            return true;
+            $this->refuseUnresolvableTarget($uid, 'Update', $dataHandler);
+
+            return false;
         }
 
         if ($this->accessControlService->canWrite($secret)) {
@@ -1247,6 +1259,67 @@ final class SecretTcaHook
         );
 
         return false;
+    }
+
+    /**
+     * Refuse a datamap write whose target this hook could not resolve, and
+     * say as precisely as the data allows what was not resolvable.
+     *
+     * Shared by both write gates — the per-secret ACL (isUpdateAuthorized())
+     * and the privileged-column policy (enforcePrivilegedColumnPolicy()) —
+     * because they guard the same write from two angles and must not disagree
+     * about what "the record is not there" means. Both resolve through a
+     * lookup that excludes soft-deleted rows, so both reach this method for
+     * the same two causes:
+     *
+     *  - **Soft-deleted (a tombstone).** The live one. Core reads its datamap
+     *    UPDATE target with `BackendUtility::getRecord($table, $id, '*', '',
+     *    false)` — delete clause OFF — and skips only a row it cannot find at
+     *    all, so it processes a deleted secret's datamap perfectly happily.
+     *    The gates cannot see the row, so before this refusal the columns of a
+     *    deleted secret were writable by anyone DataHandler let near the
+     *    table, with no per-secret tier and no policy gate. `deleted` has no
+     *    TCA column and this table refuses `undelete`, so the row cannot be
+     *    resurrected that way — but rewriting a tombstone is still an
+     *    unaudited, ungated write to vault state, and the identifier it
+     *    carries is what a later legitimate creation collides with.
+     *  - **Genuinely absent.** Core skips such a record itself, one guard
+     *    further on. Refused here anyway rather than special-cased: the gate
+     *    would otherwise have to prove core's later guard still exists to stay
+     *    correct, and "the vault could not identify the record it is being
+     *    asked to authorize" is a refusal on its own terms.
+     *
+     * Reported differently because they differ for the editor, and because
+     * only one of them HAS an identifier: the deleted-inclusive probe below
+     * is what tells them apart, and it runs only on this path — a resolvable
+     * target never pays for it. A tombstone is audited as `access_denied`
+     * under its identifier, exactly like the hook's other refusals; an absent
+     * record has no identifier to audit under, so it is reported in the
+     * DataHandler log alone (the same concession refuseCommand() makes for an
+     * unreadable row).
+     */
+    private function refuseUnresolvableTarget(int $uid, string $gate, DataHandler $dataHandler): void
+    {
+        $record = $this->readRecord($uid, ['identifier'], true);
+        $identifier = \is_string($record['identifier'] ?? null) ? $record['identifier'] : '';
+
+        if ($identifier !== '') {
+            $this->auditDenial($identifier, $gate . ' denied: the vault secret is deleted');
+            $message = 'This vault secret is deleted and can no longer be changed; '
+                . 'the vault has no restore operation.';
+        } else {
+            $message = 'No vault secret exists for this record, so the change cannot be authorized.';
+        }
+
+        /** @phpstan-ignore method.internal */
+        $dataHandler->log(
+            self::TABLE,
+            $uid,
+            2,
+            null,
+            1,
+            $message,
+        );
     }
 
     /**
@@ -1392,19 +1465,30 @@ final class SecretTcaHook
      *  - Anyone else: every privileged column is dropped and, when it
      *    differed from the stored value, the attempt is logged and audited.
      *
+     * Returns false when the record must be refused outright rather than
+     * merely filtered — see refuseUnresolvableTarget(). Dropping the
+     * privileged columns would NOT be the fail-closed answer there: the read
+     * that failed is the same read that supplies the stored values, so the
+     * policy cannot be applied at all, and letting the non-privileged columns
+     * through would still be an ungated write to a record the vault cannot
+     * identify. The caller nulls $fieldArray, because that is what makes core
+     * skip a record and this method holds it only by reference.
+     *
      * @param array<string, mixed> $fieldArray
+     *
+     * @return bool True when the record may proceed
      */
     private function enforcePrivilegedColumnPolicy(
         array &$fieldArray,
         string|int $id,
         DataHandler $dataHandler,
-    ): void {
+    ): bool {
         // Admins and system maintainers are trusted on this path. Non-backend
         // actors (CLI/scheduler/api) do not reach DataHandler form edits with a
         // BE user, so they are treated as non-privileged here and fall through
         // to the owner check (which yields actor UID 0 => not owner).
         if ($this->accessControlService->isCurrentActorAdmin()) {
-            return;
+            return true;
         }
 
         $isNew = str_starts_with((string) $id, 'NEW');
@@ -1417,7 +1501,7 @@ final class SecretTcaHook
             // locking the creator out of managing their own new secret.
             $fieldArray['owner_uid'] = $this->accessControlService->getCurrentActorUid();
 
-            return;
+            return true;
         }
 
         $uid = is_numeric($id) ? (int) $id : 0;
@@ -1426,7 +1510,9 @@ final class SecretTcaHook
         // is enforced separately, further down the calling method.
         $original = $this->readRecord($uid, [...$this->privilegedScalarColumns(), 'identifier']);
         if ($original === null) {
-            return;
+            $this->refuseUnresolvableTarget($uid, 'Policy change', $dataHandler);
+
+            return false;
         }
 
         $storedOwner = is_numeric($original['owner_uid'] ?? null) ? (int) $original['owner_uid'] : 0;
@@ -1440,7 +1526,7 @@ final class SecretTcaHook
         if ($actorUid !== 0 && $actorUid === $storedOwner
             && $this->accessControlService->isGranted(VaultPermission::SecretManagePolicy)
         ) {
-            return;
+            return true;
         }
 
         // Not authorized to manage this secret's policy: drop every
@@ -1476,7 +1562,7 @@ final class SecretTcaHook
         }
 
         if ($attempted === []) {
-            return;
+            return true;
         }
 
         $identifier = \is_string($original['identifier'] ?? null) ? $original['identifier'] : '';
@@ -1496,6 +1582,10 @@ final class SecretTcaHook
             1,
             'Vault secret ACL columns can only be changed by an administrator or by the secret owner holding the secret.manage_policy permission',
         );
+
+        // The unauthorized columns are gone; the rest of the save is a
+        // legitimate edit by someone who passed canWrite(), so it proceeds.
+        return true;
     }
 
     /**

--- a/Tests/Functional/Hook/SecretTcaHookDeletedSecretTest.php
+++ b/Tests/Functional/Hook/SecretTcaHookDeletedSecretTest.php
@@ -1,0 +1,315 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Hook;
+
+use Netresearch\NrVault\Audit\AuditAction;
+use Netresearch\NrVault\Hook\SecretTcaHook;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\CMS\Core\Database\Connection;
+use TYPO3\CMS\Core\DataHandling\DataHandler;
+use TYPO3\CMS\Core\Utility\GeneralUtility;
+
+/**
+ * Functional tests for SecretTcaHook against a SOFT-DELETED secret
+ * (`deleted = 1`), and against a uid that has no row at all.
+ *
+ * Both of the hook's datamap write gates — the per-secret write ACL and the
+ * privileged-column policy — resolve their target through a lookup that
+ * excludes soft-deleted rows, and both used to treat "not found" as "allowed".
+ * Core does not stop there on their behalf: it reads its datamap UPDATE target
+ * with `BackendUtility::getRecord($table, $id, '*', '', false)`, delete clause
+ * OFF, and skips only a row it cannot find at all. A tombstone therefore has a
+ * pid and is processed — so the columns of a deleted secret were writable by
+ * anyone core let near the table, with no per-secret tier, no policy gate and
+ * no audit entry.
+ *
+ * ## Why these tests drive the real DataHandler
+ *
+ * The finding is about what core does when the hook declines to act, and a
+ * direct call to the hook cannot show that. The actors therefore hold real
+ * table-modify and page rights, so `process_datamap()` reaches core's own
+ * update branch whenever the hook lets the record through — which is what
+ * makes an unguarded write visible. Same reasoning, and the same fixture, as
+ * {@see SecretTcaHookDisabledSecretTest}.
+ */
+#[CoversClass(SecretTcaHook::class)]
+final class SecretTcaHookDeletedSecretTest extends AbstractVaultFunctionalTestCase
+{
+    private const SECRET_TABLE = 'tx_nrvault_secret';
+
+    private const AUDIT_TABLE = 'tx_nrvault_audit_log';
+
+    /** Page the secrets live on; both actors may edit and delete here. */
+    private const PAGE_UID = 1;
+
+    /**
+     * Non-admin editor with table-modify rights and nothing else: not the
+     * owner, in neither tier, holding no operation permission.
+     */
+    private const EDITOR_UID = 2;
+
+    /** Non-admin who owns the seeded secrets, so canWrite() grants them. */
+    private const OWNER_UID = 3;
+
+    private const SEEDED_DESCRIPTION = 'seeded description';
+
+    private const SEEDED_CONTEXT = 'production';
+
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_disabled_secret.csv';
+
+    /** Logged in per test — the scenarios need different actors. */
+    protected ?int $backendUserUid = null;
+
+    /**
+     * The finding itself, stated at its strongest: the OWNER submits the
+     * change, so the per-secret tier would grant it on a live record. It must
+     * still not land, because the vault no longer holds the record to
+     * authorize the write against.
+     */
+    #[Test]
+    public function aDatamapAgainstASoftDeletedSecretDoesNotLand(): void
+    {
+        $this->setUpBackendUser(self::OWNER_UID);
+        [$uid, $identifier] = $this->seedSecret(deleted: true);
+
+        $this->submitUpdate($uid, ['description' => 'rewritten on a tombstone']);
+
+        self::assertSame(
+            self::SEEDED_DESCRIPTION,
+            $this->readDescription($uid),
+            'A soft-deleted secret must not be rewritten through the datamap.',
+        );
+        self::assertSame(
+            1,
+            $this->countAudit($identifier, AuditAction::AccessDenied->value, 0),
+            'The refusal must be recorded under the identifier it is about.',
+        );
+    }
+
+    /**
+     * The second gate, on a column only it protects. `context` is the one
+     * privileged column the TCA does NOT mark `exclude`, so DataHandler's own
+     * field-permission layer lets it through and the privileged-column policy
+     * is the only thing standing in front of it — which is exactly what makes
+     * it the honest subject here. (`frontend_accessible`, `owner_uid` and the
+     * rest are excludefields, and this fixture's group holds no
+     * `non_exclude_fields`, so a test on one of those would pass on core's
+     * behalf whatever the policy did.)
+     */
+    #[Test]
+    public function aPrivilegedColumnOfASoftDeletedSecretStaysUnchanged(): void
+    {
+        $this->setUpBackendUser(self::OWNER_UID);
+        [$uid] = $this->seedSecret(deleted: true);
+
+        $this->submitUpdate($uid, ['context' => 'staging']);
+
+        self::assertSame(
+            self::SEEDED_CONTEXT,
+            $this->readContext($uid),
+            'A soft-deleted secret must not be re-bucketed into another context.',
+        );
+    }
+
+    /**
+     * The refusal is a property of the record's state, not of the actor: an
+     * editor with no vault standing at all is refused for the same reason and
+     * gets no further than the owner did.
+     */
+    #[Test]
+    public function anEditorWithoutVaultStandingCannotRewriteASoftDeletedSecret(): void
+    {
+        $this->setUpBackendUser(self::EDITOR_UID);
+        [$uid] = $this->seedSecret(deleted: true);
+
+        $this->submitUpdate($uid, ['description' => 'rewritten by someone else']);
+
+        self::assertSame(
+            self::SEEDED_DESCRIPTION,
+            $this->readDescription($uid),
+            'A soft-deleted secret must not be rewritten by an actor the vault never authorized.',
+        );
+    }
+
+    /**
+     * The regression guard the fix has to survive: an ordinary edit of a live
+     * secret by its owner still lands, and is still audited as the metadata
+     * update it is. Failing closed on an unresolvable record must not cost the
+     * resolvable case anything.
+     */
+    #[Test]
+    public function anOrdinaryUpdateOfALiveSecretStillLandsAndIsAudited(): void
+    {
+        $this->setUpBackendUser(self::OWNER_UID);
+        [$uid, $identifier] = $this->seedSecret();
+
+        $this->submitUpdate($uid, ['description' => 'edited by the owner']);
+
+        self::assertSame(
+            'edited by the owner',
+            $this->readDescription($uid),
+            'A live secret must still be editable by its owner.',
+        );
+        self::assertSame(
+            1,
+            $this->countAudit($identifier, AuditAction::MetadataUpdate->value, 1),
+            'The landed edit must be audited as a metadata update.',
+        );
+        self::assertSame(
+            0,
+            $this->countAudit($identifier, AuditAction::AccessDenied->value, 0),
+            'An authorized edit must not be recorded as a denial.',
+        );
+    }
+
+    /**
+     * Disabled is not deleted, and the boundary this change draws runs exactly
+     * between them: the write gates resolve a disabled record through the
+     * disabled-visible lookup, so its owner keeps every administrative edit
+     * that last round established — while the tests above show a deleted one
+     * is refused. A disabled secret stays administrable; a deleted one is gone.
+     */
+    #[Test]
+    public function aDisabledSecretIsStillEditableByItsOwner(): void
+    {
+        $this->setUpBackendUser(self::OWNER_UID);
+        [$uid, $identifier] = $this->seedSecret(hidden: true);
+
+        $this->submitUpdate($uid, ['description' => 'edited while out of service']);
+
+        self::assertSame(
+            'edited while out of service',
+            $this->readDescription($uid),
+            'A disabled secret must stay administrable by its owner.',
+        );
+        self::assertSame(
+            0,
+            $this->countAudit($identifier, AuditAction::AccessDenied->value, 0),
+            'Editing a disabled secret one owns is not a denial.',
+        );
+    }
+
+    /**
+     * A uid with no row at all is refused too, but it has no identifier — so
+     * the refusal must not invent one. Nothing may enter the tamper-evident
+     * chain under an empty or guessed identifier; the DataHandler log carries
+     * the uid instead.
+     */
+    #[Test]
+    public function anAbsentRecordIsRefusedWithoutWritingAnAnonymousAuditEntry(): void
+    {
+        $this->setUpBackendUser(self::OWNER_UID);
+        $before = $this->countAllAudit();
+
+        $this->submitUpdate(2147483647, ['description' => 'no such record']);
+
+        self::assertSame(
+            $before,
+            $this->countAllAudit(),
+            'A refusal with no identifier must not append to the audit chain.',
+        );
+    }
+
+    /**
+     * Run the update as FormEngine would, through the whole DataHandler —
+     * core's own permission checks included, so that a hook which lets the
+     * record through really does leave core to write it.
+     *
+     * @param array<string, mixed> $fields
+     */
+    private function submitUpdate(int $uid, array $fields): void
+    {
+        $dataHandler = GeneralUtility::makeInstance(DataHandler::class);
+        $dataHandler->BE_USER = $GLOBALS['BE_USER'];
+        $dataHandler->start([self::SECRET_TABLE => [$uid => $fields]], []);
+        $dataHandler->process_datamap();
+    }
+
+    /**
+     * @return array{int, string} The new secret UID and its identifier
+     */
+    private function seedSecret(bool $deleted = false, bool $hidden = false): array
+    {
+        $identifier = 'tombstone_' . bin2hex(random_bytes(4));
+        $connection = $this->getConnectionPool()->getConnectionForTable(self::SECRET_TABLE);
+        $connection->insert(self::SECRET_TABLE, [
+            'pid' => self::PAGE_UID,
+            'identifier' => $identifier,
+            'description' => self::SEEDED_DESCRIPTION,
+            'context' => self::SEEDED_CONTEXT,
+            'owner_uid' => self::OWNER_UID,
+            'frontend_accessible' => 0,
+            'hidden' => $hidden ? 1 : 0,
+            'deleted' => $deleted ? 1 : 0,
+        ]);
+
+        return [(int) $connection->lastInsertId(), $identifier];
+    }
+
+    private function readDescription(int $uid): string
+    {
+        $description = $this->readColumn($uid, 'description');
+
+        return \is_string($description) ? $description : '';
+    }
+
+    private function readContext(int $uid): string
+    {
+        $context = $this->readColumn($uid, 'context');
+
+        return \is_string($context) ? $context : '';
+    }
+
+    private function readColumn(int $uid, string $column): mixed
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::SECRET_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+
+        return $queryBuilder
+            ->select($column)
+            ->from(self::SECRET_TABLE)
+            ->where($queryBuilder->expr()->eq('uid', $queryBuilder->createNamedParameter($uid, Connection::PARAM_INT)))
+            ->executeQuery()
+            ->fetchOne();
+    }
+
+    private function countAudit(string $identifier, string $action, int $success): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::AUDIT_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $count = $queryBuilder
+            ->count('uid')
+            ->from(self::AUDIT_TABLE)
+            ->where(
+                $queryBuilder->expr()->eq('secret_identifier', $queryBuilder->createNamedParameter($identifier)),
+                $queryBuilder->expr()->eq('action', $queryBuilder->createNamedParameter($action)),
+                $queryBuilder->expr()->eq('success', $queryBuilder->createNamedParameter($success, Connection::PARAM_INT)),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($count) ? (int) $count : 0;
+    }
+
+    private function countAllAudit(): int
+    {
+        $queryBuilder = $this->getConnectionPool()->getQueryBuilderForTable(self::AUDIT_TABLE);
+        $queryBuilder->getRestrictions()->removeAll();
+        $count = $queryBuilder
+            ->count('uid')
+            ->from(self::AUDIT_TABLE)
+            ->executeQuery()
+            ->fetchOne();
+
+        return is_numeric($count) ? (int) $count : 0;
+    }
+}

--- a/Tests/Unit/Hook/SecretTcaHookTest.php
+++ b/Tests/Unit/Hook/SecretTcaHookTest.php
@@ -99,6 +99,14 @@ final class SecretTcaHookTest extends TestCase
         $this->accessControlService->method('canCreate')->willReturn(true);
         $this->accessControlService->method('isGranted')->willReturn(true);
 
+        // ... and let that actor write an existing secret, for the same
+        // reason: the per-secret write gate refuses the record outright (the
+        // field array is nulled and core skips it), so an update test that
+        // does not opt into a writable target would assert against a record
+        // the hook never processed. The gate has its own tests, each building
+        // its own access-control mock.
+        $this->accessControlService->method('canWrite')->willReturn(true);
+
         $this->hook = new SecretTcaHook(
             $this->vaultService,
             $this->auditService,
@@ -673,9 +681,13 @@ final class SecretTcaHookTest extends TestCase
         // Would refuse if it were consulted — an update must not consult it.
         $accessControl->method('canCreate')->willReturn(false);
         $accessControl->expects($this->never())->method('isGranted');
+        // The gate this test IS about sits behind the per-secret write tier,
+        // so the actor has to clear that one first.
+        $accessControl->method('canWrite')->willReturn(true);
 
         // The update path snapshots the pre-change column values for the
         // compensating rollback, so it needs a readable record.
+        $this->stubResolvableSecret();
         $this->stubBackendRecords([['description' => 'stored']]);
 
         $hook = new SecretTcaHook(
@@ -1486,6 +1498,7 @@ final class SecretTcaHookTest extends TestCase
     #[Test]
     public function preProcessSnapshotsTheRelationsOfEverySubmittedAclTier(): void
     {
+        $this->stubResolvableSecret();
         $this->stubBackendRecords([['allowed_groups' => 2]]);
 
         $queryCalls = [];
@@ -1509,6 +1522,7 @@ final class SecretTcaHookTest extends TestCase
     #[Test]
     public function preProcessDropsAnMmBackedAclChangeSubmittedByANonOwner(): void
     {
+        $this->stubResolvableSecret('acl-secret');
         $this->stubBackendRecords([['owner_uid' => 99, 'frontend_accessible' => 0, 'scope_pid' => 0]]);
 
         $hook = $this->hookForNonAdmin(7, connectionPool: $this->recordPool());
@@ -1529,6 +1543,7 @@ final class SecretTcaHookTest extends TestCase
     {
         // Only one read: dropping owner_uid empties $fieldArray, so the
         // pre-change metadata capture has no submitted column left to snapshot.
+        $this->stubResolvableSecret('acl-secret');
         $this->stubBackendRecords([
             ['owner_uid' => 99, 'identifier' => 'acl-secret'],
         ]);
@@ -1558,6 +1573,7 @@ final class SecretTcaHookTest extends TestCase
         // An ordinary save by a non-owner resubmits the stored owner in group
         // notation. The column is still dropped — that is what protects it —
         // but nothing changed, so this must be neither logged nor audited.
+        $this->stubResolvableSecret('acl-secret');
         $this->stubBackendRecords([
             ['owner_uid' => 99, 'identifier' => 'acl-secret'],
         ]);
@@ -1591,6 +1607,7 @@ final class SecretTcaHookTest extends TestCase
         mixed $submitted,
         mixed $stored,
     ): void {
+        $this->stubResolvableSecret('acl-secret');
         $this->stubBackendRecords([
             [$column => $stored, 'identifier' => 'acl-secret'],
         ]);
@@ -1635,6 +1652,7 @@ final class SecretTcaHookTest extends TestCase
         mixed $submitted,
         mixed $stored,
     ): void {
+        $this->stubResolvableSecret('acl-secret');
         $this->stubBackendRecords([
             [$column => $stored, 'identifier' => 'acl-secret'],
         ]);
@@ -1672,9 +1690,150 @@ final class SecretTcaHookTest extends TestCase
         yield 'hidden enabled' => ['hidden', '1', 0];
     }
 
+    /**
+     * The write gate's lookup excludes soft-deleted rows, so a datamap
+     * against a tombstone resolves to nothing — and core does NOT stop there:
+     * it reads its UPDATE target with the delete clause off and only skips a
+     * row it cannot find at all. Waving the record through was therefore an
+     * ungated, unaudited write to a deleted secret's columns.
+     */
+    #[Test]
+    public function preProcessRefusesAnUpdateAgainstASoftDeletedSecret(): void
+    {
+        // The gate's lookup finds nothing; the deleted-inclusive probe that
+        // classifies the refusal does, which is what makes it a tombstone
+        // rather than an absent record.
+        $this->stubBackendRecords([['identifier' => 'deleted-secret']]);
+
+        $this->auditService->expects($this->once())->method('log')->with(
+            'deleted-secret',
+            'access_denied',
+            false,
+            self::stringContains('deleted'),
+        );
+
+        $fieldArray = ['description' => 'edited', 'frontend_accessible' => 1];
+        $messages = [];
+        $this->hookWith($this->recordPool())->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            self::TABLE,
+            5,
+            $this->capturingDataHandler($messages),
+        );
+
+        // Nulling the array is what makes core skip the record entirely — not
+        // merely filtering the privileged column out of it.
+        self::assertNull($fieldArray);
+        self::assertCount(1, $messages);
+        self::assertStringContainsString('deleted', $messages[0]);
+    }
+
+    /**
+     * Core skips a genuinely absent record one guard further on, but the gate
+     * refuses it here rather than relying on that: "the vault cannot identify
+     * the record it is asked to authorize" is a refusal on its own terms. The
+     * probe finds no row, so there is no identifier to audit under and the
+     * refusal is reported in the DataHandler log alone.
+     */
+    #[Test]
+    public function preProcessRefusesAnUpdateAgainstAnAbsentRecordWithoutAnAnonymousAuditEntry(): void
+    {
+        $this->stubBackendRecords([false]);
+
+        $this->auditService->expects($this->never())->method('log');
+
+        $fieldArray = ['description' => 'edited'];
+        $messages = [];
+        $this->hookWith($this->recordPool())->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            self::TABLE,
+            404,
+            $this->capturingDataHandler($messages),
+        );
+
+        self::assertNull($fieldArray);
+        self::assertCount(1, $messages);
+        self::assertStringContainsString('No vault secret exists', $messages[0]);
+    }
+
+    /**
+     * The two gates resolve their target through different reads — the
+     * repository lookup and this hook's own record read — so they can
+     * disagree, and the privileged-column policy must fail closed on its own
+     * read rather than trusting that the ACL gate already vouched for the
+     * record. Dropping the privileged columns would not do: the read that
+     * failed is the one supplying the stored values, so the policy cannot be
+     * applied at all.
+     */
+    #[Test]
+    public function preProcessRefusesTheRecordWhenThePolicyReadCannotResolveIt(): void
+    {
+        // The ACL gate passes (a resolvable secret, writable actor), then the
+        // policy's own read comes back empty, as does the classifying probe.
+        $this->stubResolvableSecret();
+        $this->stubBackendRecords([false, false]);
+
+        $hook = $this->hookForNonAdmin(7, connectionPool: $this->recordPool());
+
+        $fieldArray = ['description' => 'edited'];
+        $messages = [];
+        $hook->processDatamap_preProcessFieldArray($fieldArray, self::TABLE, 5, $this->capturingDataHandler($messages));
+
+        self::assertNull($fieldArray);
+        self::assertCount(1, $messages);
+        self::assertStringContainsString('No vault secret exists', $messages[0]);
+    }
+
+    /**
+     * A refused record must not leave the hook holding state for a write that
+     * will never happen: no pre-change snapshot to "restore" onto a row this
+     * save never touched, and no parked plaintext for
+     * afterDatabaseOperations() to store.
+     */
+    #[Test]
+    public function preProcessKeepsNoStateForARefusedUnresolvableRecord(): void
+    {
+        $this->stubBackendRecords([false]);
+
+        $hook = $this->hookWith($this->recordPool());
+
+        $fieldArray = ['description' => 'edited', 'secret_input' => 'plaintext'];
+        $messages = [];
+        $hook->processDatamap_preProcessFieldArray($fieldArray, self::TABLE, 5, $this->capturingDataHandler($messages));
+
+        self::assertNull($fieldArray);
+        self::assertSame([], $this->readPrivate($hook, 'pendingSecrets'));
+        self::assertSame([], $this->readPrivate($hook, 'originalMetadata'));
+        self::assertSame([], $this->readPrivate($hook, 'originalMmRelations'));
+    }
+
+    /**
+     * The refusal is scoped to an existing record: a creation has no stored
+     * secret to resolve, and its own gates (canCreate, secret.create) live on
+     * the create path. A NEW record must not be caught by it.
+     */
+    #[Test]
+    public function preProcessDoesNotApplyTheUnresolvableRefusalToANewRecord(): void
+    {
+        $this->secretRepository->expects($this->never())->method('findByUidIncludingDisabled');
+
+        $fieldArray = ['identifier' => 'api/token'];
+        $messages = [];
+        $this->hook->processDatamap_preProcessFieldArray(
+            $fieldArray,
+            self::TABLE,
+            'NEW123',
+            $this->capturingDataHandler($messages),
+        );
+
+        self::assertSame(['identifier' => 'api/token'], $fieldArray);
+        self::assertSame([], $messages);
+    }
+
     #[Test]
     public function preProcessLetsTheOwnerWithTheManagePolicyGrantChangeTheAcl(): void
     {
+        $this->stubResolvableSecret();
         $this->stubBackendRecords([
             ['owner_uid' => 7, 'frontend_accessible' => 0, 'scope_pid' => 0],
             ['allowed_groups' => 1],
@@ -1775,6 +1934,7 @@ final class SecretTcaHookTest extends TestCase
     public function afterDatabaseOperationsCompensatesAFailedMetadataAuditWithTheCapturedState(): void
     {
         // One read for the pre-change capture, one for the post-write lookup.
+        $this->stubResolvableSecret();
         $this->stubBackendRecords([
             ['allowed_groups' => 1],
             ['identifier' => 'api/token', 'owner_uid' => 1, 'allowed_groups' => 2, 'scope_pid' => 0],
@@ -2021,6 +2181,25 @@ final class SecretTcaHookTest extends TestCase
     }
 
     /**
+     * State the precondition every datamap UPDATE test needs: uid $uid is a
+     * secret the vault can still resolve.
+     *
+     * The hook's write gate resolves its target through
+     * `findByUidIncludingDisabled()` and refuses the record when that yields
+     * nothing — a soft-deleted row or no row at all. An update test that did
+     * not say its target exists would therefore be asserting against a
+     * refused record, so the target is declared rather than defaulted: the
+     * lookup is also what the cmdmap tests stub for their own purposes, and a
+     * blanket setUp() stub would shadow theirs.
+     */
+    private function stubResolvableSecret(string $identifier = 'api/token', int $uid = 5): void
+    {
+        $this->secretRepository->method('findByUidIncludingDisabled')->willReturn(
+            SecretFixtureBuilder::create($identifier)->withUid($uid)->buildSecret(),
+        );
+    }
+
+    /**
      * Queue the rows the hook's record reads resolve to, in the order the
      * exercised path performs them (`false` = record gone). The queue is
      * served through the hook's injected ConnectionPool, so the stub is
@@ -2131,6 +2310,9 @@ final class SecretTcaHookTest extends TestCase
         $accessControl->method('isCurrentActorAdmin')->willReturn(false);
         $accessControl->method('getCurrentActorUid')->willReturn($actorUid);
         $accessControl->method('canCreate')->willReturn($canCreate);
+        // The privileged-column policy runs on top of the per-secret write
+        // tier, so these tests are about an actor who already passed it.
+        $accessControl->method('canWrite')->willReturn(true);
         // Each gate answers for its own permission — a path that asked for the
         // wrong one falls to `false` and fails the test that expects it to
         // pass, so the permission identity stays asserted.


### PR DESCRIPTION
Two fail-**open** defaults in `SecretTcaHook`, deferred from the previous round because closing them properly needed its own change: `isUpdateAuthorized()` and `enforcePrivilegedColumnPolicy()` both treated "record not found" as "allowed". Fixing one alone would have been half a fix — they guard the same datamap write from two angles.

## What a null lookup can actually be

Since both sites resolve through `findByUidIncludingDisabled()`, a null result can no longer be a *disabled* record. It is either genuinely absent, or **soft-deleted** — and the second one is live: core reads its datamap target with `BackendUtility::getRecord($table, $id, '*', '', false)`, delete clause **off**, and skips only on an empty record. So a tombstone has a pid, is processed by core, and was waved through by the vault.

Both now refuse. Absent records are refused rather than deferred to core, so the gate does not have to keep proving that core's later guard still exists.

They **report** differently, because only one of them has an identifier: a tombstone gets an `access_denied` entry under its own identifier plus a DataHandler error; an absent record gets the DataHandler error alone — nothing enters the tamper-evident chain anonymously, the same concession the command refusals already make.

`enforcePrivilegedColumnPolicy()` now returns a bool and the caller nulls `$fieldArray`, rather than dropping the privileged columns: the read that failed is the same read that would supply the stored values to compare against, so dropping columns is not fail-closed there — and the non-privileged columns would still land on a record the vault cannot identify.

A shared `refuseUnresolvableTarget()` carries the decision once. The deleted-inclusive probe that distinguishes the two causes runs only on the refusal path, so a resolvable target costs no extra read.

## The fixtures told us something

19 unit tests failed, as predicted — but **not** for the predicted reason. The ordered read queue was not the cause and needed no re-sequencing. The real cause: `canWrite()` was **never stubbed anywhere** in the datamap tests. That whole side of the suite had been riding the fail-open default without ever stating its precondition. The fix is to state it, in `setUp()` and in the non-admin helper, with the same reasoning the file already carries for `canCreate`/`isGranted`.

One test needed redesigning rather than adjusting (it builds its own access-control mock and had to declare that its actor clears the write tier the create gate sits behind). No assertion was weakened and no production code was bent to fit a fixture.

Worth recording: one of the *new* tests was not load-bearing on first check — it used `frontend_accessible`, which carries `exclude => true`, so core's field-permission layer stripped it for that fixture's group and the test passed even with the fix reverted. It now uses `context`, the one privileged column with no `exclude` flag, where this policy is the only thing standing in front of it.

## Load-bearing proof

With the production change reverted and the tests kept, 3 functional and 4 unit tests fail. The remaining 3 functional tests pass either way **by design** — they are the regression guards: a live update still lands and is audited, a disabled secret is still editable by its owner, and an absent record appends nothing to the chain.

## Verification

- Unit 3591 (+5) · Fuzz 1612 · Functional 383 (+6) — zero failures
- PHPStan: no errors · CGL (dry-run, after clearing the cache): clean
