### PR TITLE
fix(rector): adopt the shared org rector config

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -833,7 +833,7 @@ parameters:
 			path: ../Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
 
 		-
-			rawMessage: 'Method Psr\Http\Client\ClientInterface@anonymous/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php:368::__construct() has parameter $capturedRequests with no value type specified in iterable type array.'
+			rawMessage: 'Method Psr\Http\Client\ClientInterface@anonymous/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php:369::__construct() has parameter $capturedRequests with no value type specified in iterable type array.'
 			identifier: missingType.iterableValue
 			count: 1
 			path: ../Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
@@ -845,7 +845,7 @@ parameters:
 			path: ../Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
 
 		-
-			rawMessage: 'Property Psr\Http\Client\ClientInterface@anonymous/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php:368::$capturedRequests (list<array{grant_type: string, body: string}>) does not accept array.'
+			rawMessage: 'Property Psr\Http\Client\ClientInterface@anonymous/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php:369::$capturedRequests (list<array{grant_type: string, body: string}>) does not accept array.'
 			identifier: assign.propertyType
 			count: 1
 			path: ../Tests/Functional/Http/OAuth/OAuthIntegrationTest.php

--- a/Classes/Audit/AuditChainLockTrait.php
+++ b/Classes/Audit/AuditChainLockTrait.php
@@ -62,10 +62,12 @@ trait AuditChainLockTrait
 
                 return;
             }
+
             $connection->executeStatement('BEGIN EXCLUSIVE');
 
             return;
         }
+
         $lockResult = $connection->executeQuery('SELECT GET_LOCK("nr_vault_audit", 5)')->fetchOne();
         if (!is_numeric($lockResult) || (int) $lockResult !== 1) {
             throw AuditWriteException::lockAcquisitionFailed($lockResult);
@@ -98,10 +100,12 @@ trait AuditChainLockTrait
 
                 return;
             }
+
             $connection->executeStatement('COMMIT');
 
             return;
         }
+
         $connection->commit();
     }
 
@@ -115,10 +119,12 @@ trait AuditChainLockTrait
 
                 return;
             }
+
             $connection->executeStatement('ROLLBACK');
 
             return;
         }
+
         $connection->rollBack();
     }
 

--- a/Classes/Audit/AuditLogService.php
+++ b/Classes/Audit/AuditLogService.php
@@ -258,6 +258,7 @@ final readonly class AuditLogService implements AuditLogServiceInterface
             foreach ($chunk as $entry) {
                 yield $entry;
             }
+
             $offset += $chunkSize;
         } while (\count($chunk) === $chunkSize);
     }
@@ -363,6 +364,7 @@ final readonly class AuditLogService implements AuditLogServiceInterface
                             $missingUids[] = $missing;
                         }
                     }
+
                     $errors[$uid] = \sprintf(
                         'Audit log uid gap detected: missing uids %d..%d (chain could have been tampered by deletion + previous_hash patch)',
                         $gapStart,
@@ -403,6 +405,7 @@ final readonly class AuditLogService implements AuditLogServiceInterface
                 if ($epoch > $maxEpoch) {
                     $maxEpoch = $epoch;
                 }
+
                 $epochCounts[$epoch] = ($epochCounts[$epoch] ?? 0) + 1;
 
                 // Epoch-aware hash dispatch:

--- a/Classes/Audit/GenericContext.php
+++ b/Classes/Audit/GenericContext.php
@@ -51,6 +51,6 @@ final readonly class GenericContext implements AuditContextInterface
      */
     public function jsonSerialize(): array
     {
-        return $this->toArray();
+        return $this->data;
     }
 }

--- a/Classes/Audit/Sink/JsonFileAuditSink.php
+++ b/Classes/Audit/Sink/JsonFileAuditSink.php
@@ -175,6 +175,7 @@ final class JsonFileAuditSink implements AuditSinkInterface
                 if ($written === false || $written !== \strlen($line)) {
                     throw AuditSinkException::writeFailed(self::IDENTIFIER, 'incomplete write (disk full or quota exceeded?)');
                 }
+
                 fflush($handle);
             } finally {
                 flock($handle, LOCK_UN);

--- a/Classes/Command/VaultAuditCommand.php
+++ b/Classes/Command/VaultAuditCommand.php
@@ -542,6 +542,7 @@ final class VaultAuditCommand extends Command
             if (isset($row['context']) && \is_array($row['context'])) {
                 $row['context'] = json_encode($row['context']);
             }
+
             // Filter to only scalar/null values for fputcsv
             /** @var array<string, bool|float|int|string|null> $csvRow */
             $csvRow = array_map(

--- a/Classes/Command/VaultCleanupOrphansCommand.php
+++ b/Classes/Command/VaultCleanupOrphansCommand.php
@@ -167,6 +167,7 @@ final class VaultCleanupOrphansCommand extends Command
                 if ($orphan !== null) {
                     $orphans[] = $orphan;
                 }
+
                 $progressBar->advance();
             }
         }

--- a/Classes/Command/VaultDoctorCommand.php
+++ b/Classes/Command/VaultDoctorCommand.php
@@ -183,6 +183,7 @@ final class VaultDoctorCommand extends Command
                 $context->configuredProfile->value,
             )];
         }
+
         $definitions[] = ['Controls passed' => \sprintf(
             '%d of %d',
             $report->passedControls(),

--- a/Classes/Command/VaultInitCommand.php
+++ b/Classes/Command/VaultInitCommand.php
@@ -158,6 +158,7 @@ final class VaultInitCommand extends Command
         } finally {
             umask($previousUmask);
         }
+
         if ($result === false) {
             $io->error(\sprintf('Failed to write master key to: %s', $outputFilePath));
 

--- a/Classes/Command/VaultMigrateFieldCommand.php
+++ b/Classes/Command/VaultMigrateFieldCommand.php
@@ -303,6 +303,7 @@ final class VaultMigrateFieldCommand extends Command
         foreach (\array_slice($errors, 0, 10) as $error) {
             $io->text('<error>✗</error> ' . $error);
         }
+
         if (\count($errors) > 10) {
             $io->text(\sprintf('... and %d more errors', \count($errors) - 10));
         }

--- a/Classes/Command/VaultRetrieveCommand.php
+++ b/Classes/Command/VaultRetrieveCommand.php
@@ -120,6 +120,7 @@ final class VaultRetrieveCommand extends Command
                 } finally {
                     umask($previousUmask);
                 }
+
                 if ($result === false) {
                     $io->error(\sprintf('Failed to write to file: %s', $outputFile));
                     sodium_memzero($value);

--- a/Classes/Command/VaultRotateCommand.php
+++ b/Classes/Command/VaultRotateCommand.php
@@ -150,6 +150,7 @@ final class VaultRotateCommand extends Command
 
                 return null;
             }
+
             $fileValue = file_get_contents($file);
             if ($fileValue !== false) {
                 return $fileValue;

--- a/Classes/Command/VaultRotateMasterKeyCommand.php
+++ b/Classes/Command/VaultRotateMasterKeyCommand.php
@@ -185,6 +185,7 @@ final class VaultRotateMasterKeyCommand extends Command
         if ($foreignCounts === null) {
             return Command::FAILURE;
         }
+
         $totalForeign = array_sum($foreignCounts);
 
         if ($totalSecrets === 0 && $totalForeign === 0) {
@@ -484,6 +485,7 @@ final class VaultRotateMasterKeyCommand extends Command
 
             return Command::FAILURE;
         }
+
         if (!$verification->isValid()) {
             $io->error([
                 'Audit hash chain verification FAILED — re-keying refused.',
@@ -512,8 +514,10 @@ final class VaultRotateMasterKeyCommand extends Command
                 if ($this->rotateOne($identifier, $oldKey, $newKey, $failedSecrets)) {
                     ++$successCount;
                 }
+
                 $io->progressAdvance();
             }
+
             $io->progressFinish();
 
             if ($failedSecrets !== []) {
@@ -553,7 +557,7 @@ final class VaultRotateMasterKeyCommand extends Command
                         $foreignCount,
                     ),
                     'Rotation rolled back; nothing was changed.',
-                    'Re-run the command. If the shortfall repeats, the consumer\'s rotator is missing rows'
+                    "Re-run the command. If the shortfall repeats, the consumer's rotator is missing rows"
                     . ' and committing would leave them unreadable once the old key is gone.',
                 ]);
                 $this->auditLogService->log(

--- a/Classes/Command/VaultScanCommand.php
+++ b/Classes/Command/VaultScanCommand.php
@@ -282,6 +282,7 @@ final class VaultScanCommand extends Command
                 if (!$first) {
                     $table->addRow(new TableSeparator());
                 }
+
                 $first = false;
 
                 $patterns = implode(', ', $finding->getPatterns()) ?: '-';

--- a/Classes/Command/VaultSeedDemoCommand.php
+++ b/Classes/Command/VaultSeedDemoCommand.php
@@ -74,6 +74,7 @@ final class VaultSeedDemoCommand extends Command
             foreach ($existing as $identifier) {
                 $this->vaultService->delete($identifier, 'demo reseed');
             }
+
             $io->writeln(\sprintf('Removed %d existing demo secrets.', \count($existing)));
         }
 

--- a/Classes/Command/VaultStoreCommand.php
+++ b/Classes/Command/VaultStoreCommand.php
@@ -143,6 +143,7 @@ final class VaultStoreCommand extends Command
 
                 return null;
             }
+
             $fileValue = file_get_contents($file);
             if ($fileValue !== false) {
                 return $fileValue;

--- a/Classes/Controller/AnalyticsController.php
+++ b/Classes/Controller/AnalyticsController.php
@@ -54,6 +54,7 @@ final readonly class AnalyticsController
 
         $moduleTemplate = $this->moduleTemplateFactory->create($request);
         $moduleTemplate->makeDocHeaderModuleMenu();
+
         $this->pageRenderer->addCssFile('EXT:nr_vault/Resources/Public/Css/backend.css');
 
         $window = $this->resolveWindow($request);

--- a/Classes/Controller/AuditController.php
+++ b/Classes/Controller/AuditController.php
@@ -366,6 +366,7 @@ final readonly class AuditController
                 if (\is_array($row['context'])) {
                     $row['context'] = json_encode($row['context']);
                 }
+
                 /** @var array<int, bool|float|int|string|null> $values */
                 $values = array_values($row);
                 fputcsv($output, CsvFormulaSanitizer::neutralizeRow($values), escape: '');

--- a/Classes/Controller/MigrationController.php
+++ b/Classes/Controller/MigrationController.php
@@ -205,6 +205,7 @@ final readonly class MigrationController
             if ($sourceFilter !== 'all' && $secret->getSource() !== $sourceFilter) {
                 continue;
             }
+
             if ($severityFilter !== 'all' && $secret->getSeverity()->value !== $severityFilter) {
                 continue;
             }
@@ -305,6 +306,7 @@ final readonly class MigrationController
             if (!$result instanceof MigrationResult) {
                 continue;
             }
+
             $results[] = $result->toArray();
             $totalMigrated += $result->migrated;
             $totalFailed += $result->failed;
@@ -346,6 +348,7 @@ final readonly class MigrationController
         if (!\is_array($migration)) {
             return null;
         }
+
         $tableVal = $migration['table'] ?? '';
         $table = \is_string($tableVal) ? $tableVal : '';
         $columnVal = $migration['column'] ?? '';
@@ -355,9 +358,11 @@ final readonly class MigrationController
         if ($table === '') {
             return null;
         }
+
         if ($column === '') {
             return null;
         }
+
         if ($identifierPattern === '') {
             return null;
         }

--- a/Classes/Controller/OverviewController.php
+++ b/Classes/Controller/OverviewController.php
@@ -199,6 +199,7 @@ final readonly class OverviewController
         if ($activeTab === 'dashboard') {
             $dashboardItem->setActive(true);
         }
+
         $menu->addMenuItem($dashboardItem);
 
         $helpItem = $menu->makeMenuItem()
@@ -207,6 +208,7 @@ final readonly class OverviewController
         if ($activeTab === 'help') {
             $helpItem->setActive(true);
         }
+
         $menu->addMenuItem($helpItem);
 
         $menuRegistry->addMenu($menu);

--- a/Classes/Controller/SecretsController.php
+++ b/Classes/Controller/SecretsController.php
@@ -122,12 +122,15 @@ final readonly class SecretsController
             if ($filters['identifier'] !== '' && stripos($secret->identifier, $filters['identifier']) === false) {
                 continue;
             }
+
             if ($filters['status'] === 'active' && !$secret->enabled) {
                 continue;
             }
+
             if ($filters['status'] === 'disabled' && $secret->enabled) {
                 continue;
             }
+
             if ($filters['owner'] > 0 && $secret->ownerUid !== $filters['owner']) {
                 continue;
             }
@@ -341,6 +344,7 @@ final readonly class SecretsController
                 /** @phpstan-ignore new.internalClass, method.internalClass */
                 return new JsonResponse(['success' => false, 'error' => 'Secret not found'], 404);
             }
+
             $this->addFlashMessage(
                 \sprintf($lang->sL(self::LL_NOT_FOUND), $identifier),
                 ContextualFeedbackSeverity::ERROR,
@@ -358,6 +362,7 @@ final readonly class SecretsController
                 /** @phpstan-ignore new.internalClass, method.internalClass */
                 return new JsonResponse(['success' => false, 'error' => 'An internal error occurred'], 500);
             }
+
             $this->addFlashMessage(
                 \sprintf($lang->sL('LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:secrets.error'), $e->getMessage()),
                 ContextualFeedbackSeverity::ERROR,
@@ -441,6 +446,7 @@ final readonly class SecretsController
             /** @phpstan-ignore new.internalClass, method.internalClass */
             return new JsonResponse(['success' => false, 'error' => 'No secret identifier provided'], 400);
         }
+
         $this->addFlashMessage(
             $lang->sL(self::LL_NO_IDENTIFIER),
             ContextualFeedbackSeverity::ERROR,
@@ -568,6 +574,7 @@ final readonly class SecretsController
             } elseif (\is_string($username)) {
                 $displayName = $username;
             }
+
             $uidVal = $row['uid'] ?? 0;
             $cache[is_numeric($uidVal) ? (int) $uidVal : 0] = $displayName;
         }
@@ -596,6 +603,7 @@ final readonly class SecretsController
                 'name' => $userCache[$uid] ?? 'User #' . $uid,
             ];
         }
+
         usort($options, static fn (array $a, array $b): int => strcasecmp($a['name'], $b['name']));
 
         return $options;

--- a/Classes/Crypto/EncryptionService.php
+++ b/Classes/Crypto/EncryptionService.php
@@ -97,12 +97,15 @@ final readonly class EncryptionService implements EncryptionServiceInterface
             if (isset($dek)) {
                 sodium_memzero($dek);
             }
+
             if (isset($macKey)) {
                 sodium_memzero($macKey);
             }
+
             if (isset($plaintext)) {
                 sodium_memzero($plaintext);
             }
+
             // The master key is deliberately NOT wiped: it is the provider's
             // shared request-lifetime cache entry (see decrypt()); the provider
             // owns its lifecycle and wipes it on destruction.
@@ -223,6 +226,7 @@ final readonly class EncryptionService implements EncryptionServiceInterface
             if (isset($dek)) {
                 sodium_memzero($dek);
             }
+
             sodium_memzero($oldMasterKey);
             sodium_memzero($newMasterKey);
         }

--- a/Classes/Crypto/FileMasterKeyProvider.php
+++ b/Classes/Crypto/FileMasterKeyProvider.php
@@ -73,6 +73,7 @@ final class FileMasterKeyProvider extends AbstractMasterKeyProvider
         } finally {
             umask($previousUmask);
         }
+
         if ($result === false) {
             throw MasterKeyException::cannotStore("Cannot write to: {$path}");
         }

--- a/Classes/Crypto/TransitMasterKeyProvider.php
+++ b/Classes/Crypto/TransitMasterKeyProvider.php
@@ -118,6 +118,7 @@ final class TransitMasterKeyProvider extends AbstractMasterKeyProvider
         if ($vaultToken === null) {
             return false;
         }
+
         $this->wipeTokenCopy($vaultToken, $config);
 
         return file_exists($config->wrappedKeyPath) && is_readable($config->wrappedKeyPath);
@@ -210,9 +211,11 @@ final class TransitMasterKeyProvider extends AbstractMasterKeyProvider
         if ($config->address === '') {
             throw MasterKeyException::transitNotConfigured('hashicorp.address is empty');
         }
+
         if ($config->wrappedKeyPath === '') {
             throw MasterKeyException::transitNotConfigured('hashicorp.transitWrappedKeyPath is empty');
         }
+
         if (!$config->usesTokenAuth()) {
             throw MasterKeyException::transitUnsupportedAuthMethod($config->authMethod);
         }
@@ -388,6 +391,7 @@ final class TransitMasterKeyProvider extends AbstractMasterKeyProvider
         if (!file_exists($path)) {
             throw MasterKeyException::notFound($path);
         }
+
         if (!is_readable($path)) {
             throw MasterKeyException::notFound($path . ' (not readable)');
         }

--- a/Classes/Crypto/Typo3MasterKeyProvider.php
+++ b/Classes/Crypto/Typo3MasterKeyProvider.php
@@ -60,7 +60,7 @@ final class Typo3MasterKeyProvider extends AbstractMasterKeyProvider
     {
         // Cannot store - the key is derived from TYPO3's encryption key
         throw MasterKeyException::cannotStore(
-            'TYPO3 provider derives the key from encryptionKey. To change it, rotate TYPO3\'s encryption key.',
+            "TYPO3 provider derives the key from encryptionKey. To change it, rotate TYPO3's encryption key.",
         );
     }
 

--- a/Classes/Domain/Dto/SecretFilters.php
+++ b/Classes/Domain/Dto/SecretFilters.php
@@ -76,15 +76,19 @@ readonly class SecretFilters
         if ($this->owner !== null) {
             $result['owner'] = $this->owner;
         }
+
         if ($this->prefix !== null) {
             $result['prefix'] = $this->prefix;
         }
+
         if ($this->context !== null) {
             $result['context'] = $this->context;
         }
+
         if ($this->scopePid !== null) {
             $result['scopePid'] = $this->scopePid;
         }
+
         // Only when set, like every other member: the array form is "what was
         // asked for", and the default is asking for nothing.
         if ($this->includeDisabled) {

--- a/Classes/Domain/Repository/SecretRepository.php
+++ b/Classes/Domain/Repository/SecretRepository.php
@@ -297,6 +297,7 @@ final readonly class SecretRepository implements SecretRepositoryInterface
         if ($filters instanceof SecretFilters && $filters->includeDisabled) {
             $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
         }
+
         $queryBuilder
             ->select('identifier')
             ->from(self::TABLE_NAME)
@@ -345,6 +346,7 @@ final readonly class SecretRepository implements SecretRepositoryInterface
             if (!\is_string($identifier)) {
                 continue;
             }
+
             if ($identifier === '') {
                 continue;
             }
@@ -374,6 +376,7 @@ final readonly class SecretRepository implements SecretRepositoryInterface
         foreach ($groupUids as $gid) {
             $intGroupUids[] = (int) $gid;
         }
+
         $secretUids = $mmQuery
             ->select('DISTINCT uid_local')
             ->from(self::MM_TABLE_NAME)
@@ -483,6 +486,7 @@ final readonly class SecretRepository implements SecretRepositoryInterface
         if ($filters instanceof SecretFilters && $filters->includeDisabled) {
             $queryBuilder->getRestrictions()->removeByType(HiddenRestriction::class);
         }
+
         $queryBuilder
             ->select('*')
             ->from(self::TABLE_NAME)

--- a/Classes/Hook/DataHandlerHook.php
+++ b/Classes/Hook/DataHandlerHook.php
@@ -134,6 +134,7 @@ final class DataHandlerHook
         if ($status === 'new') {
             $uidRaw = $dataHandler->substNEWwithIDs[$id] ?? $id;
         }
+
         $uid = is_numeric($uidRaw) ? (int) $uidRaw : 0;
 
         // Process pending secrets for this record
@@ -255,6 +256,7 @@ final class DataHandlerHook
             if (!\is_string($vaultIdentifier)) {
                 continue;
             }
+
             if ($vaultIdentifier === '') {
                 continue;
             }
@@ -374,6 +376,7 @@ final class DataHandlerHook
         if ($newIdRaw === null) {
             return;
         }
+
         $newId = is_numeric($newIdRaw) ? (int) $newIdRaw : 0;
 
         $vaultFields = $this->getVaultFieldNames($table);
@@ -402,6 +405,7 @@ final class DataHandlerHook
             if (!\is_string($sourceIdentifier)) {
                 continue;
             }
+
             if ($sourceIdentifier === '') {
                 continue;
             }

--- a/Classes/Hook/FlexFormVaultHook.php
+++ b/Classes/Hook/FlexFormVaultHook.php
@@ -74,6 +74,7 @@ final class FlexFormVaultHook
             if (!\is_string($configType)) {
                 continue;
             }
+
             if ($configType !== 'flex') {
                 continue;
             }
@@ -84,6 +85,7 @@ final class FlexFormVaultHook
             if (!isset($fieldArray[$fieldName])) {
                 continue;
             }
+
             if (!\is_array($fieldArray[$fieldName])) {
                 continue;
             }
@@ -125,6 +127,7 @@ final class FlexFormVaultHook
         if ($status === 'new') {
             $uidRaw = $dataHandler->substNEWwithIDs[$id] ?? $id;
         }
+
         $uid = is_numeric($uidRaw) ? (int) $uidRaw : 0;
 
         // Process pending FlexForm secrets
@@ -166,6 +169,7 @@ final class FlexFormVaultHook
             if (!\is_string($xmlValue)) {
                 continue;
             }
+
             if ($xmlValue === '') {
                 continue;
             }
@@ -226,6 +230,7 @@ final class FlexFormVaultHook
         if ($newIdRaw === null) {
             return;
         }
+
         $newId = is_numeric($newIdRaw) ? (int) $newIdRaw : 0;
 
         $flexFieldNames = $this->getFlexFieldNames($table);
@@ -249,6 +254,7 @@ final class FlexFormVaultHook
             if (!\is_string($xmlValue)) {
                 continue;
             }
+
             if ($xmlValue === '') {
                 continue;
             }
@@ -384,6 +390,7 @@ final class FlexFormVaultHook
                 );
             }
         }
+
         unset($sheetData, $fieldData);
 
         $this->discardUnprocessedVaultPlaintext($data, $table, $id, $flexFieldName);
@@ -501,9 +508,11 @@ final class FlexFormVaultHook
                 if (!\is_array($containerData)) {
                     continue;
                 }
+
                 if (!isset($containerData['el'])) {
                     continue;
                 }
+
                 if (!\is_array($containerData['el'])) {
                     continue;
                 }
@@ -521,6 +530,7 @@ final class FlexFormVaultHook
                     if (!\is_string($renderType)) {
                         continue;
                     }
+
                     if ($renderType !== 'vaultSecret') {
                         continue;
                     }
@@ -536,6 +546,7 @@ final class FlexFormVaultHook
                 }
             }
         }
+
         unset($sectionItem, $containerData, $innerFieldData);
     }
 
@@ -786,6 +797,7 @@ final class FlexFormVaultHook
                 $stripped = true;
             }
         }
+
         unset($value);
 
         return $stripped;

--- a/Classes/Hook/SecretTcaHook.php
+++ b/Classes/Hook/SecretTcaHook.php
@@ -448,6 +448,7 @@ final class SecretTcaHook
         if ($status === 'new') {
             $uidRaw = $dataHandler->substNEWwithIDs[$id] ?? $id;
         }
+
         $uid = is_numeric($uidRaw) ? (int) $uidRaw : 0;
 
         // Get the secret identifier for operations
@@ -1060,9 +1061,11 @@ final class SecretTcaHook
 
                 return true;
             }
+
             if ($originalValues === []) {
                 return false;
             }
+
             $connection->update(self::TABLE, $originalValues, ['uid' => $uid]);
 
             return true;
@@ -1538,6 +1541,7 @@ final class SecretTcaHook
             if (!\array_key_exists($column, $fieldArray)) {
                 continue;
             }
+
             // Compare before dropping, so an ordinary save that merely
             // round-trips the unchanged value does not report tampering.
             // A comparison that cannot prove equality counts as an attempt:
@@ -1547,6 +1551,7 @@ final class SecretTcaHook
             ) {
                 $attempted[] = $column;
             }
+
             unset($fieldArray[$column]);
         }
 
@@ -1554,6 +1559,7 @@ final class SecretTcaHook
             if (!\array_key_exists($column, $fieldArray)) {
                 continue;
             }
+
             // MM-backed group field: the row column holds only the relation
             // count, so the submitted value carries no comparable state —
             // its mere presence is the attempt.

--- a/Classes/Http/DefaultDnsResolver.php
+++ b/Classes/Http/DefaultDnsResolver.php
@@ -44,9 +44,11 @@ final class DefaultDnsResolver implements DnsResolverInterface
             if (\is_string($ip)) {
                 $entry['ip'] = $ip;
             }
+
             if (\is_string($ipv6)) {
                 $entry['ipv6'] = $ipv6;
             }
+
             if ($entry !== []) {
                 $out[] = $entry;
             }

--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -370,6 +370,7 @@ final class OAuthTokenManager
         if ($response->getStatusCode() === 200) {
             return;
         }
+
         $oauthError = $this->extractOauthErrorField($response);
 
         throw OAuthException::tokenRequestFailed($response->getStatusCode(), $oauthError);
@@ -388,6 +389,7 @@ final class OAuthTokenManager
         } catch (JsonException) {
             return null;
         }
+
         if (\is_array($errorBody) && isset($errorBody['error']) && \is_string($errorBody['error'])) {
             return $errorBody['error'];
         }

--- a/Classes/Http/OAuth/OAuthTokenRequestParams.php
+++ b/Classes/Http/OAuth/OAuthTokenRequestParams.php
@@ -62,6 +62,7 @@ final class OAuthTokenRequestParams
         if ($this->scope !== null) {
             $params['scope'] = $this->scope;
         }
+
         if ($this->refreshToken !== null) {
             $params['refresh_token'] = $this->refreshToken;
         }
@@ -84,6 +85,7 @@ final class OAuthTokenRequestParams
         if ($this->wiped) {
             return;
         }
+
         $this->wiped = true;
 
         /** @phpstan-ignore assign.propertyType */

--- a/Classes/Http/VaultHttpResponse.php
+++ b/Classes/Http/VaultHttpResponse.php
@@ -177,6 +177,7 @@ final readonly class VaultHttpResponse
             if (!\is_array($value) || !\array_key_exists($segment, $value)) {
                 return $default;
             }
+
             $value = $value[$segment];
         }
 

--- a/Classes/Security/AccessControlService.php
+++ b/Classes/Security/AccessControlService.php
@@ -182,6 +182,7 @@ final class AccessControlService implements AccessControlServiceInterface
         if (!$backendUser instanceof BackendUserAuthentication) {
             return false;
         }
+
         if ($this->isBackendUserDisabled($backendUser)) {
             return false;
         }
@@ -303,6 +304,7 @@ final class AccessControlService implements AccessControlServiceInterface
             } elseif (is_numeric($groupId)) {
                 $normalised = (int) $groupId;
             }
+
             $result[] = $normalised;
         }
 
@@ -655,9 +657,11 @@ final class AccessControlService implements AccessControlServiceInterface
             if (!\is_string($options)) {
                 continue;
             }
+
             if ($options === '') {
                 continue;
             }
+
             if (GeneralUtility::inList($options, self::PERM_OPTION_GROUP . ':' . $permission->value)) {
                 return true;
             }

--- a/Classes/Security/BreakGlassSession.php
+++ b/Classes/Security/BreakGlassSession.php
@@ -54,6 +54,7 @@ final readonly class BreakGlassSession
         if (!is_numeric($uid) || !\is_string($username) || !\is_string($reason)) {
             return null;
         }
+
         if (!is_numeric($activatedAt) || !is_numeric($expiresAt)) {
             return null;
         }

--- a/Classes/Service/Doctor/Check/AuditCheck.php
+++ b/Classes/Service/Doctor/Check/AuditCheck.php
@@ -311,7 +311,7 @@ final readonly class AuditCheck implements ReadinessCheckInterface
                 summary: \sprintf('Audit entries are kept for %d days.', $days),
                 risk: \sprintf(
                     'Shorter than a %d-day review cycle, so a reviewer cannot see the previous '
-                    . 'cycle\'s access. It also shortens the window in which a slow-burn credential '
+                    . "cycle's access. It also shortens the window in which a slow-burn credential "
                     . 'misuse is still reconstructable.',
                     self::RETENTION_FLOOR_DAYS,
                 ),
@@ -657,7 +657,7 @@ final readonly class AuditCheck implements ReadinessCheckInterface
                 . 'which inverts the meaning of the entry without touching a signed byte. '
                 . 'error_message, reason, ip_address, user_agent, hash_before, hash_after and context '
                 . 'are forgeable the same way; so is the hmac_key_epoch column, which leaves the '
-                . 'algorithm selector resting on verifyHashChain()\'s chain-shape guards rather than '
+                . "algorithm selector resting on verifyHashChain()'s chain-shape guards rather than "
                 . 'on the MAC; and so are the attribution fields the backend audit list and the CSV '
                 . 'export present as "who did this", so blame can be reassigned on any row.'
             : 'The epoch-2 payload signs the forensic columns but leaves two sets out. The '
@@ -905,7 +905,7 @@ final readonly class AuditCheck implements ReadinessCheckInterface
                 . 'database state alone, which is why this is a warning rather than an error.',
             remediation: 'The next audit write arms it. Once it is armed, enable "auditAnchorRequired" '
                 . 'so a later deletion of the anchor row becomes an error instead of this warning — the '
-                . 'setting lives in a settings file and is out of a database-write attacker\'s reach.',
+                . "setting lives in a settings file and is out of a database-write attacker's reach.",
             docsUrl: DocsLink::AUDIT_TIP_ANCHOR,
             details: $details,
         );

--- a/Classes/Service/Doctor/Check/CliAccessCheck.php
+++ b/Classes/Service/Doctor/Check/CliAccessCheck.php
@@ -258,6 +258,7 @@ final readonly class CliAccessCheck implements ReadinessCheckInterface
         if ($risky !== []) {
             $summaryParts[] = \sprintf('grants high-risk operation(s) %s to the unattributed CLI actor', implode(', ', $risky));
         }
+
         if ($unknown !== []) {
             $summaryParts[] = \sprintf('contains unknown value(s) %s', implode(', ', $unknown));
         }
@@ -273,7 +274,7 @@ final readonly class CliAccessCheck implements ReadinessCheckInterface
                 . 'do not admit it to, and the widened tiers read as ordinary configuration afterwards. '
                 . '"audit.view" grants no secret access at all, but the trail it opens names who touched '
                 . 'which identifier when: it maps the credential topology, and it is also where the '
-                . 'shell\'s own activity is recorded, so it is reconnaissance handed to the actor the '
+                . "shell's own activity is recorded, so it is reconnaissance handed to the actor the "
                 . 'log exists to catch. Unknown values do nothing: the grant the operator believes is '
                 . 'configured is silently absent.',
             remediation: 'Remove the high-risk operations from "cliAllowedOperations" (use a named '

--- a/Classes/Service/SecretDetectionService.php
+++ b/Classes/Service/SecretDetectionService.php
@@ -366,9 +366,11 @@ final class SecretDetectionService implements SecretDetectionServiceInterface
                 $this->scanConfigArray($valueArray, "{$prefix}.{$key}");
                 continue;
             }
+
             if (!\is_string($value)) {
                 continue;
             }
+
             if ($value === '') {
                 continue;
             }

--- a/Classes/Service/VaultFieldPermissionService.php
+++ b/Classes/Service/VaultFieldPermissionService.php
@@ -186,6 +186,7 @@ final class VaultFieldPermissionService implements SingletonInterface
             if (!\is_array($current)) {
                 return null;
             }
+
             // Try with trailing dot (TSconfig convention for nested)
             if (isset($current[$key . '.'])) {
                 $current = $current[$key . '.'];

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -101,6 +101,7 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
             } else {
                 $this->assertOperationGranted(VaultPermission::SecretRotate, $identifier, 'Update');
             }
+
             if ($existing instanceof Secret && !$isCreation) {
                 $this->assertPolicyChangeGranted($identifier, $options, $existing);
             }
@@ -761,6 +762,7 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
 
             return;
         }
+
         if (!$this->accessControlService->canWrite($existing)) {
             $this->auditLogService->log($identifier, AuditAction::AccessDenied->value, false, 'Update access denied');
 
@@ -861,6 +863,7 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
             $ownerRaw = $options['owner'];
             $requestedOwner = is_numeric($ownerRaw) ? (int) $ownerRaw : 0;
         }
+
         if ($requestedOwner !== $defaultOwner
             && $this->accessControlService->getCurrentActorType() === 'backend'
             && !$this->accessControlService->isCurrentActorAdmin()
@@ -887,6 +890,7 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
         if ($requested === $default) {
             return $default;
         }
+
         if ($this->accessControlService->getCurrentActorType() === 'backend'
             && !$this->accessControlService->isCurrentActorAdmin()
         ) {
@@ -954,6 +958,7 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
         if (!\is_array($raw)) {
             return [];
         }
+
         /** @var list<int> $groups */
         $groups = [];
         foreach ($raw as $groupId) {
@@ -988,6 +993,7 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
         if (!$this->eventDispatcher instanceof EventDispatcherInterface) {
             return;
         }
+
         if ($isNew) {
             $this->eventDispatcher->dispatch(new SecretCreatedEvent(
                 $identifier,
@@ -997,6 +1003,7 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
 
             return;
         }
+
         $this->eventDispatcher->dispatch(new SecretUpdatedEvent(
             $identifier,
             $secretEntity->getVersion(),

--- a/Classes/TCA/VaultFieldHelper.php
+++ b/Classes/TCA/VaultFieldHelper.php
@@ -155,6 +155,7 @@ final class VaultFieldHelper
         foreach ($vaultFields as $fieldName => $options) {
             $columns[$fieldName] = self::getFieldConfig($options);
         }
+
         $tca['columns'] = $columns;
 
         return $tca;
@@ -174,6 +175,7 @@ final class VaultFieldHelper
         if (!\is_array($config)) {
             return false;
         }
+
         $renderType = $config['renderType'] ?? '';
 
         return $renderType === 'vaultSecret';

--- a/Classes/Utility/FlexFormVaultResolver.php
+++ b/Classes/Utility/FlexFormVaultResolver.php
@@ -76,6 +76,7 @@ final readonly class FlexFormVaultResolver
                 if ($throwOnError) {
                     throw $e;
                 }
+
                 $this->logger->error('Failed to resolve FlexForm vault field', [
                     'field' => $field,
                     'identifier' => $identifier,

--- a/Classes/Utility/VaultFieldResolver.php
+++ b/Classes/Utility/VaultFieldResolver.php
@@ -72,6 +72,7 @@ final readonly class VaultFieldResolver
                 if ($throwOnError) {
                     throw $e;
                 }
+
                 $this->logger->error('Failed to resolve vault field', [
                     'field' => $field,
                     'identifier' => $identifier,

--- a/Tests/Architecture/ArchitectureTest.php
+++ b/Tests/Architecture/ArchitectureTest.php
@@ -244,7 +244,7 @@ final class ArchitectureTest
             ->dependOn()
             ->classes(Selector::classname(Registry::class))
             ->because(
-                'TYPO3\CMS\Core\Registry::get() unserializes attacker-writable '
+                Registry::class . '::get() unserializes attacker-writable '
                 . 'sys_registry bytes with no allowed_classes; the audit chain '
                 . 'tip anchor must reach sys_registry only via our own '
                 . 'QueryBuilder + anchored regex (ADR-034)',

--- a/Tests/Functional/AbstractVaultFunctionalTestCase.php
+++ b/Tests/Functional/AbstractVaultFunctionalTestCase.php
@@ -80,6 +80,7 @@ abstract class AbstractVaultFunctionalTestCase extends FunctionalTestCase
         if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']) || !\is_array($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'])) {
             $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'] = [];
         }
+
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_vault'] = array_merge(
             [
                 'masterKeySource' => $this->masterKeyPath,
@@ -107,6 +108,7 @@ abstract class AbstractVaultFunctionalTestCase extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+
             // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }

--- a/Tests/Functional/Audit/AuditChainAnchorTest.php
+++ b/Tests/Functional/Audit/AuditChainAnchorTest.php
@@ -322,6 +322,7 @@ final class AuditChainAnchorTest extends AbstractVaultFunctionalTestCase
             $this->get(AccessControlServiceInterface::class),
         );
         $command->setName('vault:audit');
+
         $exitCode = (new CommandTester($command))->execute(['--reset-anchor' => true, '--force' => true]);
 
         self::assertSame(0, $exitCode);

--- a/Tests/Functional/Audit/AuditChainRekeyServiceTest.php
+++ b/Tests/Functional/Audit/AuditChainRekeyServiceTest.php
@@ -149,6 +149,7 @@ final class AuditChainRekeyServiceTest extends AbstractVaultFunctionalTestCase
         $connection->commit();
 
         $connection->beginTransaction();
+
         $secondRun = $rekeyService->rekeyChain($connection, $newKey);
         $connection->commit();
 

--- a/Tests/Functional/Audit/ChainTipAnchorServiceTest.php
+++ b/Tests/Functional/Audit/ChainTipAnchorServiceTest.php
@@ -139,6 +139,7 @@ final class ChainTipAnchorServiceTest extends AbstractVaultFunctionalTestCase
         for ($i = 0; $i < 5; $i++) {
             $auditService->log('anchor_test_secret', 'read', true);
         }
+
         $anchor = $service->capture();
         $service->publish($anchor);
         self::assertSame(5, $anchor->sequence);
@@ -185,6 +186,7 @@ final class ChainTipAnchorServiceTest extends AbstractVaultFunctionalTestCase
         for ($i = 0; $i < 3; $i++) {
             $auditService->log('anchor_test_secret', 'read', true);
         }
+
         $anchor = $service->capture();
         $service->publish($anchor);
 
@@ -212,6 +214,7 @@ final class ChainTipAnchorServiceTest extends AbstractVaultFunctionalTestCase
         for ($i = 0; $i < 4; $i++) {
             $auditService->log('anchor_test_secret', 'read', true);
         }
+
         $anchor = $service->capture();
         $service->publish($anchor);
 
@@ -219,6 +222,7 @@ final class ChainTipAnchorServiceTest extends AbstractVaultFunctionalTestCase
         // appending a new entry.
         $connection = $this->getAuditConnection();
         $connection->delete(AuditLogService::TABLE_NAME, ['uid' => $anchor->sequence]);
+
         $auditService->log('anchor_test_secret', 'read', true);
 
         $report = $service->verify();
@@ -386,6 +390,7 @@ final class ChainTipAnchorServiceTest extends AbstractVaultFunctionalTestCase
         for ($i = 0; $i < 3; $i++) {
             $auditService->log('anchor_test_secret', 'read', true);
         }
+
         $service->publish($service->capture());
 
         $report = $service->verify();

--- a/Tests/Functional/Command/VaultSeedDemoCommandTest.php
+++ b/Tests/Functional/Command/VaultSeedDemoCommandTest.php
@@ -39,6 +39,7 @@ final class VaultSeedDemoCommandTest extends FunctionalTestCase
         if (!is_dir($dir)) {
             mkdir($dir, 0o700, true);
         }
+
         file_put_contents($this->masterKeyPath, sodium_crypto_secretbox_keygen());
         chmod($this->masterKeyPath, 0o600);
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_vault']['masterKeySource'] = $this->masterKeyPath;

--- a/Tests/Functional/Controller/MigrationControllerTest.php
+++ b/Tests/Functional/Controller/MigrationControllerTest.php
@@ -119,6 +119,7 @@ final class MigrationControllerTest extends AbstractVaultFunctionalTestCase
         $connectionPool = $this->get(ConnectionPool::class);
         $connection = $connectionPool->getConnectionForTable(self::FIXTURE_TABLE);
         $connection->insert(self::FIXTURE_TABLE, [self::FIXTURE_COLUMN => 'plaintext-api-key']);
+
         $uid = (int) $connection->lastInsertId();
 
         // Pattern exactly as the fixed configureAction builds it: single braces.
@@ -161,6 +162,7 @@ final class MigrationControllerTest extends AbstractVaultFunctionalTestCase
         $connectionPool = $this->get(ConnectionPool::class);
         $connection = $connectionPool->getConnectionForTable(self::FIXTURE_TABLE);
         $connection->insert(self::FIXTURE_TABLE, [self::FIXTURE_COLUMN => 'plaintext-api-key']);
+
         $uid = (int) $connection->lastInsertId();
 
         // The buggy pattern: double braces around uid.
@@ -217,6 +219,7 @@ final class MigrationControllerTest extends AbstractVaultFunctionalTestCase
         $table->addColumn('uid', Types::INTEGER, ['autoincrement' => true, 'unsigned' => true]);
         $table->addColumn(self::FIXTURE_COLUMN, Types::TEXT, ['notnull' => false]);
         $table->setPrimaryKey(['uid']);
+
         $schemaManager->createTable($table);
     }
 }

--- a/Tests/Functional/Crypto/EncryptionServiceTest.php
+++ b/Tests/Functional/Crypto/EncryptionServiceTest.php
@@ -63,6 +63,7 @@ final class EncryptionServiceTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+
             // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }

--- a/Tests/Functional/Crypto/MasterKeyRotationTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationTest.php
@@ -67,6 +67,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         if (!is_dir($dir)) {
             mkdir($dir, 0o700, true);
         }
+
         $masterKey = sodium_crypto_secretbox_keygen();
         file_put_contents($this->masterKeyPath, $masterKey);
         chmod($this->masterKeyPath, 0o600);
@@ -90,6 +91,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+
             // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }
@@ -160,6 +162,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         foreach (array_keys($secrets) as $identifier) {
             $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
         }
+
         if (file_exists($newKeyPath)) {
             // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($newKeyPath);
@@ -299,6 +302,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         foreach ($identifiers as $identifier) {
             $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
         }
+
         if (file_exists($newKeyPath)) {
             // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($newKeyPath);
@@ -433,10 +437,12 @@ final class MasterKeyRotationTest extends FunctionalTestCase
                 // ignore cleanup errors
             }
         }
+
         if (file_exists($newKeyPath)) {
             // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($newKeyPath);
         }
+
         sodium_memzero($bogusOldKey);
     }
 
@@ -515,6 +521,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         foreach (array_keys($secrets) as $identifier) {
             $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
         }
+
         foreach ([$key1Path, $key2Path] as $path) {
             if (file_exists($path)) {
                 // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path

--- a/Tests/Functional/EventListener/TypoScriptVaultListenerFrontendScopeTest.php
+++ b/Tests/Functional/EventListener/TypoScriptVaultListenerFrontendScopeTest.php
@@ -180,7 +180,7 @@ final class TypoScriptVaultListenerFrontendScopeTest extends AbstractVaultFuncti
         self::assertSame($before, $this->countAuditRows($identifier), '100 rejections must add 0 audit rows');
         self::assertTrue(
             $result[1],
-            'Outside Development the skip path must emit no record, so this request\'s log slot is still unclaimed',
+            "Outside Development the skip path must emit no record, so this request's log slot is still unclaimed",
         );
     }
 
@@ -251,7 +251,7 @@ final class TypoScriptVaultListenerFrontendScopeTest extends AbstractVaultFuncti
             ['bodytext' => $placeholder],
         ));
 
-        self::assertSame($placeholder, $later, 'A later request must not inherit the previous request\'s grant');
+        self::assertSame($placeholder, $later, "A later request must not inherit the previous request's grant");
     }
 
     /**

--- a/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
+++ b/Tests/Functional/Http/OAuth/OAuthIntegrationTest.php
@@ -126,6 +126,7 @@ final class OAuthIntegrationTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+
             // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }

--- a/Tests/Functional/Seeder/AuditChainSeederTest.php
+++ b/Tests/Functional/Seeder/AuditChainSeederTest.php
@@ -42,6 +42,7 @@ final class AuditChainSeederTest extends FunctionalTestCase
         if (!is_dir($dir)) {
             mkdir($dir, 0o700, true);
         }
+
         file_put_contents($this->masterKeyPath, sodium_crypto_secretbox_keygen());
         chmod($this->masterKeyPath, 0o600);
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_vault']['masterKeySource'] = $this->masterKeyPath;

--- a/Tests/Functional/Service/Analytics/VaultAnalyticsServiceTest.php
+++ b/Tests/Functional/Service/Analytics/VaultAnalyticsServiceTest.php
@@ -41,6 +41,7 @@ final class VaultAnalyticsServiceTest extends FunctionalTestCase
         for ($i = 0; $i < 9; $i++) {
             $this->seedReadEvent('manual_only', 'backend', self::NOW - (40 + $i) * self::DAY);
         }
+
         $this->seedReadEvent('healthy_key', 'api', self::NOW - 2 * self::DAY);
         $this->seedReadEvent('healthy_key', 'cli', self::NOW - 3 * self::DAY);
 
@@ -71,6 +72,7 @@ final class VaultAnalyticsServiceTest extends FunctionalTestCase
         foreach ($stats->byContext as $bar) {
             $contextPercent[$bar->label] = $bar->percent;
         }
+
         self::assertSame(50, $contextPercent['payment']);
         self::assertSame(50, $contextPercent['integration']);
 
@@ -111,6 +113,7 @@ final class VaultAnalyticsServiceTest extends FunctionalTestCase
                 return $c;
             }
         }
+
         self::fail('candidate not found: ' . $identifier);
     }
 

--- a/Tests/Functional/Service/VaultServiceCrossActorTest.php
+++ b/Tests/Functional/Service/VaultServiceCrossActorTest.php
@@ -69,7 +69,7 @@ final class VaultServiceCrossActorTest extends AbstractVaultFunctionalTestCase
         self::assertInstanceOf(
             AccessDeniedException::class,
             $denied,
-            'actor 13 must not read actor 10\'s secret',
+            "actor 13 must not read actor 10's secret",
         );
 
         // The denial is attributed to actor B in the audit trail.

--- a/Tests/Functional/Service/VaultServiceTest.php
+++ b/Tests/Functional/Service/VaultServiceTest.php
@@ -55,6 +55,7 @@ final class VaultServiceTest extends FunctionalTestCase
         if (!isset($GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'])) {
             $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS'] = [];
         }
+
         $GLOBALS['TYPO3_CONF_VARS']['EXTENSIONS']['nr_vault'] = [
             'masterKeySource' => $this->masterKeyPath,
             'autoKeyPath' => $this->masterKeyPath,
@@ -79,6 +80,7 @@ final class VaultServiceTest extends FunctionalTestCase
             if ($content !== false) {
                 sodium_memzero($content);
             }
+
             // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($this->masterKeyPath);
         }

--- a/Tests/Fuzz/AuditChainFuzzTest.php
+++ b/Tests/Fuzz/AuditChainFuzzTest.php
@@ -67,11 +67,13 @@ final class AuditChainFuzzTest extends TestCase
             for ($j = 0; $j < $idLen; $j++) {
                 $secretId .= \chr(mt_rand(32, 126));
             }
+
             $actionLen = mt_rand(1, 20);
             $action = '';
             for ($j = 0; $j < $actionLen; $j++) {
                 $action .= \chr(mt_rand(97, 122)); // a-z
             }
+
             $actorUid = mt_rand(0, 1000);
             $crdate = mt_rand(1000000, 2000000000);
             $prevHash = mt_rand(0, 1) !== 0 ? str_repeat('0', 64) : '';

--- a/Tests/Fuzz/AuditFilterFuzzTest.php
+++ b/Tests/Fuzz/AuditFilterFuzzTest.php
@@ -58,6 +58,7 @@ final class AuditFilterFuzzTest extends TestCase
      * @return list<array{mixed, int}>
      */
     private array $recordedParams = [];
+
     // -----------------------------------------------------------------------
     // Data providers
     // -----------------------------------------------------------------------
@@ -105,6 +106,7 @@ final class AuditFilterFuzzTest extends TestCase
             for ($j = 0; $j < $len; $j++) {
                 $buf .= \chr(mt_rand(0, 255));
             }
+
             $cases["random_{$i}_len{$len}"] = [$buf];
         }
 
@@ -256,6 +258,7 @@ final class AuditFilterFuzzTest extends TestCase
                 break;
             }
         }
+
         self::assertTrue($found, "actorUid={$uid} must be bound with PARAM_INT");
     }
 
@@ -279,6 +282,7 @@ final class AuditFilterFuzzTest extends TestCase
                     break;
                 }
             }
+
             self::assertTrue(
                 $found,
                 'success=' . ($b ? 'true' : 'false') . ' must bind as ' . $expected . ' with PARAM_INT',

--- a/Tests/Fuzz/CryptoFuzzTest.php
+++ b/Tests/Fuzz/CryptoFuzzTest.php
@@ -120,6 +120,7 @@ final class CryptoFuzzTest extends TestCase
             for ($j = 0; $j < $length; $j++) {
                 $plaintext .= \chr(mt_rand(0, 255));
             }
+
             $id = \sprintf('01937b6e-4b6c-7abc-8def-%012d', $i + 100);
             $cases["random_{$i}_len{$length}"] = [$plaintext, $id];
         }
@@ -195,6 +196,7 @@ final class CryptoFuzzTest extends TestCase
             $valueNonces[] = $encrypted->valueNonce;
             $dekNonces[] = $encrypted->dekNonce;
         }
+
         $elapsedMs = (hrtime(true) - $start) / 1_000_000;
 
         // Soft cap on runtime — if this ever exceeds 1s we'd want to know.

--- a/Tests/Fuzz/FlexFormXmlFuzzTest.php
+++ b/Tests/Fuzz/FlexFormXmlFuzzTest.php
@@ -129,6 +129,7 @@ final class FlexFormXmlFuzzTest extends TestCase
             for ($j = 0; $j < $len; $j++) {
                 $buf .= \chr(mt_rand(0, 255));
             }
+
             $cases["random_{$i}_len{$len}"] = [$buf];
         }
 

--- a/Tests/Fuzz/HttpClientFuzzTest.php
+++ b/Tests/Fuzz/HttpClientFuzzTest.php
@@ -116,6 +116,7 @@ final class HttpClientFuzzTest extends TestCase
             for ($j = 0; $j < $len; $j++) {
                 $value .= \chr(mt_rand(33, 126)); // printable, excludes space
             }
+
             $cases["random_printable_{$i}"] = [$value];
         }
 
@@ -269,6 +270,7 @@ final class HttpClientFuzzTest extends TestCase
                         );
                     }
                 }
+
                 self::assertFalse(
                     $request->hasHeader('X-Injected-Header'),
                     'CRLF injection must not create extra headers',

--- a/Tests/Fuzz/IdentifierFuzzTest.php
+++ b/Tests/Fuzz/IdentifierFuzzTest.php
@@ -247,7 +247,7 @@ final class IdentifierFuzzTest extends TestCase
             'shell backtick' => ['01937b6e-4b6c-7abc-`whoami`'],
             'shell dollar' => ['01937b6e-4b6c-7abc-$(whoami)'],
             'ldap injection' => ['01937b6e-4b6c-7abc-8def-0123456789ab)(cn=*)'],
-            'xpath injection' => ['01937b6e-4b6c-7abc-8def-0123456789ab\' or \'1\'=\'1'],
+            'xpath injection' => ["01937b6e-4b6c-7abc-8def-0123456789ab' or '1'='1"],
             'template injection' => ['01937b6e-4b6c-7abc-{{7*7}}'],
             'ssti jinja' => ['01937b6e-4b6c-7abc-{{ config }}'],
         ];

--- a/Tests/Fuzz/MasterKeyFuzzTest.php
+++ b/Tests/Fuzz/MasterKeyFuzzTest.php
@@ -111,6 +111,7 @@ final class MasterKeyFuzzTest extends TestCase
             if ($len === 32) {
                 $len = 31;
             }
+
             do {
                 $bytes = random_bytes($len);
                 // FileMasterKeyProvider trim()s file content before the length
@@ -118,6 +119,7 @@ final class MasterKeyFuzzTest extends TestCase
                 // shrink to a VALID 32-byte key (e.g. 33 bytes ending in \n).
                 // Regenerate until the trimmed form stays invalid.
             } while (\strlen(trim($bytes)) === 32);
+
             $cases["random_bytes_{$i}_len{$len}"] = [$bytes];
         }
 

--- a/Tests/Fuzz/OAuthFuzzTest.php
+++ b/Tests/Fuzz/OAuthFuzzTest.php
@@ -145,6 +145,7 @@ final class OAuthFuzzTest extends TestCase
             for ($j = 0; $j < $len; $j++) {
                 $random .= \chr(mt_rand(32, 126));
             }
+
             $cases["random_garbage_{$i}"] = [$random, true];
         }
 

--- a/Tests/Fuzz/SecretDetectionFuzzTest.php
+++ b/Tests/Fuzz/SecretDetectionFuzzTest.php
@@ -162,6 +162,7 @@ final class SecretDetectionFuzzTest extends TestCase
             for ($j = 0; $j < $len; $j++) {
                 $value .= \chr(mt_rand(32, 126)); // printable ASCII
             }
+
             $cases["random_smtp_{$i}"] = [['MAIL' => ['transport_smtp_password' => $value], 'SYS' => []]];
         }
 

--- a/Tests/Unit/Audit/AuditChainAnchorStoreTest.php
+++ b/Tests/Unit/Audit/AuditChainAnchorStoreTest.php
@@ -770,6 +770,7 @@ final class AuditChainAnchorStoreTest extends TestCase
         if ($fetchOneReturns !== []) {
             $result->method('fetchOne')->willReturn(...$fetchOneReturns);
         }
+
         if ($fetchAssociativeReturns !== []) {
             $result->method('fetchAssociative')->willReturn(...$fetchAssociativeReturns);
         }

--- a/Tests/Unit/Audit/Sink/JsonFileAuditSinkTest.php
+++ b/Tests/Unit/Audit/Sink/JsonFileAuditSinkTest.php
@@ -592,6 +592,7 @@ final class JsonFileAuditSinkTest extends TestCase
             $cursor['nested'] = [];
             $cursor = &$cursor['nested'];
         }
+
         unset($cursor);
 
         return $context;

--- a/Tests/Unit/Audit/Sink/WebhookAuditSinkTest.php
+++ b/Tests/Unit/Audit/Sink/WebhookAuditSinkTest.php
@@ -161,6 +161,7 @@ final class WebhookAuditSinkTest extends TestCase
         $subject = $this->createSubject(client: $client);
 
         $subject->publish($this->createEntry(), 'tip');
+
         $entryType = $client->decodeBody()['type'];
 
         $subject->publishAnchor(new ChainTipAnchor(1, 'tip', 1, 3));
@@ -341,6 +342,7 @@ final class WebhookAuditSinkTest extends TestCase
             $cursor['nested'] = [];
             $cursor = &$cursor['nested'];
         }
+
         unset($cursor);
 
         return $context;

--- a/Tests/Unit/Command/VaultAuditMigrateCommandTest.php
+++ b/Tests/Unit/Command/VaultAuditMigrateCommandTest.php
@@ -282,6 +282,7 @@ final class VaultAuditMigrateCommandTest extends TestCase
 
         $application = new Application();
         $application->addCommand($command);
+
         $tester = new CommandTester($command);
         $exitCode = $tester->execute([]);
 

--- a/Tests/Unit/Command/VaultDoctorCommandTest.php
+++ b/Tests/Unit/Command/VaultDoctorCommandTest.php
@@ -84,6 +84,7 @@ final class VaultDoctorCommandTest extends TestCase
         ]));
 
         $tester->execute([]);
+
         $display = $tester->getDisplay();
 
         self::assertStringContainsString('the trail exists only in the database it protects', $display);
@@ -189,6 +190,7 @@ final class VaultDoctorCommandTest extends TestCase
         ));
 
         $tester->execute([]);
+
         $display = $tester->getDisplay();
 
         self::assertStringContainsString('hardened', $display);

--- a/Tests/Unit/Command/VaultInitCommandTest.php
+++ b/Tests/Unit/Command/VaultInitCommandTest.php
@@ -53,6 +53,7 @@ final class VaultInitCommandTest extends TestCase
         foreach ($this->tempPaths as $path) {
             GeneralUtility::rmdir($path, true);
         }
+
         $this->tempPaths = [];
 
         parent::tearDown();

--- a/Tests/Unit/Command/VaultMigrateFieldCommandTest.php
+++ b/Tests/Unit/Command/VaultMigrateFieldCommandTest.php
@@ -252,6 +252,7 @@ final class VaultMigrateFieldCommandTest extends TestCase
         for ($i = 1; $i <= 25; $i++) {
             $records[] = ['uid' => $i, 'api_key' => 'secret' . $i];
         }
+
         $this->mockQueryReturnsRecords($records);
 
         $exitCode = $this->commandTester->execute([
@@ -445,6 +446,7 @@ final class VaultMigrateFieldCommandTest extends TestCase
         for ($i = 1; $i <= 15; $i++) {
             $records[] = ['uid' => $i, 'api_key' => 'secret' . $i];
         }
+
         $this->mockQueryReturnsRecords($records);
 
         $this->vaultService

--- a/Tests/Unit/Command/VaultRetrieveCommandTest.php
+++ b/Tests/Unit/Command/VaultRetrieveCommandTest.php
@@ -64,6 +64,7 @@ final class VaultRetrieveCommandTest extends TestCase
         foreach ($this->tempPaths as $path) {
             GeneralUtility::rmdir($path, true);
         }
+
         $this->tempPaths = [];
 
         parent::tearDown();

--- a/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
+++ b/Tests/Unit/Command/VaultRotateMasterKeyCommandTest.php
@@ -464,6 +464,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
                     // First call (verification) succeeds
                     return new ReEncryptedDek('new', 'n');
                 }
+
                 if ($callCount === 2) {
                     // Second call succeeds
                     return new ReEncryptedDek('new', 'n');
@@ -1002,6 +1003,7 @@ final class VaultRotateMasterKeyCommandTest extends TestCase
         if ($root === null) {
             $root = vfsStream::setup('keys');
         }
+
         vfsStream::newFile($name . '.key')
             ->withContent($content)
             ->at($root);

--- a/Tests/Unit/Controller/AuditControllerTest.php
+++ b/Tests/Unit/Controller/AuditControllerTest.php
@@ -81,13 +81,13 @@ final class AuditControllerTest extends TestCase
     #[Test]
     public function csvExportStillNeutralizesFormulaLeaders(): void
     {
-        $csv = $this->exportCsv([$this->createEntry(userAgent: '=cmd|\' /C calc\'!A0')]);
+        $csv = $this->exportCsv([$this->createEntry(userAgent: "=cmd|' /C calc'!A0")]);
 
         [$header, $row] = $this->parseCsv($csv);
 
         $columnIndex = array_search('userAgent', $header, true);
         self::assertIsInt($columnIndex);
-        self::assertSame('\'=cmd|\' /C calc\'!A0', $row[$columnIndex]);
+        self::assertSame("'=cmd|' /C calc'!A0", $row[$columnIndex]);
     }
 
     /**
@@ -201,6 +201,7 @@ final class AuditControllerTest extends TestCase
         while (($row = fgetcsv($handle, escape: '')) !== false) {
             $rows[] = array_map(static fn (mixed $cell): string => \is_string($cell) ? $cell : '', $row);
         }
+
         fclose($handle);
 
         self::assertCount(2, $rows, 'Expected exactly a header row and one data row.');

--- a/Tests/Unit/Crypto/EncryptionServiceTest.php
+++ b/Tests/Unit/Crypto/EncryptionServiceTest.php
@@ -431,6 +431,7 @@ final class EncryptionServiceTest extends TestCase
         } catch (EncryptionException) {
             $threw = true;
         }
+
         self::assertTrue($threw, 'tampered ciphertext must fail closed on the throw path');
 
         // Same request, legitimate decrypt must still round-trip.

--- a/Tests/Unit/Crypto/Typo3MasterKeyProviderTest.php
+++ b/Tests/Unit/Crypto/Typo3MasterKeyProviderTest.php
@@ -38,6 +38,7 @@ final class Typo3MasterKeyProviderTest extends TestCase
         } else {
             unset($GLOBALS['TYPO3_CONF_VARS']);
         }
+
         Typo3MasterKeyProvider::clearCachedKey();
     }
 

--- a/Tests/Unit/Exception/SecretLeakageTest.php
+++ b/Tests/Unit/Exception/SecretLeakageTest.php
@@ -169,9 +169,11 @@ final class SecretLeakageTest extends TestCase
         foreach (self::chainingFactoryProvider() as $name => $row) {
             yield $name => [$row[0]];
         }
+
         foreach (self::factoryDefaultProvider() as $name => $row) {
             yield $name => [$row[0]];
         }
+
         foreach (self::identifierOnlyFactoryProvider() as $name => $row) {
             yield $name => [$row[0]];
         }

--- a/Tests/Unit/Hook/SecretTcaHookTest.php
+++ b/Tests/Unit/Hook/SecretTcaHookTest.php
@@ -2040,6 +2040,7 @@ final class SecretTcaHookTest extends TestCase
                 if ($writeFailure instanceof Throwable) {
                     throw $writeFailure;
                 }
+
                 $calls[] = ['delete', $table, $identifier];
 
                 return 1;
@@ -2051,6 +2052,7 @@ final class SecretTcaHookTest extends TestCase
                 if ($writeFailure instanceof Throwable) {
                     throw $writeFailure;
                 }
+
                 $calls[] = ['insert', $table, $data];
 
                 return 1;
@@ -2062,6 +2064,7 @@ final class SecretTcaHookTest extends TestCase
                 if ($writeFailure instanceof Throwable) {
                     throw $writeFailure;
                 }
+
                 $calls[] = ['update', $table, $data, $identifier];
 
                 return 1;

--- a/Tests/Unit/Http/OAuth/OAuthTokenRequestParamsTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenRequestParamsTest.php
@@ -286,6 +286,7 @@ final class OAuthTokenRequestParamsTest extends TestCase
         );
 
         $params->wipeCredentials();
+
         $query = $params->toHttpQuery();
 
         $decoded = $this->decode($query);

--- a/Tests/Unit/Security/FrontendPlaceholderPolicyTest.php
+++ b/Tests/Unit/Security/FrontendPlaceholderPolicyTest.php
@@ -364,6 +364,7 @@ final class FrontendPlaceholderPolicyTest extends TestCase
         for ($i = 0; $i < 1100; ++$i) {
             $setup['key' . $i] = \sprintf('%%vault(id_%04d)%%', $i);
         }
+
         $cObj = $this->contentObjectRenderer($this->frontendRequest($setup));
 
         self::assertTrue($this->subject->isResolvable('id_0000', $cObj));

--- a/Tests/Unit/Service/Doctor/Check/MasterKeyProviderCheckTest.php
+++ b/Tests/Unit/Service/Doctor/Check/MasterKeyProviderCheckTest.php
@@ -47,6 +47,7 @@ final class MasterKeyProviderCheckTest extends TestCase
                 unlink($path);
             }
         }
+
         $this->keyFiles = [];
 
         parent::tearDown();
@@ -74,6 +75,7 @@ final class MasterKeyProviderCheckTest extends TestCase
                 \sprintf('%s should pass: %s', $finding->id, $finding->summary),
             );
         }
+
         self::assertSame(
             ['provider.configured', 'provider.known', 'provider.available', 'provider.master_key_readable'],
             $this->findingIds($findings),

--- a/Tests/Unit/Service/Doctor/DoctorReportTest.php
+++ b/Tests/Unit/Service/Doctor/DoctorReportTest.php
@@ -36,6 +36,7 @@ final class DoctorReportTest extends TestCase
         if ($worst === FindingSeverity::Warning) {
             $findings[] = Finding::warning('a.warn', 'meh', 'risk', 'fix');
         }
+
         if ($worst === FindingSeverity::Critical) {
             $findings[] = Finding::warning('a.warn', 'meh', 'risk', 'fix');
             $findings[] = Finding::critical('a.crit', 'broken', 'risk', 'fix');

--- a/Tests/Unit/Task/OrphanCleanupTaskTest.php
+++ b/Tests/Unit/Task/OrphanCleanupTaskTest.php
@@ -162,6 +162,7 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 7]);
+
         $result = $task->execute();
 
         self::assertTrue($result);
@@ -183,6 +184,7 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 7]);
+
         $result = $task->execute();
 
         self::assertTrue($result);
@@ -242,6 +244,7 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
+
         $result = $task->execute();
 
         self::assertFalse($result);
@@ -267,6 +270,7 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
+
         $result = $task->execute();
 
         self::assertTrue($result);
@@ -368,6 +372,7 @@ final class OrphanCleanupTaskTest extends TestCase
 
         $task = $this->createTask();
         $task->setTaskParameters(['nr_vault_retention_days' => 0]);
+
         $result = $task->execute();
 
         self::assertTrue($result);

--- a/Tests/Unit/Traits/EnvironmentSandboxTrait.php
+++ b/Tests/Unit/Traits/EnvironmentSandboxTrait.php
@@ -137,9 +137,11 @@ trait EnvironmentSandboxTrait
             if ($item === '.') {
                 continue;
             }
+
             if ($item === '..') {
                 continue;
             }
+
             $path = $directory . '/' . $item;
             if (is_dir($path)) {
                 $this->removeSandboxDirectory($path);

--- a/Tests/Unit/Utility/IdentifierValidatorTest.php
+++ b/Tests/Unit/Utility/IdentifierValidatorTest.php
@@ -227,6 +227,7 @@ final class IdentifierValidatorTest extends TestCase
         for ($i = 0; $i < 500; $i++) {
             $variants[] = IdentifierValidator::generateUuid()[19];
         }
+
         $variants = array_values(array_unique($variants));
         sort($variants);
 

--- a/Tests/scripts/check-cli-docs.php
+++ b/Tests/scripts/check-cli-docs.php
@@ -100,9 +100,11 @@ function commandClassFiles(string $commandDir): array
         if (!$file->isFile()) {
             continue;
         }
+
         if ($file->getExtension() !== 'php') {
             continue;
         }
+
         $paths[] = $file->getPathname();
     }
 
@@ -169,6 +171,7 @@ function parseCommandDefinitions(string $commandDir): array
         if (!preg_match('/#\[AsCommand\(\s*(?:name:\s*)?[\'"]([^\'"]+)[\'"]/', $contents, $nameMatch)) {
             continue;
         }
+
         $name = $nameMatch[1];
 
         $options = parseCommandOptions($contents);
@@ -269,6 +272,7 @@ $parseExample = static function (string $cmdLine): array {
         if ($tok === '') {
             continue;
         }
+
         if (str_starts_with($tok, '--')) {
             // Strip a value: --opt=value  OR  bare --opt.
             $opt = substr($tok, 2);
@@ -276,27 +280,33 @@ $parseExample = static function (string $cmdLine): array {
             if ($eq !== false) {
                 $opt = substr($opt, 0, $eq);
             }
+
             if ($opt !== '') {
                 $options[] = $opt;
             }
 
             continue;
         }
+
         if (str_starts_with($tok, '-') && strlen($tok) > 1) {
             // Short option (e.g. -r, -f) — not validated against long names here.
             continue;
         }
+
         // Synopsis grammar, not a real argument: [options], <identifier>,
         // [<arg>], [--], {a|b}. These describe the signature, they don't pass a value.
         if (preg_match('/^[\[<{].*[\]>}]$/', $tok)) {
             continue;
         }
+
         if ($tok === '[--]') {
             continue;
         }
+
         if ($tok === '--') {
             continue;
         }
+
         // A positional argument (placeholder or literal value).
         ++$positional;
     }
@@ -367,6 +377,7 @@ function parseDocumentedOptions(string $rst): array
             } else {
                 $inOptions = $title === 'Options';
             }
+
             $cursor += 2;
 
             continue;
@@ -377,9 +388,11 @@ function parseDocumentedOptions(string $rst): array
         if (!$inOptions) {
             continue;
         }
+
         if ($command === null) {
             continue;
         }
+
         if (preg_match('/^--\S/', $line) !== 1) {
             continue;
         }
@@ -571,6 +584,7 @@ function validateCommandOptionList(
         if (isset($seen[$name])) {
             $violations[] = "{$where} documents '--{$name}' twice (also on line {$seen[$name]})";
         }
+
         $seen[$name] = $lineNo;
 
         $mismatch = violationForSignatureMismatch($where, $term, $parsed, $real[$name]);
@@ -628,6 +642,7 @@ function validateDocumentedOptions(
         if ($terms === []) {
             continue;
         }
+
         $covered[] = $command;
 
         $result = validateCommandOptionList(
@@ -667,9 +682,11 @@ function validateOptionCoverage(array $commands, array $covered): array
         if ($definition['options'] === []) {
             continue;
         }
+
         if (in_array($command, $covered, true)) {
             continue;
         }
+
         $violations[] = sprintf(
             "no Options list documents '%s', which declares %d option(s): --%s",
             $command,
@@ -700,6 +717,7 @@ $docFiles = [];
 if (is_file($projectRoot . '/README.md')) {
     $docFiles['README.md'] = $projectRoot . '/README.md';
 }
+
 $docDir = $projectRoot . '/Documentation';
 if (is_dir($docDir)) {
     /** @var SplFileInfo $file */
@@ -707,12 +725,15 @@ if (is_dir($docDir)) {
         if (!$file->isFile()) {
             continue;
         }
+
         if (!in_array($file->getExtension(), ['rst', 'md'], true)) {
             continue;
         }
+
         $label = ltrim(str_replace($projectRoot, '', $file->getPathname()), '/');
         $docFiles[$label] = $file->getPathname();
     }
+
     ksort($docFiles);
 }
 
@@ -733,6 +754,7 @@ foreach ($docFiles as $label => $path) {
 
             continue;
         }
+
         ++$checked;
 
         $def = $commands[$command];
@@ -740,9 +762,11 @@ foreach ($docFiles as $label => $path) {
             if (isset($def['options'][$opt])) {
                 continue;
             }
+
             if (in_array($opt, $globalOptions, true)) {
                 continue;
             }
+
             $known = array_keys($def['options']);
             sort($known);
             $hint = $known === [] ? '(command has no options)' : '(have: --' . implode(', --', $known) . ')';
@@ -782,6 +806,7 @@ if ($violations !== []) {
     foreach ($violations as $v) {
         fwrite(STDERR, "  - {$v}\n");
     }
+
     fwrite(STDERR, "\nFix the documented example(s) and Options list(s) to match the command\n");
     fwrite(STDERR, "signature in Classes/Command/*Command.php, or update the command definition.\n");
     exit(1);

--- a/Tests/scripts/check-test-base-class.php
+++ b/Tests/scripts/check-test-base-class.php
@@ -57,9 +57,11 @@ if (is_file($allowListFile)) {
         if ($line === '') {
             continue;
         }
+
         if (str_starts_with($line, '#')) {
             continue;
         }
+
         $allowList[$line] = true;
     }
 }
@@ -78,17 +80,21 @@ foreach (new RecursiveIteratorIterator(new RecursiveDirectoryIterator($unitDir, 
     if (!$file->isFile()) {
         continue;
     }
+
     if ($file->getExtension() !== 'php') {
         continue;
     }
+
     // Skip the base class itself, traits, fixtures.
     $relative = ltrim(str_replace($projectRoot, '', $file->getPathname()), '/');
     if (str_ends_with($relative, 'Tests/Unit/TestCase.php')) {
         continue;
     }
+
     if (str_contains($relative, '/Traits/')) {
         continue;
     }
+
     if (str_contains($relative, '/Fixtures/')) {
         continue;
     }
@@ -169,6 +175,7 @@ if ($violations !== []) {
     foreach ($violations as $violation) {
         fwrite(STDERR, "  - {$violation}\n");
     }
+
     fwrite(STDERR, "\nHow to fix:\n");
     fwrite(STDERR, "  1. `extends UnitTestCase` -> `extends \\Netresearch\\NrVault\\Tests\\Unit\\TestCase`\n");
     fwrite(STDERR, "  2. Remove the now-unused `use TYPO3\\TestingFramework\\Core\\Unit\\UnitTestCase;`\n");
@@ -181,6 +188,7 @@ if ($staleAllowList !== []) {
     foreach ($staleAllowList as $entry) {
         fwrite(STDERR, "  - {$entry}\n");
     }
+
     fwrite(STDERR, "\nRegenerate with: php Tests/scripts/check-test-base-class.php --update-allowlist\n");
     $exitCode = 1;
 }

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     },
     "require-dev": {
         "mikey179/vfsstream": "^1.6",
-        "netresearch/typo3-ci-workflows": "^1.0",
+        "netresearch/typo3-ci-workflows": "^1.3",
         "roave/security-advisories": "dev-latest",
         "typo3/cms-dashboard": "^13.4 || ^14.3",
         "typo3/cms-scheduler": "^13.4 || ^14.3"

--- a/rector.php
+++ b/rector.php
@@ -8,44 +8,60 @@
 declare(strict_types=1);
 
 use Rector\Config\RectorConfig;
-use Rector\Set\ValueObject\SetList;
-use Rector\ValueObject\PhpVersion;
+use Rector\Privatization\Rector\Property\PrivatizeFinalClassPropertyRector;
 use Ssch\TYPO3Rector\Set\Typo3LevelSetList;
 use Ssch\TYPO3Rector\Set\Typo3SetList;
 
-return RectorConfig::configure()
-    ->withPaths([
-        __DIR__ . '/Classes',
-        __DIR__ . '/Tests',
-        __DIR__ . '/Configuration',
-    ])
-    ->withRootFiles()
-    ->withPhpVersion(PhpVersion::PHP_82)
-    ->withPhpSets(php82: true)
-    ->withSets([
-        // PHP code quality
-        SetList::CODE_QUALITY,
-        SetList::DEAD_CODE,
-        SetList::EARLY_RETURN,
-        SetList::TYPE_DECLARATION,
+$configure = require_once __DIR__ . '/.Build/vendor/netresearch/typo3-ci-workflows/config/rector/rector.php';
 
-        // TYPO3 specific
+return static function (RectorConfig $rectorConfig) use ($configure): void {
+    // Shared org base config: code-quality sets, rule skips, phpstan-rector.neon
+    $configure($rectorConfig, __DIR__);
+
+    // paths() replaces the shared list — re-declared to keep Tests/ in scope,
+    // which the shared $projectRoot default leaves out.
+    $rectorConfig->paths(array_merge(
+        [
+            __DIR__ . '/Classes',
+            __DIR__ . '/Configuration',
+            __DIR__ . '/Resources',
+            __DIR__ . '/Tests',
+        ],
+        glob(__DIR__ . '/ext_*.php') ?: [],
+    ));
+
+    $rectorConfig->sets([
         Typo3LevelSetList::UP_TO_TYPO3_13,
         Typo3SetList::CODE_QUALITY,
         Typo3SetList::GENERAL,
-    ])
-    ->withSkip([
-        // Skip vendor and build directories
-        __DIR__ . '/.Build',
+    ]);
+
+    $rectorConfig->skip([
         // Scheduler tasks use unserialize() - constructor injection breaks them
         __DIR__ . '/Classes/Task/OrphanCleanupTask.php',
         // Factory is called via GeneralUtility::makeInstance without constructor args
         __DIR__ . '/Classes/Http/SecureHttpClientFactory.php',
-        // ext_emconf.php is parsed by the TYPO3 Extension Repository (TER), whose
-        // parser is fragile and rejects many modern PHP constructs (declare(strict_types),
-        // namespaced types, etc.). The repo's CI lint check forbids strict_types in this
-        // file, so we exclude it from Rector entirely to be robust against any future
-        // rule that might also break the TER parser.
-        __DIR__ . '/ext_emconf.php',
-    ])
-    ->withImportNames(removeUnusedImports: true);
+        // The shared config enables SetList::PRIVATIZATION, whose
+        // PrivatizeFinalClassPropertyRector narrows protected properties in final
+        // classes to private. Two places here depend on the wider visibility and
+        // Rector cannot see either contract:
+        //
+        // Classes/Task: TYPO3 13.4 stores a scheduler task as a serialized object
+        // (tx_scheduler_task.serialized_task_object, restored by
+        // Scheduler\Task\TaskSerializer::deserialize()), and PHP encodes property
+        // visibility in the serialized key ("\0*\0prop" protected vs "\0FQCN\0prop"
+        // private). Narrowing therefore orphans the stored value in every existing
+        // task row: unserialize() leaves the typed property uninitialized and the
+        // next read fails with "must not be accessed before initialization".
+        //
+        // Tests: Tests/Unit/TestCase.php pulls in TcaSchemaMockTrait, whose
+        // mockTcaSchemaForTable() reads isset($this->tcaSchemaFactory) — a property
+        // each final test class declares itself. From the base-class scope a private
+        // child property is invisible, so isset() reports false and the helper
+        // throws (50 unit tests failed on exactly that).
+        PrivatizeFinalClassPropertyRector::class => [
+            __DIR__ . '/Classes/Task',
+            __DIR__ . '/Tests',
+        ],
+    ]);
+};


### PR DESCRIPTION
## Why

The repo's `rector.php` carried its own copy of the org rule baseline. That duplication is what made the Rector 2.6.0 release on 2026-08-03 a fleet-wide outage rather than a one-line fix: Rector removed `SetList::STRICT_BOOLEANS`, and every extension with a hand-rolled set list had to be repaired individually. [netresearch/typo3-ci-workflows](https://github.com/netresearch/typo3-ci-workflows) owns that baseline now — [v1.3.4](https://github.com/netresearch/typo3-ci-workflows/releases/tag/v1.3.4) contains the fix — so this config delegates to `config/rector/rector.php` and keeps only what is genuinely specific to `nr_vault`. Same conversion as [netresearch/t3x-nr-image-optimize#150](https://github.com/netresearch/t3x-nr-image-optimize/pull/150).

## What stays repo-specific

Preserved: the TYPO3 13 level set plus the TYPO3 `CODE_QUALITY` and `GENERAL` sets; `Tests/` in the scan paths, re-declared because the shared `$projectRoot` default omits it and `paths()` replaces rather than merges; and the existing `OrphanCleanupTask` and `SecureHttpClientFactory` skips with their original reasons. Dropped as redundant: the PHP sets, `phpVersion`, `importNames` and the `ext_emconf.php` skip — the shared config supplies all four.

## One new skip, and why it is not cleanup

The shared config also enables `SetList::PRIVATIZATION`, whose `PrivatizeFinalClassPropertyRector` narrows `protected` properties in `final` classes to `private`. Two places here depend on the wider visibility across a class boundary Rector cannot see, so the rule is skipped for `Classes/Task` and `Tests`.

`Classes/Task`: TYPO3 13.4 — which this extension still supports — restores a scheduler task by unserialising the whole object from `tx_scheduler_task.serialized_task_object` (`Scheduler\Task\TaskSerializer::deserialize()`). PHP encodes visibility in the mangled property key (`"\0*\0prop"` protected versus `"\0FQCN\0prop"` private), so narrowing `AuditVerifyTask::$tamperOnly` would orphan the stored value in every existing task row: `unserialize()` leaves the typed property uninitialised and the next read fails with "must not be accessed before initialization". This is the same reason already documented on the neighbouring `OrphanCleanupTask` skip.

`Tests`: `Tests/Unit/TestCase.php` pulls in `TcaSchemaMockTrait`, whose `mockTcaSchemaForTable()` reads `isset($this->tcaSchemaFactory)` — a property each `final` test class declares for itself. Read from the base-class scope a private child property is invisible, `isset()` reports `false` and the helper throws. This was not theory: the first run privatised it in two test classes and 50 unit tests failed.

## Rector's own changes

Included here, as they belong to the config change: 90 files, nearly all of it blank lines after statements, plus quote simplifications, `Registry::class` in place of a literal FQCN, and one getter-to-property rewrite in `GenericContext::jsonSerialize()` (`toArray()` returns `$this->data` verbatim, so the value is unchanged). All string literals were compared token-by-token before and after to confirm no quote conversion altered a value.

`Build/phpstan-baseline.neon` moves by two lines: one inserted blank line shifted an anonymous class from line 368 to 369, and two baseline entries name that class by line number. Renumbering them is exactly what regenerating the baseline produces.

## Verification

Run against a CI-matched toolchain — `platform.php` pinned to 8.2.33, `.Build` and `composer.lock` deleted and cold-installed, resolving `netresearch/typo3-ci-workflows` v1.3.4 and Rector 2.6.1; the pin was removed again before committing and no lock file is committed. `rector process --dry-run` reaches exit 0 (fixpoint after one apply pass), `php-cs-fixer` finds 0 of 490 files to fix, `phpstan analyse` reports no errors, the architecture check passes, and the unit suite is green at 3592 tests / 12406 assertions. PHPStan was also run against unmodified `main` with the identical toolchain to confirm the clean result is not an artefact of this branch.

No version bump and no CHANGELOG entry: that belongs to the release flow.
