### PR TITLE
Stop store() from resetting a secret's access accounting

### DIFF
--- a/Classes/Adapter/LocalEncryptionAdapter.php
+++ b/Classes/Adapter/LocalEncryptionAdapter.php
@@ -114,18 +114,24 @@ final readonly class LocalEncryptionAdapter implements VaultAdapterInterface
     }
 
     /**
+     * The merge is read-then-write, so the resolved record supplies both the
+     * base metadata and the UID the write is addressed to. Only the `metadata`
+     * column is written: saving the whole entity back would restore the
+     * envelope, version and read counters as they stood at the read above,
+     * discarding a `retrieve()` or `rotate()` that committed in between — the
+     * exact exposure `setHidden()` avoids, on a method whose contract is
+     * "without changing the secret value".
+     *
      * @param array<string, mixed> $metadata
      */
     public function updateMetadata(string $identifier, array $metadata): void
     {
         $secret = $this->secretRepository->findByIdentifier($identifier);
-        if (!$secret instanceof Secret) {
+        $uid = $secret?->getUid();
+        if (!$secret instanceof Secret || $uid === null) {
             return;
         }
 
-        $existing = $secret->getMetadata();
-        /** @var array<string, mixed> $merged */
-        $merged = array_merge($existing, $metadata);
-        $this->secretRepository->save($secret->withMetadata($merged));
+        $this->secretRepository->setMetadata($uid, array_merge($secret->getMetadata(), $metadata));
     }
 }

--- a/Classes/Adapter/VaultAdapterInterface.php
+++ b/Classes/Adapter/VaultAdapterInterface.php
@@ -112,7 +112,14 @@ interface VaultAdapterInterface
     public function getMetadata(string $identifier): ?array;
 
     /**
-     * Update metadata without changing the secret value.
+     * Merge into a secret's metadata without changing the secret value.
+     *
+     * "Without changing the value" is a requirement on the write, not just a
+     * description of the arguments: an implementation that persists a whole
+     * entity to change one column restores the envelope, version and read
+     * counters from the read it started with, undoing anything that committed
+     * in between. Write the metadata alone — see {@see setHidden()} for the
+     * same rule on the availability flag.
      *
      * @param array<string, mixed> $metadata
      */

--- a/Classes/Domain/Model/Secret.php
+++ b/Classes/Domain/Model/Secret.php
@@ -163,9 +163,12 @@ final readonly class Secret
     }
 
     /**
-     * Replace the metadata array. Called from
-     * `LocalEncryptionAdapter::storeMetadata()` when an adapter needs to
-     * persist its own bookkeeping (e.g. external-reference details).
+     * Replace the metadata array on a copy of the entity, for an adapter that
+     * needs to carry its own bookkeeping (e.g. external-reference details)
+     * through a call taking a `Secret`. Note that persisting the result via
+     * `SecretRepositoryInterface::save()` writes every scalar column; the
+     * targeted write of that one column is
+     * `SecretRepositoryInterface::setMetadata()`.
      *
      * @param array<string, mixed> $metadata
      */

--- a/Classes/Domain/Repository/SecretRepository.php
+++ b/Classes/Domain/Repository/SecretRepository.php
@@ -253,6 +253,25 @@ final readonly class SecretRepository implements SecretRepositoryInterface
         );
     }
 
+    /**
+     * Set a record's metadata, addressed by UID.
+     *
+     * The `metadata` counterpart of {@see setHidden()}: one UPDATE of that
+     * column and `tstamp`. `json_encode()` is the same serialisation
+     * {@see Secret::toDatabaseRow()} applies, so a row written here is
+     * indistinguishable from one written by a full save.
+     *
+     * @param array<string, mixed> $metadata
+     */
+    public function setMetadata(int $uid, array $metadata): void
+    {
+        $this->getConnection()->update(
+            self::TABLE_NAME,
+            ['metadata' => json_encode($metadata), 'tstamp' => time()],
+            ['uid' => $uid],
+        );
+    }
+
     public function delete(Secret $secret): void
     {
         if ($secret->getUid() === null) {

--- a/Classes/Domain/Repository/SecretRepositoryInterface.php
+++ b/Classes/Domain/Repository/SecretRepositoryInterface.php
@@ -80,6 +80,21 @@ interface SecretRepositoryInterface
      */
     public function setHidden(int $uid, bool $hidden): void;
 
+    /**
+     * Set a record's metadata (the `metadata` column) without round-tripping
+     * the entity: one targeted UPDATE of that column plus `tstamp`, addressed
+     * by UID. Absolute, not merging — the caller decides what the column ends
+     * up holding.
+     *
+     * The sibling of {@see setHidden()}, and for the same reason: routing a
+     * metadata change through {@see save()} would write the envelope, the
+     * version and the read counters back from an entity read moments earlier,
+     * discarding whatever committed in between.
+     *
+     * @param array<string, mixed> $metadata
+     */
+    public function setMetadata(int $uid, array $metadata): void;
+
     public function delete(Secret $secret): void;
 
     /**

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -783,6 +783,12 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
      * by secret.manage_policy, so an accidental reset is a policy change
      * without its permission.
      *
+     * The same applies to the columns no caller submits at all and this path
+     * does not own: `last_rotated_at` belongs to `rotate()`, `read_count` and
+     * `last_read_at` to the read path. `toDatabaseRow()` writes every scalar
+     * column, so omitting one here is not "leaving it alone" — it is writing
+     * the constructor default over whatever the owning path recorded.
+     *
      * @param array<string, mixed> $options
      */
     private function buildSecretEntity(
@@ -812,6 +818,12 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
             frontendAccessible: $this->resolveFrontendAccessible($optional['frontendAccessible'], $existing),
             version: $existing instanceof Secret ? $existing->getVersion() : 1,
             expiresAt: $optional['expiresAt'],
+            // Carried, not recomputed: `store()` writes a value, it does not
+            // rotate one, so it has no rotation instant of its own to record.
+            // Leaving this to the constructor default would report a secret
+            // that WAS rotated as never rotated, because `toDatabaseRow()`
+            // writes the column on every UPDATE.
+            lastRotatedAt: $existing?->getLastRotatedAt() ?? 0,
             metadata: $optional['metadata'],
             adapter: 'local',
             crdate: $existing instanceof Secret ? $existing->getCrdate() : time(),
@@ -821,6 +833,14 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
             // quietly put it back into service. `setEnabled()` is the only
             // path that changes this, and it asserts secret.manage_policy.
             hidden: $existing instanceof Secret && $existing->isHidden(),
+            // Access accounting belongs to the read path
+            // (`incrementReadCount()`), which owns both columns. Rebuilding
+            // the entity from the write path's inputs must carry them over —
+            // the alternative is a write that silently zeroes how often the
+            // secret was read and when it was last read, the numbers an audit
+            // consults.
+            readCount: $existing?->getReadCount() ?? 0,
+            lastReadAt: $existing?->getLastReadAt() ?? 0,
         );
     }
 

--- a/Tests/Functional/Adapter/LocalEncryptionAdapterMetadataTest.php
+++ b/Tests/Functional/Adapter/LocalEncryptionAdapterMetadataTest.php
@@ -1,0 +1,150 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Adapter;
+
+use Netresearch\NrVault\Adapter\LocalEncryptionAdapter;
+use Netresearch\NrVault\Domain\Model\Secret;
+use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
+use Netresearch\NrVault\Tests\Functional\Traits\SecretRowTrait;
+use PHPUnit\Framework\Attributes\Test;
+use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
+
+/**
+ * What `updateMetadata()` writes, under the interleaving that makes the answer
+ * matter.
+ *
+ * The method is read-then-write by nature: it has to load the record to merge
+ * into its existing metadata. That opens a window, and the contract on
+ * {@see \Netresearch\NrVault\Adapter\VaultAdapterInterface::updateMetadata()}
+ * — "without changing the secret value" — is a claim about what the write at
+ * the end of that window touches. Persisting the whole entity satisfies the
+ * merge while restoring every scalar column to the state the read at the top
+ * saw, so anything that committed in between is silently rolled back: a
+ * `retrieve()`'s read-count increment, or a `rotate()`'s new envelope.
+ *
+ * The test creates that interleaving deterministically by decorating the
+ * repository the adapter is built on — the read hands back the record and
+ * commits a read-count increment on the way out, exactly as another request
+ * calling `retrieve()` would. Everything the adapter actually calls is the
+ * container's real repository behind that decoration, so the write under test
+ * is a genuine one.
+ */
+final class LocalEncryptionAdapterMetadataTest extends FunctionalTestCase
+{
+    use SecretRowTrait;
+
+    protected array $testExtensionsToLoad = [
+        'netresearch/nr-vault',
+    ];
+
+    protected array $coreExtensionsToLoad = [
+        'backend',
+    ];
+
+    private SecretRepositoryInterface $repository;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->importCSVDataSet(__DIR__ . '/../Fixtures/Users/be_users.csv');
+        $this->setUpBackendUser(1);
+
+        $this->repository = $this->get(SecretRepositoryInterface::class);
+    }
+
+    #[Test]
+    public function updatingMetadataMergesIntoWhatTheRecordAlreadyHas(): void
+    {
+        $this->saveSecret('metadata_merge', ['existing' => 'value']);
+
+        $this->buildAdapterWithConcurrentRead()->updateMetadata('metadata_merge', ['new' => 'data']);
+
+        $secret = $this->repository->findByIdentifier('metadata_merge');
+        self::assertNotNull($secret);
+        self::assertSame(['existing' => 'value', 'new' => 'data'], $secret->getMetadata());
+    }
+
+    #[Test]
+    public function updatingMetadataWritesNothingButTheMetadataColumn(): void
+    {
+        $this->saveSecret('metadata_narrow', ['existing' => 'value']);
+        $before = $this->readSecretRow('metadata_narrow');
+
+        $this->buildAdapterWithConcurrentRead()->updateMetadata('metadata_narrow', ['new' => 'data']);
+
+        $after = $this->readSecretRow('metadata_narrow');
+
+        self::assertSame(
+            (int) $before['read_count'] + 1,
+            (int) $after['read_count'],
+            'A read committed while the metadata change was in flight must survive it.',
+        );
+
+        // `tstamp` moves by design (the record changed); `metadata` is the
+        // change; `read_count` and `last_read_at` were moved by the concurrent
+        // read and asserted above.
+        foreach (['metadata', 'tstamp', 'read_count', 'last_read_at'] as $expected) {
+            unset($before[$expected], $after[$expected]);
+        }
+
+        self::assertSame(
+            $before,
+            $after,
+            'A metadata change must leave every other column exactly as it found it.',
+        );
+    }
+
+    /**
+     * The real adapter on the real repository, with one addition: the lookup
+     * it merges from commits a read-count increment on its way out — the
+     * concurrent `retrieve()`, landing inside the adapter's window. The
+     * increment goes through the repository's own targeted statement, so it is
+     * a genuine committed row change rather than a test-only shortcut.
+     */
+    private function buildAdapterWithConcurrentRead(): LocalEncryptionAdapter
+    {
+        $real = $this->repository;
+
+        $decorated = self::createStub(SecretRepositoryInterface::class);
+        $decorated->method('findByIdentifier')->willReturnCallback(
+            static function (string $identifier) use ($real): ?Secret {
+                $secret = $real->findByIdentifier($identifier);
+                $uid = $secret?->getUid();
+                if ($uid !== null) {
+                    $real->incrementReadCount($uid);
+                }
+
+                return $secret;
+            },
+        );
+        $decorated->method('setMetadata')->willReturnCallback($real->setMetadata(...));
+        $decorated->method('save')->willReturnCallback($real->save(...));
+
+        return new LocalEncryptionAdapter($decorated);
+    }
+
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    private function saveSecret(string $identifier, array $metadata): void
+    {
+        $this->repository->save(new Secret(
+            identifier: $identifier,
+            encryptedValue: 'encrypted',
+            encryptedDek: 'dek',
+            dekNonce: 'n1',
+            valueNonce: 'n2',
+            valueChecksum: str_repeat('c', 64),
+            metadata: $metadata,
+            cruserId: 1,
+        ));
+    }
+}

--- a/Tests/Functional/Domain/Repository/SecretRepositoryTest.php
+++ b/Tests/Functional/Domain/Repository/SecretRepositoryTest.php
@@ -13,6 +13,7 @@ use Netresearch\NrVault\Domain\Dto\SecretFilters;
 use Netresearch\NrVault\Domain\Model\Secret;
 use Netresearch\NrVault\Domain\Repository\SecretRepository;
 use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
+use Netresearch\NrVault\Tests\Functional\Traits\SecretRowTrait;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
@@ -30,6 +31,8 @@ use TYPO3\TestingFramework\Core\Functional\FunctionalTestCase;
 #[CoversClass(SecretFilters::class)]
 final class SecretRepositoryTest extends FunctionalTestCase
 {
+    use SecretRowTrait;
+
     protected array $testExtensionsToLoad = [
         'netresearch/nr-vault',
     ];
@@ -233,15 +236,58 @@ final class SecretRepositoryTest extends FunctionalTestCase
     }
 
     /**
-     * Persist a disabled secret and return its UID.
+     * The column set of the primitive itself: `metadata` and the record
+     * timestamp, nothing else. Whether the write is narrow ENOUGH — that it
+     * cannot roll back a change committed inside a caller's read-then-write
+     * window — is a property of the caller and is pinned where that window
+     * exists, in
+     * `Tests/Functional/Adapter/LocalEncryptionAdapterMetadataTest.php`.
      */
-    private function saveDisabledSecret(string $identifier): int
+    #[Test]
+    public function setMetadataWritesNothingButTheMetadataColumn(): void
     {
-        $saved = $this->subject->save($this->newSecret($identifier, hidden: true));
+        $uid = $this->saveSecretReturningUid('metadata_narrow');
+        $this->subject->incrementReadCount($uid);
+
+        $before = $this->readSecretRow('metadata_narrow');
+
+        $this->subject->setMetadata($uid, ['source' => 'cron']);
+
+        $after = $this->readSecretRow('metadata_narrow');
+
+        self::assertIsString($after['metadata']);
+        self::assertSame('{"source":"cron"}', $after['metadata'], 'The change itself must have landed.');
+        // `tstamp` moves by design (the record changed); `metadata` is the
+        // change and is asserted above.
+        foreach (['metadata', 'tstamp'] as $expected) {
+            unset($before[$expected], $after[$expected]);
+        }
+
+        self::assertSame(
+            $before,
+            $after,
+            'A metadata change must leave every other column exactly as it found it.',
+        );
+    }
+
+    /**
+     * Persist a secret and return its UID.
+     */
+    private function saveSecretReturningUid(string $identifier, bool $hidden = false): int
+    {
+        $saved = $this->subject->save($this->newSecret($identifier, hidden: $hidden));
         $uid = $saved->getUid();
         self::assertNotNull($uid);
 
         return $uid;
+    }
+
+    /**
+     * Persist a disabled secret and return its UID.
+     */
+    private function saveDisabledSecret(string $identifier): int
+    {
+        return $this->saveSecretReturningUid($identifier, hidden: true);
     }
 
     /**

--- a/Tests/Functional/Service/SecretAccountingTest.php
+++ b/Tests/Functional/Service/SecretAccountingTest.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * Copyright (c) 2025-2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Functional\Service;
+
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Tests\Functional\AbstractVaultFunctionalTestCase;
+use Netresearch\NrVault\Tests\Functional\Traits\SecretRowTrait;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * What a value write does to the columns it does not own.
+ *
+ * `store()` rebuilds the whole `Secret` aggregate from its inputs and the
+ * record it read, and `Secret::toDatabaseRow()` writes every scalar column on
+ * the resulting UPDATE. A field the rebuild forgets is therefore not left
+ * alone — it is overwritten with the constructor default. Three columns are
+ * owned by other paths and can only ever be carried here:
+ *
+ *  - `last_rotated_at`, written by `rotate()`,
+ *  - `read_count` and `last_read_at`, written by the read path's
+ *    `incrementReadCount()`.
+ *
+ * The consequence of losing them is not cosmetic. A rotated secret that reads
+ * back as never rotated is what rotation-age reporting, the module's Reads /
+ * Last read columns and the orphan-cleanup heuristics consult — the numbers an
+ * audit asks for. Nothing in the write path fails when they reset, which is
+ * exactly why the guard has to live at this level: a real service against a
+ * real database, reading the row as it stands.
+ */
+final class SecretAccountingTest extends AbstractVaultFunctionalTestCase
+{
+    use SecretRowTrait;
+
+    /** Admin, so the gates pass and the tests are about the write scope only. */
+    protected ?string $backendUserFixture = __DIR__ . '/Fixtures/be_users_permissions.csv';
+
+    /**
+     * The full sequence in one test on purpose: the three columns are lost by
+     * one and the same omission, and asserting them apart would let a partial
+     * fix look complete.
+     */
+    #[Test]
+    public function storingANewValuePreservesTheAccountingAPriorRotationAndReadLeftBehind(): void
+    {
+        $vault = $this->getVaultService();
+        $vault->store('accounting_preserved', 'first-value');
+
+        // Reads first, so the counters start non-zero and a reset to the
+        // column default is distinguishable from a value they were always
+        // going to have.
+        self::assertSame('first-value', $vault->retrieve('accounting_preserved'));
+        self::assertSame('first-value', $vault->retrieve('accounting_preserved'));
+
+        $vault->rotate('accounting_preserved', 'second-value', 'scheduled rotation');
+
+        $before = $this->readSecretRow('accounting_preserved');
+        self::assertSame(2, (int) $before['read_count'], 'Precondition: both reads were counted.');
+        self::assertGreaterThan(0, (int) $before['last_read_at'], 'Precondition: the reads set a timestamp.');
+        self::assertGreaterThan(0, (int) $before['last_rotated_at'], 'Precondition: the rotation was recorded.');
+
+        $vault->store('accounting_preserved', 'third-value');
+
+        $after = $this->readSecretRow('accounting_preserved');
+
+        self::assertSame('third-value', $vault->retrieve('accounting_preserved'), 'The write itself must have landed.');
+        self::assertSame(
+            (int) $before['read_count'],
+            (int) $after['read_count'],
+            'Writing a value must not reset how often the secret was read.',
+        );
+        self::assertSame(
+            (int) $before['last_read_at'],
+            (int) $after['last_read_at'],
+            'Writing a value must not reset when the secret was last read.',
+        );
+        self::assertSame(
+            (int) $before['last_rotated_at'],
+            (int) $after['last_rotated_at'],
+            'Writing a value is not a rotation, and must not report the secret as never rotated.',
+        );
+    }
+
+    /**
+     * The counterpart. Carrying from `$existing` is only correct because there
+     * is nothing to carry on a create — a fresh record starts at zero rather
+     * than inheriting whatever a same-named predecessor accumulated.
+     */
+    #[Test]
+    public function creatingASecretStartsItsAccountingAtZero(): void
+    {
+        $this->getVaultService()->store('accounting_fresh', 'the-plaintext');
+
+        $row = $this->readSecretRow('accounting_fresh');
+
+        self::assertSame(0, (int) $row['read_count']);
+        self::assertSame(0, (int) $row['last_read_at']);
+        self::assertSame(0, (int) $row['last_rotated_at']);
+    }
+
+    private function getVaultService(): VaultServiceInterface
+    {
+        return $this->get(VaultServiceInterface::class);
+    }
+}

--- a/Tests/Unit/Adapter/LocalEncryptionAdapterTest.php
+++ b/Tests/Unit/Adapter/LocalEncryptionAdapterTest.php
@@ -253,28 +253,48 @@ final class LocalEncryptionAdapterTest extends TestCase
     {
         $repository = $this->createMock(SecretRepositoryInterface::class);
         $repository->method('findByIdentifier')->willReturn(null);
+        $repository->expects(self::never())->method('setMetadata');
         $repository->expects(self::never())->method('save');
 
         $adapter = new LocalEncryptionAdapter($repository);
         $adapter->updateMetadata('nonexistent', ['key' => 'value']);
     }
 
+    /**
+     * A record without a UID cannot be addressed by the targeted write, and
+     * the fallback of saving the entity instead is precisely what this method
+     * must not do. Refusing is the only correct answer: an unsaved entity has
+     * no persisted metadata to merge into either.
+     */
     #[Test]
-    public function updateMetadataMergesAndSaves(): void
+    public function updateMetadataDoesNothingWhenTheRecordHasNoUid(): void
     {
-        $secret = new Secret(identifier: 'test', metadata: ['existing' => 'value']);
+        $repository = $this->createMock(SecretRepositoryInterface::class);
+        $repository->method('findByIdentifier')->willReturn(new Secret(identifier: 'test'));
+        $repository->expects(self::never())->method('setMetadata');
+        $repository->expects(self::never())->method('save');
+
+        $adapter = new LocalEncryptionAdapter($repository);
+        $adapter->updateMetadata('test', ['key' => 'value']);
+    }
+
+    /**
+     * The merge is the adapter's; the write is one column. Asserting the
+     * absence of `save()` is the load-bearing half — a full entity save would
+     * produce the same metadata while restoring every other column to the
+     * state the `findByIdentifier()` above saw.
+     */
+    #[Test]
+    public function updateMetadataMergesAndWritesOnlyTheMetadataColumn(): void
+    {
+        $secret = new Secret(identifier: 'test', uid: 42, metadata: ['existing' => 'value']);
 
         $repository = $this->createMock(SecretRepositoryInterface::class);
         $repository->method('findByIdentifier')->willReturn($secret);
-
-        // The adapter calls `withMetadata($merged)` (returning a NEW Secret)
-        // and persists that — so we assert on the saved-instance metadata,
-        // not on `$secret` (which is now immutable and unchanged).
         $repository->expects(self::once())
-            ->method('save')
-            ->with(self::callback(static fn (Secret $s): bool => $s->getMetadata() === ['existing' => 'value', 'new' => 'data']
-                && $s->getIdentifier() === 'test'))
-            ->willReturnArgument(0);
+            ->method('setMetadata')
+            ->with(42, ['existing' => 'value', 'new' => 'data']);
+        $repository->expects(self::never())->method('save');
 
         $adapter = new LocalEncryptionAdapter($repository);
         $adapter->updateMetadata('test', ['new' => 'data']);


### PR DESCRIPTION
Two defects of the same family: a write that is lossier or wider than the operation it performs.

## `store()` reset a secret's access accounting and rotation timestamp

`buildSecretEntity()` carried `version`, `crdate` and `cruserId` over from the existing record but omitted `lastRotatedAt`, `readCount` and `lastReadAt` — so they fell back to their `0` constructor defaults, and `toDatabaseRow()` wrote all three on every UPDATE.

Measured before the fix (store → retrieve → rotate → store):

```
before: read_count=2  last_read_at=1785763938  last_rotated_at=1785763938
after:  read_count=0  last_read_at=0           last_rotated_at=0
```

Every `store()` on an existing secret was affected: the module's create/edit form, `vault:store`, `vault:migrate-field`, the FormEngine completion path, and any programmatic call. `rotate()` was not (it uses `withValueRotation()`).

This is not cosmetic. **A rotated secret read as never rotated afterwards** — feeding the module's Reads / Last read columns, rotation-age reporting and the orphan-cleanup heuristics, i.e. exactly the figures an audit consults. No test caught it, which is itself the finding: the bug was live while the whole suite was green.

**Load-bearing proof, per field.** Each of the three arguments was removed individually, and each drops a *different* assertion — not merely the first one:

```
removed lastRotatedAt → "Writing a value is not a rotation, and must not report the
                         secret as never rotated."   0 !== 1785774868
removed readCount     → "Writing a value must not reset how often the secret was read."
                                                     0 !== 2
removed lastReadAt    → "Writing a value must not reset when the secret was last read."
                                                     0 !== 1785774873
```

## `updateMetadata()` wrote the whole row

It called `save($secret->withMetadata($merged))`, carrying the same concurrency exposure `setEnabled()` was fixed for — its own docblock promised "without changing the secret value", which the `save()` body violated.

**Narrowed, not removed.** There is no production caller, but the method is declared on `VaultAdapterInterface` — the documented extension point for third-party adapters (ADR-007) — and a test fixture implements it. Deleting it would be a public-API break for a defect that is fixable in place. A new `setMetadata(int $uid, array $metadata)` on the repository writes the metadata column and `tstamp`, nothing else; the merge stays in the adapter, as the contract says.

Proven the same way: with the body reverted to the full-row `save()`, a read committed while the metadata change is in flight is lost — `0 !== 1`.

**One caveat stated rather than counted:** the accompanying repository test pins only the primitive's column set and does *not* fail against a `findByUid()`-then-`save()` counterfactual (that re-reads, so nothing is lost). Its docblock now says so; the adapter test is the load-bearing one.

## Verification

- Unit 3587 · Fuzz 1612 · Functional 382 — zero failures
- PHPStan: no errors · CGL (dry-run, cache cleared): clean · Rector dry-run: clean · base-class check: clean

Noted, not done: `Secret::withMetadata()` now has no production caller (only its own unit test and ADR-025). Removing it would mean editing an accepted ADR — out of scope here.
