### PR TITLE
Include disabled secrets in the master-key rotation inventory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -409,6 +409,16 @@ and end with **Migration**, which collects everything you actually have to do.
 
 ### Fixed
 
+- **Master-key rotation skipped disabled secrets** (#286). The rotation
+  inventory, the pre-flight smoke test and the per-secret loop all used the
+  hidden-restricted repository lookups, so a disabled secret's DEK stayed
+  wrapped under the old master key — the very key the command's next-steps
+  output tells the operator to destroy. Re-enabling the secret later would
+  surface a permanently undecryptable ciphertext; with only disabled secrets
+  in the vault the command even reported "No secrets found" and exited
+  successfully. All three lookups now use the disabled-visible repository
+  paths, and a functional test rotates a vault holding an active and a
+  disabled secret and proves both plaintexts survive the key switch.
 - **`reseal()` skipped its anti-truncation guard on the master-key rotation
   path** (#283). The guard refuses to re-sign a shortened chain, but it can
   only check a stored anchor it has authenticated — and it authenticated under

--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -20,6 +20,7 @@ use Netresearch\NrVault\Crypto\EnvelopeCodecInterface;
 use Netresearch\NrVault\Crypto\EnvelopeRotationContext;
 use Netresearch\NrVault\Crypto\ForeignEnvelopeRotatorInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface;
+use Netresearch\NrVault\Domain\Dto\SecretFilters;
 use Netresearch\NrVault\Domain\Model\Secret;
 use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
 use Netresearch\NrVault\Event\MasterKeyRotatedEvent;
@@ -175,7 +176,14 @@ final class VaultRotateMasterKeyCommand extends Command
             return Command::FAILURE;
         }
 
-        $identifiers = $this->secretRepository->findIdentifiers();
+        // Disabled secrets stay in the cryptographic inventory: their DEKs are
+        // wrapped under the master key being retired, and a secret re-enabled
+        // AFTER the rotation must still decrypt once the old key is destroyed.
+        // The default (hidden-restricted) lookup would silently leave them
+        // behind on the old key (#286).
+        $identifiers = $this->secretRepository->findIdentifiers(
+            new SecretFilters(includeDisabled: true),
+        );
         $totalSecrets = \count($identifiers);
 
         // Consumer-owned envelopes are part of the rotation, so they are part of
@@ -378,7 +386,9 @@ final class VaultRotateMasterKeyCommand extends Command
         string $newKey,
     ): bool {
         $io->text('Verifying old master key...');
-        $firstSecret = $this->secretRepository->findByIdentifier($firstIdentifier);
+        // The inventory includes disabled secrets, so the smoke-test candidate
+        // may be one — load it through the disabled-visible lookup.
+        $firstSecret = $this->secretRepository->findByIdentifierIncludingDisabled($firstIdentifier);
 
         if (!$firstSecret instanceof Secret) {
             $io->error('Failed to load first secret for verification.');
@@ -696,7 +706,9 @@ final class VaultRotateMasterKeyCommand extends Command
         string $newKey,
         array &$failedSecrets,
     ): bool {
-        $secret = $this->secretRepository->findByIdentifier($identifier);
+        // Disabled-visible for the same reason as the inventory: a disabled
+        // secret's DEK must move to the new key with everything else.
+        $secret = $this->secretRepository->findByIdentifierIncludingDisabled($identifier);
         if (!$secret instanceof Secret) {
             $failedSecrets[] = ['identifier' => $identifier, 'error' => 'Not found'];
 

--- a/Tests/Functional/Crypto/MasterKeyRotationTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationTest.php
@@ -524,6 +524,57 @@ final class MasterKeyRotationTest extends FunctionalTestCase
     }
 
     /**
+     * #286 — the rotation inventory must include DISABLED secrets. Their DEKs
+     * are wrapped under the key being retired, and the command's own next-steps
+     * output tells the operator to destroy that key. A hidden-restricted
+     * inventory leaves the disabled secret on the old key, so re-enabling it
+     * later surfaces a permanently undecryptable ciphertext.
+     */
+    #[Test]
+    public function rotationReWrapsDisabledSecretsSoTheyDecryptAfterReEnabling(): void
+    {
+        $vaultService = $this->get(VaultServiceInterface::class);
+        $commandTester = new CommandTester($this->get(VaultRotateMasterKeyCommand::class));
+
+        $activeIdentifier = $this->generateUuidV7();
+        $disabledIdentifier = $this->generateUuidV7();
+        $vaultService->store($activeIdentifier, 'active-value');
+        $vaultService->store($disabledIdentifier, 'disabled-value');
+        $vaultService->setEnabled($disabledIdentifier, false, 'out of service during rotation');
+
+        $newKeyPath = $this->instancePath . self::NEW_KEY_FILENAME;
+        file_put_contents($newKeyPath, sodium_crypto_secretbox_keygen());
+
+        $this->runRotationCommand($commandTester, $newKeyPath);
+        self::assertStringContainsString(
+            'Found 2 secret(s) to re-encrypt',
+            $commandTester->getDisplay(),
+            'the disabled secret must be part of the rotation inventory',
+        );
+
+        // The operator completes the switch; from here the old key is gone.
+        $this->switchMasterKeyFile($newKeyPath);
+
+        self::assertSame('active-value', $vaultService->retrieve($activeIdentifier));
+
+        $vaultService->setEnabled($disabledIdentifier, true, 're-enable after rotation');
+        self::assertSame(
+            'disabled-value',
+            $vaultService->retrieve($disabledIdentifier),
+            'a secret disabled during the rotation must decrypt under the new key once re-enabled',
+        );
+
+        // Cleanup
+        foreach ([$activeIdentifier, $disabledIdentifier] as $identifier) {
+            $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
+        }
+        if (file_exists($newKeyPath)) {
+            // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
+            unlink($newKeyPath);
+        }
+    }
+
+    /**
      * Assert the chain verifies AND the tip anchor is armed on the current tip,
      * under the currently configured key.
      *

--- a/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
+++ b/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
@@ -21,6 +21,7 @@ use Netresearch\NrVault\Crypto\ForeignEnvelopeRotatorInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface;
 use Netresearch\NrVault\Crypto\MasterKeyProviderInterface;
 use Netresearch\NrVault\Crypto\ReEncryptedDek;
+use Netresearch\NrVault\Domain\Dto\SecretFilters;
 use Netresearch\NrVault\Domain\Model\Secret;
 use Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface;
 use Netresearch\NrVault\Event\MasterKeyRotatedEvent;
@@ -176,7 +177,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
             ->willReturn(['test-secret']);
 
         $this->secretRepository
-            ->method('findByIdentifier')
+            ->method('findByIdentifierIncludingDisabled')
             ->willReturn($secret);
 
         $this->encryptionService
@@ -229,7 +230,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
             ->willReturn(['failing-secret']);
 
         $this->secretRepository
-            ->method('findByIdentifier')
+            ->method('findByIdentifierIncludingDisabled')
             ->willReturn($secret);
 
         $this->encryptionService
@@ -259,7 +260,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
             ->willReturn(['b64-secret']);
 
         $this->secretRepository
-            ->method('findByIdentifier')
+            ->method('findByIdentifierIncludingDisabled')
             ->willReturn($secret);
 
         $this->encryptionService
@@ -284,7 +285,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
             ->willReturn(['nonexistent-secret']);
 
         $this->secretRepository
-            ->method('findByIdentifier')
+            ->method('findByIdentifierIncludingDisabled')
             ->willReturn(null);
 
         $exitCode = $this->commandTester->execute([
@@ -336,12 +337,18 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
     {
         $secret = $this->createTestSecret('test-secret');
 
+        // The inventory must be built disabled-visible (#286): a disabled
+        // secret's DEK is wrapped under the key being retired too.
         $this->secretRepository
+            ->expects(self::once())
             ->method('findIdentifiers')
+            ->with(self::callback(
+                static fn (SecretFilters $filters): bool => $filters->includeDisabled,
+            ))
             ->willReturn(['test-secret']);
 
         $this->secretRepository
-            ->method('findByIdentifier')
+            ->method('findByIdentifierIncludingDisabled')
             ->willReturn($secret);
 
         $this->encryptionService
@@ -404,7 +411,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
             ->willReturn(['test-secret']);
 
         $this->secretRepository
-            ->method('findByIdentifier')
+            ->method('findByIdentifierIncludingDisabled')
             ->willReturn($secret);
 
         $this->encryptionService
@@ -452,7 +459,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
             ->willReturn(['secret-1', 'secret-2']);
 
         $this->secretRepository
-            ->method('findByIdentifier')
+            ->method('findByIdentifierIncludingDisabled')
             ->willReturnCallback(static fn (string $id): Secret => $id === 'secret-1' ? $secret1 : $secret2);
 
         $callCount = 0;
@@ -503,7 +510,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
 
         $callCount = 0;
         $this->secretRepository
-            ->method('findByIdentifier')
+            ->method('findByIdentifierIncludingDisabled')
             ->willReturnCallback(function (string $id) use ($secret, &$callCount): ?Secret {
                 ++$callCount;
                 // Return secret for verification
@@ -550,7 +557,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
             ->willReturn(['test-secret']);
 
         $this->secretRepository
-            ->method('findByIdentifier')
+            ->method('findByIdentifierIncludingDisabled')
             ->willReturn($secret);
 
         $this->encryptionService
@@ -578,7 +585,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
 
         $callCount = 0;
         $this->secretRepository
-            ->method('findByIdentifier')
+            ->method('findByIdentifierIncludingDisabled')
             ->willReturn($secret);
 
         $this->encryptionService
@@ -713,7 +720,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
     public function dryRunCountsConsumerEnvelopesWithoutRewrappingThem(): void
     {
         $this->secretRepository->method('findIdentifiers')->willReturn(['test-secret']);
-        $this->secretRepository->method('findByIdentifier')->willReturn($this->createTestSecret('test-secret'));
+        $this->secretRepository->method('findByIdentifierIncludingDisabled')->willReturn($this->createTestSecret('test-secret'));
         $this->encryptionService->method('reEncryptDek')->willReturn(new ReEncryptedDek('dek', 'nonce'));
 
         $rotator = $this->createRotator(envelopes: 12);
@@ -739,7 +746,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
     public function rotationIsRefusedWhenAConsumerTableIsOnAnotherConnection(): void
     {
         $this->secretRepository->method('findIdentifiers')->willReturn(['test-secret']);
-        $this->secretRepository->method('findByIdentifier')->willReturn($this->createTestSecret('test-secret'));
+        $this->secretRepository->method('findByIdentifierIncludingDisabled')->willReturn($this->createTestSecret('test-secret'));
         $this->encryptionService->method('reEncryptDek')->willReturn(new ReEncryptedDek('dek', 'nonce'));
 
         $vaultConnection = $this->createMock(Connection::class);
@@ -953,7 +960,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
     private function givenOneRotatableSecret(bool $expectRollback = false): void
     {
         $this->secretRepository->method('findIdentifiers')->willReturn(['test-secret']);
-        $this->secretRepository->method('findByIdentifier')->willReturn($this->createTestSecret('test-secret'));
+        $this->secretRepository->method('findByIdentifierIncludingDisabled')->willReturn($this->createTestSecret('test-secret'));
         $this->encryptionService->method('reEncryptDek')->willReturn(new ReEncryptedDek('new-dek', 'new-nonce'));
 
         $lockResult = $this->createStub(Result::class);


### PR DESCRIPTION
Closes #286.

## What

`vault:rotate-master-key` built its inventory with `findIdentifiers()` (no filters) and loaded each secret with `findByIdentifier()` — both hidden-restricted, so disabled secrets never reached the re-wrap loop. Their DEKs stayed wrapped under the old master key, the very key the command's next-steps output tells the operator to "securely archive or destroy". A secret re-enabled after that is permanently undecryptable. With only disabled secrets in the vault, the command reported "No secrets found" and exited successfully.

## How

All three lookups now use the disabled-visible repository paths the repository already provides for exactly this class of operation (its docblock names "re-enabling it, rotating it, deleting it"):

- inventory: `findIdentifiers(new SecretFilters(includeDisabled: true))`
- pre-flight smoke test and `rotateOne()`: `findByIdentifierIncludingDisabled()`

Safety of the write path was verified before changing the reads: `SecretRepository::save()` persists via a raw `Connection::update(... WHERE uid)` (no restrictions) and the `Secret` model round-trips the `hidden` flag through `toDatabaseRow()`, so rotating a disabled secret re-wraps its DEK without re-enabling it.

## Tests

- Functional (`MasterKeyRotationTest::rotationReWrapsDisabledSecretsSoTheyDecryptAfterReEnabling`): stores an active and a disabled secret, runs the real `vault:rotate-master-key` command, asserts the inventory says "Found 2 secret(s)", switches the provider key, then reads the active secret and re-enables + reads the disabled one — both plaintexts intact. Fails on the unfixed command with "Found 1 secret(s)" (verified A/B via stash).
- Unit: the command test doubles now stub `findByIdentifierIncludingDisabled()`, and `successfulRotationWithConfirm` pins the disabled-visible inventory contract (`includeDisabled === true`).

## Checked, deliberately not changed

`VaultCleanupOrphansCommand` scans via `vaultService->list()` (default `includeDisabled: false`), so disabled orphans are never examined — but that command **deletes** what it classifies as orphaned. Including disabled secrets there would make a deliberately-parked secret auto-deletable, a separate behavior decision with its own risk trade-off; the current skip is fail-safe. Noted in #286.