### PR TITLE
Close the reseal() anti-truncation guard gap on master-key rotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -409,6 +409,17 @@ and end with **Migration**, which collects everything you actually have to do.
 
 ### Fixed
 
+- **`reseal()` skipped its anti-truncation guard on the master-key rotation
+  path** (#283). The guard refuses to re-sign a shortened chain, but it can
+  only check a stored anchor it has authenticated — and it authenticated under
+  the key it was about to sign with. Rotation is the one path that passes a
+  different key, so the old-key MAC never verified, the guard was skipped, and
+  `reseal()` minted a fresh anchor over whatever the tip was at that moment.
+  The command's pre-flight chain verification kept this theoretical (the rows
+  would have to disappear inside the rotate transaction), which is why it was
+  tracked as a follow-up rather than an advisory. `reseal()` now falls back to
+  the provider's current key to authenticate the stored anchor, putting the
+  rotation path behind the same guard as the two migration paths.
 - **A rotated secret read as never rotated** (#281). `store()` carried
   `version`, `crdate` and `cruser_id` forward from the existing record but not
   `last_rotated_at`, `read_count` or `last_read_at`, so all three fell back to

--- a/Classes/Audit/AuditChainAnchorStore.php
+++ b/Classes/Audit/AuditChainAnchorStore.php
@@ -176,12 +176,35 @@ final readonly class AuditChainAnchorStore implements AuditChainAnchorStoreInter
             }
 
             $stored = $raw === null ? null : $this->parse($raw, $anchorKey);
+            $storedUnderAnchorKey = $stored instanceof AuditChainAnchor;
+
+            if ($raw !== null && !$storedUnderAnchorKey && $masterKey !== null) {
+                // A caller-supplied key means a re-key is in flight: the stored
+                // anchor is still signed under the provider's CURRENT key, so
+                // parsing it under the key being rotated IN always fails — which
+                // used to skip the truncation guard below on exactly the one
+                // path that passes a different key (#283). Fall back to the
+                // provider's key so the guard has an authenticated anchor to
+                // check against.
+                $currentKey = $this->deriveAnchorKey(null);
+
+                try {
+                    $stored = $this->parse($raw, $currentKey);
+                } finally {
+                    sodium_memzero($currentKey);
+                }
+            }
+
             if ($stored instanceof AuditChainAnchor) {
-                if ($stored->uid === $tip->uid && hash_equals($stored->entryHash, $tip->entryHash)) {
-                    // Already asserts exactly this tip. The stored `tstamp` differs
-                    // on every call (it is minted here), so the comparison is on
-                    // (uid, entry_hash) — comparing raw bytes would rewrite the row
-                    // on every re-seal for no reason.
+                if ($storedUnderAnchorKey && $stored->uid === $tip->uid && hash_equals($stored->entryHash, $tip->entryHash)) {
+                    // Already asserts exactly this tip UNDER THIS KEY. The stored
+                    // `tstamp` differs on every call (it is minted here), so the
+                    // comparison is on (uid, entry_hash) — comparing raw bytes
+                    // would rewrite the row on every re-seal for no reason. An
+                    // anchor recovered via the fallback parse must never take
+                    // this exit: it still carries the OLD key's MAC (an all-
+                    // epoch-0 chain re-keys without a single hash changing) and
+                    // has to be re-signed below.
                     return;
                 }
 

--- a/Classes/Audit/AuditChainAnchorStoreInterface.php
+++ b/Classes/Audit/AuditChainAnchorStoreInterface.php
@@ -81,7 +81,11 @@ interface AuditChainAnchorStoreInterface
      *
      * `$masterKey` null means "derive from the master-key provider"; master-key
      * rotation passes the NEW key explicitly, because it must sign under that
-     * key before the provider is reconfigured.
+     * key before the provider is reconfigured. The stored anchor is still
+     * signed under the provider's CURRENT key at that point, so the
+     * anti-truncation guard authenticates it under that key before the re-sign
+     * — refusing, like every other path, to sign a chain whose anchored row is
+     * gone or whose tip fell below the anchored uid.
      */
     public function reseal(
         Connection $connection,

--- a/Documentation/Developer/Adr/ADR-034-AuditChainTipAnchor.rst
+++ b/Documentation/Developer/Adr/ADR-034-AuditChainTipAnchor.rst
@@ -189,6 +189,15 @@ the HMAC upgrade wizard, ``vault:audit-migrate-hmac``) rewrite
 ``entry_hash``/``previous_hash`` ``WHERE uid = …`` and preserve every uid, so
 neither condition can false-alarm on them — and both fail on a truncated chain.
 
+Both assertions need an *authenticated* stored anchor to check against, and
+master-key rotation is the one path that cannot authenticate it under the key
+it signs with: it passes the NEW key, while the stored anchor still carries
+the current key's MAC. Parsing under the new key therefore always fails, which
+originally skipped the guard on exactly that path (#283). ``reseal()`` falls
+back to the provider's current key to authenticate the stored anchor before
+re-signing, so the rotation path takes the same guard as the two migration
+paths.
+
 Without it, the re-seal paths launder a truncation. The gate in front of them,
 ``verifyChainForReseal()``, lets a chain through when no row carries
 ``hmac_key_epoch >= 1``, on the grounds that a keyless epoch-0 chain has no

--- a/Tests/Functional/Audit/AuditChainAnchorTest.php
+++ b/Tests/Functional/Audit/AuditChainAnchorTest.php
@@ -590,6 +590,49 @@ final class AuditChainAnchorTest extends AbstractVaultFunctionalTestCase
         unlink($newKeyPath);
     }
 
+    /**
+     * The rotation-path companion to the migration-path test above (#283).
+     * Rotation hands `reseal()` the NEW key, under which the stored anchor's
+     * MAC can never verify — that parse failure used to skip the
+     * anti-truncation guard on exactly the one path that passes a different
+     * key, so a chain shortened between the rotate command's pre-flight
+     * verification and the re-seal was signed anyway. The guard now
+     * authenticates the stored anchor under the provider's current key.
+     *
+     * The rotation flow end-to-end (re-key, then the operator's key switch)
+     * is covered in `AuditChainRekeyServiceTest`; this pins the store-level
+     * guard itself.
+     */
+    #[Test]
+    public function resealWithACallerSuppliedKeyCannotSignATruncatedChain(): void
+    {
+        $auditLogService = $this->get(AuditLogServiceInterface::class);
+        $this->writeEntries($auditLogService, 7);
+        self::assertTrue($auditLogService->verifyHashChain()->isValid(), 'precondition: chain valid and armed');
+
+        $this->deleteEntriesAbove(3);
+        self::assertSame(
+            AuditChainAnchorStatus::Violated,
+            $auditLogService->verifyHashChain()->anchorStatus,
+            'precondition: the anchor is evidence at this point',
+        );
+        $before = $this->rawAnchorValue();
+
+        $newKey = sodium_crypto_secretbox_keygen();
+        $this->get(AuditChainAnchorStoreInterface::class)->reseal($this->auditConnection(), $newKey);
+        sodium_memzero($newKey);
+
+        self::assertSame(
+            $before,
+            $this->rawAnchorValue(),
+            'the anchor must not be re-signed onto the shortened chain',
+        );
+
+        $result = $auditLogService->verifyHashChain();
+        self::assertFalse($result->isValid(), 'the truncation must stay detected after the refused re-seal');
+        self::assertSame(AuditChainAnchorStatus::Violated, $result->anchorStatus);
+    }
+
     // =====================================================================
     // Anchor tampering
     // =====================================================================

--- a/Tests/Functional/Audit/AuditChainRekeyServiceTest.php
+++ b/Tests/Functional/Audit/AuditChainRekeyServiceTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Functional\Audit;
 
+use Netresearch\NrVault\Audit\AuditChainAnchorStatus;
 use Netresearch\NrVault\Audit\AuditChainAnchorStoreInterface;
 use Netresearch\NrVault\Audit\AuditChainRekeyService;
 use Netresearch\NrVault\Audit\AuditChainRekeyServiceInterface;
@@ -153,6 +154,83 @@ final class AuditChainRekeyServiceTest extends AbstractVaultFunctionalTestCase
 
         self::assertSame(2, $firstRun, 'First run rewrites every HMAC row');
         self::assertSame(0, $secondRun, 'Second run with the same key must rewrite nothing');
+    }
+
+    /**
+     * #283 — the rotation-path truncation guard. A truncation that slips in
+     * between the rotate command's pre-flight verification and the re-seal
+     * must not be laundered: `reseal()` is handed the NEW key, under which
+     * the stored anchor's MAC can never verify, and that parse failure used
+     * to bypass the guard that refuses to sign a shortened chain. The stored
+     * anchor is now authenticated under the provider's current key instead.
+     */
+    #[Test]
+    public function rekeyChainDoesNotResealATruncatedChain(): void
+    {
+        $auditService = $this->get(AuditLogServiceInterface::class);
+        $rekeyService = $this->get(AuditChainRekeyServiceInterface::class);
+        $connection = $this->getAuditConnection();
+
+        $auditService->log('truncation_secret', 'create', true);
+        $auditService->log('truncation_secret', 'read', true);
+        $auditService->log('truncation_secret', 'read', true);
+        $auditService->log('truncation_secret', 'read', true);
+        self::assertTrue($auditService->verifyHashChain()->isValid(), 'precondition: chain valid and armed');
+
+        // The window the guard has to close: rows disappear after the
+        // pre-flight verification, before the re-seal.
+        $queryBuilder = $connection->createQueryBuilder();
+        $queryBuilder
+            ->delete(self::TABLE_NAME)
+            ->where($queryBuilder->expr()->gt('uid', $queryBuilder->createNamedParameter(2, Connection::PARAM_INT)))
+            ->executeStatement();
+
+        $before = $this->rawAnchorValue();
+        self::assertIsString($before, 'precondition: the anchor is armed');
+
+        $newKey = sodium_crypto_secretbox_keygen();
+        $connection->beginTransaction();
+        $rekeyService->rekeyChain($connection, $newKey);
+        $connection->commit();
+
+        self::assertSame(
+            $before,
+            $this->rawAnchorValue(),
+            'the anchor must not be re-signed onto the shortened chain',
+        );
+
+        // After the operator completes the key switch, the surviving rows
+        // verify under the new key — the anchor is what keeps the truncation
+        // detected: its old-key MAC no longer parses, and an unreadable
+        // anchor is an error.
+        $this->switchMasterKeyFile($newKey);
+
+        $result = $auditService->verifyHashChain();
+        self::assertFalse($result->isValid(), 'the truncated chain must stay invalid across the rotation');
+        self::assertSame(AuditChainAnchorStatus::Unreadable, $result->anchorStatus);
+    }
+
+    private function rawAnchorValue(): ?string
+    {
+        $connection = $this->get(ConnectionPool::class)->getConnectionForTable('sys_registry');
+        $queryBuilder = $connection->createQueryBuilder();
+        $value = $queryBuilder
+            ->select('entry_value')
+            ->from('sys_registry')
+            ->where(
+                $queryBuilder->expr()->eq('entry_namespace', $queryBuilder->createNamedParameter('tx_nrvault_audit_anchor')),
+                $queryBuilder->expr()->eq('entry_key', $queryBuilder->createNamedParameter('auditChainTip')),
+            )
+            ->executeQuery()
+            ->fetchOne();
+
+        if (\is_resource($value)) {
+            $contents = stream_get_contents($value);
+
+            return \is_string($contents) ? $contents : null;
+        }
+
+        return \is_string($value) ? $value : null;
     }
 
     private function getAuditConnection(): Connection

--- a/Tests/Functional/Audit/AuditChainRekeyServiceTest.php
+++ b/Tests/Functional/Audit/AuditChainRekeyServiceTest.php
@@ -208,6 +208,8 @@ final class AuditChainRekeyServiceTest extends AbstractVaultFunctionalTestCase
         $result = $auditService->verifyHashChain();
         self::assertFalse($result->isValid(), 'the truncated chain must stay invalid across the rotation');
         self::assertSame(AuditChainAnchorStatus::Unreadable, $result->anchorStatus);
+
+        sodium_memzero($newKey);
     }
 
     private function rawAnchorValue(): ?string


### PR DESCRIPTION
Closes #283.

## What

`AuditChainAnchorStore::reseal()` refuses to re-sign a shortened chain, but it could only apply that guard to a stored anchor it had authenticated — and it authenticated under the key it was about to sign with. Master-key rotation is the one caller that passes a different key (`AuditChainRekeyService::rekeyChain()` hands in the NEW key while the provider still holds the old one), so the old-key MAC never verified, `parse()` returned null, the guard block was skipped, and `write()` minted a fresh anchor over whatever `fetchTip()` returned at that moment.

## How

When a caller-supplied key is present and the stored anchor does not parse under it, `reseal()` now falls back to parsing under the provider's current key, so the guard has an authenticated anchor to check the row-existence and uid-monotonicity assertions against. An anchor recovered via the fallback never takes the "already asserts exactly this tip" early exit — it still carries the old key's MAC (an all-epoch-0 chain re-keys without a single hash changing) and has to be re-signed.

No interface change; the two no-key callers (`AuditHmacMigrationWizard`, `VaultAuditMigrateCommand`) and the healthy rotation are unaffected — all three preserve uids, so the guard stays silent for them. A doubly-unparseable (corrupt) anchor keeps its existing overwrite behaviour on every path.

## Tests

- `AuditChainAnchorTest::resealWithACallerSuppliedKeyCannotSignATruncatedChain` — store-level: truncate the tail, `reseal()` with a foreign key, assert the raw anchor is byte-identical and the verdict stays `Violated`.
- `AuditChainRekeyServiceTest::rekeyChainDoesNotResealATruncatedChain` — rotation flow: truncation in the window between the rotate command's pre-flight verification and the re-seal, then the operator's key switch; the surviving rows verify under the new key but the anchor stays the old-key assertion, so the truncation remains detected (`Unreadable`, chain invalid).

Both tests fail against the unfixed store with "the anchor must not be re-signed onto the shortened chain" (verified A/B via stash).

One environment note found while writing the tests: `AuditChainAnchorTest` runs under the auto-detected `Typo3MasterKeyProvider` (the class sets no `masterKeyProvider`), so file-key switching is inert there — the rotation-flow half of the coverage therefore lives in `AuditChainRekeyServiceTest`, which pins `masterKeyProvider = file`. Relatedly, `masterKeyRotationResealsTheAnchorUnderTheNewKey` exercises the command with zero stored secrets, which exits before `rekeyAuditChain()` — its assertions hold, but it does not reach `reseal()`. Left as-is here; can be a follow-up.

## Docs

ADR-034 ("Re-sealing is constrained too") and the `reseal()` interface docblock now describe the fallback authentication; CHANGELOG entry under Unreleased → Fixed.