### PR TITLE
fix(tests): narrow substNEWwithIDs annotation to string keys

### DIFF
--- a/Tests/Unit/Hook/FlexFormVaultHookTest.php
+++ b/Tests/Unit/Hook/FlexFormVaultHookTest.php
@@ -1462,7 +1462,7 @@ final class FlexFormVaultHookTest extends TestCase
     /**
      * Kill CastInt + Coalesce mutations on the substNEWwithIDs lookup.
      *
-     * @return iterable<string, array{string, string|int, array<string|int, int>, int}>
+     * @return iterable<string, array{string, string|int, array<string, int>, int}>
      */
     public static function newRecordUidResolutionProvider(): iterable
     {
@@ -1474,7 +1474,7 @@ final class FlexFormVaultHookTest extends TestCase
     }
 
     /**
-     * @param array<string|int, int> $substMap
+     * @param array<string, int> $substMap
      */
     #[Test]
     #[DataProvider('newRecordUidResolutionProvider')]


### PR DESCRIPTION
TYPO3 14.3.6 narrowed `DataHandler::$substNEWwithIDs` to `array<string, int>`. The test declared `array<string|int, int>`, so PHPStan rejects the assignment on all four `^14.3` legs. `main` is red for this reason since 14.3.6 was released on 2026-08-11 — the last green `ci` run on `main` is from 2026-08-10.

The data provider yields only string keys (`NEW123`, `NEW777`), so the narrower annotation describes what the test already does. No behaviour change.

## Evidence

Controlled before/after on the same tree, TYPO3 v14.3.6, `Build/phpstan.no-plugins.neon`:

| | PHPStan |
|---|---|
| without the change | `Found 1 error` — FlexFormVaultHookTest.php:1487, the exact CI message |
| with the change | `No errors` |

`runTests.sh -s unit -p 8.4`: OK (3604 tests, 12429 assertions).
`runTests.sh -s cgl -n -p 8.4`: SUCCESS.

## Tests

No new test — the change is a type annotation on an existing test whose assertions are unchanged.

Unblocks #300.