### PR TITLE
Add the blank line the shared rector config requires after the cleanup loop

### DIFF
--- a/Tests/Functional/Crypto/MasterKeyRotationTest.php
+++ b/Tests/Functional/Crypto/MasterKeyRotationTest.php
@@ -575,6 +575,7 @@ final class MasterKeyRotationTest extends FunctionalTestCase
         foreach ([$activeIdentifier, $disabledIdentifier] as $identifier) {
             $vaultService->delete($identifier, self::REASON_TEST_CLEANUP);
         }
+
         if (file_exists($newKeyPath)) {
             // nosemgrep: php.lang.security.unlink-use.unlink-use - test-owned path
             unlink($newKeyPath);


### PR DESCRIPTION
`ci / Rector` went red on `main` after #287 merged: the branch was rebased and merged in parallel with #288, which adopted the shared org rector config including `NewlineAfterStatementRector` — the branch's own green Rector run predated that config. One blank line in `MasterKeyRotationTest::rotationReWrapsDisabledSecretsSoTheyDecryptAfterReEnabling()`.

Local verification: `composer ci:test:php:rector` → "[OK] Rector is done!", cgl 0 findings.