### PR TITLE
Assert the anchor re-seal where the rotation actually runs

### DIFF
--- a/Tests/Functional/Audit/AuditChainAnchorTest.php
+++ b/Tests/Functional/Audit/AuditChainAnchorTest.php
@@ -551,17 +551,11 @@ final class AuditChainAnchorTest extends AbstractVaultFunctionalTestCase
     }
 
     // The happy path — a legitimate rotation re-seals the anchor under the new
-    // key — is covered end to end by
+    // key — belongs in
     // `MasterKeyRotationTest::secondRotationKeepsSecretsDecryptableAndAuditChainValid`,
-    // which stores real secrets, pins `masterKeyProvider = file` and switches
-    // the key file, so the re-key actually runs. A copy of it lived here and
-    // proved nothing: this class stores no secrets, so the rotate command
-    // returns at its `$totalSecrets === 0 && $totalForeign === 0` guard long
-    // before `rekeyAuditChain()`, and it leaves `masterKeyProvider`
-    // unconfigured, so auto-detection picks the TYPO3 provider and copying a
-    // file over `master.key` changes no key the verification uses. Removing
-    // `reseal()` from `AuditChainRekeyService` left that test green and failed
-    // the one in `MasterKeyRotationTest`.
+    // not here: it needs stored secrets and a pinned file key provider, and
+    // this class has neither. A copy of it lived here and passed without the
+    // re-seal existing at all. Full analysis in #285.
 
     /**
      * The rotation-path companion to the migration-path test above (#283).

--- a/Tests/Functional/Audit/AuditChainAnchorTest.php
+++ b/Tests/Functional/Audit/AuditChainAnchorTest.php
@@ -17,9 +17,7 @@ use Netresearch\NrVault\Audit\AuditLogService;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Command\VaultAuditCommand;
 use Netresearch\NrVault\Command\VaultAuditMigrateCommand;
-use Netresearch\NrVault\Command\VaultRotateMasterKeyCommand;
 use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
-use Netresearch\NrVault\Crypto\FileMasterKeyProvider;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
 use Netresearch\NrVault\Security\AccessControlServiceInterface;
 use Netresearch\NrVault\Seeder\AuditChainSeeder;
@@ -552,43 +550,18 @@ final class AuditChainAnchorTest extends AbstractVaultFunctionalTestCase
         self::assertSame(AuditChainAnchorStatus::Violated, $result->anchorStatus);
     }
 
-    /**
-     * Master-key rotation rewrites every entry hash under the NEW key, so the
-     * anchor has to be re-signed with that key inside the same transaction.
-     * Omitting the re-seal — or signing it with the old key — makes every
-     * install report a chain violation right after a rotation.
-     */
-    #[Test]
-    public function masterKeyRotationResealsTheAnchorUnderTheNewKey(): void
-    {
-        $auditLogService = $this->get(AuditLogServiceInterface::class);
-        $this->writeEntries($auditLogService, 3);
-
-        self::assertIsString($this->masterKeyPath);
-        $newKeyPath = $this->instancePath . '/master-rotated.key';
-        file_put_contents($newKeyPath, sodium_crypto_secretbox_keygen());
-
-        $commandTester = new CommandTester($this->get(VaultRotateMasterKeyCommand::class));
-        $exitCode = $commandTester->execute([
-            '--old-key' => $this->masterKeyPath,
-            '--new-key' => $newKeyPath,
-            '--confirm' => true,
-        ]);
-        self::assertSame(0, $exitCode, $commandTester->getDisplay());
-
-        // The operator's next step: make the new key the configured one.
-        self::assertIsString($this->masterKeyPath, 'the master key path is wired by the base test case');
-        copy($newKeyPath, $this->masterKeyPath);
-        FileMasterKeyProvider::clearCachedKey();
-
-        $result = $auditLogService->verifyHashChain();
-
-        self::assertTrue($result->isValid(), 'chain must verify under the new key');
-        self::assertSame(AuditChainAnchorStatus::Ok, $result->anchorStatus);
-
-        // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
-        unlink($newKeyPath);
-    }
+    // The happy path — a legitimate rotation re-seals the anchor under the new
+    // key — is covered end to end by
+    // `MasterKeyRotationTest::secondRotationKeepsSecretsDecryptableAndAuditChainValid`,
+    // which stores real secrets, pins `masterKeyProvider = file` and switches
+    // the key file, so the re-key actually runs. A copy of it lived here and
+    // proved nothing: this class stores no secrets, so the rotate command
+    // returns at its `$totalSecrets === 0 && $totalForeign === 0` guard long
+    // before `rekeyAuditChain()`, and it leaves `masterKeyProvider`
+    // unconfigured, so auto-detection picks the TYPO3 provider and copying a
+    // file over `master.key` changes no key the verification uses. Removing
+    // `reseal()` from `AuditChainRekeyService` left that test green and failed
+    // the one in `MasterKeyRotationTest`.
 
     /**
      * The rotation-path companion to the migration-path test above (#283).

--- a/Tests/Functional/Crypto/MasterKeyRotationTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Functional\Crypto;
 
+use Netresearch\NrVault\Audit\AuditChainAnchorStatus;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Command\VaultRotateMasterKeyCommand;
 use Netresearch\NrVault\Crypto\EncryptionService;
@@ -449,6 +450,14 @@ final class MasterKeyRotationTest extends FunctionalTestCase
      * survive repeated DEK re-wrapping, and the chain re-key runs inside the
      * rotation transaction each time, so verification under the
      * currently-configured key passes at every observable point.
+     *
+     * It is also the only test that reaches the tip-anchor re-seal
+     * (`AuditChainRekeyService` → `AuditChainAnchorStore::reseal()`) through
+     * the real command: the re-key only runs when secrets exist, and the
+     * anchor is only re-signed under a key the verification afterwards
+     * actually uses because this class pins `masterKeyProvider = file`. The
+     * anchor status is therefore asserted explicitly rather than left to
+     * `isValid()`, which merely happens to fold anchor errors in.
      */
     #[Test]
     public function secondRotationKeepsSecretsDecryptableAndAuditChainValid(): void
@@ -466,9 +475,12 @@ final class MasterKeyRotationTest extends FunctionalTestCase
             $secrets[$identifier] = $value;
         }
 
-        self::assertTrue(
-            $auditLogService->verifyHashChain()->isValid(),
-            'Audit chain must be valid before any rotation (K0)',
+        $beforeRotation = $auditLogService->verifyHashChain();
+        self::assertTrue($beforeRotation->isValid(), 'Audit chain must be valid before any rotation (K0)');
+        self::assertSame(
+            AuditChainAnchorStatus::Ok,
+            $beforeRotation->anchorStatus,
+            'precondition: the tip anchor is armed under K0',
         );
 
         // === Rotation 1: K0 -> K1 ===
@@ -478,6 +490,8 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         $this->runRotationCommand($commandTester, $key1Path);
         $this->switchMasterKeyFile($key1Path);
 
+        $this->assertChainAndAnchorSealedUnder($auditLogService, 'K1');
+
         foreach ($secrets as $identifier => $expectedValue) {
             self::assertSame(
                 $expectedValue,
@@ -486,17 +500,14 @@ final class MasterKeyRotationTest extends FunctionalTestCase
             );
         }
 
-        self::assertTrue(
-            $auditLogService->verifyHashChain()->isValid(),
-            'Audit chain must verify under K1 after the first rotation',
-        );
-
         // === Rotation 2 (epoch 2): K1 -> K2 ===
         $key2Path = $this->instancePath . '/master-epoch2.key';
         file_put_contents($key2Path, sodium_crypto_secretbox_keygen());
 
         $this->runRotationCommand($commandTester, $key2Path);
         $this->switchMasterKeyFile($key2Path);
+
+        $this->assertChainAndAnchorSealedUnder($auditLogService, 'K2');
 
         foreach ($secrets as $identifier => $expectedValue) {
             self::assertSame(
@@ -505,11 +516,6 @@ final class MasterKeyRotationTest extends FunctionalTestCase
                 'Secret must decrypt after the SECOND rotation: ' . $identifier,
             );
         }
-
-        self::assertTrue(
-            $auditLogService->verifyHashChain()->isValid(),
-            'Audit chain must verify under K2 after the second rotation',
-        );
 
         // Cleanup
         foreach (array_keys($secrets) as $identifier) {
@@ -521,6 +527,38 @@ final class MasterKeyRotationTest extends FunctionalTestCase
                 unlink($path);
             }
         }
+    }
+
+    /**
+     * Assert the chain verifies AND the tip anchor is armed on the current tip,
+     * under the key the rotation just installed.
+     *
+     * Must be called BEFORE any further vault operation. An ordinary audit
+     * write arms a missing anchor (that is deliberate — `auditAnchorRequired`
+     * is what turns a missing anchor into an error), so a single `retrieve()`
+     * in between would re-arm an anchor the re-seal had dropped and hide
+     * exactly the defect this asserts. Verified: a probe replacing the
+     * `reseal()` call with a delete of the anchor row passes when this runs
+     * after the reads and fails when it runs here.
+     *
+     * `isValid()` alone is not enough either — a missing anchor is only a
+     * warning, so the status has to be asserted on its own.
+     */
+    private function assertChainAndAnchorSealedUnder(
+        AuditLogServiceInterface $auditLogService,
+        string $keyLabel,
+    ): void {
+        $result = $auditLogService->verifyHashChain();
+
+        self::assertTrue(
+            $result->isValid(),
+            'Audit chain must verify under ' . $keyLabel . ' after the rotation',
+        );
+        self::assertSame(
+            AuditChainAnchorStatus::Ok,
+            $result->anchorStatus,
+            'the tip anchor must be re-sealed onto the current tip under ' . $keyLabel,
+        );
     }
 
     /**

--- a/Tests/Functional/Crypto/MasterKeyRotationTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationTest.php
@@ -475,13 +475,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
             $secrets[$identifier] = $value;
         }
 
-        $beforeRotation = $auditLogService->verifyHashChain();
-        self::assertTrue($beforeRotation->isValid(), 'Audit chain must be valid before any rotation (K0)');
-        self::assertSame(
-            AuditChainAnchorStatus::Ok,
-            $beforeRotation->anchorStatus,
-            'precondition: the tip anchor is armed under K0',
-        );
+        $this->assertChainAndAnchorSealedUnder($auditLogService, 'K0');
 
         // === Rotation 1: K0 -> K1 ===
         $key1Path = $this->instancePath . '/master-epoch1.key';
@@ -531,18 +525,18 @@ final class MasterKeyRotationTest extends FunctionalTestCase
 
     /**
      * Assert the chain verifies AND the tip anchor is armed on the current tip,
-     * under the key the rotation just installed.
+     * under the currently configured key.
      *
-     * Must be called BEFORE any further vault operation. An ordinary audit
-     * write arms a missing anchor (that is deliberate — `auditAnchorRequired`
-     * is what turns a missing anchor into an error), so a single `retrieve()`
-     * in between would re-arm an anchor the re-seal had dropped and hide
-     * exactly the defect this asserts. Verified: a probe replacing the
-     * `reseal()` call with a delete of the anchor row passes when this runs
-     * after the reads and fails when it runs here.
+     * Call this BEFORE any further vault operation. An ordinary audit write
+     * arms a missing anchor (deliberately — `auditAnchorRequired` is what turns
+     * a missing anchor into an error), so a single `retrieve()` in between
+     * re-arms an anchor a broken re-seal had dropped and hides the defect.
+     * Verified: a probe replacing the `reseal()` call with a delete of the
+     * anchor row passes when this runs after the reads and fails when it runs
+     * directly after the rotation.
      *
-     * `isValid()` alone is not enough either — a missing anchor is only a
-     * warning, so the status has to be asserted on its own.
+     * The anchor status needs its own assertion — `isValid()` folds a violated
+     * anchor into its errors but a missing one only into its warnings.
      */
     private function assertChainAndAnchorSealedUnder(
         AuditLogServiceInterface $auditLogService,
@@ -552,12 +546,12 @@ final class MasterKeyRotationTest extends FunctionalTestCase
 
         self::assertTrue(
             $result->isValid(),
-            'Audit chain must verify under ' . $keyLabel . ' after the rotation',
+            'Audit chain must verify under ' . $keyLabel,
         );
         self::assertSame(
             AuditChainAnchorStatus::Ok,
             $result->anchorStatus,
-            'the tip anchor must be re-sealed onto the current tip under ' . $keyLabel,
+            'the tip anchor must be armed on the current tip under ' . $keyLabel,
         );
     }
 


### PR DESCRIPTION
Follow-up to #284, which named this in its own description: `AuditChainAnchorTest::masterKeyRotationResealsTheAnchorUnderTheNewKey` did not exercise the tip-anchor re-seal it was named after.

## Why it proved nothing

Two independent reasons, both verified by reading the code:

- The class stores **no secrets**, so `vault:rotate-master-key` returns at its `$totalSecrets === 0 && $totalForeign === 0` guard (`Classes/Command/VaultRotateMasterKeyCommand.php:190-193`) long before `rekeyAuditChain()` (line 569) — the re-key, and therefore `reseal()`, never ran.
- The class leaves `masterKeyProvider` unset, so `MasterKeyProviderFactory::getAvailableProvider()` auto-detects and `Typo3MasterKeyProvider::isAvailable()` wins. Copying the new key file over `master.key` and clearing the `FileMasterKeyProvider` cache therefore changed no key the subsequent verification used.

Both accidents pull in the same direction: the assertions held because nothing had happened.

## The measurement

Removing the `reseal()` call from `AuditChainRekeyService`:

| Test | Verdict |
|---|---|
| `AuditChainAnchorTest::masterKeyRotationResealsTheAnchorUnderTheNewKey` | still **green** |
| `MasterKeyRotationTest::secondRotationKeepsSecretsDecryptableAndAuditChainValid` | **fails** — `Audit chain must verify under K1 after the first rotation` |

So the coverage already existed, in the test that stores real secrets, pins `masterKeyProvider = file` and switches the key file. That is where the assertion belongs.

## What this changes

The misleading test is removed and replaced by a comment recording why, so it does not get re-added. `MasterKeyRotationTest` now asserts the anchor status **explicitly** via a small helper, at K0, K1 and K2 — the re-seal is not a first-rotation special case.

The placement of that assertion is itself load-bearing, in both directions:

- `isValid()` alone is not enough: `verifyAnchor()` folds a *violated* anchor into `$errors`, but an **absent** one only into `$warnings` (`reportUnanchored()` — deliberate, `auditAnchorRequired` is what promotes it). A re-seal that dropped the anchor instead of re-signing it would pass `isValid()`.
- It has to run **before** the post-rotation `retrieve()` calls: an ordinary audit write arms a missing anchor. A probe replacing `reseal()` with a delete of the `sys_registry` anchor row **passes** with the assertion after the reads and **fails** with `Unanchored` when it runs directly after the rotation. That probe is what fixed the placement — the first version of this change asserted after the reads and was worthless.

## Verification

```
functional  389 tests, 1385 assertions   (one test fewer than before; #284 added two)
unit+fuzz  5204 tests, 19588 assertions
phpstan    [OK] No errors
cgl        Found 0 of 490 files that can be fixed
rector     [OK] Rector is done!
check-test-base-class.php  OK: 0 legacy tests allow-listed, no new violations
```

Tests only — no production code touched.
