### PR TITLE
Let vault:store write as a configured provisioning actor

### DIFF
--- a/Classes/Command/VaultStoreCommand.php
+++ b/Classes/Command/VaultStoreCommand.php
@@ -9,7 +9,10 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Command;
 
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
+use Netresearch\NrVault\Exception\TechnicalActorException;
 use Netresearch\NrVault\Exception\VaultException;
+use Netresearch\NrVault\Security\TechnicalActorContextInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -30,6 +33,8 @@ final class VaultStoreCommand extends Command
 {
     public function __construct(
         private readonly VaultServiceInterface $vaultService,
+        private readonly ExtensionConfigurationInterface $configuration,
+        private readonly TechnicalActorContextInterface $technicalActorContext,
     ) {
         parent::__construct();
     }
@@ -71,6 +76,14 @@ final class VaultStoreCommand extends Command
                 'g',
                 InputOption::VALUE_REQUIRED | InputOption::VALUE_IS_ARRAY,
                 'Backend user group IDs that can access this secret',
+            )
+            ->addOption(
+                'as-provisioner',
+                null,
+                InputOption::VALUE_NONE,
+                'Write as the configured provisioning backend user (nr_vault option '
+                . '"provisioningBeUserUid") instead of the unattributed CLI actor. The UID '
+                . 'comes from configuration, never from this command line.',
             );
     }
 
@@ -102,15 +115,40 @@ final class VaultStoreCommand extends Command
             );
         }
 
+        $asProvisioner = $input->getOption('as-provisioner') !== false;
+        $provisionerUid = $this->configuration->getProvisioningBeUserUid();
+
+        if ($asProvisioner && $provisionerUid === 0) {
+            sodium_memzero($value);
+            $io->error(
+                'No provisioning actor is configured. Set the nr_vault option '
+                . '"provisioningBeUserUid" to a backend user whose group carries the '
+                . 'tx_nrvault:secret.create permission option.',
+            );
+
+            return Command::FAILURE;
+        }
+
         try {
-            $this->vaultService->store($identifier, $value, $metadata);
+            if ($asProvisioner) {
+                $this->technicalActorContext->runAs(
+                    $provisionerUid,
+                    function () use ($identifier, $value, $metadata): void {
+                        $this->vaultService->store($identifier, $value, $metadata);
+                    },
+                );
+            } else {
+                $this->vaultService->store($identifier, $value, $metadata);
+            }
+
             $io->success(\sprintf('Secret "%s" stored successfully', $identifier));
 
             // Clear the value from memory
             sodium_memzero($value);
 
             return Command::SUCCESS;
-        } catch (VaultException $e) {
+        } catch (VaultException|TechnicalActorException $e) {
+            sodium_memzero($value);
             $io->error($e->getMessage());
 
             return Command::FAILURE;

--- a/Classes/Command/VaultStoreCommand.php
+++ b/Classes/Command/VaultStoreCommand.php
@@ -131,9 +131,14 @@ final class VaultStoreCommand extends Command
 
         try {
             if ($asProvisioner) {
+                // $value by REFERENCE: capturing it by value gives the closure
+                // its own copy of the plaintext, and sodium_memzero() below
+                // separates the copy-on-write pair instead of wiping both — the
+                // secret would survive in memory in the copy the command
+                // believes it has cleared.
                 $this->technicalActorContext->runAs(
                     $provisionerUid,
-                    function () use ($identifier, $value, $metadata): void {
+                    function () use ($identifier, &$value, $metadata): void {
                         $this->vaultService->store($identifier, $value, $metadata);
                     },
                 );

--- a/Classes/Configuration/ExtensionConfiguration.php
+++ b/Classes/Configuration/ExtensionConfiguration.php
@@ -204,6 +204,27 @@ final class ExtensionConfiguration implements ExtensionConfigurationInterface, S
     }
 
     /**
+     * UID of the technical backend user `vault:store --as-provisioner` acts as.
+     *
+     * Fail-closed on anything that is not a positive integer: a stray string or
+     * a negative value must read as "no provisioning actor", never as uid 0,
+     * which TYPO3 treats as the unauthenticated CLI placeholder — the very
+     * actor this option exists to avoid.
+     *
+     * @return int<0, max>
+     */
+    public function getProvisioningBeUserUid(): int
+    {
+        $raw = $this->configuration['provisioningBeUserUid'] ?? 0;
+
+        if (!is_numeric($raw)) {
+            return 0;
+        }
+
+        return max(0, (int) $raw);
+    }
+
+    /**
      * Get backend groups that can access secrets via CLI.
      *
      * @return int[]

--- a/Classes/Configuration/ExtensionConfigurationInterface.php
+++ b/Classes/Configuration/ExtensionConfigurationInterface.php
@@ -70,6 +70,24 @@ interface ExtensionConfigurationInterface
     public function getCliAllowedOperations(): array;
 
     /**
+     * UID of the technical backend user that `vault:store --as-provisioner`
+     * enters via {@see TechnicalActorContextInterface::runAs()}.
+     *
+     * The alternative for an unattended deployment is `allowCliAccess`, which
+     * grants the operation to every process holding a shell in that container.
+     * A named actor narrows it to one identity that needs no admin flag —
+     * a group carrying `tx_nrvault:secret.create` is enough — and makes every
+     * write attributable in the audit log.
+     *
+     * Deliberately read from configuration rather than accepted as a command
+     * argument: a flag taking a UID would be a general impersonation
+     * primitive, strictly worse than the switch it replaces.
+     *
+     * @return int<0, max> 0 when no provisioning actor is configured
+     */
+    public function getProvisioningBeUserUid(): int;
+
+    /**
      * Check if read operations should be written to the audit log.
      */
     public function isAuditReadsEnabled(): bool;

--- a/Tests/Unit/Command/VaultStoreCommandTest.php
+++ b/Tests/Unit/Command/VaultStoreCommandTest.php
@@ -10,8 +10,10 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Command;
 
 use Netresearch\NrVault\Command\VaultStoreCommand;
+use Netresearch\NrVault\Configuration\ExtensionConfigurationInterface;
 use Netresearch\NrVault\Exception\ValidationException;
 use Netresearch\NrVault\Exception\VaultException;
+use Netresearch\NrVault\Security\TechnicalActorContextInterface;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Netresearch\NrVault\Tests\Unit\TestCase;
 use org\bovigo\vfs\vfsStream;
@@ -28,6 +30,10 @@ final class VaultStoreCommandTest extends TestCase
 {
     private VaultServiceInterface&MockObject $vaultService;
 
+    private ExtensionConfigurationInterface&MockObject $configuration;
+
+    private TechnicalActorContextInterface&MockObject $technicalActorContext;
+
     private CommandTester $commandTester;
 
     protected function setUp(): void
@@ -35,8 +41,10 @@ final class VaultStoreCommandTest extends TestCase
         parent::setUp();
 
         $this->vaultService = $this->createMock(VaultServiceInterface::class);
+        $this->configuration = $this->createMock(ExtensionConfigurationInterface::class);
+        $this->technicalActorContext = $this->createMock(TechnicalActorContextInterface::class);
 
-        $command = new VaultStoreCommand($this->vaultService);
+        $command = $this->createCommand();
 
         $application = new Application();
         $application->addCommand($command);
@@ -47,9 +55,77 @@ final class VaultStoreCommandTest extends TestCase
     #[Test]
     public function hasCorrectName(): void
     {
-        $command = new VaultStoreCommand($this->vaultService);
+        self::assertSame('vault:store', $this->createCommand()->getName());
+    }
 
-        self::assertSame('vault:store', $command->getName());
+    /**
+     * Without the flag nothing changes: no actor scope is entered, and the
+     * configured UID is irrelevant. Guards against the option silently
+     * re-attributing an interactive operator's write.
+     */
+    #[Test]
+    public function storesAsTheCallingActorWhenTheFlagIsAbsent(): void
+    {
+        $this->configuration->method('getProvisioningBeUserUid')->willReturn(991);
+        $this->technicalActorContext->expects($this->never())->method('runAs');
+        $this->vaultService->expects($this->once())->method('store');
+
+        $exitCode = $this->commandTester->execute([
+            'identifier' => 'openai_api_key',
+            '--value' => 'secret-value',
+        ]);
+
+        self::assertSame(0, $exitCode);
+    }
+
+    #[Test]
+    public function storesInsideTheConfiguredActorScopeWithTheFlag(): void
+    {
+        $this->configuration->method('getProvisioningBeUserUid')->willReturn(991);
+
+        $ranInsideScope = false;
+        $this->technicalActorContext
+            ->expects($this->once())
+            ->method('runAs')
+            ->with(991, self::isCallable())
+            ->willReturnCallback(static function (int $uid, callable $fn) use (&$ranInsideScope): mixed {
+                $ranInsideScope = true;
+
+                return $fn();
+            });
+
+        $this->vaultService->expects($this->once())->method('store');
+
+        $exitCode = $this->commandTester->execute([
+            'identifier' => 'openai_api_key',
+            '--value' => 'secret-value',
+            '--as-provisioner' => true,
+        ]);
+
+        self::assertSame(0, $exitCode);
+        self::assertTrue($ranInsideScope, 'store() ran outside the technical actor scope.');
+    }
+
+    /**
+     * Fail closed. Writing as the unattributed CLI actor because no provisioning
+     * user is configured would silently deliver the opposite of what the flag
+     * asks for — an unattributed write where an attributed one was requested.
+     */
+    #[Test]
+    public function refusesTheFlagWhenNoProvisioningActorIsConfigured(): void
+    {
+        $this->configuration->method('getProvisioningBeUserUid')->willReturn(0);
+        $this->technicalActorContext->expects($this->never())->method('runAs');
+        $this->vaultService->expects($this->never())->method('store');
+
+        $exitCode = $this->commandTester->execute([
+            'identifier' => 'openai_api_key',
+            '--value' => 'secret-value',
+            '--as-provisioner' => true,
+        ]);
+
+        self::assertSame(1, $exitCode);
+        self::assertStringContainsString('provisioningBeUserUid', $this->commandTester->getDisplay());
     }
 
     #[Test]
@@ -282,5 +358,14 @@ final class VaultStoreCommandTest extends TestCase
         ]);
 
         self::assertSame(0, $exitCode);
+    }
+
+    private function createCommand(): VaultStoreCommand
+    {
+        return new VaultStoreCommand(
+            $this->vaultService,
+            $this->configuration,
+            $this->technicalActorContext,
+        );
     }
 }

--- a/Tests/Unit/Configuration/ExtensionConfigurationTest.php
+++ b/Tests/Unit/Configuration/ExtensionConfigurationTest.php
@@ -157,6 +157,50 @@ final class ExtensionConfigurationTest extends TestCase
         self::assertFalse($config->isCliAccessAllowed());
     }
 
+    /**
+     * Every non-usable value must read as "no provisioning actor". Anything that
+     * fell through to a numeric 0 would name the unauthenticated CLI placeholder
+     * TYPO3 puts in $GLOBALS['BE_USER'] — the actor this option exists to avoid —
+     * so the failure mode of a typo has to be "off", never "unattributed".
+     *
+     * @param mixed $configured the raw provisioningBeUserUid value
+     */
+    #[DataProvider('provisioningUidProvider')]
+    #[Test]
+    public function getProvisioningBeUserUidFailsClosed(mixed $configured, int $expected): void
+    {
+        $this->typo3Config->method('get')->willReturn(['provisioningBeUserUid' => $configured]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame($expected, $config->getProvisioningBeUserUid());
+    }
+
+    /**
+     * @return iterable<string, array{mixed, int}>
+     */
+    public static function provisioningUidProvider(): iterable
+    {
+        yield 'configured uid' => [991, 991];
+        yield 'numeric string' => ['991', 991];
+        yield 'explicitly off' => [0, 0];
+        yield 'negative' => [-5, 0];
+        yield 'non-numeric' => ['admin', 0];
+        yield 'empty string' => ['', 0];
+        yield 'array' => [[991], 0];
+        yield 'null' => [null, 0];
+    }
+
+    #[Test]
+    public function getProvisioningBeUserUidIsOffWhenUnset(): void
+    {
+        $this->typo3Config->method('get')->willReturn([]);
+
+        $config = new ExtensionConfiguration($this->typo3Config);
+
+        self::assertSame(0, $config->getProvisioningBeUserUid());
+    }
+
     #[Test]
     public function getCliAccessGroupsParsesCommaString(): void
     {

--- a/ext_conf_template.txt
+++ b/ext_conf_template.txt
@@ -42,6 +42,9 @@ cliAccessGroups =
 # cat=Security; type=string; label=CLI Allowed Operations: Comma-separated operation permissions the unattributed CLI actor may hold when "allowCliAccess" is on. High-risk operations (secret.reveal, secret.delete, secret.manage_policy, audit.view, audit.export, master_key.rotate, vault.configure) are excluded by default - add them explicitly only where the deployment genuinely needs them, or prefer a named technical actor (TechnicalActorContext::runAs()).
 cliAllowedOperations = secret.use,secret.create,secret.rotate
 
+# cat=Security; type=int+; label=Provisioning Backend User: UID of the technical backend user that "vault:store --as-provisioner" acts as. Lets an unattended deployment write a secret without switching on the unattributed CLI actor: the user needs no admin flag, only a group carrying the tx_nrvault:secret.create (and secret.rotate) permission option, so the grant is exactly one operation on one identity and every write is attributed to it in the audit log. The UID is read from here and never from the command line - a flag that took it as an argument would be an impersonation primitive for anyone with a shell. 0 disables the option.
+provisioningBeUserUid = 0
+
 # cat=Security; type=int+; label=Audit Log Retention (days): Number of days to keep audit log entries (0 = forever)
 auditLogRetention = 365
 


### PR DESCRIPTION
An unattended deployment that needs to put a secret into the vault has exactly one option today: switch on `allowCliAccess`. That grants the operation to every process holding a shell in the container and attributes the write to nobody.

`ext_conf_template.txt` already names the better answer — *"prefer a named technical actor (TechnicalActorContext::runAs())"* — but no command could enter such a scope, so the advice had nothing behind it.

## What changes

`vault:store --as-provisioner` runs the store inside `runAs(provisioningBeUserUid)`.

The actor needs **no admin flag**. `hasTechnicalActorGrant()` falls through to the actor's groups, so a group carrying the `tx_nrvault:secret.create` permission option is enough. The grant is one operation on one named identity, and every write it makes is attributable in the audit log — as opposed to the unattributed CLI actor, whose grant covers `secret.use,secret.create,secret.rotate` for anyone who can reach a shell.

**The UID comes from configuration, never from the command line.** A flag that accepted a UID as an argument would be a general impersonation primitive, strictly worse than the switch it replaces. That constraint is the reason the option looks the way it does, and it is written into the docblock so a later "why not just pass it?" has an answer.

## Fail-closed at both ends

`getProvisioningBeUserUid()` maps anything non-numeric, negative or absent to `0`. That matters more than it looks: a value that fell through to a numeric `0` would name the unauthenticated CLI placeholder TYPO3 puts in `$GLOBALS['BE_USER']` — precisely the actor this option exists to avoid. The failure mode of a typo has to be *off*, never *unattributed*.

The flag without a configured actor is an error, not a fallback. Writing as the unattributed CLI actor because no provisioning user is configured would deliver the opposite of what the caller asked for.

## Verification

| Check | Result |
|---|---|
| unit suite | 3604 tests, 12429 assertions, no failures |
| `phpstan` | No errors |
| `cgl -n` | SUCCESS |
| defect injection | replacing the `runAs` branch with a direct store fails `storesInsideTheConfiguredActorScopeWithTheFlag` with *"store() ran outside the technical actor scope"* |

The injection run is the load-bearing one — it shows the test detects this defect at the place it guards, rather than the suite merely being green.

Coverage: flag absent (no scope entered, so an interactive operator's write is never silently re-attributed), flag present (scope entered with the configured UID, store runs inside it), flag without configuration (refused), and the eight UID-parsing cases.

Found while making the TYPO3 demo instance provision its OpenAI key reproducibly.