### PR TITLE
docs(agents): test-runner rule, pre-push gate gotchas, audit-log invariants

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,8 @@
 | All CI | `make ci` | cgl + phpstan + unit + fuzz (no lint/rector/functional) |
 | Docs render | `make docs` | |
 
+**Test execution ALWAYS goes through `Build/Scripts/runTests.sh`** (or the `composer test:*` scripts that wrap it) — the TYPO3 core-style containerized runner with its own ephemeral containers. NEVER run tests inside DDEV (`ddev exec phpunit`, DDEV-prefixed make targets); DDEV is the dev *environment*, not the test runner.
+
 Direct composer (without make):
 - `composer ci` — unit + fuzz + phpstan + cgl
 - `composer ci:test:php:functional` — functional suite
@@ -89,6 +91,20 @@ Build/           → phpunit.xml, FunctionalTests.xml
 | Running locally | `make up` then `make shell` |
 | Committing | Subject-style enforced by `captainhook.json`: capitalized, imperative mood, length-limited, no trailing period (NOT lowercase `feat:`/`fix:` prefixes). Sign off with `git commit -s`. See CONTRIBUTING.md |
 | Merging PRs | Merge commit (not squash, not rebase) — preserves GPG signatures |
+
+## Pre-push gate gotchas (cost real CI round-trips)
+
+- **php-cs-fixer's cache masks violations**: a cached-clean file reports `files:[]` locally while fresh-checkout CI fails Code Style. Pre-push check with `--using-cache=no`; CI's fixer version may also be newer than local.
+- **`no_unused_imports` strips an import added before its first usage** (import in one edit, usage in a later one, fixer run between) — CI then dies with `Class … not found`. After appending test methods, re-check their imports.
+- **Cross-worktree Rector/fixer runs produce false positives**: `main`'s `.Build/bin/rector` resolves classes via main's autoloader, not the branch's — signature changes misfire `RemoveExtraParametersRector`, and rules needing a new interface method fire only in CI. Judge each finding: real, or cross-worktree artifact?
+- **`RemoveDefaultArgumentValueRector` strips load-bearing trailing args** that equal the default (`verifyHashChain(null, null, 0)` → `verifyHashChain()`); keep them with a named argument (`verifyHashChain(minEpoch: 0)`), which the rule leaves alone.
+- **Opengrep vs Rector on `unlink`**: Rector's first-class-callable rewrite turns cleanup loops into `array_map(unlink(...), …)`, which Opengrep flags. Sidestep both — use `GeneralUtility::rmdir($path, true)` for tempdir cleanup.
+
+## Audit log invariants
+
+- `crdate` is bound into the entry hash and `log()` hardcodes `time()` — you cannot `log()` then `UPDATE crdate` without breaking `verifyHashChain()`. Backdated/historic rows require chain reconstruction in time order via the public static hashing API (`calculateHash()`/`calculateHashV2()`/`extractHashRow()`/`deriveHmacKey()`), mirroring `insertAndUpdateHash`; never delete rows (uid gaps are detected).
+- Audit retention (`getAuditLogRetention()`, default 365d) is configured but has **zero consumers** — nothing purges audit rows; `OrphanCleanupTask` touches only orphaned secrets. Audit-derived metrics are safe for windows ≤365d.
+- `actor_type` separates manual reveals (`backend`) from automated (`cli`/`api`/`scheduler`); `AuditLogFilter` cannot filter on it — query the table directly.
 
 ## Security Requirements
 This extension handles sensitive data. Non-negotiable rules:


### PR DESCRIPTION
## What

Three promoted learning groups (`/retro promote`, batch 4) into `AGENTS.md`:

- **Test runner rule, stated explicitly**: tests always go through `Build/Scripts/runTests.sh` (or the `composer test:*` wrappers) — never inside DDEV. The Commands table listed DDEV as env starter next to test targets without saying this, and the confusion caused repeated corrections.
- **Pre-push gate gotchas** from the 2026-07-23 six-PR sweep: cs-fixer cache masking (`--using-cache=no`), the `no_unused_imports` strip trap, cross-worktree Rector false positives, `RemoveDefaultArgumentValueRector` vs load-bearing defaults (named-arg fix), and the Opengrep-vs-Rector `unlink` conflict (`GeneralUtility::rmdir`).
- **Audit log invariants**: `crdate` is hash-bound with no clock seam (backdating = chain reconstruction via the public static hashing API, never row deletion), retention is configured but unenforced (zero consumers), `actor_type` is not filterable via `AuditLogFilter`.

Came from /retro: yes
