### PR TITLE
fix(build): actually exclude .Build from the lint suite

### DIFF
--- a/Build/Scripts/runTests.sh
+++ b/Build/Scripts/runTests.sh
@@ -669,7 +669,13 @@ case ${TEST_SUITE} in
         SUITE_EXIT_CODE=$?
         ;;
     lint)
-        COMMAND="find . -name \\*.php ! -path \"./.Build/\\*\" -print0 | xargs -0 -n1 -P\$(nproc) php ${PHP_OPCACHE_OPTS} -dxdebug.mode=off -l >/dev/null"
+        # -prune rather than a `! -path` filter: the old exclusion was written
+        # `! -path "./.Build/\*"`, and the escaped star survives the double
+        # quotes, so find looked for a literal `*` and never matched. .Build was
+        # linted too and the suite died on class-alias-loader's
+        # alias-loader-include.tmpl.php, a template that is deliberately not
+        # valid PHP. Pruning also skips walking the vendor tree.
+        COMMAND="find . -path ./.Build -prune -o -name '*.php' -print0 | xargs -0 -n1 -P\$(nproc) php ${PHP_OPCACHE_OPTS} -dxdebug.mode=off -l >/dev/null"
         ${CONTAINER_BIN} run ${CONTAINER_COMMON_PARAMS} --name lint-${SUFFIX} -e COMPOSER_CACHE_DIR=.Build/.cache/composer -e COMPOSER_ROOT_VERSION=${COMPOSER_ROOT_VERSION} ${IMAGE_PHP} /bin/sh -c "${COMMAND}"
         SUITE_EXIT_CODE=$?
         ;;


### PR DESCRIPTION
`runTests.sh -s lint` cannot pass on a checkout that has dependencies installed.

## Cause

```sh
find . -name \*.php ! -path "./.Build/\*" -print0
```

Inside the double quotes the escaped star survives, so `find` looks for a path containing a literal `*`. Nothing matches, `.Build` is never excluded, and all 14715 PHP files under it are linted — where the run aborts on `typo3/class-alias-loader/res/php/alias-loader-include.tmpl.php`, a template that is deliberately not valid PHP.

## Change

`-prune` instead of the negative `-path` filter. Besides working, it skips walking the vendor tree rather than walking it and throwing the results away.

## Verification

Both expressions run against this checkout's actual `.Build`:

| expression | exit | output |
|---|---|---|
| old | 124 | `xargs: php: exited with status 255; aborting` |
| new | **0** | none |

Exit 124 is xargs' documented code for a child exiting 255 — the parse error — not a timeout.

The exclusion was also counter-checked in a scratch directory (netresearch/nr-landingpage#24, same change): an invalid file in the extension's own source is still reported, so the prune is not too broad.

## Not just here

`netresearch/nr-landingpage` (#20, PR #24) and `netresearch/t3x-nr-mcp-agent` (PR #109) carry the same line. Worth fixing at the template source if there is one.
