### PR TITLE
Add a cancellable secure outbound send

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,137 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **A cancellable secure outbound send** (#302). `VaultHttpClient` now also
+  implements `CancellableHttpClientInterface`, whose `sendCancellable($request,
+  $signal)` polls a caller-supplied `CancellationSignalInterface` and tears the
+  socket down when it turns true. Until now a consumer whose own work was
+  cancelled still waited out the timeout — up to about 45 seconds for the caller
+  that asked for this
+  ([netresearch/t3x-nr-llm#774](https://github.com/netresearch/t3x-nr-llm/issues/774))
+  — because PSR-18 returns a response and never a handle, and because Guzzle's
+  synchronous branch settles its promise before it exists, which makes
+  `cancel()` a no-op there.
+
+  The new interface is separate from `VaultHttpClientInterface` and purely
+  additive, so consumers feature-detect (`$client instanceof
+  CancellableHttpClientInterface && $client->supportsCancellation()`) instead of
+  raising a version floor. Nothing existing changes shape.
+
+  The invariant is that **nothing hands a caller a client that already carries a
+  vault secret**, and `VaultHttpClient` is the only place nr-vault attaches a
+  secret to a *caller's* request. No send a caller can drive puts a vault secret
+  on the wire without the four protections that are statements in the sending
+  method rather than middleware — the scheme allowlist, the host allowlist, the
+  credential injection and the audit write. (nr-vault sends two credentials of
+  its own elsewhere, on paths that are not a caller's request: the transit
+  master-key provider's `X-Vault-Token` header and the OAuth token leg's
+  `client_secret`. Both are listed in ADR-037.) Every public method of
+  `VaultHttpClient` returns a configured clone, a PSR-7 response or a bool — no
+  client, no handler, no promise — and `sendCancellable()` accepts no
+  per-request option surface (a caller-supplied `stream => true` or `curl` array
+  would silently drop the `CURLOPT_RESOLVE` DNS pin). Both are asserted by
+  `VaultHttpClientCancellableTest::theCredentialBearingClientExportsNoTransportAndNoPromise()`.
+  Building a hardened transport *without* vault
+  credentials stays a supported public case: `SecureHttpClientFactory::create()`
+  and the new `createCancellable()` return one, carrying the SSRF middleware and
+  the DNS pin and nothing else.
+
+  A PSR-18 client injected into `VaultHttpClient`'s constructor is never replaced
+  by a cancellable transport — it may carry that caller's own middleware or
+  proxy. `supportsCancellation()` reports false for such an instance and the call
+  completes blocking on their client. The one exception is `withTimeout()`, which
+  has to bake the override into a client and therefore rebuilds one from the
+  factory; the clone it returns reports `supportsCancellation()` true
+  (`anInjectedGuzzleClientIsNeverSwappedForACancellableTransport()`,
+  `withTimeoutRebuildsACallerSuppliedClientAndTurnsCancellationOn()`). A client
+  obtained from `VaultServiceInterface::http()` supports cancellation wherever
+  `curl_multi_*` is available, and degrades to a blocking send where it is not —
+  feature-detect with `supportsCancellation()` rather than assuming either.
+
+  `allow_redirects => false` is re-pinned per request on the async path. Guzzle
+  pins it for every PSR-18 send but sets nothing on an async one, so on an
+  install that configured
+  `$GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects']` this path alone would
+  have started following redirects — past a DNS pin computed for the original
+  host.
+
+  The timeout stays authoritative: a transport this client builds carries the
+  same deadline as its blocking client, so cancellation is an early exit and
+  never an extension
+  (`VaultHttpClientCancellableTest::theTransportTheClientResolvesForItselfCarriesTheRememberedTimeout()`).
+
+- **Two new audit actions for abandoned calls**, each meaning exactly one thing.
+  Every call leaves exactly one row from this client — `sendCancellable()` and
+  `sendRequest()` alike — so the log is complete with respect to *calls* and not
+  merely with respect to egress: a call that was already cancelled when it began
+  gets a row too. ADR-037 maps every outcome to the test that asserts its row.
+
+  `http_call_cancelled` (badge: `warning`) is written **only** when the
+  cancellation signal stopped an in-flight request, i.e. after the credential was
+  retrieved, injected and handed to the transport. Because it means nothing else,
+  "which calls were abandoned after their credential went out?" is a query on one
+  action value, with no message parsing
+  (`theTwoCancellationOutcomesAreToldApartByTheirAction()`). It is a separate action rather than a
+  failed `http_call` because status `0` there already means both "connection
+  refused" and "SSRF middleware rejected".
+
+  `http_call_cancelled_before_send` (badge: `info`) is written when the signal
+  was already set on entry: no secret was read and nothing egressed. Its own
+  action rather than a distinguishing message, so an auditor can *exclude* those
+  rows by query.
+
+  Everything that failed rather than was cancelled stays `http_call` with
+  `success = false` — a transport that could not be built, a transport error, the
+  defensive wall-clock bound, a settlement that is not an HTTP response, and a
+  throw from the caller's signal or the ticker. Nobody asked for those; filing them under the cancellation
+  action would put a second meaning back on it. The fixed-literal `error_message`
+  rendered under the badge identifies the situation within an action.
+
+  The audit write for a cancellable transfer happens in a `finally` that opens on
+  the first statement after the credential was injected: Guzzle's option handling
+  inside `sendAsync()`, the caller's signal and the ticker can all throw, and
+  none of them may be the one outbound call that leaves no trace.
+
+### Fixed
+
+- **A refused scheme, a host outside `allowed_hosts`, and a credential that
+  could not be obtained left no audit row.** All three are thrown by
+  `VaultHttpClient` before the send, and all three used to escape without a
+  trace — on `sendRequest()` as much as on the new cancellable path. They are
+  exactly the calls an operator goes looking for: somebody tried `file://`, or a
+  host nobody approved. Each now writes one `http_call` row with
+  `success = false`, status `0`, the attempted method/host/path, and a fixed
+  literal saying which gate refused it (`Request refused before any secret was
+  read: …`, `Credential injection failed; nothing was sent: …`). No new audit
+  action: that tuple already means "a refused outbound call" here — the SSRF
+  middleware rejection lands in it too.
+
+  The exceptions are unchanged, byte for byte: same class, same code, same
+  message, pinned by characterization tests written before the rows existed. A
+  consumer that catches `VaultException` sees no difference.
+
+- **A blocking send that threw something other than a PSR-18
+  `ClientExceptionInterface` left no audit row.** `Client::applyOptions()` raises
+  `InvalidArgumentException` outside `Client::transfer()`'s try/catch on the
+  synchronous path as well, so a bad option set escaped `VaultHttpClient`'s
+  catch — credential already injected, nothing in the log. The send-and-audit
+  helper now writes its row from a `finally`, which covers plain `sendRequest()`
+  and the degraded branch of `sendCancellable()` alike, under `http_call` with
+  the fixed literal `Blocking send aborted by an unexpected error after the
+  credential was injected: …`. Success and transport-failure rows are unchanged.
+
+### Changed
+
+- **`guzzlehttp/guzzle` is now a declared direct dependency** (`^7.10`).
+  Production code already imported `GuzzleHttp\Client`, `HandlerStack` and
+  `RequestException` while the manifest named only the PSR interfaces and relied
+  on `typo3/cms-core` to pull Guzzle in transitively. The cancellable transport
+  reaches deeper still — `CurlMultiHandler`, `Proxy`, `StreamHandler`, promise
+  cancel semantics — and a Guzzle major arriving through a third path would
+  break it with no warning in our own manifest.
+
 ## [0.15.0] - 2026-08-10
 
 One feature, aimed at a gap that only shows up in unattended deployments: there

--- a/Classes/Audit/AuditAction.php
+++ b/Classes/Audit/AuditAction.php
@@ -32,6 +32,50 @@ enum AuditAction: string
     case MetadataUpdate = 'metadata_update';
     case AccessDenied = 'access_denied';
     case HttpCall = 'http_call';
+    /**
+     * The cancellation signal stopped an IN-FLIGHT request — written by
+     * `VaultHttpClient::sendCancellable()` only, and by nothing else.
+     *
+     * This action means exactly one thing: the credential was retrieved,
+     * injected into the request and handed to the transport, and then the
+     * caller's signal turned true and the transfer was torn down. Treat the
+     * credential as exposed.
+     *
+     * Because it means only that, "which calls were abandoned after their
+     * credential went out?" is answerable by querying this single action value.
+     * Nothing else is filed here:
+     *
+     * - a cancellation BEFORE the send is `HttpCallCancelledBeforeSend` — no
+     *   secret was read, nothing egressed, and an auditor must be able to
+     *   exclude those rows without parsing an error string;
+     * - the tick loop's defensive wall-clock bound and an unexpected throwable
+     *   are `HttpCall` with `success = false`. They are failures, not
+     *   cancellations: nobody asked for them, and counting them here would put
+     *   a second meaning back on this action.
+     *
+     * Distinct from `HttpCall` with `success = false` because status `0` is
+     * already overloaded there: a connection refusal and an SSRF middleware
+     * rejection produce the same tuple, and folding a deliberate abort into it
+     * would make the question above unanswerable by query.
+     */
+    case HttpCallCancelled = 'http_call_cancelled';
+    /**
+     * The cancellation signal was already true when
+     * `VaultHttpClient::sendCancellable()` was entered, so the call was refused
+     * before the send began.
+     *
+     * The one abandoned outcome in which NO credential was involved: the vault
+     * was never read and nothing was handed to the transport. It is a separate
+     * case rather than a distinguishing error string so that it is separately
+     * filterable and countable — an error message is free text an auditor
+     * cannot query on, while the action drives the backend's filter dropdown.
+     *
+     * The row is written even though nothing egressed: the log is complete with
+     * respect to CALLS, not merely with respect to egress, so an operator
+     * asking "what did this run do?" gets an answer for every send that was
+     * asked for.
+     */
+    case HttpCallCancelledBeforeSend = 'http_call_cancelled_before_send';
     case MasterKeyRotateStart = 'master_key_rotate_start';
     case MasterKeyRotateEnd = 'master_key_rotate_end';
     case AuditChainRekey = 'audit_chain_rekey';

--- a/Classes/Controller/AuditController.php
+++ b/Classes/Controller/AuditController.php
@@ -150,11 +150,7 @@ final readonly class AuditController
             'filters' => ['_form' => $formData],
             'pagination' => $pagination,
             'canExport' => $this->accessGuard->isGranted(VaultPermission::AuditExport),
-            // Derive the action-filter list from the AuditAction enum so the UI
-            // can never drift from the actions actually written to the chain
-            // (the previous hard-coded list silently omitted master_key_* and
-            // oauth_* actions).
-            'actions' => array_map(static fn (AuditAction $action): string => $action->value, AuditAction::cases()),
+            'actions' => $this->filterableActions(),
         ]);
 
         $moduleTemplate->setTitle(
@@ -421,6 +417,22 @@ final readonly class AuditController
         // Note: Reload button is automatically added by TYPO3's DocHeaderComponent
     }
 
+    /**
+     * The action values the module's filter dropdown offers.
+     *
+     * Derived from the AuditAction enum so the UI can never drift from the
+     * actions actually written to the chain — the hard-coded list this replaced
+     * silently omitted the master_key_* and oauth_* actions, which made those
+     * rows unfilterable. A writer that adds an action must appear here without
+     * anyone editing this method.
+     *
+     * @return list<string>
+     */
+    private function filterableActions(): array
+    {
+        return array_map(static fn (AuditAction $action): string => $action->value, AuditAction::cases());
+    }
+
     private function getActionBadgeClass(string $action): string
     {
         return match ($action) {
@@ -430,6 +442,15 @@ final readonly class AuditController
             'delete' => 'danger',
             'rotate' => 'info',
             'access_denied' => 'danger',
+            // An in-flight call torn down after its credential was injected.
+            // Every row under this action means the credential went out, so it
+            // is worth a second look and must not sit in the grey default next
+            // to an ordinary completed call.
+            'http_call_cancelled' => 'warning',
+            // Refused before the send began: no secret was read and nothing
+            // egressed. Distinct from the grey default because it IS an
+            // abandoned call, but not `warning` — there is nothing to act on.
+            'http_call_cancelled_before_send' => 'info',
             // A break-glass activation is the most review-worthy row in the
             // log; it must not blend into the grey default.
             'break_glass_activated' => 'danger',

--- a/Classes/Exception/RequestCancelledException.php
+++ b/Classes/Exception/RequestCancelledException.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the nr-vault TYPO3 extension.
+ *
+ * (c) Netresearch DTT GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Exception;
+
+/**
+ * A `sendCancellable()` call was aborted by its cancellation signal.
+ *
+ * Thrown for both cancellation outcomes — before the send began and after the
+ * credential was injected — so a caller has one exception type to catch. The
+ * two are distinguished in the audit log, which is where the distinction
+ * matters: only one of them means a credential was put on the wire.
+ *
+ * The message is always a fixed literal — both throw sites pass a constant, and
+ * both constants are asserted on `getMessage()` of the exception a caller
+ * receives by
+ * `VaultHttpClientCancellableTest::cancellingBeforeSendReadsNoSecretAndStillLeavesADistinguishableRow()`,
+ * `…::aPreFlightSignalIsHonouredEvenWhenCancellationIsUnsupported()`,
+ * `…::cancellingMidFlightAbortsTheTransferAndAuditsItAsCancelled()` and
+ * `…::theTwoCancellationOutcomesAreToldApartByTheirAction()`, which also assert
+ * the exception codes and the audit row. The row is not the exception: pinning
+ * the literal there alone would have left this class free to append the request
+ * URI to the message with the suite staying green — and for
+ * `SecretPlacement::QueryParam` that URI carries the secret. The promise's own
+ * rejection reason is
+ * deliberately not carried through: transport error strings on this client can
+ * contain the injected secret, and they are redacted only by
+ * `AuditLogService::sanitizeErrorMessage()` on the way into the audit row. An
+ * exception handed back to a consumer does not pass that boundary.
+ */
+final class RequestCancelledException extends VaultException {}

--- a/Classes/Http/CancellableHttpClientInterface.php
+++ b/Classes/Http/CancellableHttpClientInterface.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * This file is part of the nr-vault TYPO3 extension.
+ *
+ * (c) Netresearch DTT GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Http;
+
+use Netresearch\NrVault\Exception\RequestCancelledException;
+use Netresearch\NrVault\Exception\VaultException;
+use Psr\Http\Client\ClientExceptionInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+/**
+ * An outbound send that a caller can abort while it is still on the wire.
+ *
+ * Separate from :php:`VaultHttpClientInterface` on purpose: this is additive,
+ * so the existing interface — and every implementor and consumer of it — is
+ * untouched, and a consumer feature-detects instead of requiring a version
+ * floor::
+ *
+ *     $client = $vault->http()->withReason('MCP tool call')->withTimeout(15);
+ *     $response = $client instanceof CancellableHttpClientInterface && $client->supportsCancellation()
+ *         ? $client->sendCancellable($request, $signal)
+ *         : $client->sendRequest($request);
+ *
+ * **No transport type crosses THIS interface**, and the class that attaches the
+ * secret exports none either: every public method of `VaultHttpClient` returns
+ * a configured clone, a PSR-7 response or a bool — no client, no handler, no
+ * promise — and `sendCancellable()` takes no options parameter through which a
+ * caller could reach the transport. Both are pinned by
+ * `VaultHttpClientCancellableTest::theCredentialBearingClientExportsNoTransportAndNoPromise()`.
+ *
+ * The boundary this package actually has is two-tier, and always was:
+ *
+ * - `SecureHttpClientFactory::create()` and `createCancellable()` are public and
+ *   hand out a raw transport — a Guzzle client, and next to it the ticker that
+ *   drives its event loop. Consumers depend on that (nr-llm injects the factory
+ *   directly), and it is a supported case: what they get carries the SSRF reject
+ *   middleware and the `CURLOPT_RESOLVE` DNS pin, and carries no vault secret,
+ *   no scheme guard, no `allowed_hosts` gate and no audit write.
+ * - All four together live on `VaultHttpClient`, and it is the only send a
+ *   caller can drive that puts a vault secret on their request. That is what
+ *   this interface's shape protects: the request and response are PSR-7, and
+ *   the signal and the exception are ours.
+ *
+ * nr-vault does send two credentials of its own elsewhere, on paths that are
+ * not a caller's request and are not covered by the four: the `X-Vault-Token`
+ * header in `TransitMasterKeyProvider::callTransit()`, on the plain Guzzle
+ * client `MasterKeyProviderFactory` builds, and the `client_secret` form body
+ * in `OAuthTokenManager::dispatchTokenRequest()`, which does apply the
+ * `allowed_hosts` gate but writes no audit row. "No credential-bearing send
+ * exists outside `VaultHttpClient`" would therefore be false; see ADR-037.
+ *
+ * The four are plain statements in the sending method, not middleware, so a
+ * shape that handed a caller the promise for an authenticated send — or the
+ * client with the credential already on it — would drop all four, including the
+ * allowlist that runs before the credential reaches the request. On this send
+ * that gate precedes the vault read as well; on the OAuth token leg the secrets
+ * are read first and the gate runs before the body carrying them is built.
+ *
+ * **There is no per-request option surface, and adding one is a security
+ * change.** A caller-supplied `stream => true` would route the request to the
+ * stream handler, which ignores the `CURLOPT_RESOLVE` DNS pin without warning;
+ * a caller-supplied `curl` array is applied last by Guzzle's curl factory and
+ * would overwrite that same vetted pin.
+ *
+ * @see CancellationSignalInterface
+ * @see VaultHttpClientInterface for the plain PSR-18 send
+ */
+interface CancellableHttpClientInterface
+{
+    /**
+     * Send an HTTP request, aborting the transfer as soon as `$signal` says so.
+     *
+     * Runs the same guard sequence as :php:`sendRequest()` — scheme allowlist,
+     * host allowlist, credential injection, audit write — so the log stays
+     * complete with respect to *calls*, not merely with respect to egress.
+     * **Every call leaves exactly one row from this client**, under one of
+     * three actions. Each outcome below names the test in
+     * `VaultHttpClientCancellableTest` that asserts its row:
+     *
+     * - ``http_call_cancelled`` — and only this — when the signal stopped an
+     *   in-flight request. The credential was injected and handed to the
+     *   transport: treat it as exposed. Because the action means nothing else,
+     *   "which calls were abandoned after their credential went out?" is one
+     *   query on one action value
+     *   (`cancellingMidFlightAbortsTheTransferAndAuditsItAsCancelled()`,
+     *   `theTwoCancellationOutcomesAreToldApartByTheirAction()`; that the
+     *   failures below stay OUT of it is pinned by
+     *   `anExhaustedWallClockBudgetAbortsTheTransferAndAuditsIt()` and
+     *   `aSignalThatThrowsMidFlightStillLeavesAnAuditRow()`);
+     * - ``http_call_cancelled_before_send`` when the signal was already true on
+     *   entry. No secret was read, nothing egressed
+     *   (`cancellingBeforeSendReadsNoSecretAndStillLeavesADistinguishableRow()`,
+     *   and on a degraded instance
+     *   `aPreFlightSignalIsHonouredEvenWhenCancellationIsUnsupported()`);
+     * - ``http_call`` for everything else: the completed call
+     *   (`anUncancelledCallReturnsTheResponseAndAuditsAnOrdinaryHttpCall()`) and,
+     *   with ``success = false``, everything that failed rather than was
+     *   cancelled — a refused scheme or host
+     *   (`schemeGuardRunsOnTheCancellablePathBeforeAnySecretIsRead()`,
+     *   `hostAllowlistRunsOnTheCancellablePathBeforeAnySecretIsRead()`), a
+     *   credential that could not be obtained
+     *   (`aFailedCredentialInjectionOnTheCancellablePathLeavesARow()`), a
+     *   transport rejection
+     *   (`anSsrfRejectionSettlesBeforeTheFirstTickAndStillWritesItsRow()`), the
+     *   tick loop's defensive wall-clock bound, a settlement that is not a
+     *   response (`aNonResponseSettlementIsRefusedInsteadOfReturned()`), or a
+     *   throw from the signal, the ticker or Guzzle's option handling
+     *   (`aThrowFromTheSendItselfStillLeavesAnAuditRow()`). Which one it was is
+     *   a fixed literal in the row's error message, rendered under the badge.
+     *
+     * The rows for everything after the credential was injected are written
+     * from a `finally`, on the cancellable branch and on the degraded blocking
+     * one alike, so the guarantee does not depend on which branch a call took:
+     * a throw that is not a PSR-18 `ClientExceptionInterface` (Guzzle's option
+     * handling raises `InvalidArgumentException` outside its own try/catch on
+     * the synchronous path as well) still leaves a row
+     * (`aThrowFromTheDegradedBlockingSendStillLeavesAnAuditRow()`).
+     *
+     * When this instance builds its own transport, that transport comes from
+     * `SecureHttpClientFactory` and carries the same `ssrf-dns-pin` middleware
+     * (`ssrfDnsPinIsInstalledOnTheCancellableTransport()`) and the same timeout
+     * as the blocking client (`theTransportTheClientResolvesForItselfCarriesTheRememberedTimeout()`)
+     * — cancellation is an early exit, and a transport that could run longer
+     * than the send it replaces would be the opposite of one. A client a caller
+     * passed to the constructor is never replaced by a transport; see
+     * :php:`supportsCancellation()`.
+     *
+     * When :php:`supportsCancellation()` is false the call still completes —
+     * blocking, through the ordinary path, with an ordinary ``http_call`` audit
+     * row (`aNonGuzzleInnerClientDegradesToABlockingSendWithAnOrdinaryAuditRow()`).
+     * It degrades; it does not fail.
+     *
+     * @param RequestInterface $request PSR-7 request
+     * @param CancellationSignalInterface $signal Polled before the send and between transport ticks
+     *
+     * @throws RequestCancelledException When the signal aborted the call
+     * @throws ClientExceptionInterface When the transfer itself failed
+     * @throws VaultException When the scheme or host is rejected, or secret retrieval fails
+     *
+     * @return ResponseInterface PSR-7 response
+     */
+    public function sendCancellable(
+        RequestInterface $request,
+        CancellationSignalInterface $signal,
+    ): ResponseInterface;
+
+    /**
+     * Whether this instance can actually abort a transfer in flight.
+     *
+     * False whenever the inner client was supplied by the caller rather than
+     * built by `SecureHttpClientFactory` — that check runs first, so nothing
+     * overrides it, not even an `@internal` injected transport
+     * (`anInjectedGuzzleClientIsNeverSwappedForACancellableTransport()`,
+     * `anInjectedTransportNeverDisplacesACallerSuppliedClient()`). A supplied
+     * client may carry that caller's own middleware, proxy or handler, so on
+     * this path it stays the one that sends; this method says so instead. The
+     * fact is derived from who built the client and cannot be passed in as a
+     * flag (`aCallerCannotAssertTheFactoryBuiltFactByCloningFromAnotherInstance()`).
+     *
+     * Where that stops: :php:`withTimeout()` has to bake the override into a
+     * client, so it rebuilds one from the factory and drops the supplied one —
+     * and the clone then reports true
+     * (`withTimeoutRebuildsACallerSuppliedClientAndTurnsCancellationOn()`).
+     *
+     * Also false when the transport would have to be built here and the
+     * platform has no `curl_multi_*` support. (An `@internal` injected
+     * transport brings its own ticker, so that gate does not apply to it — but
+     * the factory-built check above still does.)
+     *
+     * When it is false, :php:`sendCancellable()` still honours a *pre-flight*
+     * signal — nothing has egressed yet, so refusing to send is possible on any
+     * instance, with the same exception and the same row
+     * (`aPreFlightSignalIsHonouredEvenWhenCancellationIsUnsupported()`) — but it
+     * cannot interrupt a transfer that has begun.
+     */
+    public function supportsCancellation(): bool;
+}

--- a/Classes/Http/CancellableTransport.php
+++ b/Classes/Http/CancellableTransport.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the nr-vault TYPO3 extension.
+ *
+ * (c) Netresearch DTT GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Http;
+
+use GuzzleHttp\ClientInterface as GuzzleClientInterface;
+
+/**
+ * The two halves of a cancellable transport, kept together so they cannot drift.
+ *
+ * A cancellable send needs an async-capable client AND a reference to the event
+ * loop that client's bottom handler is driven by. Held apart, the two silently
+ * decouple — the classic failure is a client rebuilt by `withTimeout()` while
+ * the caller keeps ticking the handler of the previous one, which serves
+ * nothing and spins until the wall-clock bound. Passing them as one value makes
+ * that mistake structurally impossible.
+ *
+ * `SecureHttpClientFactory::createCancellable()` builds it, and returns `null`
+ * rather than a half-usable transport when the platform cannot support one, so
+ * there is no "transport without a ticker" state to reason about. This
+ * constructor is public, and the test suite builds transports directly through
+ * it — "only the factory builds one" would be false.
+ *
+ * Reachable from outside: `createCancellable()` is public, like `create()`
+ * before it, and returns this. What it hands out is a hardened but
+ * credential-free transport — SSRF reject middleware and the `CURLOPT_RESOLVE`
+ * DNS pin, no vault secret, no `allowed_hosts` gate, no audit write.
+ *
+ * What holds for the credential path is narrower, and tested: a transport never
+ * displaces a client a caller supplied
+ * (`VaultHttpClientCancellableTest::anInjectedTransportNeverDisplacesACallerSuppliedClient()`),
+ * and `VaultHttpClient` exports neither transport nor promise
+ * (`VaultHttpClientCancellableTest::theCredentialBearingClientExportsNoTransportAndNoPromise()`).
+ */
+final readonly class CancellableTransport
+{
+    /**
+     * @param GuzzleClientInterface $client Async-capable client carrying the full hardened option set
+     * @param TransportTickerInterface $ticker Drives the loop the above client's handler runs on
+     * @param float $wallClockBudgetSeconds Defensive upper bound for the tick loop.
+     *                                      Derived from the transport's own
+     *                                      `timeout` + `connect_timeout` plus a
+     *                                      margin, so it can only ever fire
+     *                                      AFTER libcurl's own deadline should
+     *                                      have. If it does fire, the handler
+     *                                      misbehaved — better to abort and
+     *                                      audit than to hang a TYPO3 request.
+     */
+    public function __construct(
+        private GuzzleClientInterface $client,
+        private TransportTickerInterface $ticker,
+        private float $wallClockBudgetSeconds,
+    ) {}
+
+    public function client(): GuzzleClientInterface
+    {
+        return $this->client;
+    }
+
+    public function ticker(): TransportTickerInterface
+    {
+        return $this->ticker;
+    }
+
+    public function wallClockBudgetSeconds(): float
+    {
+        return $this->wallClockBudgetSeconds;
+    }
+}

--- a/Classes/Http/CancellationSignalInterface.php
+++ b/Classes/Http/CancellationSignalInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the nr-vault TYPO3 extension.
+ *
+ * (c) Netresearch DTT GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Http;
+
+/**
+ * A caller-owned "should this transfer stop?" question.
+ *
+ * `VaultHttpClient::sendCancellable()` polls this between ticks of the
+ * transport event loop. It is deliberately the smallest possible contract: the
+ * caller decides what cancellation means (a killed agent run, a closed
+ * connection, a deadline of its own), and nr-vault never learns about it.
+ *
+ * Implementations MUST be cheap — the method is called on every loop iteration,
+ * i.e. up to ten times a second per in-flight request — and MUST NOT throw. An
+ * exception here would escape mid-transfer, after the credential has already
+ * been injected and put on the wire, on a path whose whole purpose is to leave
+ * an audit row for exactly that situation.
+ *
+ * A `deadline(): ?float` sibling was considered and deliberately left out: no
+ * caller needs it yet, and the interface has room to grow when one does.
+ *
+ * @see CancellableHttpClientInterface::sendCancellable()
+ */
+interface CancellationSignalInterface
+{
+    /**
+     * Return true to abort the in-flight request.
+     *
+     * MUST NOT throw. MUST be cheap.
+     */
+    public function isCancelled(): bool;
+}

--- a/Classes/Http/CurlMultiTicker.php
+++ b/Classes/Http/CurlMultiTicker.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the nr-vault TYPO3 extension.
+ *
+ * (c) Netresearch DTT GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Http;
+
+use GuzzleHttp\Handler\CurlMultiHandler;
+
+/**
+ * Ticks a Guzzle `CurlMultiHandler`.
+ *
+ * The handler is held privately and this class exposes only `tick()`:
+ * `CurlMultiHandler::cancel()` is private in Guzzle, so the only route to an
+ * abort is the cancel function of the promise the handler produced. That
+ * promise does not leave `VaultHttpClient::sendCancellable()`, whose export
+ * surface is asserted by
+ * `VaultHttpClientCancellableTest::theCredentialBearingClientExportsNoTransportAndNoPromise()`.
+ *
+ * One tick runs the pending promise queue, then advances libcurl's multi
+ * interface, blocking at most `select_timeout` inside `curl_multi_select`. That
+ * bound is what makes the cancellation latency predictable; see
+ * `SecureHttpClientFactory::CANCELLABLE_SELECT_TIMEOUT_SECONDS`.
+ */
+final readonly class CurlMultiTicker implements TransportTickerInterface
+{
+    public function __construct(private CurlMultiHandler $handler) {}
+
+    public function tick(): void
+    {
+        $this->handler->tick();
+    }
+}

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -15,6 +15,10 @@ namespace Netresearch\NrVault\Http;
 use Closure;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\Handler\CurlHandler;
+use GuzzleHttp\Handler\CurlMultiHandler;
+use GuzzleHttp\Handler\Proxy;
+use GuzzleHttp\Handler\StreamHandler;
 use GuzzleHttp\HandlerStack;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
@@ -43,6 +47,36 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  */
 final class SecureHttpClientFactory
 {
+    /**
+     * How long one tick of the cancellable transport may block inside
+     * `curl_multi_select` — and therefore the worst-case delay between a
+     * cancellation signal turning true and the socket being torn down.
+     *
+     * Measured against a stalling local TCP server (3 runs each, worst tick
+     * duration; the server timestamps the moment it observes the peer close;
+     * php 8.5.9 / curl 8.5.0):
+     *
+     *   select_timeout=1     3 ticks   worst tick 1.001 s   peer close at +2.002 s
+     *   select_timeout=0.1  16 ticks   worst tick 0.100 s   peer close at +1.504 s
+     *   select_timeout=0.05 31 ticks   worst tick 0.050 s   peer close at +1.506 s
+     *
+     * (signal turned true at +1.5 s in every run.) Guzzle's default of 1 second
+     * costs up to a full second of overshoot and is unusable here. Between the
+     * other two the measurement shows no latency problem at 0.1 — it already
+     * bounds the abort under a tenth of a second — so the CPU-conservative
+     * value wins: 0.05 would double the wakeups to buy 50 ms that nothing in
+     * this feature's motivating case (a ~45 s hang) can perceive.
+     */
+    private const CANCELLABLE_SELECT_TIMEOUT_SECONDS = 0.1;
+
+    /**
+     * Margin added on top of the transport's own `timeout` + `connect_timeout`
+     * for the tick loop's defensive wall-clock bound. libcurl enforces the real
+     * deadlines; this only catches a handler that stopped settling its promise
+     * at all, so it must sit strictly above them.
+     */
+    private const CANCELLABLE_WALL_CLOCK_MARGIN_SECONDS = 5.0;
+
     public function __construct(
         private readonly DnsResolverInterface $dnsResolver = new DefaultDnsResolver(),
     ) {}
@@ -62,67 +96,7 @@ final class SecureHttpClientFactory
      */
     public function create(?int $timeoutSeconds = null): ClientInterface
     {
-        /** @var array<string, array<string, mixed>> $confVars */
-        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? [];
-        /** @var array<string, mixed> $typo3Config */
-        $typo3Config = $confVars['HTTP'] ?? [];
-
-        /** @var array<string, mixed> $options */
-        $options = [
-            // Security: Always disable debug to prevent secret logging
-            'debug' => false,
-
-            // Let VaultHttpClient handle errors for proper audit logging
-            'http_errors' => false,
-
-            // Respect TYPO3's timeout settings, with sensible defaults
-            'timeout' => \is_int($typo3Config['timeout'] ?? null) ? $typo3Config['timeout'] : 30,
-            'connect_timeout' => \is_int($typo3Config['connect_timeout'] ?? null) ? $typo3Config['connect_timeout'] : 10,
-
-            // Respect TYPO3's HTTP version preference
-            'version' => \is_string($typo3Config['version'] ?? null) ? $typo3Config['version'] : '1.1',
-        ];
-
-        // Per-client timeout override: long-running API calls (LLM generation,
-        // large exports) may legitimately exceed the instance-wide TYPO3
-        // timeout. Only `timeout` is overridden — `connect_timeout` keeps the
-        // platform value because a slow RESPONSE never justifies waiting
-        // longer for the connection to be established.
-        if ($timeoutSeconds !== null && $timeoutSeconds > 0) {
-            $options['timeout'] = $timeoutSeconds;
-        }
-
-        // Proxy settings (critical for corporate networks)
-        if (!empty($typo3Config['proxy'])) {
-            $options['proxy'] = $typo3Config['proxy'];
-        } else {
-            // Fall back to environment variables (common in containers)
-            $options['proxy'] = $this->getProxyFromEnvironment();
-        }
-
-        // SSL/TLS settings
-        if (\array_key_exists('verify', $typo3Config)) {
-            if ($typo3Config['verify'] === false) {
-                $this->getLogger()->warning(
-                    'TLS verification is disabled in TYPO3 HTTP configuration. '
-                    . 'This weakens security for vault HTTP client requests.',
-                );
-            }
-            $options['verify'] = $typo3Config['verify'];
-        }
-        if (!empty($typo3Config['cert'])) {
-            $options['cert'] = $typo3Config['cert'];
-        }
-        if (!empty($typo3Config['ssl_key'])) {
-            $options['ssl_key'] = $typo3Config['ssl_key'];
-        }
-
-        // Redirect settings: disable by default to prevent credential leakage on cross-origin redirects
-        if (\array_key_exists('allow_redirects', $typo3Config)) {
-            $options['allow_redirects'] = $typo3Config['allow_redirects'];
-        } else {
-            $options['allow_redirects'] = false;
-        }
+        $options = $this->buildOptions($timeoutSeconds);
 
         // Create handler stack without any logging middleware
         $stack = HandlerStack::create();
@@ -134,23 +108,77 @@ final class SecureHttpClientFactory
         $stack->push($this->buildSsrfDefenceMiddleware(), 'ssrf-dns-pin');
         $options['handler'] = $stack;
 
-        // ext-curl absence: Guzzle's HandlerStack::create() falls back to
-        // StreamHandler, which IGNORES the curl-only `CURLOPT_RESOLVE` option.
-        // The middleware still rejects dangerous-resolving hosts at lookup
-        // time (defence-in-depth), but the race-free pinning guarantee is
-        // gone — between our DNS check and stream's own resolution, an
-        // attacker can still rebind. Warn so operators notice the gap.
-        if (!\function_exists('curl_init')) {
-            $this->getLogger()->warning(
-                'PHP ext-curl is not loaded; the nr-vault HTTP client falls back '
-                . 'to the stream handler. DNS rebinding is no longer race-protected '
-                . '(the pre-request resolve-and-check is still enforced, but the '
-                . 'connect-time IP can drift). Install ext-curl to restore the '
-                . 'CURLOPT_RESOLVE pin.',
-            );
-        }
+        $this->warnWhenTlsVerificationIsDisabled();
+        $this->warnWhenCurlIsMissing();
 
         return new Client($options);
+    }
+
+    /**
+     * Create a transport whose in-flight transfer can be aborted.
+     *
+     * Same hardened options and the same `ssrf-dns-pin` middleware as
+     * `create()` — the option set comes from the shared `buildOptions()`
+     * precisely so the two paths cannot drift — but with a handler stack whose
+     * bottom is a `CurlMultiHandler`. That handler is the only one in Guzzle
+     * that attaches a real cancel function to its promise: the blocking
+     * `CurlHandler` that `Client::sendRequest()` routes to has already finished
+     * `curl_exec` by the time its (already-settled) promise exists, and
+     * cancelling it is a no-op.
+     *
+     * The handler is NOT passed bare. `Utils::chooseHandler()` composes
+     * `Proxy::wrapStreaming(Proxy::wrapSync($multi, new CurlHandler()), new StreamHandler())`,
+     * and passing the bare multi handler would silently delete both the sync
+     * and the streaming branch. Re-composing it here preserves both and yields
+     * the `$multi` reference the tick loop needs.
+     *
+     * @param int|null $timeoutSeconds Same meaning as in `create()`
+     *
+     * @return CancellableTransport|null Null when the platform has no
+     *                                   `curl_multi_*` support. The gate is
+     *                                   `curl_multi_exec`, deliberately not the
+     *                                   `curl_init` the warning below tests:
+     *                                   `CurlMultiHandler`'s constructor is lazy
+     *                                   and only fatals on first property
+     *                                   access, which would turn the documented
+     *                                   curl-less degraded mode into a hard
+     *                                   failure. A null return lets
+     *                                   `VaultHttpClient` fall back to the
+     *                                   blocking path instead.
+     */
+    public function createCancellable(?int $timeoutSeconds = null): ?CancellableTransport
+    {
+        if (!\function_exists('curl_multi_exec')) {
+            return null;
+        }
+
+        $options = $this->buildOptions($timeoutSeconds);
+
+        $multiHandler = new CurlMultiHandler([
+            'select_timeout' => self::CANCELLABLE_SELECT_TIMEOUT_SECONDS,
+        ]);
+
+        $stack = HandlerStack::create(
+            Proxy::wrapStreaming(
+                Proxy::wrapSync($multiHandler, new CurlHandler()),
+                new StreamHandler(),
+            ),
+        );
+
+        // Pushed AFTER HandlerStack::create()'s own defaults, exactly as in
+        // create(): resolve() wraps in reverse, so this stays the innermost
+        // middleware and therefore still sees every redirect hop.
+        $stack->push($this->buildSsrfDefenceMiddleware(), 'ssrf-dns-pin');
+        $options['handler'] = $stack;
+
+        $timeout = \is_int($options['timeout'] ?? null) ? $options['timeout'] : 30;
+        $connectTimeout = \is_int($options['connect_timeout'] ?? null) ? $options['connect_timeout'] : 10;
+
+        return new CancellableTransport(
+            new Client($options),
+            new CurlMultiTicker($multiHandler),
+            $timeout + $connectTimeout + self::CANCELLABLE_WALL_CLOCK_MARGIN_SECONDS,
+        );
     }
 
     /**
@@ -215,6 +243,134 @@ final class SecureHttpClientFactory
         }
 
         return false;
+    }
+
+    /**
+     * Build the hardened Guzzle option set shared by every client this factory
+     * produces.
+     *
+     * Extracted verbatim from `create()` so the blocking and the cancellable
+     * transport cannot drift apart: a proxy, TLS or timeout setting that
+     * applied to one and not the other would be a security posture that depends
+     * on which send method a consumer happened to call.
+     *
+     * The `handler` key is deliberately NOT set here — each caller composes its
+     * own stack and installs the `ssrf-dns-pin` middleware on it.
+     *
+     * @param int|null $timeoutSeconds Optional `timeout` override; see `create()`
+     *
+     * @return array<string, mixed>
+     */
+    private function buildOptions(?int $timeoutSeconds): array
+    {
+        /** @var array<string, array<string, mixed>> $confVars */
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? [];
+        /** @var array<string, mixed> $typo3Config */
+        $typo3Config = $confVars['HTTP'] ?? [];
+
+        /** @var array<string, mixed> $options */
+        $options = [
+            // Security: Always disable debug to prevent secret logging
+            'debug' => false,
+
+            // Let VaultHttpClient handle errors for proper audit logging
+            'http_errors' => false,
+
+            // Respect TYPO3's timeout settings, with sensible defaults
+            'timeout' => \is_int($typo3Config['timeout'] ?? null) ? $typo3Config['timeout'] : 30,
+            'connect_timeout' => \is_int($typo3Config['connect_timeout'] ?? null) ? $typo3Config['connect_timeout'] : 10,
+
+            // Respect TYPO3's HTTP version preference
+            'version' => \is_string($typo3Config['version'] ?? null) ? $typo3Config['version'] : '1.1',
+        ];
+
+        // Per-client timeout override: long-running API calls (LLM generation,
+        // large exports) may legitimately exceed the instance-wide TYPO3
+        // timeout. Only `timeout` is overridden — `connect_timeout` keeps the
+        // platform value because a slow RESPONSE never justifies waiting
+        // longer for the connection to be established.
+        if ($timeoutSeconds !== null && $timeoutSeconds > 0) {
+            $options['timeout'] = $timeoutSeconds;
+        }
+
+        // Proxy settings (critical for corporate networks)
+        if (!empty($typo3Config['proxy'])) {
+            $options['proxy'] = $typo3Config['proxy'];
+        } else {
+            // Fall back to environment variables (common in containers)
+            $options['proxy'] = $this->getProxyFromEnvironment();
+        }
+
+        // SSL/TLS settings. The operator warning for `verify => false` is NOT
+        // emitted here: this method runs for every client the factory builds,
+        // and the cancellable transport is built per send. A warning that
+        // repeats once per outbound call trains operators to ignore it. It is
+        // emitted from create() instead, which every VaultHttpClient goes
+        // through (the constructor builds its inner client there), so the
+        // warning still reaches the log exactly as before this change.
+        if (\array_key_exists('verify', $typo3Config)) {
+            $options['verify'] = $typo3Config['verify'];
+        }
+        if (!empty($typo3Config['cert'])) {
+            $options['cert'] = $typo3Config['cert'];
+        }
+        if (!empty($typo3Config['ssl_key'])) {
+            $options['ssl_key'] = $typo3Config['ssl_key'];
+        }
+
+        // Redirect settings: disable by default to prevent credential leakage on cross-origin redirects
+        if (\array_key_exists('allow_redirects', $typo3Config)) {
+            $options['allow_redirects'] = $typo3Config['allow_redirects'];
+        } else {
+            $options['allow_redirects'] = false;
+        }
+
+        return $options;
+    }
+
+    /**
+     * Warn once per built client when the platform disabled TLS verification.
+     *
+     * Split out of `buildOptions()` so it fires on the same occasions as before
+     * this change — one client built through `create()` — rather than on every
+     * cancellable send, which builds its own transport.
+     */
+    private function warnWhenTlsVerificationIsDisabled(): void
+    {
+        /** @var array<string, array<string, mixed>> $confVars */
+        $confVars = $GLOBALS['TYPO3_CONF_VARS'] ?? [];
+        /** @var array<string, mixed> $typo3Config */
+        $typo3Config = $confVars['HTTP'] ?? [];
+
+        if (($typo3Config['verify'] ?? null) === false) {
+            $this->getLogger()->warning(
+                'TLS verification is disabled in TYPO3 HTTP configuration. '
+                . 'This weakens security for vault HTTP client requests.',
+            );
+        }
+    }
+
+    /**
+     * Warn when ext-curl is absent, i.e. when the `CURLOPT_RESOLVE` pin cannot
+     * be applied.
+     */
+    private function warnWhenCurlIsMissing(): void
+    {
+        // ext-curl absence: Guzzle's HandlerStack::create() falls back to
+        // StreamHandler, which IGNORES the curl-only `CURLOPT_RESOLVE` option.
+        // The middleware still rejects dangerous-resolving hosts at lookup
+        // time (defence-in-depth), but the race-free pinning guarantee is
+        // gone — between our DNS check and stream's own resolution, an
+        // attacker can still rebind. Warn so operators notice the gap.
+        if (!\function_exists('curl_init')) {
+            $this->getLogger()->warning(
+                'PHP ext-curl is not loaded; the nr-vault HTTP client falls back '
+                . 'to the stream handler. DNS rebinding is no longer race-protected '
+                . '(the pre-request resolve-and-check is still enforced, but the '
+                . 'connect-time IP can drift). Install ext-curl to restore the '
+                . 'CURLOPT_RESOLVE pin.',
+            );
+        }
     }
 
     /**

--- a/Classes/Http/TransportTickerInterface.php
+++ b/Classes/Http/TransportTickerInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the nr-vault TYPO3 extension.
+ *
+ * (c) Netresearch DTT GmbH
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Http;
+
+/**
+ * Drives one step of the transport event loop.
+ *
+ * This seam exists so the cancellation loop can be tested at all. The suite's
+ * only in-process HTTP seam replaces a client's BOTTOM handler
+ * (`HandlerStack::setHandler()`), which destroys the very `CurlMultiHandler`
+ * the loop would have to tick — a primitive that ticked a privately held
+ * handler could therefore never be exercised by a unit test, only asserted at
+ * by inspection.
+ *
+ * With the ticker behind an interface, a test builds a transport from a stub
+ * bottom handler plus a ticker closure that settles the stubbed promise on the
+ * Nth call, and the abort is provable without a socket, a sleep or a flake.
+ *
+ * Mirrors the injection precedent already in this namespace
+ * (`DnsResolverInterface` / `DefaultDnsResolver`).
+ *
+ * @see CurlMultiTicker for the production implementation
+ */
+interface TransportTickerInterface
+{
+    /**
+     * Advance the transport by one step.
+     *
+     * Blocks for at most the transport's own select timeout. It MUST NOT block
+     * for the remaining duration of the transfer — that would leave no window
+     * in which a cancellation signal could be observed.
+     */
+    public function tick(): void;
+}

--- a/Classes/Http/VaultHttpClient.php
+++ b/Classes/Http/VaultHttpClient.php
@@ -12,10 +12,15 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Http;
 
+use GuzzleHttp\ClientInterface as GuzzleClientInterface;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
 use GuzzleHttp\Psr7\Utils;
+use GuzzleHttp\RequestOptions;
 use JsonException;
+use Netresearch\NrVault\Audit\AuditAction;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Audit\HttpCallContext;
+use Netresearch\NrVault\Exception\RequestCancelledException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Exception\VaultException;
 use Netresearch\NrVault\Http\OAuth\OAuthConfig;
@@ -25,6 +30,7 @@ use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Throwable;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 
 /**
@@ -69,9 +75,119 @@ use TYPO3\CMS\Core\Utility\GeneralUtility;
  *
  * @see SecureHttpClientFactory for TYPO3 HTTP configuration handling
  */
-final readonly class VaultHttpClient implements VaultHttpClientInterface
+final readonly class VaultHttpClient implements VaultHttpClientInterface, CancellableHttpClientInterface
 {
+    /**
+     * Fixed literal for a call refused before anything was sent.
+     *
+     * Never derived from the promise's rejection reason: transport error
+     * strings on this client can contain the injected secret and are redacted
+     * only on the way INTO the audit row.
+     */
+    private const CANCELLED_BEFORE_SEND_MESSAGE
+        = 'Request cancelled before send: nothing egressed and no secret was retrieved';
+
+    /**
+     * Fixed literal for a call aborted after the credential was injected.
+     *
+     * Deliberately NOT phrased as "the bytes left the process": the signal can
+     * turn true on the first pass through the loop, before the first tick, and
+     * the handler only queued the easy handle at that point. What IS certain at
+     * this point — and what separates this outcome from the pre-flight one — is
+     * that the secret was retrieved, injected into the request and handed to the
+     * transport, i.e. it must be treated as exposed.
+     */
+    private const CANCELLED_IN_FLIGHT_MESSAGE
+        = 'Request cancelled after send began: credential injected and transfer handed to the transport';
+
+    /**
+     * Fixed literal for a throw that came from neither the transport nor this
+     * class — the caller's signal or a ticker implementation — after the
+     * credential had already been injected. The row is written from a `finally`
+     * so that this case cannot be the one call missing from the log.
+     */
+    private const UNEXPECTED_OUTCOME_MESSAGE
+        = 'Cancellable transfer aborted by an unexpected error after the credential was injected';
+
+    /**
+     * Fixed literal for the defensive wall-clock bound. Reaching it means the
+     * transport stopped settling its promise, which is a bug in the handler and
+     * not something a caller did.
+     */
+    private const TICK_BUDGET_EXHAUSTED_MESSAGE
+        = 'Cancellable transfer exceeded its wall-clock budget and was aborted';
+
+    /**
+     * Fixed literal for a transport that settled with something that is not a
+     * PSR-7 response. Not reachable through any handler this package builds;
+     * it exists so the case cannot be silently returned as a response.
+     */
+    private const NON_RESPONSE_SETTLEMENT_MESSAGE
+        = 'Cancellable transport settled with a value that is not an HTTP response';
+
+    /**
+     * Fixed literal for a throw out of the blocking send that is not a PSR-18
+     * `ClientExceptionInterface` — `Client::applyOptions()` raises
+     * `InvalidArgumentException` outside `Client::transfer()`'s try/catch, so a
+     * bad option set leaves `sendRequest()` as a plain throw. The credential is
+     * already injected by then, so the row is written from a `finally`.
+     */
+    private const UNEXPECTED_BLOCKING_OUTCOME_MESSAGE
+        = 'Blocking send aborted by an unexpected error after the credential was injected';
+
+    /**
+     * Fixed literal for a URI whose scheme is not http/https. The scheme is
+     * appended because `HttpCallContext` records method, host, path and status
+     * and has nowhere to put it — and "somebody tried `file://`" is the whole
+     * reason this row exists.
+     *
+     * Guarded by `VaultHttpClientTest::aRefusedSchemeIsAuditedAsAFailedHttpCall()`.
+     */
+    private const SCHEME_REFUSED_MESSAGE
+        = 'Request refused before any secret was read: unsupported URI scheme';
+
+    /**
+     * Fixed literal for a host outside `allowed_hosts`. The host itself is on
+     * the row already, in the audit context.
+     *
+     * Guarded by `VaultHttpClientTest::aRefusedHostIsAuditedAsAFailedHttpCall()`.
+     */
+    private const HOST_REFUSED_MESSAGE
+        = 'Request refused before any secret was read: host is not in the allowed hosts list';
+
+    /**
+     * Fixed literal for a credential that could not be obtained — a missing
+     * secret, a denied read, a failed OAuth token leg. Nothing was sent, and
+     * the original message follows the colon.
+     *
+     * Guarded by `VaultHttpClientTest::aFailedCredentialInjectionIsAuditedAsAFailedHttpCall()`.
+     */
+    private const INJECTION_FAILED_MESSAGE
+        = 'Credential injection failed; nothing was sent';
+
+    /**
+     * Fixed literal for a transport that could not be built at all. The
+     * resolution runs before the credential is read, so nothing egressed and no
+     * secret was retrieved — but the call was asked for, and "every
+     * `sendCancellable()` leaves exactly one row" has to hold for it too.
+     *
+     * Guarded by
+     * `VaultHttpClientCancellableTest::aThrowFromTheTransportResolutionLeavesAnAuditRow()`.
+     */
+    private const TRANSPORT_RESOLUTION_FAILED_MESSAGE
+        = 'Cancellable transport could not be built; nothing was sent';
+
     private ClientInterface $innerClient;
+
+    /**
+     * Whether `$this->innerClient` is one this class built from the factory
+     * with `$this->timeoutSeconds`, rather than one a caller handed in.
+     *
+     * Derived, never asserted by a caller — see the `$clonedFrom` parameter.
+     * The cancellable path may only act when this is true; see
+     * `supportsCancellation()`.
+     */
+    private bool $innerClientIsFactoryBuilt;
 
     private OAuthTokenManager $oauthManager;
 
@@ -106,6 +222,45 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
      *                                placement (e.g. "Key " → "Authorization: Key <secret>").
      *                                Logically a Header-placement option, but placed last in the
      *                                signature to preserve positional BC for pre-PR callers.
+     * @param int|null $timeoutSeconds The `withTimeout()` override, remembered so a
+     *                                 cancellable transport built later honours it.
+     *                                 `withTimeout()` bakes the override into the inner
+     *                                 client; without remembering the value, a transport
+     *                                 built on demand would silently fall back to the
+     *                                 platform timeout.
+     * @param CancellableTransport|null $cancellableTransport Explicit transport for
+     *                                                        `sendCancellable()`. Normally null:
+     *                                                        the transport is built on demand,
+     *                                                        so the common case (a client that
+     *                                                        only ever calls `sendRequest()`)
+     *                                                        pays nothing.
+     *                                                        `@internal` test seam — it is how
+     *                                                        the suite drives the tick loop
+     *                                                        deterministically, and it is only
+     *                                                        honoured when the inner client is
+     *                                                        factory-built, so it can never
+     *                                                        displace a client a caller supplied.
+     *                                                        Trailing position preserves
+     *                                                        positional BC.
+     * @param self|null $clonedFrom The instance whose inner client is being forwarded,
+     *                              passed by the `with*()` clones and by nothing else.
+     *                              It exists so `$innerClientIsFactoryBuilt` cannot be
+     *                              ASSERTED by a caller: the fact is inherited only when
+     *                              the forwarded client is the very object a factory-built
+     *                              instance holds, which requires already holding such an
+     *                              instance. A caller who passes their own client cannot
+     *                              reach that branch — see
+     *                              `VaultHttpClientCancellableTest::aCallerCannotAssertTheFactoryBuiltFactByCloningFromAnotherInstance()`
+     *                              — so "a supplied client is never replaced by a
+     *                              transport" holds by construction rather than by
+     *                              discipline, with the one documented exception of
+     *                              `withTimeout()`, which rebuilds the client outright.
+     *                              So does the equal-timeout property,
+     *                              because the only instance that can be cloned from is one
+     *                              whose client was built with its own `$timeoutSeconds`.
+     *                              Typing it as the class is what makes it unforgeable and
+     *                              also why `Services.yaml` pins it to null: autowiring
+     *                              would read it as a dependency of this service on itself.
      */
     public function __construct(
         private VaultServiceInterface $vaultService,
@@ -122,6 +277,9 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
         ?OAuthTokenManager $oauthManager = null,
         ?SecureHttpClientFactory $secureHttpClientFactory = null,
         private ?string $authPrefix = null,
+        private ?int $timeoutSeconds = null,
+        private ?CancellableTransport $cancellableTransport = null,
+        ?self $clonedFrom = null,
     ) {
         // Resolve the factory once: it builds the inner client (when missing)
         // AND backs the OAuth manager's `isHostAllowed()` gate. VaultHttpClient
@@ -131,7 +289,21 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
         $this->secureHttpClientFactory = $secureHttpClientFactory
             ?? GeneralUtility::makeInstance(SecureHttpClientFactory::class);
 
-        $this->innerClient = $innerClient ?? $this->secureHttpClientFactory->create();
+        // No client passed → this constructor builds it below, so it is
+        // factory-built by definition. A client that WAS passed only counts as
+        // factory-built when it is the identical object a factory-built
+        // instance already holds, i.e. when a `with*()` clone forwarded it.
+        $this->innerClientIsFactoryBuilt = !$innerClient instanceof ClientInterface
+            || ($clonedFrom instanceof self
+                && $clonedFrom->innerClientIsFactoryBuilt
+                && $clonedFrom->innerClient === $innerClient);
+
+        // The remembered override is applied HERE too, not only in
+        // withTimeout(): a client constructed with a timeout but without an
+        // inner client would otherwise send blocking at the platform default
+        // while the cancellable transport used the override, i.e. the two send
+        // paths would disagree on the deadline.
+        $this->innerClient = $innerClient ?? $this->secureHttpClientFactory->create($timeoutSeconds);
 
         // Share the hardened innerClient with the OAuth manager so token
         // requests inherit the SSRF / DNS-rebinding / no-redirect defences.
@@ -164,6 +336,9 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             oauthManager: $this->oauthManager,
             secureHttpClientFactory: $this->secureHttpClientFactory,
             authPrefix: $options['prefix'] ?? null,
+            timeoutSeconds: $this->timeoutSeconds,
+            cancellableTransport: $this->cancellableTransport,
+            clonedFrom: $this,
         );
     }
 
@@ -178,6 +353,9 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             reason: $reason,
             oauthManager: $this->oauthManager,
             secureHttpClientFactory: $this->secureHttpClientFactory,
+            timeoutSeconds: $this->timeoutSeconds,
+            cancellableTransport: $this->cancellableTransport,
+            clonedFrom: $this,
         );
     }
 
@@ -198,6 +376,9 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             oauthManager: $this->oauthManager,
             secureHttpClientFactory: $this->secureHttpClientFactory,
             authPrefix: $this->authPrefix,
+            timeoutSeconds: $this->timeoutSeconds,
+            cancellableTransport: $this->cancellableTransport,
+            clonedFrom: $this,
         );
     }
 
@@ -211,13 +392,29 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
         // instance — plain and authenticated alike — honours it. Non-positive
         // values rebuild with the platform default (no override). A custom
         // inner client injected at construction time is replaced by the
-        // factory-built one. The forwarded OAuth token manager keeps its own
+        // factory-built one — the one place where "a supplied client is never
+        // replaced" stops, and the returned clone therefore reports
+        // supportsCancellation() true
+        // (VaultHttpClientCancellableTest::withTimeoutRebuildsACallerSuppliedClientAndTurnsCancellationOn()).
+        // The forwarded OAuth token manager keeps its own
         // platform-default client: the override governs the API call, not the
         // token-endpoint round trip, and forwarding preserves the token cache.
+        //
+        // The cancellable transport is deliberately NOT forwarded: it carries
+        // its own client, built with the PREVIOUS timeout. Carrying it over
+        // would leave a caller ticking the event loop of a client that is not
+        // serving the request — the loop would spin until its wall-clock bound
+        // while the transfer it meant to watch ran somewhere else. Dropping it
+        // to null makes the next sendCancellable() build a transport with the
+        // override applied, so the two cannot disagree by construction.
+        //
+        // No `innerClient` argument below, deliberately: leaving it at the
+        // default has the constructor build the client from the same factory
+        // with the very `timeoutSeconds` passed here, which is also what makes
+        // the clone factory-built without anyone having to assert it.
         return new self(
             vaultService: $this->vaultService,
             auditLogService: $this->auditLogService,
-            innerClient: $this->secureHttpClientFactory->create($seconds > 0 ? $seconds : null),
             secretIdentifier: $this->secretIdentifier,
             placement: $this->placement,
             oauthConfig: $this->oauthConfig,
@@ -229,6 +426,7 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
             oauthManager: $this->oauthManager,
             secureHttpClientFactory: $this->secureHttpClientFactory,
             authPrefix: $this->authPrefix,
+            timeoutSeconds: $seconds > 0 ? $seconds : null,
         );
     }
 
@@ -240,51 +438,606 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
      */
     public function sendRequest(RequestInterface $request): ResponseInterface
     {
-        // Validate scheme (only HTTP/HTTPS allowed to prevent file://, gopher://, etc.)
-        $scheme = strtolower($request->getUri()->getScheme());
-        if ($scheme !== 'https' && $scheme !== 'http') {
-            throw new VaultException(
-                \sprintf('Unsupported URI scheme "%s"; only https and http are allowed', $scheme),
-                1735858523,
-            );
+        $this->assertSchemeIsAllowed($request);
+        $this->assertHostIsAllowed($request);
+
+        $secretForAudit = $this->getSecretIdentifierForAudit();
+        $authenticatedRequest = $this->injectAuthenticationAudited($request, $secretForAudit);
+
+        // The send-and-audit body lives in sendBlocking() and is called from
+        // exactly two places — here and the degraded cancellable path. Inlining
+        // it here as well would let the two copies drift, and "the blocking
+        // send audits differently depending on which method you entered
+        // through" is precisely the class of bug the audit row exists to rule
+        // out.
+        return $this->sendBlocking($request, $authenticatedRequest, $secretForAudit);
+    }
+
+    public function supportsCancellation(): bool
+    {
+        // FIRST, before anything else can say yes: a client passed to the
+        // constructor stays the one that sends. It may carry a caller's own
+        // middleware, proxy or handler, and quietly sending through a different
+        // client would be a substitution nobody asked for. Such an instance
+        // degrades to a blocking send on the caller's client — including when a
+        // transport was injected, which is why this check is not below that one.
+        if (!$this->innerClientIsFactoryBuilt) {
+            return false;
         }
 
-        // Validate host against allowlist before injecting authentication secrets
-        $host = strtolower($request->getUri()->getHost());
-        if (!$this->secureHttpClientFactory->isHostAllowed($host)) {
-            throw new VaultException(
-                \sprintf('Host "%s" is not in the allowed hosts list', $host),
-                1735858522,
-            );
+        // An injected transport brings its own ticker, so the platform's
+        // curl-multi support is not what decides here.
+        if ($this->cancellableTransport instanceof CancellableTransport) {
+            return true;
         }
 
-        $authenticatedRequest = $this->injectAuthentication($request);
+        // Otherwise the transport has to be BUILT, and cancellation is then a
+        // property of Guzzle's curl-multi handler, which only
+        // `SecureHttpClientFactory::createCancellable()` can hand out together
+        // with the ticker that drives it. This reports exactly what
+        // `resolveCancellableTransport()` will do.
+        return $this->innerClient instanceof GuzzleClientInterface
+            && \function_exists('curl_multi_exec');
+    }
+
+    /**
+     * Send an HTTP request, aborting the transfer when `$signal` says so.
+     *
+     * Runs the identical guard sequence to `sendRequest()`: scheme allowlist,
+     * host allowlist, credential injection, audit write. Those four are plain
+     * statements in the sending method rather than middleware, so they do NOT
+     * come along for free with a different send — they are re-executed here on
+     * purpose, in the same order, and the pre-flight signal check sits between
+     * the allowlist and the secret retrieval so a cancelled call never reads a
+     * secret it will not use.
+     *
+     * A transport this method resolves for itself comes from
+     * `SecureHttpClientFactory`: an abort needs the event loop that only the
+     * factory hands out. It carries the option set and the middleware `create()`
+     * installs (`VaultHttpClientCancellableTest::ssrfDnsPinIsInstalledOnTheCancellableTransport()`)
+     * and the timeout the blocking client carries
+     * (`…::theTransportTheClientResolvesForItselfCarriesTheRememberedTimeout()`).
+     *
+     * No client a caller supplied is ever replaced by a transport
+     * (`…::anInjectedGuzzleClientIsNeverSwappedForACancellableTransport()`).
+     * When the inner client came from the caller — or the platform has no
+     * `curl_multi_*` — `supportsCancellation()` is false and this method
+     * completes the call blocking, on that client, with an ordinary `http_call`
+     * row. A pre-flight signal is still honoured there, because nothing has
+     * egressed yet
+     * (`…::aPreFlightSignalIsHonouredEvenWhenCancellationIsUnsupported()`).
+     *
+     * @throws RequestCancelledException When the signal aborted the call
+     * @throws ClientExceptionInterface When the transfer itself failed
+     * @throws VaultException If the scheme/host is rejected or secret retrieval fails
+     */
+    public function sendCancellable(
+        RequestInterface $request,
+        CancellationSignalInterface $signal,
+    ): ResponseInterface {
+        $this->assertSchemeIsAllowed($request);
+        $this->assertHostIsAllowed($request);
+
         $secretForAudit = $this->getSecretIdentifierForAudit();
 
-        try {
-            $response = $this->innerClient->sendRequest($authenticatedRequest);
-
-            $this->logHttpCall(
-                $secretForAudit,
-                $request->getMethod(),
-                (string) $request->getUri(),
-                $response->getStatusCode(),
-                true,
-                null,
-            );
-
-            return $response;
-        } catch (ClientExceptionInterface $e) {
+        // Checked BEFORE injectAuthentication(): an already-cancelled call must
+        // not retrieve a secret. The row is still written — an operator asking
+        // "what did this run do?" gets an answer for every sendCancellable().
+        // This is the ONE abort where no credential was involved, and it gets
+        // its own action rather than a distinguishing error string: an auditor
+        // must be able to EXCLUDE these rows by query when asking which calls
+        // were abandoned after their credential went out. An error message is
+        // free text nobody can filter on.
+        if ($signal->isCancelled()) {
             $this->logHttpCall(
                 $secretForAudit,
                 $request->getMethod(),
                 (string) $request->getUri(),
                 0,
                 false,
-                $e->getMessage(),
+                self::CANCELLED_BEFORE_SEND_MESSAGE,
+                AuditAction::HttpCallCancelledBeforeSend,
             );
 
+            throw new RequestCancelledException(self::CANCELLED_BEFORE_SEND_MESSAGE, 1786579201);
+        }
+
+        $transport = $this->resolveCancellableTransportAudited($request, $secretForAudit);
+        $authenticatedRequest = $this->injectAuthenticationAudited($request, $secretForAudit);
+
+        if (!$transport instanceof CancellableTransport) {
+            // Degraded: this platform or this instance cannot tick a transport.
+            // The call still happens, blocking, with an ordinary audit row.
+            return $this->sendBlocking($request, $authenticatedRequest, $secretForAudit);
+        }
+
+        return $this->sendCancellably($transport, $request, $authenticatedRequest, $secretForAudit, $signal);
+    }
+
+    /**
+     * Reject anything but http/https (file://, gopher://, …) before a secret is
+     * ever read.
+     *
+     * The refusal is audited, on both send paths: these are the calls an
+     * operator goes looking for — somebody tried `file://` — and until this row
+     * existed the attempt left no trace at all.
+     * The exception is unchanged, byte for byte; only the row is new.
+     * `VaultHttpClientTest::sendRequestRefusesAnUnsupportedSchemeWithAnUnchangedException()`
+     * pins the class, the code and the message against exactly that.
+     *
+     * Filed as `http_call` / `success = false`, not as a new action: the row is
+     * a refused outbound call, which is what that tuple already means here —
+     * the SSRF middleware rejection lands in it too, and is the same kind of
+     * egress-policy refusal caught one layer later.
+     *
+     * @throws VaultException
+     */
+    private function assertSchemeIsAllowed(RequestInterface $request): void
+    {
+        $scheme = strtolower($request->getUri()->getScheme());
+        if ($scheme === 'https' || $scheme === 'http') {
+            return;
+        }
+
+        $this->logRefusal($request, \sprintf('%s "%s"', self::SCHEME_REFUSED_MESSAGE, $scheme));
+
+        throw new VaultException(
+            \sprintf('Unsupported URI scheme "%s"; only https and http are allowed', $scheme),
+            1735858523,
+        );
+    }
+
+    /**
+     * Validate the host against the allowlist BEFORE injecting authentication
+     * secrets.
+     *
+     * Audited for the same reason as the scheme guard, and under the same
+     * action: a host nobody approved is precisely the attempt an operator wants
+     * to find. The exception is unchanged —
+     * `VaultHttpClientTest::sendRequestRefusesAHostOutsideTheAllowlistWithAnUnchangedException()`.
+     *
+     * @throws VaultException
+     */
+    private function assertHostIsAllowed(RequestInterface $request): void
+    {
+        $host = strtolower($request->getUri()->getHost());
+        if ($this->secureHttpClientFactory->isHostAllowed($host)) {
+            return;
+        }
+
+        $this->logRefusal($request, self::HOST_REFUSED_MESSAGE);
+
+        throw new VaultException(
+            \sprintf('Host "%s" is not in the allowed hosts list', $host),
+            1735858522,
+        );
+    }
+
+    /**
+     * Inject the credential, and audit the call when that fails.
+     *
+     * `injectAuthentication()` reads the vault and, for OAuth, runs a token
+     * round trip; either can throw. That window sits between the allowlist and
+     * the send, so without this wrapper a call that was asked for would leave
+     * no `http_call` row — which is the one thing the row is for. Nothing
+     * egressed, so it is a failure like any other: `http_call` /
+     * `success = false`.
+     *
+     * This row is the CALL's, and it does not replace anything the vault or the
+     * OAuth manager wrote about the credential itself (a denied read is still
+     * an `access_denied` row from `VaultService`, a failed refresh still an
+     * `oauth_refresh_failed` one). They answer different questions: what
+     * happened to the secret, and what happened to the call.
+     *
+     * The exception reaches the caller unchanged —
+     * `VaultHttpClientTest::sendRequestRefusesAMissingSecretWithAnUnchangedException()`.
+     */
+    private function injectAuthenticationAudited(RequestInterface $request, string $secretForAudit): RequestInterface
+    {
+        try {
+            return $this->injectAuthentication($request);
+        } catch (Throwable $throwable) {
+            $this->logHttpCall(
+                $secretForAudit,
+                $request->getMethod(),
+                (string) $request->getUri(),
+                0,
+                false,
+                self::INJECTION_FAILED_MESSAGE . ': ' . $throwable->getMessage(),
+            );
+
+            throw $throwable;
+        }
+    }
+
+    /**
+     * The audit row for a call refused before the credential was read.
+     *
+     * Written from the guards themselves so both send paths get it from one
+     * place; the URI is the pre-injection one, so no secret can reach the row.
+     */
+    private function logRefusal(RequestInterface $request, string $message): void
+    {
+        $this->logHttpCall(
+            $this->getSecretIdentifierForAudit(),
+            $request->getMethod(),
+            (string) $request->getUri(),
+            0,
+            false,
+            $message,
+        );
+    }
+
+    /**
+     * Resolve the transport, and audit the call when that fails.
+     *
+     * `resolveCancellableTransport()` sat outside every audited region on
+     * `sendCancellable()`: it runs after the guards and before the credential
+     * injection, so a throw from `SecureHttpClientFactory::createCancellable()`
+     * — the option build, the handler composition, the Guzzle client
+     * construction — left no row, and "every call leaves exactly one row" had
+     * an outcome nobody had enumerated.
+     *
+     * Same shape as `injectAuthenticationAudited()`, for the same reason and
+     * with the same restraint: `http_call` / `success = false`, the original
+     * message after the colon, and the throwable itself rethrown unchanged.
+     * Nothing egressed here and no secret was read — the row records that a
+     * call was asked for, not that a credential was exposed.
+     */
+    private function resolveCancellableTransportAudited(
+        RequestInterface $request,
+        string $secretForAudit,
+    ): ?CancellableTransport {
+        try {
+            return $this->resolveCancellableTransport();
+        } catch (Throwable $throwable) {
+            $this->logHttpCall(
+                $secretForAudit,
+                $request->getMethod(),
+                (string) $request->getUri(),
+                0,
+                false,
+                self::TRANSPORT_RESOLUTION_FAILED_MESSAGE . ': ' . $throwable->getMessage(),
+            );
+
+            throw $throwable;
+        }
+    }
+
+    /**
+     * The transport for `sendCancellable()`: the injected one, or a freshly
+     * built one carrying the current timeout override.
+     *
+     * Built on demand rather than in the constructor so a client that only ever
+     * calls `sendRequest()` — which is nearly all of them — does not pay for a
+     * second Guzzle client and a curl multi handle it never uses.
+     *
+     * An inner client passed into the constructor can never serve a cancellable
+     * send: an abort needs the `CurlMultiHandler` reference that
+     * `createCancellable()` hands out next to its client. That leaves one
+     * question — what to do for an instance whose inner client came from a
+     * caller — and the answer is to degrade rather than substitute:
+     *
+     * - A caller-supplied client is the one that sends. It may carry that
+     *   caller's middleware, proxy or handler stack, and replacing it with a
+     *   factory-built one behind their back would silently drop all of it on
+     *   this path only. `supportsCancellation()` reports false for such an
+     *   instance and `sendCancellable()` completes it blocking, on their client
+     *   (`VaultHttpClientCancellableTest::anInjectedGuzzleClientIsNeverSwappedForACancellableTransport()`).
+     * - Only a factory-built inner client gets a cancellable sibling. When this
+     *   method builds it, it is built from the same `buildOptions()`, carries
+     *   the same `ssrf-dns-pin` middleware and — because the fact is derived
+     *   from the constructor having built that client with this instance's
+     *   `$timeoutSeconds` — the same deadline
+     *   (`…::theTransportTheClientResolvesForItselfCarriesTheRememberedTimeout()`).
+     *
+     * "The transport is always one the factory built" would be false, and is
+     * not claimed: the `@internal` `$cancellableTransport` parameter is public,
+     * and a transport handed in that way is returned here as-is, with whatever
+     * hardening it was built with. What the seam cannot do is displace a
+     * caller-supplied client, because the guard above runs before it is read
+     * (`…::anInjectedTransportNeverDisplacesACallerSuppliedClient()`).
+     */
+    private function resolveCancellableTransport(): ?CancellableTransport
+    {
+        // Asked FIRST, so an injected transport cannot displace a client the
+        // caller supplied; `supportsCancellation()` reports the same answer.
+        if (!$this->supportsCancellation()) {
+            return null;
+        }
+
+        return $this->cancellableTransport
+            ?? $this->secureHttpClientFactory->createCancellable($this->timeoutSeconds);
+    }
+
+    /**
+     * The blocking send plus its audit row — the body `sendRequest()` runs,
+     * reused by the degraded cancellable path so the guards are not evaluated
+     * (and the host not re-resolved) a second time.
+     *
+     * The row is written from a `finally`, for the same reason the cancellable
+     * path writes its own from one: `Client::applyOptions()` raises
+     * `InvalidArgumentException` OUTSIDE `Client::transfer()`'s try/catch, so a
+     * bad option set leaves `sendRequest()` as a throw and not as a PSR-18
+     * `ClientExceptionInterface`. Catching only the latter would let such a
+     * call — credential already injected — leave no trace, on the plain
+     * `sendRequest()` path and on the degraded cancellable one alike.
+     *
+     * @throws ClientExceptionInterface
+     */
+    private function sendBlocking(
+        RequestInterface $request,
+        RequestInterface $authenticatedRequest,
+        string $secretForAudit,
+    ): ResponseInterface {
+        $auditStatus = 0;
+        $auditSuccess = false;
+        $auditMessage = self::UNEXPECTED_BLOCKING_OUTCOME_MESSAGE;
+
+        try {
+            $response = $this->innerClient->sendRequest($authenticatedRequest);
+
+            $auditStatus = $response->getStatusCode();
+            $auditSuccess = true;
+            $auditMessage = null;
+
+            return $response;
+        } catch (ClientExceptionInterface $e) {
+            // Unchanged from before the `finally`: a transport failure keeps
+            // status 0, success false and the transport's own message, which
+            // `logHttpCall()` redacts on the way into the row.
+            $auditMessage = $e->getMessage();
+
             throw $e;
+        } catch (Throwable $throwable) {
+            $auditMessage = self::UNEXPECTED_BLOCKING_OUTCOME_MESSAGE . ': ' . $throwable->getMessage();
+
+            throw $throwable;
+        } finally {
+            $this->logHttpCall(
+                $secretForAudit,
+                $request->getMethod(),
+                (string) $request->getUri(),
+                $auditStatus,
+                $auditSuccess,
+                $auditMessage,
+            );
+        }
+    }
+
+    /**
+     * Drive one transfer on the cancellable transport.
+     *
+     * The promise never leaves this method, and `wait()` is never used to make
+     * it settle: that would run `CurlMultiHandler::execute()`, which loops until
+     * every handle on the handler completes and leaves no window in which the
+     * signal could be observed. The loop settles the promise itself, one bounded
+     * tick at a time, and only reads the value once the promise has left the
+     * pending state.
+     *
+     * Every exit from this method writes exactly one audit row, from a
+     * `finally` that opens on the FIRST statement — the credential was injected
+     * before this method was entered, so there is no window here that may throw
+     * unaudited. Three of the moving parts belong to somebody else: Guzzle's own
+     * option handling inside `sendAsync()`, the caller's signal, and the ticker
+     * seam. A throw from any of them would otherwise escape a method whose
+     * entire purpose is to leave a trace when a credential went out.
+     *
+     * @throws RequestCancelledException
+     * @throws ClientExceptionInterface
+     * @throws VaultException
+     */
+    private function sendCancellably(
+        CancellableTransport $transport,
+        RequestInterface $request,
+        RequestInterface $authenticatedRequest,
+        string $secretForAudit,
+        CancellationSignalInterface $signal,
+    ): ResponseInterface {
+        // The single outcome the `finally` writes. Pre-set to the one case no
+        // branch below records: a throw from code this method does not own —
+        // Guzzle's option handling, the caller's signal, a ticker
+        // implementation. `$outcomeRecorded` says whether the ladder was
+        // reached, so that message is not overwritten by a later one.
+        $auditAction = AuditAction::HttpCall;
+        $auditStatus = 0;
+        $auditSuccess = false;
+        $auditMessage = self::UNEXPECTED_OUTCOME_MESSAGE;
+        $outcomeRecorded = false;
+
+        // Declared before the try so the catch can tear down a transfer that had
+        // already been handed to the transport when the throw happened, and can
+        // tell that case apart from one where no promise exists yet.
+        $promise = null;
+
+        try {
+            // Inside the try, deliberately. `Client::applyOptions()` raises
+            // InvalidArgumentException OUTSIDE `Client::transfer()`'s own
+            // try/catch, so a bad option set leaves sendAsync() as a THROW
+            // rather than as a rejected promise. The credential is already
+            // injected by the time this method is entered, so a throw here
+            // without an audit row would be exactly the hole the pre-flight
+            // decision exists to close. Same reasoning for the `then()`
+            // registration and the two transport accessors below.
+            $promise = $transport->client()->sendAsync($authenticatedRequest, [
+                // Client::sendRequest() pins these per request; an async send
+                // sets neither, so allow_redirects would fall back to the client
+                // default — which honours
+                // $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects'] when an
+                // operator set it. On such an install this path alone would
+                // start following redirects, past a DNS pin computed for the
+                // ORIGINAL host. Measured, not theoretical: the same client
+                // answered "302 not followed" synchronously and "200 followed"
+                // asynchronously.
+                RequestOptions::ALLOW_REDIRECTS => false,
+                RequestOptions::HTTP_ERRORS => false,
+                // RequestOptions::SYNCHRONOUS is deliberately absent: setting it
+                // routes the send back to the blocking CurlHandler, whose
+                // promise is already settled and whose cancel() is a no-op — an
+                // abort that fails by doing nothing.
+            ]);
+
+            // Settlement is observed through a handler, NOT through getState(): a
+            // promise counts as fulfilled the moment it is resolved WITH ANOTHER
+            // PROMISE, which may still be pending. State alone would therefore call
+            // an unfinished transfer done and hand the caller a value that is not a
+            // response. A handler fires only when the chain has resolved all the way
+            // down to a real value.
+            $settled = false;
+            $rejected = false;
+            $settledValue = null;
+            $promise->then(
+                static function (mixed $value) use (&$settled, &$settledValue): void {
+                    $settled = true;
+                    $settledValue = $value;
+                },
+                static function (mixed $reason) use (&$settled, &$rejected, &$settledValue): void {
+                    $settled = true;
+                    $rejected = true;
+                    $settledValue = $reason;
+                },
+            );
+
+            $ticker = $transport->ticker();
+            $deadline = microtime(true) + $transport->wallClockBudgetSeconds();
+
+            // Drained BEFORE the first tick. sendAsync() can return an ALREADY
+            // rejected promise — the SSRF middleware rejects synchronously and
+            // Client::transfer() converts the throw into a rejection — whose
+            // handler is queued rather than run inline. Draining first settles
+            // that case without touching the transport at all, instead of
+            // ticking a handler that has nothing on it.
+            PromiseUtils::queue()->run();
+
+            $cancelled = false;
+            $budgetExhausted = false;
+
+            while (!$settled) {
+                // Neither branch tears the transfer down here. Every way out of
+                // this loop other than a settled promise ends in a throw, and
+                // the catch below cancels exactly once for all of them —
+                // including the throws that come from the signal or the ticker,
+                // which no branch here could have caught. One teardown site
+                // instead of three, and no path that aborts without one.
+                if ($signal->isCancelled()) {
+                    $cancelled = true;
+                    break;
+                }
+
+                if (microtime(true) >= $deadline) {
+                    $budgetExhausted = true;
+                    break;
+                }
+
+                $ticker->tick();
+
+                // The tick advances the transfer; this propagates the result up
+                // the middleware chain. Done here rather than relying on the
+                // ticker so the loop's progress does not depend on which ticker
+                // implementation it was handed.
+                PromiseUtils::queue()->run();
+            }
+
+            if ($cancelled) {
+                $auditAction = AuditAction::HttpCallCancelled;
+                $auditMessage = self::CANCELLED_IN_FLIGHT_MESSAGE;
+                $outcomeRecorded = true;
+
+                throw new RequestCancelledException(self::CANCELLED_IN_FLIGHT_MESSAGE, 1786579202);
+            }
+
+            if ($budgetExhausted) {
+                // A FAILURE, not a cancellation: nobody asked for this. The
+                // defensive bound only trips when the handler stopped settling
+                // its promise, which is a bug in the transport and belongs with
+                // the other transport failures under `http_call` /
+                // `success = false`. `http_call_cancelled` answers exactly one
+                // question — which calls did a caller abandon after their
+                // credential went out — and a second meaning on it would make
+                // that query wrong again. The fixed literal below is what tells
+                // this failure apart from a connection refusal.
+                $auditMessage = self::TICK_BUDGET_EXHAUSTED_MESSAGE;
+                $outcomeRecorded = true;
+
+                throw new VaultException(self::TICK_BUDGET_EXHAUSTED_MESSAGE, 1786579203);
+            }
+
+            if ($rejected) {
+                // Audited more widely than sendRequest()'s catch on purpose: an
+                // async rejection reason need not implement any PSR-18
+                // interface, and a call whose credential already egressed must
+                // never be the one row missing from the log. `wait()` is never
+                // used to surface it — that would run
+                // CurlMultiHandler::execute() and block until every other handle
+                // on the loop finished. The error string still travels through
+                // logHttpCall(), which is where secret redaction happens.
+                $message = $settledValue instanceof Throwable
+                    ? $settledValue->getMessage()
+                    : 'Cancellable transfer was rejected';
+
+                $auditMessage = $message;
+                $outcomeRecorded = true;
+
+                if ($settledValue instanceof Throwable) {
+                    throw $settledValue;
+                }
+
+                throw new VaultException($message, 1786579204);
+            }
+
+            if (!$settledValue instanceof ResponseInterface) {
+                // `http_call` with success = false, deliberately: the transfer
+                // ran to a settlement and produced something unusable. That is
+                // a transport failure, and it sits with the other transport
+                // failures rather than with the one thing
+                // `http_call_cancelled` means. The fixed literal below is what
+                // separates it from a connection refusal in the row.
+                $auditMessage = self::NON_RESPONSE_SETTLEMENT_MESSAGE;
+                $outcomeRecorded = true;
+
+                throw new VaultException(self::NON_RESPONSE_SETTLEMENT_MESSAGE, 1786579205);
+            }
+
+            $auditStatus = $settledValue->getStatusCode();
+            $auditSuccess = true;
+            $auditMessage = null;
+            $outcomeRecorded = true;
+
+            return $settledValue;
+        } catch (Throwable $throwable) {
+            // THE teardown. Every abort — a signalled one, the wall-clock bound,
+            // and a throw from the caller's signal or the ticker — leaves the
+            // try block through here with the transfer still running, and this
+            // is what closes the socket: Promise::cancel() runs the cancel
+            // function CurlMultiHandler attached, which removes the easy handle
+            // from the multi handle and drops the last reference to it. On a
+            // promise that already settled it returns immediately, so the
+            // outcomes that need no teardown pay nothing. Null only when
+            // sendAsync() itself threw, i.e. when there is no transfer yet.
+            $promise?->cancel();
+
+            if (!$outcomeRecorded) {
+                // A FAILURE, and audited as one: `http_call` / success = false.
+                // Nobody asked for it — the signal was not set, the transfer was
+                // not abandoned on purpose, something in code this class does
+                // not own threw. `http_call_cancelled` stays reserved for the
+                // single case where a caller's signal stopped an in-flight
+                // request; the literal below, plus the original message, is what
+                // identifies this one.
+                $auditMessage = self::UNEXPECTED_OUTCOME_MESSAGE . ': ' . $throwable->getMessage();
+            }
+
+            throw $throwable;
+        } finally {
+            $this->logHttpCall(
+                $secretForAudit,
+                $request->getMethod(),
+                (string) $request->getUri(),
+                $auditStatus,
+                $auditSuccess,
+                $auditMessage,
+                $auditAction,
+            );
         }
     }
 
@@ -527,6 +1280,25 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
 
     /**
      * Log HTTP call to audit log.
+     *
+     * The context is built from the PRE-injection request, so a QueryParam-placed
+     * secret can never reach the audit row. `$errorMessage` may still contain the
+     * injected secret — a transport error string quotes the URL it failed on —
+     * and is redacted by `AuditLogService::sanitizeErrorMessage()` on the way in.
+     * Every audit row this client writes therefore goes through THIS method.
+     * An exception handed back to a caller does not — which is why the ones
+     * this class raises itself are fixed literals.
+     *
+     * @param AuditAction $action Which action this row is filed under. Only three
+     *                            values ever reach this method, and each means one
+     *                            thing: `HttpCallCancelled` — a caller's signal
+     *                            stopped an in-flight request; `HttpCallCancelledBeforeSend`
+     *                            — refused before the send, no secret read;
+     *                            `HttpCall` — everything else, including every
+     *                            failure. The two cancellations are actions rather
+     *                            than distinguishing error strings because a string
+     *                            is free text an auditor cannot filter on, while the
+     *                            action drives the backend's filter dropdown.
      */
     private function logHttpCall(
         string $secretIdentifier,
@@ -535,10 +1307,11 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface
         int $statusCode,
         bool $success,
         ?string $errorMessage,
+        AuditAction $action = AuditAction::HttpCall,
     ): void {
         $this->auditLogService->log(
             $secretIdentifier,
-            'http_call',
+            $action->value,
             $success,
             $errorMessage,
             $this->reason,

--- a/Classes/Http/VaultHttpClientFactory.php
+++ b/Classes/Http/VaultHttpClientFactory.php
@@ -30,13 +30,19 @@ final readonly class VaultHttpClientFactory implements VaultHttpClientFactoryInt
 
     /**
      * Create a new VaultHttpClient for the given vault service.
+     *
+     * The inner client is left to the constructor rather than built here: it
+     * then comes from the injected factory, and the client knows it is holding
+     * a factory-built transport. That is what licenses `sendCancellable()` to
+     * build a cancellable sibling — a client handed in from outside is never
+     * replaced by one.
      */
     public function create(VaultServiceInterface $vaultService): VaultHttpClientInterface
     {
         return new VaultHttpClient(
             $vaultService,
             $this->auditLogService,
-            $this->secureHttpClientFactory->create(),
+            secureHttpClientFactory: $this->secureHttpClientFactory,
         );
     }
 }

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -153,6 +153,16 @@ services:
   Netresearch\NrVault\Http\VaultHttpClientInterface:
     alias: Netresearch\NrVault\Http\VaultHttpClient
 
+  # `$clonedFrom` is the seam the with*() clones use to carry "this inner client
+  # came from the factory" across a fluent chain, so it is typed as
+  # VaultHttpClient itself. Autowiring would read that as a dependency on the
+  # very service being built and refuse the container with a circular
+  # reference. Pinning the argument to null leaves every other one autowired,
+  # and the container-built instance is the one that has no prototype anyway.
+  Netresearch\NrVault\Http\VaultHttpClient:
+    arguments:
+      $clonedFrom: null
+
   Netresearch\NrVault\Service\Analytics\VaultAnalyticsServiceInterface:
     alias: Netresearch\NrVault\Service\Analytics\VaultAnalyticsService
 

--- a/Documentation/Developer/Adr/ADR-037-CancellableOutboundSend.rst
+++ b/Documentation/Developer/Adr/ADR-037-CancellableOutboundSend.rst
@@ -1,0 +1,474 @@
+.. include:: /Includes.rst.txt
+
+.. _adr-037-cancellable-outbound-send:
+
+===============================================================
+ADR-037: A cancellable send is a method, not an exported handle
+===============================================================
+
+.. contents:: Table of contents
+   :local:
+   :depth: 2
+
+Status
+======
+
+Accepted
+
+Date
+====
+
+2026-08-13
+
+Context
+=======
+
+A consumer that cancels a long-running operation cannot stop the outbound HTTP call nr-vault started on its behalf.
+The call runs to its timeout — for `netresearch/t3x-nr-llm#774 <https://github.com/netresearch/t3x-nr-llm/issues/774>`__ that is up to about 45 seconds across the three legs of one tool step, long after the work it was serving was abandoned.
+
+Two independent reasons block an abort today, either sufficient on its own.
+PSR-18 ``sendRequest()`` returns a response, never a handle, so there is nothing for a caller to cancel.
+And Guzzle's ``Client::sendRequest()`` sets ``RequestOptions::SYNCHRONOUS``, which routes the send to the blocking ``CurlHandler``: its promise is already settled by the time it exists, and its ``cancel()`` is a no-op.
+Guzzle promises support cancellation in general; that one does not.
+
+A genuine abort needs ``CurlMultiHandler``, which attaches a real cancel function to its promise and exposes ``tick()``.
+Both are unreachable from outside this package: the Guzzle client is built inside ``SecureHttpClientFactory::create()``, its handler stack is local to that method, and ``VaultHttpClientInterface`` exposes only PSR-18 plus four withers.
+
+The obvious blocking alternative was rejected on evidence rather than taste.
+Aborting from ``CURLOPT_PROGRESSFUNCTION`` without going async needs ``CURLOPT_NOPROGRESS => false`` set alongside the callback; Guzzle's curl factory sets both together for its own ``progress`` option, and nothing sets it on the raw ``curl`` seam.
+A progress callback registered by hand there is therefore never invoked.
+It fails by doing nothing, which is the worst possible failure mode for a security-relevant abort.
+
+Decision
+========
+
+The primitive is a **method on** ``VaultHttpClient``
+----------------------------------------------------
+
+``sendCancellable(RequestInterface $request, CancellationSignalInterface $signal): ResponseInterface``, declared on a new ``CancellableHttpClientInterface``.
+
+This is not a stylistic preference about where to put a method — it follows from where the protections actually live.
+Of the seven properties that make this client safe, only two are properties of the handler stack:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Protection
+     - Where it lives
+     - Survives a different send method?
+   * - Scheme allowlist (``http``/``https`` only)
+     - plain code in the sending method
+     - **No**
+   * - ``allowed_hosts`` gate
+     - plain code in the sending method
+     - **No**
+   * - Credential injection
+     - plain code in the sending method
+     - **No**
+   * - Audit write
+     - plain code in the sending method
+     - **No**
+   * - SSRF reject (dangerous IP, legacy ``inet_aton`` forms)
+     - ``ssrf-dns-pin`` middleware
+     - Yes
+   * - ``CURLOPT_RESOLVE`` DNS pin
+     - ``ssrf-dns-pin`` middleware
+     - Yes
+   * - Proxy, TLS and timeout settings
+     - client option set
+     - Yes, for the same client object
+
+Any shape that handed a consumer the inner client, the handler or a promise would drop the first four — including the allowlist that runs *before the credential reaches the request*, and the audit row that records the call happened at all.
+
+The two legs order that differently, and only one of them reads the secret after the gate.
+On the outer request the gate runs before any vault read: ``assertHostIsAllowed()`` precedes ``injectAuthentication()``.
+On the OAuth token leg the credentials are read first, in ``buildTokenRequestParams()`` (``OAuthTokenManager.php:286-306``), and ``isHostAllowed()`` runs afterwards in ``dispatchTokenRequest()`` (``:337``) — still before the body carrying ``client_secret`` is built (``:351``).
+Nothing egresses before the gate either way; "before the secret is read" would be the wrong verb for the second leg.
+A handle object (``startRequest()`` → ``tick()`` → ``response()``) fails the same test from the other direction: it makes the audit write conditional on consumer discipline, because a caller that breaks out of its loop or drops the handle produces an outbound call, credential already on the wire, with no audit row.
+
+The invariant this shape protects
+--------------------------------
+
+It is **not** "no transport type crosses the package boundary" — the codebase has never had that, and asserting it would be wrong.
+``SecureHttpClientFactory::create()`` was already public before this change and already returned a raw ``ClientInterface``; nr-llm injects the factory directly in three places (``McpHttpTransport``, ``SecureHttpDispatchTrait``, ``ModelDiscovery``).
+``createCancellable()`` adds a second such entry point, returning a ``CancellableTransport`` that exposes a Guzzle client and its ticker.
+
+The boundary is two-tier, and the narrower statement is the one that must hold:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Tier
+     - What a caller gets
+     - What it carries
+   * - ``create()`` / ``createCancellable()`` — public, supported
+     - a raw transport
+     - SSRF reject middleware and the ``CURLOPT_RESOLVE`` DNS pin. **No** vault credential, no scheme guard, no ``allowed_hosts`` gate, no audit write
+   * - ``VaultHttpClient`` — ``sendRequest()`` / ``sendCancellable()``
+     - PSR-7 in, PSR-7 out
+     - everything the first tier carries, plus the four inline ones: the scheme
+       guard, the ``allowed_hosts`` gate, credential injection and the audit write
+
+**Nothing hands a caller a client that already carries a vault secret**, and ``VaultHttpClient`` is the only place nr-vault attaches a secret to a *caller's* request.
+That is the invariant, stated at the width it actually holds, and the half of it a test can hold to that width is the export surface: ``theCredentialBearingClientExportsNoTransportAndNoPromise()`` fails the moment a public method of ``VaultHttpClient`` returns anything other than a configured clone, a PSR-7 response or a bool.
+A caller who wants a hardened transport *without* vault credentials is a supported case, which is why the first tier is public.
+
+The wider statement — "no credential-bearing send exists outside ``VaultHttpClient``" — is **false**, and two senders inside this package are the counterexamples.
+They are named here, where a reader checks the invariant, and not only under `Where the guarantee stops`_:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Sender
+     - Credential
+     - Client
+   * - ``TransitMasterKeyProvider::callTransit()`` (``TransitMasterKeyProvider.php:282``)
+     - ``X-Vault-Token`` header
+     - the plain Guzzle client ``MasterKeyProviderFactory`` builds (``MasterKeyProviderFactory.php:52``) — no middleware, no allowlist, deliberately, for on-prem RFC1918 Vault
+   * - ``OAuthTokenManager::dispatchTokenRequest()`` (``OAuthTokenManager.php:357``)
+     - ``client_secret`` in the form body built at ``OAuthTokenRequestParams.php:60``
+     - the hardened inner client, with the ``allowed_hosts`` gate applied at ``OAuthTokenManager.php:337`` but no audit write
+
+Neither is a *caller's* request: the transit call belongs to master-key handling, and the token leg runs inside ``injectAuthentication()`` on nr-vault's own behalf.
+Both are covered further under `Where the guarantee stops`_.
+
+What the shape enforces, and what enforces it: every public method of ``VaultHttpClient`` returns a configured clone, a PSR-7 response or a bool — no client, no handler, no promise — and ``sendCancellable()`` has no options parameter through which a caller could reach the transport.
+Both are asserted by ``VaultHttpClientCancellableTest::theCredentialBearingClientExportsNoTransportAndNoPromise()``, so a future method that hands one of them back fails a test rather than quietly widening the surface.
+
+The transport is composed, not swapped
+--------------------------------------
+
+``SecureHttpClientFactory::create()`` is unchanged in behaviour; its option-building block moved into a shared private ``buildOptions()`` so the blocking and cancellable transports cannot drift apart — asserted option by option by ``theBlockingAndCancellableTransportsCarryTheSameOptions()``, which compares the two clients' full request-option sets and excludes only the handler.
+A new ``createCancellable()`` builds the second transport from the same options and pushes the same ``ssrf-dns-pin`` middleware — that the middleware really runs on this transport is asserted by ``ssrfDnsPinIsInstalledOnTheCancellableTransport()``, which reads the ``CURLOPT_RESOLVE`` entry off the request that reached the bottom handler.
+
+Two details that are easy to get wrong:
+
+The multi handler is **not** passed bare.
+Guzzle's own handler selection composes ``Proxy::wrapStreaming(Proxy::wrapSync($multi, new CurlHandler()), new StreamHandler())``; passing the bare handler would silently delete both the sync and the streaming branch.
+Re-composing preserves both and yields the ``$multi`` reference the loop needs.
+
+The capability gate is ``curl_multi_exec``, not ``curl_init``.
+``CurlMultiHandler``'s constructor is lazy and only fatals on first property access, so gating on the wrong function would turn the documented curl-less degraded mode into a hard failure.
+Without ``curl_multi_exec`` the factory returns ``null`` and ``sendCancellable()`` completes the call blocking, with an ordinary audit row.
+That blocking fallback is the same private helper ``sendRequest()`` uses, not a second copy of it: two copies of the send-and-audit body would let the audit behaviour differ by which method a consumer entered through.
+
+**A caller's client is never replaced by a cancellable transport** (``anInjectedGuzzleClientIsNeverSwappedForACancellableTransport()``, ``anInjectedTransportNeverDisplacesACallerSuppliedClient()``).
+An abort needs the ``CurlMultiHandler`` reference that ``createCancellable()`` hands out beside its client, so no inner client passed into ``VaultHttpClient``'s constructor can serve a cancellable send.
+That leaves one question: what to do for an instance whose inner client came from a caller.
+The answer is to degrade, not to substitute.
+
+The wider claim — "the cancellable transport is *always* one the factory built" — is **false** and is not made: the ``@internal`` ``$cancellableTransport`` parameter is public, and a transport handed in that way is used as it was built.
+What the seam cannot do is displace a caller's client, and that is the half with a test.
+
+A supplied client may carry that caller's middleware, proxy or handler stack, and swapping in a factory-built one behind their back would silently drop all of it — on the cancellable path only, which is the worst place for a difference to hide.
+So ``supportsCancellation()`` reports **false** whenever the inner client was supplied, and ``sendCancellable()`` completes such a call blocking, on that client, with an ordinary ``http_call`` row.
+Only a factory-built inner client gets a cancellable sibling; ``VaultHttpClientFactory`` therefore leaves the construction to ``VaultHttpClient`` itself rather than passing a client in, and the ``with*()`` clones carry the fact along with the client.
+
+**That fact cannot be asserted by a caller** (``aCallerCannotAssertTheFactoryBuiltFactByCloningFromAnotherInstance()``), which is what makes the rule above a property of the code rather than of consumer discipline.
+The constructor takes no "this client is factory-built" flag.
+It takes the instance the client is being forwarded *from* (``$clonedFrom``, passed by the ``with*()`` clones and by nothing else) and inherits the fact only when the forwarded client is the identical object that instance holds.
+Reaching that branch requires already holding a factory-built instance, so ``new VaultHttpClient(innerClient: $factory->create(5), …)`` cannot claim it — and with it goes the mismatch it would otherwise buy, a blocking client at 5 s beside a cancellable one at 30.
+
+The parameter is typed as the class itself, which is what makes it unforgeable and also what makes ``Services.yaml`` pin it: autowiring would otherwise read it as a dependency of ``VaultHttpClient`` on ``VaultHttpClient`` and refuse the whole container with a circular reference.
+An explicit ``arguments: {$clonedFrom: null}`` entry leaves every other argument autowired.
+Two alternatives were rejected: a ``WeakMap`` of clients the factory built would accept a client whose handler stack the caller mutated after ``create()``, which is the substitution the rule exists to prevent; and having the clones drop the client and let the constructor rebuild it would emit the ``verify => false`` operator warning once per wither instead of once per client.
+
+This also settles the timeout for a transport the client builds itself: it is built from the same remembered override the inner client was built with, so it cannot outlive the blocking path — cancellation is an early exit, and a transport that could run *longer* than the send it replaces would be the opposite of one.
+``theTransportTheClientResolvesForItselfCarriesTheRememberedTimeout()`` asserts both halves against one client, with an override-free control so the number cannot have arrived by coincidence.
+
+Where that stops, and it is worth naming because the sentence above is the one a reader will generalise: ``withTimeout()`` **does** replace a client the caller supplied.
+PSR-18 carries no per-request options, so the override has to be baked into a client, and the one that gets built comes from the factory — which also flips ``supportsCancellation()`` to true for the clone (``withTimeoutRebuildsACallerSuppliedClientAndTurnsCancellationOn()``).
+
+Tests that need to drive the loop inject a ``CancellableTransport`` through the ``$cancellableTransport`` constructor parameter.
+That parameter is ``@internal``, and it is **not** a way around the rule above: ``supportsCancellation()`` checks the factory-built fact *first*, so an injected transport on an instance whose client came from a caller is never read and the call degrades to a blocking send on that client.
+What the seam remains able to do is substitute the transport of an instance that has no caller-supplied client — the four inline protections still run, but the transport's own hardening is then whatever was handed in.
+It is a test seam, documented as one; PHP offers no way to make a constructor parameter unreachable while the constructor is public.
+
+Two posture changes are handled explicitly, not inherited
+---------------------------------------------------------
+
+``allow_redirects => false`` is re-pinned per request.
+``Client::sendRequest()`` pins it for every PSR-18 send; an async send sets nothing and falls back to the client default, which honours ``$GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects']`` when an operator set it.
+On such an install the cancellable path alone would start following redirects — past a DNS pin computed for the *original* host, which is precisely the hole this client exists to close.
+This was measured, not inferred: the same factory-built client answered ``302 not followed`` synchronously and ``200 followed`` asynchronously.
+``redirectsStayOffOnTheCancellablePathEvenWhenTypo3EnablesThem()`` is the regression guard, and it fails on the status rather than by hanging.
+
+``sendCancellable()`` accepts **no per-request option surface**.
+That is a security decision, not an omission.
+A caller-supplied ``stream => true`` would route the request to the stream handler, which ignores ``$options['curl']`` entirely and drops the DNS pin without warning; a caller-supplied ``curl`` array is applied last by Guzzle's curl factory and would overwrite the vetted ``CURLOPT_RESOLVE`` entry.
+Adding an options parameter later requires revisiting both.
+
+Cancellation is an early exit, never an extension
+-------------------------------------------------
+
+``timeout`` and ``connect_timeout`` are per-handle curl options and libcurl enforces them inside the multi interface exactly as inside the blocking path.
+Whichever fires first wins; a timeout expiry still surfaces as the existing ``http_call`` / ``success=false`` / status ``0`` row.
+
+The loop's blocking bound is ``select_timeout``, set to **0.1 s**.
+Measured against a stalling local TCP server that timestamps the moment it observes the peer close, with the signal turning true at +1.5 s (three runs each):
+
+.. code-block:: text
+
+   select_timeout=1      3 ticks   worst tick 1.001 s   peer close at +2.002 s
+   select_timeout=0.1   16 ticks   worst tick 0.100 s   peer close at +1.504 s
+   select_timeout=0.05  31 ticks   worst tick 0.050 s   peer close at +1.506 s
+
+Guzzle's default of 1 second costs up to a full second of overshoot and is unusable here.
+Between the other two the measurement shows no latency problem at 0.1, so the CPU-conservative value wins: 0.05 doubles the wakeups to buy 50 ms that nothing in the motivating case can perceive.
+
+A defensive wall-clock bound of ``timeout + connect_timeout + 5 s`` sits strictly above libcurl's own deadlines (``theFactoryBuildsACancellableTransportWithABudgetAboveTheTransferDeadlines()``).
+If it ever trips, the handler stopped settling its promise — better to abort and audit than to hang a TYPO3 request.
+
+``withTimeout()`` does not carry a transport across.
+A client rebuilt with a new timeout while the caller keeps ticking the previous client's event loop would tick a loop that serves nothing, and spin to the wall-clock bound.
+The transport is built on demand from the remembered override instead, so the two cannot disagree (``withTimeoutDropsTheTransportAndRemembersTheOverride()``).
+
+Settlement is observed through a handler, not through promise state
+--------------------------------------------------------------------
+
+A Guzzle promise counts as fulfilled the moment it is resolved *with another promise*, which may still be pending.
+Reading ``getState()`` would therefore call an unfinished transfer done and hand the caller a value that is not a response.
+A ``then()`` handler fires only when the chain has resolved all the way down to a real value, so the loop uses that.
+
+``wait()`` is never called.
+Its wait function is ``CurlMultiHandler::execute()``, which loops until *every* handle on that handler completes — no cancellation window at all.
+The stubbed transfer counts invocations of its promise's wait function and ``cancellingMidFlightAbortsTheTransferAndAuditsItAsCancelled()`` asserts that count is zero, so a loop that started waiting fails a test instead of quietly becoming uncancellable.
+
+Every call leaves one row, and each action means exactly one thing
+------------------------------------------------------------------
+
+**Every call leaves exactly one row from this client**, on ``sendCancellable()`` and on ``sendRequest()`` alike, so the log is complete with respect to **calls** and not merely with respect to egress — including the call that was already cancelled when it began, the one refused by an allowlist, and the one whose credential could not be obtained.
+That overrides the "no row when nothing egressed" position the design proposed: the operator expectation is that a call that was asked for is a call that shows up.
+
+The rightmost column is what keeps that sentence honest: an outcome with no test in it is an outcome nobody has checked writes a row.
+Three of these rows are new here — the scheme guard, the host guard and the vault read between them and the send all used to throw before anything was written.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Situation
+     - Action
+     - success
+     - statusCode
+     - Test
+   * - Completed (any HTTP status)
+     - ``http_call``
+     - true
+     - real status
+     - ``anUncancelledCallReturnsTheResponseAndAuditsAnOrdinaryHttpCall()``
+   * - Scheme outside http/https
+     - ``http_call``
+     - false
+     - 0
+     - ``aRefusedSchemeIsAuditedAsAFailedHttpCall()``, ``schemeGuardRunsOnTheCancellablePathBeforeAnySecretIsRead()``
+   * - Host outside ``allowed_hosts``
+     - ``http_call``
+     - false
+     - 0
+     - ``aRefusedHostIsAuditedAsAFailedHttpCall()``, ``hostAllowlistRunsOnTheCancellablePathBeforeAnySecretIsRead()``
+   * - The cancellable transport could not be built (``sendCancellable()`` only)
+     - ``http_call``
+     - false
+     - 0
+     - ``aThrowFromTheTransportResolutionLeavesAnAuditRow()``
+   * - The credential could not be obtained (missing secret, denied read, failed token leg)
+     - ``http_call``
+     - false
+     - 0
+     - ``aFailedCredentialInjectionIsAuditedAsAFailedHttpCall()``, ``aFailedCredentialInjectionOnTheCancellablePathLeavesARow()``
+   * - Transport failure, incl. SSRF rejection
+     - ``http_call``
+     - false
+     - 0
+     - ``anSsrfRejectionSettlesBeforeTheFirstTickAndStillWritesItsRow()``
+   * - A rejection whose reason is not a Throwable
+     - ``http_call``
+     - false
+     - 0
+     - ``aRejectionWithoutAThrowableIsRefusedWithAFixedLiteral()``
+   * - A settlement that is not a response
+     - ``http_call``
+     - false
+     - 0
+     - ``aNonResponseSettlementIsRefusedInsteadOfReturned()``
+   * - The wall-clock bound
+     - ``http_call``
+     - false
+     - 0
+     - ``anExhaustedWallClockBudgetAbortsTheTransferAndAuditsIt()``
+   * - A throw from the signal, the ticker or Guzzle's option handling
+     - ``http_call``
+     - false
+     - 0
+     - ``aSignalThatThrowsMidFlightStillLeavesAnAuditRow()``, ``aThrowFromTheSendItselfStillLeavesAnAuditRow()``, ``aThrowFromTheDegradedBlockingSendStillLeavesAnAuditRow()``
+   * - The signal stopped an in-flight request
+     - ``http_call_cancelled``
+     - false
+     - 0
+     - ``cancellingMidFlightAbortsTheTransferAndAuditsItAsCancelled()``, ``theTwoCancellationOutcomesAreToldApartByTheirAction()``
+   * - The signal was already true on entry
+     - ``http_call_cancelled_before_send``
+     - false
+     - 0
+     - ``cancellingBeforeSendReadsNoSecretAndStillLeavesADistinguishableRow()``, ``aPreFlightSignalIsHonouredEvenWhenCancellationIsUnsupported()``
+
+The action is what an auditor can filter and count on; the error message is free text they cannot.
+So the question this feature exists to answer — **which calls were abandoned after their credential went out?** — is answerable by querying **one** action value, which requires that action to carry exactly one meaning.
+``SELECT … WHERE action = 'http_call_cancelled'`` is therefore the whole answer, with no post-filtering on message text.
+
+Two consequences are deliberate.
+
+**The wall-clock bound and an unexpected throwable are failures, not cancellations.**
+Nobody asked for either: the bound only trips when the handler stopped settling its promise, and the throwable comes from code neither the caller nor this class intended to run. Filing them under the cancellation action would restore the overloading the action was created to prevent — the auditor would be back to reading messages.
+They keep ``http_call`` / ``success = false``, alongside the connection refusal and the SSRF rejection that already share that tuple, and the fixed literal in the row is what tells them apart *within* that action.
+
+**The pre-flight case is its own action, not a message on the shared one.**
+It is the only abandoned outcome with no credential involved, so it is the one an auditor must be able to *exclude* by query rather than by reading. ``http_call_cancelled`` gets a ``warning`` badge — every row under it means a credential went out; ``http_call_cancelled_before_send`` gets ``info``, because there is nothing to act on.
+
+**The early rejections are audited, and under no new action.**
+``assertSchemeIsAllowed()`` and ``assertHostIsAllowed()`` ran before any audit write and threw, so a rejected scheme or a host nobody approved left no row at all — pre-existing on ``sendRequest()``, and the one thing an operator would most want to find.
+They now write one, on both send paths, before the same unchanged exception is thrown; the vault read between the guards and the send does too.
+
+No new enum case for them, deliberately.
+``http_call`` / ``success = false`` / status ``0`` already *is* "a refused outbound call" here — the SSRF middleware rejection lands in that tuple and is the same kind of egress-policy refusal, caught one layer later.
+A fourth action would split one meaning across two values without giving an auditor a question they could not already ask: the destination is on the row, and the fixed literal says which gate refused it.
+The audit vocabulary is Ask First in this repository, and this change does not need it.
+
+Because these run on a pre-existing path, the exception a caller receives is pinned character for character by three characterization tests written before the row existed — ``sendRequestRefusesAnUnsupportedSchemeWithAnUnchangedException()``, ``sendRequestRefusesAHostOutsideTheAllowlistWithAnUnchangedException()``, ``sendRequestRefusesAMissingSecretWithAnUnchangedException()``.
+An audit row is additive; the refusal itself must not move.
+
+The row's ``error_message`` is a **fixed literal**, rendered by the audit module under the badge (``Audit/List.html:116``), and identifies the situation *within* an action rather than carrying the distinction on its own.
+Five of them append one variable: the offending scheme, or the original message of a throw that came from somewhere else.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Literal
+     - Action
+     - What it means
+   * - ``Request cancelled before send: nothing egressed and no secret was retrieved``
+     - ``http_call_cancelled_before_send``
+     - The signal was already true. No vault read, nothing handed to the transport.
+   * - ``Request cancelled after send began: credential injected and transfer handed to the transport``
+     - ``http_call_cancelled``
+     - Treat the credential as exposed.
+   * - ``Cancellable transfer exceeded its wall-clock budget and was aborted``
+     - ``http_call``
+     - The defensive bound tripped; the handler stopped settling its promise.
+   * - ``Cancellable transport settled with a value that is not an HTTP response``
+     - ``http_call``
+     - The transfer settled with something unusable.
+   * - ``Cancellable transfer aborted by an unexpected error after the credential was injected: …``
+     - ``http_call``
+     - Guzzle's option handling, the caller's signal or the ticker threw.
+   * - ``Blocking send aborted by an unexpected error after the credential was injected: …``
+     - ``http_call``
+     - The blocking send threw something that is not a PSR-18 ``ClientExceptionInterface``. Reachable through the degraded cancellable branch and through plain ``sendRequest()`` alike.
+   * - ``Request refused before any secret was read: unsupported URI scheme "…"``
+     - ``http_call``
+     - The scheme guard refused the URI. The scheme is appended because ``HttpCallContext`` records method, host, path and status and has nowhere else to put it.
+   * - ``Request refused before any secret was read: host is not in the allowed hosts list``
+     - ``http_call``
+     - The ``allowed_hosts`` gate refused the destination; the host itself is on the row, in the context.
+   * - ``Credential injection failed; nothing was sent: …``
+     - ``http_call``
+     - The vault read or the OAuth token leg threw. Nothing egressed.
+   * - ``Cancellable transport could not be built; nothing was sent: …``
+     - ``http_call``
+     - ``SecureHttpClientFactory::createCancellable()`` threw. The resolution runs after the guards and before the credential injection, so nothing egressed and no secret was read (``aThrowFromTheTransportResolutionLeavesAnAuditRow()``).
+   * - ``Cancellable transfer was rejected``
+     - ``http_call``
+     - The promise rejected with a reason that is not a ``Throwable``, so there is no foreign message to append (``aRejectionWithoutAThrowableIsRefusedWithAFixedLiteral()``).
+
+Note what the second literal does **not** claim.
+The signal can turn true on the first pass through the loop, before the first tick, and at that moment the handler has only queued the easy handle — no byte need have left yet.
+What is certain is that the secret was retrieved, injected into the request and handed to the transport, which is the property an auditor must act on. Claiming "the credential left the process" would be a stronger statement than the code can support in that one case.
+
+Adding enum cases is safe for the tamper-evident chain: the rule is that existing backing values must never *change*, because that would break verification of historical rows. A new value only ever appears in new rows.
+The two new values are pinned against literals by ``AuditControllerTest::theCancellationActionValuesAreFrozen()``, and ``AuditControllerTest::everyActionTheHttpClientWritesReachesTheFilterDropdown()`` keeps them filterable in the module.
+
+The audit write for the cancellable transfer sits in a ``finally``, and that ``finally`` opens on the **first statement** after the credential was injected — not after the send was started.
+Three of the moving parts belong to somebody else: Guzzle's own option handling inside ``sendAsync()`` (``Client::applyOptions()`` raises ``InvalidArgumentException`` *outside* ``Client::transfer()``'s try/catch, so a bad option set leaves ``sendAsync()`` as a throw rather than as a rejected promise), the caller's signal, and the ticker seam.
+A throw from any of them would otherwise escape the one method whose purpose is to leave a trace when a credential went out, and the window between injection and the ``try`` is exactly where such a throw would land.
+The same ``finally`` also tears the transfer down before rethrowing, so an abandoned request does not leave a socket open behind it.
+
+**The blocking send gets the same treatment**, because otherwise "every call leaves exactly one row" would be true of one branch of ``sendCancellable()`` and false of the other.
+``sendBlocking()`` caught only ``ClientExceptionInterface``, and ``Client::applyOptions()`` throws outside ``Client::transfer()``'s try/catch on the synchronous path exactly as on the async one — so a degraded cancellable call, credential already injected, could leave no row.
+It now writes from a ``finally`` too.
+That also closes the same hole on plain ``sendRequest()``, which runs the same helper; the pre-existing outcomes (a status row on success, status ``0`` plus the transport's message on a ``ClientExceptionInterface``) are unchanged.
+
+The exceptions this class *raises* on the cancellable path carry fixed literals, because an exception handed back to a consumer does not pass ``AuditLogService::sanitizeErrorMessage()`` and transport error strings on this client can contain the injected secret — for ``SecretPlacement::QueryParam`` the URI *is* the secret.
+The tests in the table above pin the audit-row literals and the exception codes; they do not pin the message a caller receives, and until they did, this class could have started appending the URI to either cancellation message with the suite staying green.
+Every code it raises there is now asserted on ``getMessage()`` as well: ``1786579201`` by ``cancellingBeforeSendReadsNoSecretAndStillLeavesADistinguishableRow()`` and ``aPreFlightSignalIsHonouredEvenWhenCancellationIsUnsupported()``, ``1786579202`` by ``cancellingMidFlightAbortsTheTransferAndAuditsItAsCancelled()`` and ``theTwoCancellationOutcomesAreToldApartByTheirAction()``, ``1786579203`` by ``anExhaustedWallClockBudgetAbortsTheTransferAndAuditsIt()``, ``1786579204`` by ``aRejectionWithoutAThrowableIsRefusedWithAFixedLiteral()``, ``1786579205`` by ``aNonResponseSettlementIsRefusedInsteadOfReturned()``.
+The guards' own messages are pinned by the three characterization tests.
+
+Exceptions this class does not raise are rethrown **unchanged**, which is the other half and was not stated before: an async rejection reason is rethrown as it arrived (``anSsrfRejectionSettlesBeforeTheFirstTickAndStillWritesItsRow()`` asserts the transport's own text reaching the caller), and so is a throw from the caller's signal or the ticker (``aSignalThatThrowsMidFlightStillLeavesAnAuditRow()``).
+Rethrowing them unchanged is what ``sendRequest()`` has always done, and it is not free: a transport error string quotes the URL it failed on, which for ``QueryParam`` placement carries the secret.
+That is a pre-existing property of every send on this client, it is unchanged here, and it is why the *audit* boundary redacts rather than the exception boundary.
+
+The ticker is an interface
+--------------------------
+
+``TransportTickerInterface`` exists so the feature is provable.
+The suite's only in-process HTTP seam replaces a client's bottom handler, which destroys the very ``CurlMultiHandler`` a cancellation loop would have to tick — a primitive holding that handler privately could not be exercised by any unit test, only read.
+With the ticker behind an interface, a test drives the real middleware stack from a closure and the abort is provable without a socket, a sleep or a flake.
+This mirrors the ``DnsResolverInterface`` injection precedent in the same namespace.
+
+Guzzle becomes a declared dependency
+------------------------------------
+
+``composer.json`` now requires ``guzzlehttp/guzzle`` directly.
+Production code already imported ``GuzzleHttp\Client``, ``HandlerStack`` and ``RequestException`` while the manifest named only the PSR interfaces and relied on ``typo3/cms-core`` to drag Guzzle in.
+This change reaches deeper still — ``CurlMultiHandler``, ``Proxy``, ``StreamHandler``, promise cancel semantics — and a Guzzle major arriving through a third path would break it with no warning in our own manifest.
+
+Where the guarantee stops
+=========================
+
+Each of these is a real residual gap, not a hypothetical.
+
+Each is filed, so it can be argued somewhere: `#303 <https://github.com/netresearch/t3x-nr-vault/issues/303>`__ (OAuth leg), `#304 <https://github.com/netresearch/t3x-nr-vault/issues/304>`__ (double DNS resolve), `#306 <https://github.com/netresearch/t3x-nr-vault/issues/306>`__ (api-surface snapshot), `#307 <https://github.com/netresearch/t3x-nr-vault/issues/307>`__ (mutation gate scope).
+`#305 <https://github.com/netresearch/t3x-nr-vault/issues/305>`__ (unaudited rejections) is closed by this change: the scheme and host guards write a row, and so does a failed credential injection.
+`#309 <https://github.com/netresearch/t3x-nr-vault/issues/309>`__ asked for a second audit action for the pre-flight case; it is implemented here as ``http_call_cancelled_before_send``.
+
+**The OAuth token round trip stays uncancellable.**
+``injectAuthentication()`` → ``injectOAuth()`` → ``OAuthTokenManager::getAccessToken()`` performs a blocking PSR-18 send *before* the cancellable transfer, on a client the timeout override and the signal never reach.
+That manager is also constructed without an audit log service, so the token call is unaudited today and stays so.
+For OAuth-configured clients only part of the "three legs" complaint is addressed.
+
+**The two blocking DNS lookups stay.**
+``isHostAllowed()`` resolves the host, and the middleware resolves it again at request time.
+Both are synchronous, both precede the socket, neither is interruptible.
+
+**The OAuth token leg still writes no** ``http_call`` **row of its own.**
+A *failed* token leg is audited from this client now, as a failed credential injection, because ``injectAuthentication()`` runs inside the audited region.
+A *successful* one is not: the token request itself egresses with ``client_secret`` in its body and leaves no row from ``OAuthTokenManager``, which has no audit log service. `#303 <https://github.com/netresearch/t3x-nr-vault/issues/303>`__.
+
+**The other two egress paths are untouched.**
+``MasterKeyProviderFactory`` builds a plain Guzzle client with no middleware and no allowlist (deliberately, for on-prem RFC1918 Vault), and ``WebhookAuditSink`` uses a factory-built client but calls neither the allowlist gate nor the audit write.
+This primitive lives on ``VaultHttpClient`` and covers neither.
+
+**That cancellation closes a real socket is a property of libcurl, not of our code.**
+It is verified by a recorded probe, not by CI.
+A local TCP server accepts the connection, reads the 81 request bytes and never answers; the signal turns true at +1.500 s; ``sendCancellable()`` returns at +1.506 s and the server observes the peer close in the same millisecond (3 runs, php 8.5.9 / curl 8.5.0). The probe drives the production path and substitutes only the ticker, wrapped so it can watch the server side between ticks.
+This repository has no socket-based test infrastructure, and a timing-sensitive socket test in the unit suite would be a flake generator.
+
+**The tick loop runs a process-global queue.**
+``CurlMultiHandler::tick()`` adds to and runs Guzzle's static promise task queue, so a vault-owned loop will execute pending callbacks belonging to unrelated Guzzle clients elsewhere in the same TYPO3 request, reentrantly.
+No security invariant is lost, but it is a real boundary effect.
+
+Consequences
+============
+
+Positive
+--------
+
+A consumer that already holds a ``VaultHttpClientInterface`` can feature-detect and abort a call without a version floor and without learning anything about the transport.
+The change is purely additive: ``VaultHttpClientInterface`` is untouched, and the single in-repo implementor and every downstream consumer keep compiling.
+The audit log gains a queryable answer to "which outbound calls were abandoned after their credential went out?", which it did not have before — one action value, no message parsing — and a second action for the calls that were abandoned before anything was read or sent.
+
+Cost
+----
+
+A second transport is built per cancellable send rather than shared, so the primitive costs one extra client construction per call — deliberate, so the overwhelmingly more common ``sendRequest()`` path pays nothing.
+The abort is not sub-second end to end and must not be advertised as such: ``select_timeout`` is only the last of several serial stages, preceded by two blocking DNS lookups and, for OAuth clients, a full token round trip.
+Against the ~45 s it replaces, it is still the win the issue asked for.

--- a/Documentation/Developer/Adr/Index.rst
+++ b/Documentation/Developer/Adr/Index.rst
@@ -61,6 +61,7 @@ ADR      Title                                                    Status
 034      :ref:`adr-034-audit-chain-tip-anchor`                    Accepted
 035      :ref:`adr-035-frontend-placeholder-allow-set`            Amended
 036      :ref:`adr-036-mutation-audit-atomicity`                  Accepted
+037      :ref:`adr-037-cancellable-outbound-send`                 Accepted
 =======  =======================================================  ========
 
 .. toctree::
@@ -103,3 +104,4 @@ ADR      Title                                                    Status
    ADR-034-AuditChainTipAnchor
    ADR-035-FrontendPlaceholderAllowSet
    ADR-036-MutationAuditAtomicity
+   ADR-037-CancellableOutboundSend

--- a/Documentation/Developer/Api.rst
+++ b/Documentation/Developer/Api.rst
@@ -574,6 +574,253 @@ Via VaultService
       :returns: PSR-7 response.
       :throws ClientExceptionInterface: If request fails.
 
+.. _api-http-cancellable:
+
+Cancelling an outbound request
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+PSR-18 returns a response, never a handle, so :php:`sendRequest()` cannot be
+aborted once it is running — a caller whose own work was cancelled still waits
+out the timeout. :php:`CancellableHttpClientInterface` adds a second send that
+polls a caller-supplied signal and tears the socket down when it turns true.
+
+It is a *send*, not an exported handle, and that is a security property rather
+than a matter of taste. Four of this client's protections — the scheme
+allowlist, the ``allowed_hosts`` gate, the credential injection and the audit
+write — are statements inside the sending method, not middleware on the handler
+stack, so they do not travel with a transport. The rule the package holds to is
+therefore narrow and sharp: **nothing hands you a client that already carries a
+vault secret**, and :php:`VaultHttpClient` is the only place nr-vault attaches a
+secret to *your* request. There is no send you can drive that puts a vault
+secret on the wire without those four: every public method of that class returns
+a configured clone, a PSR-7 response or a bool, and
+:php:`sendCancellable()` takes no options parameter — asserted by
+``VaultHttpClientCancellableTest::theCredentialBearingClientExportsNoTransportAndNoPromise()``.
+
+nr-vault sends two credentials of its own on paths that are not your request and
+do not carry all four: the ``X-Vault-Token`` header of the transit master-key
+provider, on a plain Guzzle client, and the ``client_secret`` of the OAuth token
+leg, which does apply the ``allowed_hosts`` gate but writes no audit row. They
+are listed in :ref:`adr-037-cancellable-outbound-send`.
+
+Building a hardened transport *without* vault credentials remains a supported,
+public case: :php:`SecureHttpClientFactory::create()` and
+:php:`createCancellable()` return one, carrying the SSRF reject middleware and
+the ``CURLOPT_RESOLVE`` DNS pin — and no secret, no allowlist gate, no audit
+write.
+
+The interface is separate from :php:`VaultHttpClientInterface` and purely
+additive, so consumers feature-detect instead of raising a version floor:
+
+.. code-block:: php
+   :caption: Aborting a call when the surrounding operation is cancelled
+
+   use Netresearch\NrVault\Http\CancellableHttpClientInterface;
+   use Netresearch\NrVault\Http\CancellationSignalInterface;
+   use Netresearch\NrVault\Exception\RequestCancelledException;
+
+   final class RunCancellationSignal implements CancellationSignalInterface
+   {
+       public function __construct(private readonly MyRunState $run) {}
+
+       public function isCancelled(): bool
+       {
+           return $this->run->wasCancelled();
+       }
+   }
+
+   $client = $this->vaultService->http()
+       ->withAuthentication('tool_api_key')
+       ->withReason('MCP tool call')
+       ->withTimeout(15);
+
+   try {
+       $response = $client instanceof CancellableHttpClientInterface && $client->supportsCancellation()
+           ? $client->sendCancellable($request, new RunCancellationSignal($run))
+           : $client->sendRequest($request);
+   } catch (RequestCancelledException $e) {
+       // The call was abandoned on purpose; the audit log already recorded it.
+   }
+
+The signal is polled once before the request is sent and then between ticks of
+the transport event loop. Implementations must be cheap and must not throw:
+the method is called several times a second per in-flight request, and it runs
+after the credential has been injected. A signal that throws anyway still leaves
+an audit row — the write is in a ``finally`` — but the exception reaches the
+caller unchanged
+(``VaultHttpClientCancellableTest::aSignalThatThrowsMidFlightStillLeavesAnAuditRow()``).
+
+.. note::
+
+   Where a guarantee in this section names a test, that test is in
+   ``Tests/Unit/Http/VaultHttpClientCancellableTest.php`` or
+   ``Tests/Unit/Http/VaultHttpClientTest.php`` and enforces the sentence it is
+   named in; each fixed literal listed below is asserted by a test as well,
+   through the outcome-to-test table in
+   :ref:`adr-037-cancellable-outbound-send`, which names one per row.
+
+   Two statements here name none and are descriptions rather than pinned
+   guarantees: what :php:`SecureHttpClientFactory::create()` and
+   :php:`createCancellable()` hand out, and the invariant sentence introducing
+   this section — whose operative half, that no send you can drive skips the
+   four protections, does name one.
+
+.. note::
+
+   When this client builds the transport itself, it comes from
+   :php:`SecureHttpClientFactory` and carries the same hardened options, the
+   same SSRF/DNS-pin middleware
+   (``ssrfDnsPinIsInstalledOnTheCancellableTransport()``) and the same timeout
+   as the blocking client
+   (``theTransportTheClientResolvesForItselfCarriesTheRememberedTimeout()``) —
+   cancellation is an early exit, never an extension.
+
+   A PSR-18 client you injected into :php:`VaultHttpClient`'s constructor is
+   never replaced by a transport
+   (``anInjectedGuzzleClientIsNeverSwappedForACancellableTransport()``):
+   :php:`supportsCancellation()` reports false for such an instance and
+   :php:`sendCancellable()` completes the call blocking, on your client. The one
+   exception is :php:`withTimeout()`, which has to bake the override into a
+   client and therefore rebuilds one from the factory — the clone it returns
+   reports :php:`supportsCancellation()` **true**
+   (``withTimeoutRebuildsACallerSuppliedClientAndTurnsCancellationOn()``).
+
+   A client obtained from :php:`VaultServiceInterface::http()` supports
+   cancellation on any platform with ``curl_multi_*``, through the withers
+   included (``cancellationSurvivesTheWithersAndTheProductionFactory()``);
+   without that extension it degrades. Ask
+   :php:`supportsCancellation()` rather than assuming either.
+
+Every :php:`sendCancellable()` writes exactly one audit row — and so does every
+:php:`sendRequest()` — so the log is complete with respect to calls and not
+merely to egress. The outcome-to-test table in
+:ref:`adr-037-cancellable-outbound-send` is the enumeration that backs this
+sentence: one row per way a call can end, one named test per row. Three actions
+can result, and each means one thing — the
+action is what you filter and count on, so none of them needs the error message
+to be understood:
+
+``http_call_cancelled`` (badge: warning)
+   The signal stopped an **in-flight** request. The credential was retrieved,
+   injected and handed to the transport: treat it as exposed. Nothing else is
+   filed under this action, so "which calls were abandoned after their
+   credential went out?" is a query on this one value
+   (``theTwoCancellationOutcomesAreToldApartByTheirAction()``).
+
+``http_call_cancelled_before_send`` (badge: info)
+   The signal was already set when the send began. No secret was retrieved and
+   nothing was handed to the transport. Its own action so you can exclude these
+   rows by query rather than by reading messages
+   (``cancellingBeforeSendReadsNoSecretAndStillLeavesADistinguishableRow()``).
+
+``http_call`` with ``success = false``
+   Everything that failed rather than was cancelled — a refused scheme or host,
+   a transport that could not be built, a credential that could not be obtained,
+   a transport error, the defensive wall-clock bound, a settlement that is not a
+   response, or a throw from your signal or the ticker. Nobody asked for those,
+   so they sit with the other failures. ADR-037 lists the test for each.
+
+Within an action, the row's error message is a fixed literal shown under the
+badge:
+
+``Request cancelled before send: nothing egressed and no secret was retrieved``
+   The pre-flight refusal.
+
+``Request cancelled after send began: credential injected and transfer handed to the transport``
+   In the usual case the bytes are already out; if the signal turns true before
+   the first tick they may not be, which is why the literal does not claim more
+   than it can.
+
+``Cancellable transfer exceeded its wall-clock budget and was aborted``
+   The defensive bound above the curl timeouts tripped, i.e. the transport
+   stopped settling its promise.
+
+``Cancellable transport settled with a value that is not an HTTP response``
+   The transfer settled with something unusable.
+
+``Cancellable transfer aborted by an unexpected error after the credential was injected: …``
+   Guzzle's option handling, your signal or the ticker threw.
+
+``Blocking send aborted by an unexpected error after the credential was injected: …``
+   The degraded blocking branch threw something that is not a PSR-18
+   ``ClientExceptionInterface``. The same literal can appear for a plain
+   :php:`sendRequest()`, which runs the same send-and-audit helper.
+
+``Cancellable transport could not be built; nothing was sent: …``
+   Building the transport for :php:`sendCancellable()` threw. It is built after
+   the two guards and before the credential is read, so nothing egressed and no
+   secret was retrieved. This one is specific to :php:`sendCancellable()`.
+
+``Cancellable transfer was rejected``
+   The promise rejected with a reason that is not a ``Throwable``, so there is
+   no foreign message to append. Specific to :php:`sendCancellable()`.
+
+``Request refused before any secret was read: unsupported URI scheme "…"``
+   The URI was neither ``http`` nor ``https``. The scheme is in the message
+   because the audit context records method, host, path and status only.
+
+``Request refused before any secret was read: host is not in the allowed hosts list``
+   ``$GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts']`` refused the
+   destination. The host is on the row, in the context.
+
+``Credential injection failed; nothing was sent: …``
+   The vault read, or the OAuth token leg, threw. Nothing egressed.
+
+The last three appear for :php:`sendRequest()` as well: they are refusals of a
+call that was asked for, and a call that was asked for shows up in the log.
+The exception you receive is unchanged by that row — pinned by three
+characterization tests in ``VaultHttpClientTest``, written before the rows
+existed.
+
+See :ref:`adr-037-cancellable-outbound-send` for the transport details and the
+residual gaps — in particular that the OAuth token round trip preceding an
+OAuth-authenticated call is not cancellable.
+
+.. php:interface:: CancellableHttpClientInterface
+
+   An outbound send that can be aborted while it is still on the wire.
+   Implemented by :php:`VaultHttpClient` alongside
+   :php:`VaultHttpClientInterface`.
+
+   .. php:method:: sendCancellable(RequestInterface $request, CancellationSignalInterface $signal): ResponseInterface
+
+      Send an HTTP request, aborting the transfer as soon as ``$signal`` says
+      so. Runs the same guard sequence as :php:`sendRequest()`: scheme
+      allowlist, host allowlist, credential injection, audit write.
+
+      Accepts no per-request transport options, deliberately — see
+      :ref:`adr-037-cancellable-outbound-send`.
+
+      When :php:`supportsCancellation()` is false the call still completes,
+      blocking, with an ordinary ``http_call`` audit row. It degrades; it does
+      not fail
+      (``aNonGuzzleInnerClientDegradesToABlockingSendWithAnOrdinaryAuditRow()``).
+
+      :param RequestInterface $request: PSR-7 request.
+      :param CancellationSignalInterface $signal: Polled before the send and between transport ticks.
+      :returns: PSR-7 response.
+      :throws RequestCancelledException: If the signal aborted the call.
+      :throws ClientExceptionInterface: If the transfer itself failed.
+      :throws VaultException: If the scheme or host is rejected, or secret retrieval fails.
+
+   .. php:method:: supportsCancellation(): bool
+
+      Whether this instance can abort a transfer in flight. False when the
+      platform has no ``curl_multi_*`` support, and false when the inner client
+      was supplied by the caller instead of built by
+      :php:`SecureHttpClientFactory` — a supplied client may carry your own
+      middleware or proxy, so it stays the one that sends. A *pre-flight* signal
+      is still honoured in either case, because nothing has egressed yet, and
+      the call is still audited
+      (``aPreFlightSignalIsHonouredEvenWhenCancellationIsUnsupported()``).
+
+.. php:interface:: CancellationSignalInterface
+
+   .. php:method:: isCancelled(): bool
+
+      Return true to abort the in-flight request. Must not throw, and must be
+      cheap.
+
 .. _api-http-auth-options:
 
 Authentication options

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -321,9 +321,13 @@ Options
    Filter by action — any :php:`AuditAction` value. The common ones are
    ``create``, ``read``, ``update``, ``delete``, ``rotate`` and
    ``access_denied``; the enum also covers ``metadata_update``, ``http_call``,
-   the master-key and chain lifecycle (``master_key_rotate_start`` /
-   ``_end``, ``audit_chain_rekey``, ``audit_anchor_reset``), break-glass
-   (``break_glass_activated`` / ``_deactivated``) and the OAuth actions.
+   ``http_call_cancelled`` (an in-flight outbound call stopped by its
+   cancellation signal, after the credential went out) and
+   ``http_call_cancelled_before_send`` (refused before the send; no secret was
+   read — see :ref:`adr-037-cancellable-outbound-send`), the master-key and chain
+   lifecycle (``master_key_rotate_start`` / ``_end``, ``audit_chain_rekey``,
+   ``audit_anchor_reset``), break-glass (``break_glass_activated`` /
+   ``_deactivated``) and the OAuth actions.
 
 --actor=UID
    Filter by actor (backend user UID).

--- a/Tests/Unit/Controller/AuditControllerTest.php
+++ b/Tests/Unit/Controller/AuditControllerTest.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 
 namespace Netresearch\NrVault\Tests\Unit\Controller;
 
+use Netresearch\NrVault\Audit\AuditAction;
 use Netresearch\NrVault\Audit\AuditLogEntry;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
 use Netresearch\NrVault\Controller\AuditController;
@@ -135,6 +136,74 @@ final class AuditControllerTest extends TestCase
 
         self::assertSame(200, $response->getStatusCode());
         self::assertSame('application/json', $response->getHeaderLine('Content-Type'));
+    }
+
+    /**
+     * The audit module renders `{entry.action}` inside a badge whose CSS class
+     * comes from `getActionBadgeClass()` (`Audit/List.html:99`).
+     *
+     * Every row under `http_call_cancelled` means a credential was injected and
+     * handed to the transport before the call was abandoned, so it must not sit
+     * in the grey default next to an ordinary completed call — that grey is what
+     * an operator scans past. The pre-flight case is an abandoned call too, but
+     * with nothing to act on, so it is distinguishable without being alarming.
+     */
+    #[Test]
+    public function eachAbandonedOutboundCallGetsItsOwnBadgeInTheAuditModule(): void
+    {
+        $reflection = new ReflectionClass(AuditController::class);
+        $subject = $reflection->newInstanceWithoutConstructor();
+        $badgeClass = $reflection->getMethod('getActionBadgeClass');
+
+        self::assertSame('warning', $badgeClass->invoke($subject, 'http_call_cancelled'));
+        self::assertSame('info', $badgeClass->invoke($subject, 'http_call_cancelled_before_send'));
+        self::assertSame(
+            'secondary',
+            $badgeClass->invoke($subject, 'http_call'),
+            'An ordinary completed call keeps the neutral badge, or the new ones signal nothing.',
+        );
+    }
+
+    /**
+     * The filter dropdown is what makes a row queryable in the module, and its
+     * whole point is that a writer never has to remember to register an action
+     * there. So the needle here is the literal string `VaultHttpClient` persists
+     * — NOT `AuditAction::cases()`, which is the same expression the controller
+     * evaluates and would make this assertion true of itself.
+     *
+     * A hard-coded list in the controller (which is what this derivation
+     * replaced, and which had silently omitted the master_key_* and oauth_*
+     * actions) fails here.
+     */
+    #[Test]
+    public function everyActionTheHttpClientWritesReachesTheFilterDropdown(): void
+    {
+        $reflection = new ReflectionClass(AuditController::class);
+        $subject = $reflection->newInstanceWithoutConstructor();
+
+        $offered = $reflection->getMethod('filterableActions')->invoke($subject);
+        self::assertIsArray($offered);
+
+        foreach (['http_call', 'http_call_cancelled', 'http_call_cancelled_before_send'] as $written) {
+            self::assertContains(
+                $written,
+                $offered,
+                \sprintf('"%s" is written to the chain but cannot be filtered for.', $written),
+            );
+        }
+    }
+
+    /**
+     * The persisted strings are bound into the HMAC hash payload, so changing
+     * one breaks verification of every historical row that used it. Pinning the
+     * two cancellation values against literals is what makes such a rename show
+     * up as a test failure rather than as an unverifiable chain.
+     */
+    #[Test]
+    public function theCancellationActionValuesAreFrozen(): void
+    {
+        self::assertSame('http_call_cancelled', AuditAction::HttpCallCancelled->value);
+        self::assertSame('http_call_cancelled_before_send', AuditAction::HttpCallCancelledBeforeSend->value);
     }
 
     /**

--- a/Tests/Unit/Http/SecureHttpClientFactoryTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryTest.php
@@ -15,6 +15,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use Psr\Http\Client\ClientInterface;
+use TYPO3\CMS\Core\Log\LogLevel;
+use TYPO3\CMS\Core\Log\LogRecord;
+use TYPO3\CMS\Core\Log\Writer\AbstractWriter;
 
 #[CoversClass(SecureHttpClientFactory::class)]
 final class SecureHttpClientFactoryTest extends TestCase
@@ -35,6 +38,7 @@ final class SecureHttpClientFactoryTest extends TestCase
     protected function tearDown(): void
     {
         unset($GLOBALS['TYPO3_CONF_VARS']);
+        CollectingLogWriter::reset();
         parent::tearDown();
     }
 
@@ -84,6 +88,51 @@ final class SecureHttpClientFactoryTest extends TestCase
         $client = $this->factory->create();
 
         self::assertInstanceOf(ClientInterface::class, $client);
+    }
+
+    /**
+     * @param array<string, mixed> $httpConfig
+     */
+    #[Test]
+    #[DataProvider('tlsVerificationValues')]
+    public function createWarnsExactlyWhenTlsVerificationIsTurnedOff(array $httpConfig, bool $expectWarning): void
+    {
+        // The condition moved out of the option-building block when it was
+        // extracted into `buildOptions()`, from `array_key_exists('verify', …)`
+        // plus `=== false` to `($typo3Config['verify'] ?? null) === false`.
+        // Nothing covered it before, so this pins the whole value range rather
+        // than the one case that motivated the warning.
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP'] = $httpConfig;
+
+        // The logger is reached through the real LogManager, configured from
+        // $TYPO3_CONF_VARS['LOG'] — no @internal singleton injection needed.
+        CollectingLogWriter::reset();
+        $GLOBALS['TYPO3_CONF_VARS']['LOG']['Netresearch']['NrVault']['Http']['SecureHttpClientFactory']['writerConfiguration'] = [
+            LogLevel::WARNING => [CollectingLogWriter::class => []],
+        ];
+
+        $this->factory->create();
+
+        $tlsWarnings = array_values(array_filter(
+            CollectingLogWriter::messages(),
+            static fn (string $message): bool => str_starts_with($message, 'TLS verification is disabled'),
+        ));
+
+        self::assertCount($expectWarning ? 1 : 0, $tlsWarnings);
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, mixed>, 1: bool}>
+     */
+    public static function tlsVerificationValues(): iterable
+    {
+        yield 'key absent' => [[], false];
+        yield 'verify null' => [['verify' => null], false];
+        yield 'verify false' => [['verify' => false], true];
+        yield 'verify true' => [['verify' => true], false];
+        yield 'verify zero' => [['verify' => 0], false];
+        yield 'verify empty string' => [['verify' => ''], false];
+        yield 'verify ca bundle path' => [['verify' => '/path/to/ca.pem'], false];
     }
 
     #[Test]
@@ -288,5 +337,36 @@ final class SecureHttpClientFactoryTest extends TestCase
 
         // Neither exact match nor wildcard match
         self::assertFalse($this->factory->isHostAllowed('different.domain.org'));
+    }
+}
+
+/**
+ * Collects the messages written to a logger, so a test can assert on what the
+ * factory logged without touching `@internal` singleton injection: the real
+ * LogManager builds its writers from `$TYPO3_CONF_VARS['LOG']`.
+ */
+final class CollectingLogWriter extends AbstractWriter
+{
+    /** @var list<string> */
+    private static array $messages = [];
+
+    public function writeLog(LogRecord $record): self
+    {
+        self::$messages[] = $record->getMessage();
+
+        return $this;
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function messages(): array
+    {
+        return self::$messages;
+    }
+
+    public static function reset(): void
+    {
+        self::$messages = [];
     }
 }

--- a/Tests/Unit/Http/VaultHttpClientCancellableTest.php
+++ b/Tests/Unit/Http/VaultHttpClientCancellableTest.php
@@ -1,0 +1,1762 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Http;
+
+use Closure;
+use Error;
+use GuzzleHttp\Client;
+use GuzzleHttp\ClientInterface as GuzzleClientInterface;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\FulfilledPromise;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use InvalidArgumentException;
+use Netresearch\NrVault\Audit\AuditContextInterface;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Exception\RequestCancelledException;
+use Netresearch\NrVault\Exception\SecretNotFoundException;
+use Netresearch\NrVault\Exception\VaultException;
+use Netresearch\NrVault\Http\CancellableHttpClientInterface;
+use Netresearch\NrVault\Http\CancellableTransport;
+use Netresearch\NrVault\Http\CancellationSignalInterface;
+use Netresearch\NrVault\Http\DnsResolverInterface;
+use Netresearch\NrVault\Http\SecretPlacement;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Http\TransportTickerInterface;
+use Netresearch\NrVault\Http\VaultHttpClient;
+use Netresearch\NrVault\Http\VaultHttpClientFactory;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+use ReflectionClass;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionProperty;
+use RuntimeException;
+use stdClass;
+
+/**
+ * The cancellable outbound send.
+ *
+ * Every test here is deterministic: no sockets, no sleeps, no wall-clock
+ * dependence. The transport under test is the REAL one the factory builds —
+ * full hardened option set, `ssrf-dns-pin` middleware installed — with only its
+ * bottom handler replaced by a stub that returns a promise nobody settles, and
+ * its ticker replaced by a closure that settles that promise on the Nth call.
+ *
+ * Requires ext-curl and deliberately does not skip without it: the factory
+ * returns no transport when `curl_multi_exec` is missing, so these tests would
+ * silently stop covering the feature on a platform where it degrades. CI has
+ * the extension — `SecureHttpClientFactoryRebindingTest` has asserted on the
+ * `\CURLOPT_RESOLVE` constant unguarded for as long as that file has existed —
+ * and a run without it should be loud, not green.
+ *
+ * That second substitution is why `TransportTickerInterface` exists. The
+ * suite's established seam (`HandlerStack::setHandler()`) destroys the
+ * `CurlMultiHandler` a cancellation loop would have to tick, so a primitive
+ * holding that handler privately could not be exercised by any unit test at
+ * all — only asserted at by reading it.
+ *
+ * @see CancellableHttpClientInterface
+ */
+#[CoversClass(VaultHttpClient::class)]
+#[CoversClass(CancellableTransport::class)]
+final class VaultHttpClientCancellableTest extends TestCase
+{
+    use GuzzleClientConfigTrait;
+
+    private const API_URL = 'https://api.example.com/v1/things';
+
+    private const API_HOST = 'api.example.com';
+
+    private const PUBLIC_IP = '93.184.216.34';
+
+    /**
+     * The literals the class under test raises and audits.
+     *
+     * Copied rather than read from the class: they are private constants there,
+     * and a test that reads its expectation out of the subject cannot notice
+     * the subject changing. Asserted twice on purpose — once on the audit row,
+     * once on `getMessage()` of the exception handed back to the caller. Only
+     * the row passes `AuditLogService::sanitizeErrorMessage()`, so an exception
+     * message that started carrying the URI would be redacted nowhere, and for
+     * `SecretPlacement::QueryParam` that URI carries the secret.
+     */
+    private const CANCELLED_BEFORE_SEND_MESSAGE
+        = 'Request cancelled before send: nothing egressed and no secret was retrieved';
+
+    private const CANCELLED_IN_FLIGHT_MESSAGE
+        = 'Request cancelled after send began: credential injected and transfer handed to the transport';
+
+    private const TICK_BUDGET_EXHAUSTED_MESSAGE
+        = 'Cancellable transfer exceeded its wall-clock budget and was aborted';
+
+    private const NON_RESPONSE_SETTLEMENT_MESSAGE
+        = 'Cancellable transport settled with a value that is not an HTTP response';
+
+    private const REJECTED_WITHOUT_THROWABLE_MESSAGE = 'Cancellable transfer was rejected';
+
+    private const TRANSPORT_RESOLUTION_FAILED_MESSAGE
+        = 'Cancellable transport could not be built; nothing was sent';
+
+    private VaultServiceInterface&MockObject $vaultService;
+
+    private AuditLogServiceInterface&MockObject $auditLogService;
+
+    private ProgrammedDnsResolver $dnsResolver;
+
+    private SecureHttpClientFactory $clientFactory;
+
+    private mixed $originalGlobals;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->vaultService = $this->createMock(VaultServiceInterface::class);
+        $this->auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $this->dnsResolver = new ProgrammedDnsResolver();
+        $this->dnsResolver->program(self::API_HOST, [['ip' => self::PUBLIC_IP]]);
+
+        $this->clientFactory = new SecureHttpClientFactory($this->dnsResolver);
+
+        $this->originalGlobals = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $GLOBALS['TYPO3_CONF_VARS'] = ['HTTP' => []];
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalGlobals === null) {
+            unset($GLOBALS['TYPO3_CONF_VARS']);
+        } else {
+            $GLOBALS['TYPO3_CONF_VARS'] = $this->originalGlobals;
+        }
+
+        parent::tearDown();
+    }
+
+    // =========================================================================
+    // 1 — the abort itself
+    // =========================================================================
+
+    #[Test]
+    public function cancellingMidFlightAbortsTheTransferAndAuditsItAsCancelled(): void
+    {
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $transfer = new StubbedTransfer();
+        // Never settles: the only way out of the loop is the signal.
+        $transport = $this->transportWith($transfer, new ClosureTicker(static function (): void {}));
+
+        // The pre-flight check consumes the first answer, so three falses put
+        // the abort on the third pass through the loop.
+        $signal = new CountdownSignal(3);
+
+        $auditedActions = [];
+        $this->recordAuditActions($auditedActions);
+
+        $client = $this->clientWithTransport($transport)
+            ->withAuthentication('api_key', SecretPlacement::Bearer);
+
+        try {
+            $client->sendCancellable(new Request('GET', self::API_URL), $signal);
+            self::fail('Expected the signal to abort the transfer.');
+        } catch (RequestCancelledException $e) {
+            self::assertSame(1786579202, $e->getCode());
+            self::assertSame(self::CANCELLED_IN_FLIGHT_MESSAGE, $e->getMessage());
+        }
+
+        self::assertSame(1, $transfer->cancelCalls(), 'The promise cancel function must have run.');
+        self::assertSame(
+            0,
+            $transfer->waitCalls(),
+            'wait() would run CurlMultiHandler::execute() and leave no cancellation window at all.',
+        );
+        self::assertSame(
+            [['http_call_cancelled', false]],
+            $auditedActions,
+            'A mid-flight cancellation writes exactly one row, under its own action.',
+        );
+    }
+
+    // =========================================================================
+    // 2 — the happy path is unaffected
+    // =========================================================================
+
+    #[Test]
+    public function anUncancelledCallReturnsTheResponseAndAuditsAnOrdinaryHttpCall(): void
+    {
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $transfer = new StubbedTransfer();
+        $transport = $this->transportWith(
+            $transfer,
+            new ClosureTicker(static function (int $tick) use ($transfer): void {
+                if ($tick >= 2) {
+                    $transfer->settleWith(new Response(200, [], 'ok'));
+                }
+            }),
+        );
+
+        $auditedActions = [];
+        $this->recordAuditActions($auditedActions);
+
+        $response = $this->clientWithTransport($transport)
+            ->withAuthentication('api_key', SecretPlacement::Bearer)
+            ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertSame(0, $transfer->cancelCalls(), 'Nothing may be cancelled when the signal stays false.');
+        self::assertSame([['http_call', true]], $auditedActions);
+    }
+
+    // =========================================================================
+    // 3 + 4 — the two guards that are statements in the sending method, not
+    //         middleware, and therefore had to be re-executed on this path
+    // =========================================================================
+
+    #[Test]
+    public function schemeGuardRunsOnTheCancellablePathBeforeAnySecretIsRead(): void
+    {
+        $this->vaultService->expects(self::never())->method('retrieve');
+
+        $transfer = new StubbedTransfer();
+        $transport = $this->transportWith($transfer, new ClosureTicker(static function (): void {}));
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        $client = $this->clientWithTransport($transport)
+            ->withAuthentication('api_key', SecretPlacement::Bearer);
+
+        try {
+            $client->sendCancellable(new Request('GET', 'file:///etc/passwd'), new NeverCancelledSignal());
+            self::fail('Expected the scheme guard to refuse a file:// URI.');
+        } catch (VaultException $e) {
+            self::assertSame(1735858523, $e->getCode());
+        }
+
+        self::assertFalse($transfer->wasReached(), 'The transport must never see the request.');
+        self::assertSame(
+            [[
+                'http_call',
+                false,
+                'Request refused before any secret was read: unsupported URI scheme "file"',
+            ]],
+            $auditedRows,
+            'A refused scheme is a call that was asked for, so it leaves a row here too.',
+        );
+    }
+
+    #[Test]
+    public function hostAllowlistRunsOnTheCancellablePathBeforeAnySecretIsRead(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'] = ['allowed.example'];
+
+        $this->vaultService->expects(self::never())->method('retrieve');
+
+        $transfer = new StubbedTransfer();
+        $transport = $this->transportWith($transfer, new ClosureTicker(static function (): void {}));
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        $client = $this->clientWithTransport($transport)
+            ->withAuthentication('api_key', SecretPlacement::Bearer);
+
+        try {
+            $client->sendCancellable(new Request('GET', 'https://blocked.example/x'), new NeverCancelledSignal());
+            self::fail('Expected the allowlist to refuse the host.');
+        } catch (VaultException $e) {
+            self::assertSame(1735858522, $e->getCode());
+        }
+
+        self::assertFalse($transfer->wasReached(), 'The transport must never see the request.');
+        self::assertSame(
+            [[
+                'http_call',
+                false,
+                'Request refused before any secret was read: host is not in the allowed hosts list',
+            ]],
+            $auditedRows,
+        );
+    }
+
+    #[Test]
+    public function aFailedCredentialInjectionOnTheCancellablePathLeavesARow(): void
+    {
+        // The third window in which a call could be asked for and leave no
+        // trace: the vault read sits between the allowlist and the send, and
+        // `sendCancellably()`'s `finally` only opens after it.
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn(null);
+
+        $transfer = new StubbedTransfer();
+        $transport = $this->transportWith($transfer, new ClosureTicker(static function (): void {}));
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        $client = $this->clientWithTransport($transport)
+            ->withAuthentication('api_key', SecretPlacement::Bearer);
+
+        try {
+            $client->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+            self::fail('Expected the missing secret to refuse the send.');
+        } catch (SecretNotFoundException $e) {
+            self::assertSame(1735858521, $e->getCode());
+        }
+
+        self::assertFalse($transfer->wasReached(), 'Nothing may egress without a credential.');
+        self::assertSame(
+            [['http_call', false, 'Credential injection failed; nothing was sent: api_key']],
+            $auditedRows,
+        );
+    }
+
+    // =========================================================================
+    // 5 — credential injection
+    // =========================================================================
+
+    #[Test]
+    public function credentialInjectionRunsOnTheCancellablePath(): void
+    {
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+        $this->auditLogService->expects(self::once())->method('log');
+
+        $transfer = new StubbedTransfer();
+        $transport = $this->transportWith(
+            $transfer,
+            new ClosureTicker(static function (int $tick) use ($transfer): void {
+                if ($tick >= 1) {
+                    $transfer->settleWith(new Response(200));
+                }
+            }),
+        );
+
+        $this->clientWithTransport($transport)
+            ->withAuthentication('api_key', SecretPlacement::Bearer)
+            ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+
+        $sent = $transfer->request();
+        self::assertInstanceOf(RequestInterface::class, $sent);
+        self::assertSame('Bearer s3cret', $sent->getHeaderLine('Authorization'));
+    }
+
+    // =========================================================================
+    // 6 — the DNS pin survives the new handler stack
+    // =========================================================================
+
+    #[Test]
+    public function ssrfDnsPinIsInstalledOnTheCancellableTransport(): void
+    {
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+        $this->auditLogService->expects(self::once())->method('log');
+
+        $transfer = new StubbedTransfer();
+        $transport = $this->transportWith(
+            $transfer,
+            new ClosureTicker(static function (int $tick) use ($transfer): void {
+                if ($tick >= 1) {
+                    $transfer->settleWith(new Response(200));
+                }
+            }),
+        );
+
+        $this->clientWithTransport($transport)
+            ->withAuthentication('api_key', SecretPlacement::Bearer)
+            ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+
+        $options = $transfer->options();
+        self::assertIsArray($options);
+        self::assertArrayHasKey('curl', $options, 'The ssrf-dns-pin middleware did not run.');
+        $curlOptions = $options['curl'];
+        self::assertIsArray($curlOptions);
+        self::assertArrayHasKey(\CURLOPT_RESOLVE, $curlOptions);
+        self::assertSame(
+            [self::API_HOST . ':443:' . self::PUBLIC_IP],
+            $curlOptions[\CURLOPT_RESOLVE],
+        );
+    }
+
+    // =========================================================================
+    // 7 — the async/sync redirect divergence
+    // =========================================================================
+
+    #[Test]
+    public function redirectsStayOffOnTheCancellablePathEvenWhenTypo3EnablesThem(): void
+    {
+        // An async send inherits the CLIENT default for allow_redirects, where a
+        // PSR-18 send pins false per request. On an install that turned redirects
+        // on, this path alone would follow them — past a DNS pin computed for the
+        // original host. sendCancellable() re-pins false per request; this is the
+        // regression guard for that pin.
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allow_redirects'] = true;
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+        $this->auditLogService->expects(self::once())->method('log');
+
+        $transfer = new StubbedTransfer();
+        // Answers the FIRST transfer with the 302 and any further transfer with a
+        // 200, so a followed redirect settles instead of hanging the loop: with
+        // the pin removed this test fails on the status, immediately, rather than
+        // by timing out.
+        $transport = $this->transportWith(
+            $transfer,
+            new ClosureTicker(static function () use ($transfer): void {
+                $transfer->settleWith(
+                    $transfer->transferCount() === 1
+                        ? new Response(302, ['Location' => 'https://api.example.com/moved'])
+                        : new Response(200),
+                );
+            }),
+        );
+
+        $response = $this->clientWithTransport($transport)
+            ->withAuthentication('api_key', SecretPlacement::Bearer)
+            ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+
+        self::assertSame(302, $response->getStatusCode(), 'The redirect must not be followed.');
+        self::assertSame(1, $transfer->transferCount(), 'Exactly one request may reach the transport.');
+    }
+
+    // =========================================================================
+    // 8 — pre-flight cancellation
+    // =========================================================================
+
+    #[Test]
+    public function cancellingBeforeSendReadsNoSecretAndStillLeavesADistinguishableRow(): void
+    {
+        // Decision on this feature: a pre-flight cancellation DOES leave a trace,
+        // so the log is complete with respect to CALLS and not merely to egress.
+        // The distinction from a mid-flight abort — the one an auditor cares
+        // about, because only the other one put a credential on the wire — is
+        // carried by the ACTION, not by the message: an action can be filtered
+        // and counted, a message is free text. The literal is pinned as well
+        // because the audit module renders it next to the badge
+        // (Audit/List.html:116-117).
+        $this->vaultService->expects(self::never())->method('retrieve');
+
+        $transfer = new StubbedTransfer();
+        $transport = $this->transportWith($transfer, new ClosureTicker(static function (): void {}));
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        $client = $this->clientWithTransport($transport)
+            ->withAuthentication('api_key', SecretPlacement::Bearer);
+
+        try {
+            $client->sendCancellable(new Request('GET', self::API_URL), new AlreadyCancelledSignal());
+            self::fail('Expected the pre-flight signal to refuse the send.');
+        } catch (RequestCancelledException $e) {
+            self::assertSame(1786579201, $e->getCode());
+            self::assertSame(self::CANCELLED_BEFORE_SEND_MESSAGE, $e->getMessage());
+        }
+
+        self::assertFalse($transfer->wasReached(), 'Nothing may egress on a pre-flight cancellation.');
+        self::assertSame(0, $transfer->cancelCalls(), 'There is no transfer to cancel yet.');
+        self::assertSame(
+            [['http_call_cancelled_before_send', false, self::CANCELLED_BEFORE_SEND_MESSAGE]],
+            $auditedRows,
+        );
+    }
+
+    #[Test]
+    public function theTwoCancellationOutcomesAreToldApartByTheirAction(): void
+    {
+        // The question the feature exists to answer — which calls were abandoned
+        // AFTER their credential went out — is a query on one action value. That
+        // only works while `http_call_cancelled` means the in-flight abort and
+        // nothing else, so this pins the action of the outcome that must be the
+        // ONLY one under it. The pre-flight row's action is pinned in the test
+        // above; a copy-paste of one into the other fails one of the two.
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $transfer = new StubbedTransfer();
+        $transport = $this->transportWith($transfer, new ClosureTicker(static function (): void {}));
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        $client = $this->clientWithTransport($transport)
+            ->withAuthentication('api_key', SecretPlacement::Bearer);
+
+        try {
+            $client->sendCancellable(new Request('GET', self::API_URL), new CountdownSignal(1));
+            self::fail('Expected the signal to abort the transfer.');
+        } catch (RequestCancelledException $e) {
+            self::assertSame(1786579202, $e->getCode());
+            self::assertSame(self::CANCELLED_IN_FLIGHT_MESSAGE, $e->getMessage());
+        }
+
+        self::assertSame(
+            [['http_call_cancelled', false, self::CANCELLED_IN_FLIGHT_MESSAGE]],
+            $auditedRows,
+        );
+    }
+
+    // =========================================================================
+    // 9 — withTimeout() must not carry a stale transport across
+    // =========================================================================
+
+    #[Test]
+    public function withTimeoutDropsTheTransportAndRemembersTheOverride(): void
+    {
+        // The failure this guards: a client rebuilt with a new timeout while the
+        // caller keeps ticking the event loop of the PREVIOUS client. That loop
+        // serves nothing and spins to its wall-clock bound. Asserting identity
+        // rather than behaviour, because building a transport for real would put
+        // the timeout clone on a socket.
+        $this->vaultService->expects(self::never())->method('retrieve');
+        $this->auditLogService->expects(self::once())->method('log');
+
+        $transfer = new StubbedTransfer();
+        $ticker = new ClosureTicker(static function (int $tick) use ($transfer): void {
+            if ($tick >= 1) {
+                $transfer->settleWith(new Response(200));
+            }
+        });
+        $transport = $this->transportWith($transfer, $ticker);
+
+        $client = $this->clientWithTransport($transport);
+
+        // The instance that OWNS the transport uses exactly that transport.
+        $client->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+        self::assertGreaterThan(0, $ticker->ticks(), 'The injected transport must be the one driven.');
+
+        $timeoutClient = $client->withTimeout(5);
+
+        $transportProperty = new ReflectionProperty(VaultHttpClient::class, 'cancellableTransport');
+        $timeoutProperty = new ReflectionProperty(VaultHttpClient::class, 'timeoutSeconds');
+
+        self::assertSame(
+            $transport,
+            $transportProperty->getValue($client),
+            'The original instance keeps its transport.',
+        );
+        self::assertNull(
+            $transportProperty->getValue($timeoutClient),
+            'A transport built for the previous timeout must not survive withTimeout().',
+        );
+        self::assertSame(
+            5,
+            $timeoutProperty->getValue($timeoutClient),
+            'The override must be remembered, or a transport built later would ignore it.',
+        );
+    }
+
+    // =========================================================================
+    // 10 — degradation
+    // =========================================================================
+
+    #[Test]
+    public function aNonGuzzleInnerClientDegradesToABlockingSendWithAnOrdinaryAuditRow(): void
+    {
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $innerClient = $this->createMock(ClientInterface::class);
+        $innerClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn(new Response(204));
+
+        $auditedActions = [];
+        $this->recordAuditActions($auditedActions);
+
+        $client = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            innerClient: $innerClient,
+            secureHttpClientFactory: $this->clientFactory,
+        );
+
+        self::assertFalse(
+            $client->supportsCancellation(),
+            'A client that cannot be ticked must say so instead of pretending.',
+        );
+
+        $response = $client
+            ->withAuthentication('api_key', SecretPlacement::Bearer)
+            ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+
+        self::assertSame(204, $response->getStatusCode());
+        self::assertSame([['http_call', true]], $auditedActions);
+    }
+
+    #[Test]
+    public function aPreFlightSignalIsHonouredEvenWhenCancellationIsUnsupported(): void
+    {
+        // Degrading means the transfer cannot be interrupted once it runs. It
+        // does NOT mean the signal is ignored: nothing has egressed before the
+        // send, so refusing is always possible, and the refusal is the same
+        // row and the same exception as on the supported path.
+        $this->vaultService->expects(self::never())->method('retrieve');
+
+        $innerClient = $this->createMock(ClientInterface::class);
+        $innerClient->expects(self::never())->method('sendRequest');
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        $client = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            innerClient: $innerClient,
+            secureHttpClientFactory: $this->clientFactory,
+        );
+
+        self::assertFalse($client->supportsCancellation());
+
+        try {
+            $client
+                ->withAuthentication('api_key', SecretPlacement::Bearer)
+                ->sendCancellable(new Request('GET', self::API_URL), new AlreadyCancelledSignal());
+            self::fail('Expected the pre-flight signal to refuse the send.');
+        } catch (RequestCancelledException $e) {
+            self::assertSame(1786579201, $e->getCode());
+            self::assertSame(self::CANCELLED_BEFORE_SEND_MESSAGE, $e->getMessage());
+        }
+
+        self::assertSame(
+            [['http_call_cancelled_before_send', false, self::CANCELLED_BEFORE_SEND_MESSAGE]],
+            $auditedRows,
+        );
+    }
+
+    #[Test]
+    public function aThrowFromTheDegradedBlockingSendStillLeavesAnAuditRow(): void
+    {
+        // The degraded branch must honour the same promise the cancellable one
+        // does — "every call leaves exactly one row". `Client::applyOptions()`
+        // raises InvalidArgumentException OUTSIDE `Client::transfer()`'s
+        // try/catch, so a bad option set leaves the blocking send as a throw
+        // that is not a PSR-18 ClientExceptionInterface; catching only that
+        // interface would drop the row for a call whose credential was already
+        // injected. `sendRequest()` runs the same helper, so this guards both.
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $innerClient = $this->createMock(ClientInterface::class);
+        $innerClient->expects(self::once())
+            ->method('sendRequest')
+            ->willThrowException(new InvalidArgumentException('sendRequest refused the option set'));
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        $client = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            innerClient: $innerClient,
+            secureHttpClientFactory: $this->clientFactory,
+        );
+
+        try {
+            $client
+                ->withAuthentication('api_key', SecretPlacement::Bearer)
+                ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+            self::fail('Expected the blocking send to throw.');
+        } catch (InvalidArgumentException $e) {
+            self::assertSame('sendRequest refused the option set', $e->getMessage());
+        }
+
+        self::assertCount(1, $auditedRows, 'A post-injection throw must still leave exactly one row.');
+        self::assertSame('http_call', $auditedRows[0][0]);
+        self::assertFalse($auditedRows[0][1]);
+        self::assertSame(
+            'Blocking send aborted by an unexpected error after the credential was injected: '
+            . 'sendRequest refused the option set',
+            (string) $auditedRows[0][2],
+            'The fixed literal identifies the situation; the original message says what threw.',
+        );
+    }
+
+    #[Test]
+    public function withTimeoutRebuildsACallerSuppliedClientAndTurnsCancellationOn(): void
+    {
+        // The limit of "a client you injected is never replaced": it holds on
+        // the cancellable path, and `withTimeout()` is where it stops. PSR-18
+        // carries no per-request options, so the override has to be baked into
+        // a client — and the one that gets built comes from the factory, which
+        // drops the caller's client and flips supportsCancellation() to true.
+        // Documented on `withTimeout()` itself; pinned here so the two cannot
+        // drift apart and so the docs can point at something.
+        $this->vaultService->expects(self::never())->method('retrieve');
+        $this->auditLogService->expects(self::never())->method('log');
+
+        $callerClient = $this->createMock(ClientInterface::class);
+
+        $client = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            innerClient: $callerClient,
+            secureHttpClientFactory: $this->clientFactory,
+        );
+
+        self::assertFalse($client->supportsCancellation());
+
+        $rebuilt = $client->withTimeout(5);
+
+        $inner = (new ReflectionProperty(VaultHttpClient::class, 'innerClient'))->getValue($rebuilt);
+        self::assertNotSame($callerClient, $inner, 'withTimeout() cannot keep a client it must reconfigure.');
+        self::assertInstanceOf(Client::class, $inner);
+        self::assertTrue(
+            $rebuilt->supportsCancellation(),
+            'The rebuilt client is factory-built, and says so.',
+        );
+    }
+
+    #[Test]
+    public function theCredentialBearingClientExportsNoTransportAndNoPromise(): void
+    {
+        // What keeps the four inline protections — scheme allowlist, host
+        // allowlist, credential injection, audit write — from being bypassable:
+        // no public method of the class that attaches the secret returns
+        // anything a caller could send with. Every one returns a configured
+        // clone, a PSR-7 response or a bool. A future method handing back the
+        // inner client, the transport or the promise fails here.
+        $publicMethods = (new ReflectionClass(VaultHttpClient::class))->getMethods(ReflectionMethod::IS_PUBLIC);
+
+        foreach ($publicMethods as $method) {
+            if ($method->isConstructor()) {
+                continue;
+            }
+
+            $returnType = $method->getReturnType();
+            self::assertInstanceOf(
+                ReflectionNamedType::class,
+                $returnType,
+                \sprintf('%s() must declare a single, named return type.', $method->getName()),
+            );
+            self::assertContains(
+                $returnType->getName(),
+                ['static', ResponseInterface::class, 'bool'],
+                \sprintf('%s() exports something a caller could send with.', $method->getName()),
+            );
+        }
+
+        // The second half of the same rule: no per-request option surface, so
+        // no caller-supplied `stream` or `curl` array can reach the transport
+        // and drop the vetted CURLOPT_RESOLVE pin.
+        self::assertSame(
+            2,
+            (new ReflectionMethod(VaultHttpClient::class, 'sendCancellable'))->getNumberOfParameters(),
+            'sendCancellable() takes the request and the signal, and nothing else.',
+        );
+    }
+
+    #[Test]
+    public function aClientWhoseTransportItBuiltItselfReportsCancellationSupport(): void
+    {
+        $this->vaultService->expects(self::never())->method('retrieve');
+        $this->auditLogService->expects(self::never())->method('log');
+
+        // No inner client: the constructor builds one from the factory, so
+        // swapping in a cancellable sibling replaces nothing a caller chose.
+        $client = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            secureHttpClientFactory: $this->clientFactory,
+        );
+
+        self::assertTrue($client->supportsCancellation());
+    }
+
+    #[Test]
+    public function cancellationSurvivesTheWithersAndTheProductionFactory(): void
+    {
+        // The withers forward the inner client, so the "this one is mine" fact
+        // has to travel with it or the primary use case —
+        // `$vault->http()->withAuthentication(...)->sendCancellable(...)` —
+        // would silently degrade to a blocking send.
+        $this->vaultService->expects(self::never())->method('retrieve');
+        $this->auditLogService->expects(self::never())->method('log');
+
+        $client = (new VaultHttpClientFactory($this->auditLogService, $this->clientFactory))
+            ->create($this->vaultService);
+
+        self::assertInstanceOf(CancellableHttpClientInterface::class, $client);
+        self::assertTrue($client->supportsCancellation(), 'A client from the DI factory must be cancellable.');
+
+        $configured = $client
+            ->withAuthentication('api_key', SecretPlacement::Bearer)
+            ->withReason('MCP tool call')
+            ->withTimeout(15);
+
+        // No second instanceof check: the withers return `static`, so the
+        // narrowing above carries over.
+        self::assertTrue($configured->supportsCancellation(), 'The withers must not drop cancellation.');
+    }
+
+    #[Test]
+    public function anInjectedGuzzleClientIsNeverSwappedForACancellableTransport(): void
+    {
+        // The hazard: an injected Guzzle client can carry a caller's own
+        // middleware, proxy or handler. Building a factory transport for the
+        // cancellable path would drop all of it, on that path only — the worst
+        // place for a difference to hide. So the client stays the one that
+        // sends and supportsCancellation() says false, which is exactly what its
+        // own comment promises. Here the injected client answers 204 from a
+        // stubbed bottom handler; a substituted transport would try to reach
+        // api.example.com instead and never see it.
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $innerClient = $this->clientFactory->create();
+        self::assertInstanceOf(Client::class, $innerClient);
+        $handler = $this->getGuzzleConfig($innerClient)['handler'] ?? null;
+        self::assertInstanceOf(HandlerStack::class, $handler);
+        $handler->setHandler(static fn (): PromiseInterface => new FulfilledPromise(new Response(204)));
+
+        $auditedActions = [];
+        $this->recordAuditActions($auditedActions);
+
+        $client = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            innerClient: $innerClient,
+            secureHttpClientFactory: $this->clientFactory,
+        );
+
+        self::assertFalse(
+            $client->supportsCancellation(),
+            'A caller-supplied client cannot be ticked, and must not be replaced by one that can.',
+        );
+
+        $response = $client
+            ->withAuthentication('api_key', SecretPlacement::Bearer)
+            ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+
+        self::assertSame(204, $response->getStatusCode(), 'The injected client must be the one that answered.');
+        self::assertSame([['http_call', true]], $auditedActions);
+    }
+
+    #[Test]
+    public function aThrowFromTheSendItselfStillLeavesAnAuditRow(): void
+    {
+        // The window this closes: injectAuthentication() has already run when
+        // sendCancellably() is entered, and `Client::applyOptions()` raises
+        // InvalidArgumentException OUTSIDE `Client::transfer()`'s own try/catch
+        // — so a bad option set leaves sendAsync() as a THROW, not as a rejected
+        // promise. With the try opening after the send, that throw would be a
+        // post-injection call with no audit row: precisely the hole the
+        // pre-flight decision exists to close.
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $ticker = new ClosureTicker(static function (): void {});
+        $transport = new CancellableTransport(new ThrowingOnSendClient(), $ticker, 5.0);
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        $client = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            secureHttpClientFactory: $this->clientFactory,
+            cancellableTransport: $transport,
+        );
+
+        try {
+            $client
+                ->withAuthentication('api_key', SecretPlacement::Bearer)
+                ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+            self::fail('Expected the send to throw.');
+        } catch (InvalidArgumentException $e) {
+            self::assertSame('sendAsync refused the option set', $e->getMessage());
+        }
+
+        self::assertSame(0, $ticker->ticks(), 'Nothing was started, so nothing may be ticked.');
+        self::assertCount(1, $auditedRows, 'A post-injection throw must still leave exactly one row.');
+        self::assertSame('http_call', $auditedRows[0][0]);
+        self::assertFalse($auditedRows[0][1]);
+        self::assertStringStartsWith(
+            'Cancellable transfer aborted by an unexpected error after the credential was injected',
+            (string) $auditedRows[0][2],
+        );
+    }
+
+    #[Test]
+    public function theTransportTheClientResolvesForItselfCarriesTheRememberedTimeout(): void
+    {
+        // Cancellation is an early exit, so the cancellable transport must never
+        // be allowed to run LONGER than the blocking send. Both halves are
+        // asserted against ONE client: the inner client it built, and the
+        // transport IT resolves — not a second transport the test built from a
+        // hard-coded number, which would still read 5 if
+        // resolveCancellableTransport() stopped forwarding `$this->timeoutSeconds`
+        // altogether. A factory spy recording the argument would say the same
+        // thing more directly; SecureHttpClientFactory is final, so the seam is
+        // the resolve method.
+        $this->vaultService->expects(self::never())->method('retrieve');
+        $this->auditLogService->expects(self::never())->method('log');
+
+        $resolve = new ReflectionMethod(VaultHttpClient::class, 'resolveCancellableTransport');
+
+        $client = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            secureHttpClientFactory: $this->clientFactory,
+            timeoutSeconds: 5,
+        );
+
+        $innerClient = (new ReflectionProperty(VaultHttpClient::class, 'innerClient'))->getValue($client);
+        self::assertInstanceOf(Client::class, $innerClient);
+        self::assertSame(5, $this->getGuzzleConfig($innerClient)['timeout']);
+
+        $transport = $resolve->invoke($client);
+        self::assertInstanceOf(CancellableTransport::class, $transport);
+        $transportClient = $transport->client();
+        self::assertInstanceOf(Client::class, $transportClient);
+        self::assertSame(
+            5,
+            $this->getGuzzleConfig($transportClient)['timeout'],
+            'Both send paths must carry the same deadline.',
+        );
+
+        // The control that makes the assertion above load-bearing: an instance
+        // with no override resolves a transport at the platform default, so 5
+        // cannot have arrived by coincidence.
+        $platformDefaultClient = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            secureHttpClientFactory: $this->clientFactory,
+        );
+
+        $platformDefaultTransport = $resolve->invoke($platformDefaultClient);
+        self::assertInstanceOf(CancellableTransport::class, $platformDefaultTransport);
+        $platformDefaultTransportClient = $platformDefaultTransport->client();
+        self::assertInstanceOf(Client::class, $platformDefaultTransportClient);
+        self::assertSame(
+            30,
+            $this->getGuzzleConfig($platformDefaultTransportClient)['timeout'],
+            'Without an override the resolved transport must carry the platform default.',
+        );
+    }
+
+    #[Test]
+    public function anInjectedTransportNeverDisplacesACallerSuppliedClient(): void
+    {
+        // The `cancellableTransport` constructor parameter is an @internal test
+        // seam, and it must not be a way around the rule the parameter above it
+        // enforces. An instance whose inner client came from the caller stays
+        // blocking on that client even when a transport is handed in: the
+        // factory-built check runs BEFORE the injected transport is read.
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $callerClient = $this->createMock(ClientInterface::class);
+        $callerClient->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn(new Response(204));
+
+        $transfer = new StubbedTransfer();
+        $ticker = new ClosureTicker(static function (): void {});
+        $transport = $this->transportWith($transfer, $ticker);
+
+        $auditedActions = [];
+        $this->recordAuditActions($auditedActions);
+
+        $client = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            innerClient: $callerClient,
+            secureHttpClientFactory: $this->clientFactory,
+            cancellableTransport: $transport,
+        );
+
+        self::assertFalse(
+            $client->supportsCancellation(),
+            'An injected transport must not make a caller-supplied client claim cancellation.',
+        );
+
+        $response = $client
+            ->withAuthentication('api_key', SecretPlacement::Bearer)
+            ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+
+        self::assertSame(204, $response->getStatusCode(), 'The caller-supplied client must be the one that answered.');
+        self::assertSame(0, $ticker->ticks(), 'The injected transport must not have been driven.');
+        self::assertFalse($transfer->wasReached(), 'Nothing may reach the injected transport.');
+        self::assertSame([['http_call', true]], $auditedActions);
+    }
+
+    #[Test]
+    public function aCallerCannotAssertTheFactoryBuiltFactByCloningFromAnotherInstance(): void
+    {
+        // `$clonedFrom` is what carries the factory-built fact across the
+        // withers. It inherits that fact ONLY when the forwarded client is the
+        // very object the prototype holds — otherwise a caller could pair their
+        // own client with a legitimate instance and get a cancellable transport
+        // built behind their back.
+        $this->vaultService->expects(self::never())->method('retrieve');
+        $this->auditLogService->expects(self::never())->method('log');
+
+        $legitimate = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            secureHttpClientFactory: $this->clientFactory,
+        );
+        self::assertTrue($legitimate->supportsCancellation());
+
+        $forged = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            innerClient: $this->clientFactory->create(),
+            secureHttpClientFactory: $this->clientFactory,
+            clonedFrom: $legitimate,
+        );
+
+        self::assertFalse(
+            $forged->supportsCancellation(),
+            'A prototype must not launder a client it does not hold.',
+        );
+    }
+
+    #[Test]
+    public function theFactoryBuildsACancellableTransportWithABudgetAboveTheTransferDeadlines(): void
+    {
+        $this->vaultService->expects(self::never())->method('retrieve');
+        $this->auditLogService->expects(self::never())->method('log');
+
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['timeout'] = 20;
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['connect_timeout'] = 4;
+
+        $transport = $this->clientFactory->createCancellable();
+
+        self::assertInstanceOf(CancellableTransport::class, $transport);
+        self::assertGreaterThan(
+            24.0,
+            $transport->wallClockBudgetSeconds(),
+            'The defensive bound must sit strictly above timeout + connect_timeout.',
+        );
+    }
+
+    #[Test]
+    public function theBlockingAndCancellableTransportsCarryTheSameOptions(): void
+    {
+        // `create()`'s option block moved into a shared private `buildOptions()`
+        // so the two transports cannot drift apart. Nothing enforced that but
+        // the fact that one method calls the other — this does: every request
+        // option must match, the handler excepted, which is the one thing that
+        // differs on purpose.
+        $this->vaultService->expects(self::never())->method('retrieve');
+        $this->auditLogService->expects(self::never())->method('log');
+
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['connect_timeout'] = 7;
+
+        $blocking = $this->clientFactory->create(11);
+        self::assertInstanceOf(Client::class, $blocking);
+
+        $cancellable = $this->clientFactory->createCancellable(11);
+        self::assertInstanceOf(CancellableTransport::class, $cancellable);
+        $cancellableClient = $cancellable->client();
+        self::assertInstanceOf(Client::class, $cancellableClient);
+
+        $blockingConfig = $this->getGuzzleConfig($blocking);
+        $cancellableConfig = $this->getGuzzleConfig($cancellableClient);
+        unset($blockingConfig['handler'], $cancellableConfig['handler']);
+
+        self::assertSame($blockingConfig, $cancellableConfig);
+        self::assertSame(11, $blockingConfig['timeout'], 'The override must be in the compared set.');
+        self::assertSame(7, $blockingConfig['connect_timeout']);
+    }
+
+    // =========================================================================
+    // 13 — the promise that is already rejected before the loop starts
+    // =========================================================================
+
+    #[Test]
+    public function anSsrfRejectionSettlesBeforeTheFirstTickAndStillWritesItsRow(): void
+    {
+        // The host answers a public address to the allowlist gate and a loopback
+        // address to the middleware a moment later — DNS rebinding, which is the
+        // attack the pin exists for. The middleware throws inside
+        // Client::transfer(), so sendAsync() returns an ALREADY-REJECTED promise
+        // whose handler is merely QUEUED. Two things must hold and neither is
+        // free: the loop must drain that queue before it ticks (there is no
+        // transfer on the handler to advance), and the rejection must still
+        // produce an audit row, because this is a call that was refused after
+        // the credential had been injected.
+        $this->dnsResolver->programSequence(self::API_HOST, [
+            [['ip' => self::PUBLIC_IP]],
+            [['ip' => '127.0.0.1']],
+        ]);
+
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $transfer = new StubbedTransfer();
+        $ticker = new ClosureTicker(static function (): void {});
+        $transport = $this->transportWith($transfer, $ticker);
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        try {
+            $this->clientWithTransport($transport)
+                ->withAuthentication('api_key', SecretPlacement::Bearer)
+                ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+            self::fail('Expected the ssrf-dns-pin middleware to refuse the rebound host.');
+        } catch (RequestException $e) {
+            self::assertStringContainsString('disallowed IP range', $e->getMessage());
+        }
+
+        self::assertSame(0, $ticker->ticks(), 'A settled-before-the-loop promise must not tick a dead handler.');
+        self::assertFalse($transfer->wasReached(), 'The middleware rejected below no bottom handler.');
+        self::assertCount(1, $auditedRows, 'A refused call still gets exactly one row.');
+        self::assertSame('http_call', $auditedRows[0][0]);
+        self::assertFalse($auditedRows[0][1]);
+        self::assertStringContainsString('disallowed IP range', (string) $auditedRows[0][2]);
+    }
+
+    // =========================================================================
+    // 14 — the transport settles with something that is not a response
+    // =========================================================================
+
+    #[Test]
+    public function aNonResponseSettlementIsRefusedInsteadOfReturned(): void
+    {
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $transfer = new StubbedTransfer();
+        $transport = $this->transportWith(
+            $transfer,
+            new ClosureTicker(static function (int $tick) use ($transfer): void {
+                if ($tick >= 1) {
+                    $transfer->settleWithValue('not a response at all');
+                }
+            }),
+        );
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        try {
+            $this->clientWithTransport($transport)
+                ->withAuthentication('api_key', SecretPlacement::Bearer)
+                ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+            self::fail('Expected a non-response settlement to be refused.');
+        } catch (VaultException $e) {
+            self::assertSame(1786579205, $e->getCode());
+            self::assertSame(self::NON_RESPONSE_SETTLEMENT_MESSAGE, $e->getMessage());
+        }
+
+        self::assertSame(
+            [['http_call', false, self::NON_RESPONSE_SETTLEMENT_MESSAGE]],
+            $auditedRows,
+        );
+    }
+
+    // =========================================================================
+    // 15 — the defensive wall-clock bound
+    // =========================================================================
+
+    #[Test]
+    public function anExhaustedWallClockBudgetAbortsTheTransferAndAuditsIt(): void
+    {
+        // A budget of zero makes the bound trip on the first pass: the loop
+        // compares two microtime() readings, so this is a deterministic
+        // comparison and not a timing-dependent test. What it pins is that the
+        // bound aborts (rather than hanging a TYPO3 request) and that it is
+        // audited as a FAILURE — `http_call` / success = false — not as a
+        // cancellation. Nobody asked for it: the bound only trips when the
+        // handler stopped settling its promise. Filing it under
+        // `http_call_cancelled` would put a second meaning on the action and
+        // make "which calls did a caller abandon?" over-count.
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $transfer = new StubbedTransfer();
+        $ticker = new ClosureTicker(static function (): void {});
+        $client = $this->transportWith($transfer, $ticker)->client();
+        $transport = new CancellableTransport($client, $ticker, 0.0);
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        try {
+            $this->clientWithTransport($transport)
+                ->withAuthentication('api_key', SecretPlacement::Bearer)
+                ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+            self::fail('Expected the wall-clock bound to abort the transfer.');
+        } catch (VaultException $e) {
+            self::assertSame(1786579203, $e->getCode());
+            self::assertSame(self::TICK_BUDGET_EXHAUSTED_MESSAGE, $e->getMessage());
+        }
+
+        self::assertSame(1, $transfer->cancelCalls(), 'The bound must tear the transfer down, not just give up on it.');
+        self::assertSame(0, $ticker->ticks(), 'An exhausted budget must not tick first.');
+        self::assertSame(
+            [['http_call', false, self::TICK_BUDGET_EXHAUSTED_MESSAGE]],
+            $auditedRows,
+        );
+    }
+
+    #[Test]
+    public function aRejectionWithoutAThrowableIsRefusedWithAFixedLiteral(): void
+    {
+        // The fifth and last exception code the cancellable path raises. A
+        // rejection reason that is not a Throwable cannot be rethrown, so the
+        // class raises its own — and it does NOT carry the reason, in the
+        // exception or in the row: a transport error string on this client can
+        // quote the URL it failed on, which for `SecretPlacement::QueryParam`
+        // is the secret. The reason programmed below is exactly that shape.
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $transfer = new StubbedTransfer();
+        $transport = $this->transportWith(
+            $transfer,
+            new ClosureTicker(static function (int $tick) use ($transfer): void {
+                if ($tick >= 1) {
+                    $transfer->rejectWithValue('https://api.example.com/v1/things?api_key=s3cret refused');
+                }
+            }),
+        );
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        try {
+            $this->clientWithTransport($transport)
+                ->withAuthentication('api_key', SecretPlacement::Bearer)
+                ->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+            self::fail('Expected a non-throwable rejection to be refused.');
+        } catch (VaultException $e) {
+            self::assertSame(1786579204, $e->getCode());
+            self::assertSame(self::REJECTED_WITHOUT_THROWABLE_MESSAGE, $e->getMessage());
+        }
+
+        self::assertSame(
+            [['http_call', false, self::REJECTED_WITHOUT_THROWABLE_MESSAGE]],
+            $auditedRows,
+        );
+    }
+
+    // =========================================================================
+    // 16 — the row survives a throw from code this class does not own
+    // =========================================================================
+
+    #[Test]
+    public function aSignalThatThrowsMidFlightStillLeavesAnAuditRow(): void
+    {
+        // `CancellationSignalInterface` says MUST NOT throw, but a docblock is
+        // not an enforcement and the signal is written by the caller. It is
+        // polled AFTER the credential has been injected and handed to the
+        // transport, so a throw here would otherwise be the one outbound call
+        // that leaves no trace — exactly the hole this feature exists to close.
+        //
+        // The row is a FAILURE (`http_call` / success = false), not a
+        // cancellation: the signal never said "cancel", it broke. Only a signal
+        // that actually reports true reaches `http_call_cancelled`.
+        $this->vaultService->expects(self::once())->method('retrieve')->willReturn('s3cret');
+
+        $transfer = new StubbedTransfer();
+        $transport = $this->transportWith($transfer, new ClosureTicker(static function (): void {}));
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        try {
+            $this->clientWithTransport($transport)
+                ->withAuthentication('api_key', SecretPlacement::Bearer)
+                // False once for the pre-flight check, then throws inside the loop.
+                ->sendCancellable(new Request('GET', self::API_URL), new ThrowingSignal(1));
+            self::fail('Expected the signal to throw.');
+        } catch (RuntimeException $e) {
+            self::assertSame("the caller's signal blew up", $e->getMessage());
+        }
+
+        self::assertSame(1, $transfer->cancelCalls(), 'A transfer nobody is waiting for must be torn down.');
+        self::assertCount(1, $auditedRows);
+        self::assertSame('http_call', $auditedRows[0][0]);
+        self::assertFalse($auditedRows[0][1]);
+        self::assertStringStartsWith(
+            'Cancellable transfer aborted by an unexpected error after the credential was injected',
+            (string) $auditedRows[0][2],
+        );
+    }
+
+    // =========================================================================
+    // 17 — the transport build is inside the audited region too
+    // =========================================================================
+
+    #[Test]
+    public function aThrowFromTheTransportResolutionLeavesAnAuditRow(): void
+    {
+        // `resolveCancellableTransport()` runs after the guards and before the
+        // credential injection, i.e. between two audited regions and inside
+        // neither. A throw out of `SecureHttpClientFactory::createCancellable()`
+        // therefore used to leave no row at all, and "every sendCancellable()
+        // leaves exactly one row" had an outcome nobody had enumerated.
+        //
+        // Nothing egressed and no secret was read on this path, so the row is
+        // `http_call` / success = false — the same tuple as a refused host.
+        $this->vaultService->expects(self::never())->method('retrieve');
+
+        // No injected transport: the send has to BUILD one, which is the call
+        // under test. The inner client is factory-built, so the build happens.
+        $client = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            secureHttpClientFactory: $this->clientFactory,
+        );
+        $client = $client->withAuthentication('api_key', SecretPlacement::Bearer);
+        self::assertTrue($client->supportsCancellation());
+
+        $auditedRows = [];
+        $this->recordAuditRows($auditedRows);
+
+        // The factory reads the platform configuration every time it builds, and
+        // `buildOptions()` subscripts it without a type check. Broken AFTER the
+        // constructor, which builds the blocking client through the same
+        // method; `isHostAllowed()` type-checks and is unaffected, so the two
+        // guards still pass and the throw lands exactly where this test needs
+        // it. This is the only in-process way to make that build fail — which
+        // is also why the branch had no test until it had this one.
+        $GLOBALS['TYPO3_CONF_VARS'] = new stdClass();
+
+        $thrown = '';
+
+        try {
+            $client->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+            self::fail('Expected the transport build to throw.');
+        } catch (Error $e) {
+            // Rethrown unchanged, like every other throw this class does not raise.
+            $thrown = $e->getMessage();
+            self::assertStringContainsString('as array', $thrown);
+        }
+
+        // The whole row, not just its prefix: the literal, the separator and the
+        // original message in that order.
+        self::assertSame(
+            [['http_call', false, self::TRANSPORT_RESOLUTION_FAILED_MESSAGE . ': ' . $thrown]],
+            $auditedRows,
+            'A call whose transport could not be built still gets exactly one row.',
+        );
+    }
+
+    // =========================================================================
+    // Harness
+    // =========================================================================
+
+    /**
+     * Build the REAL cancellable transport, then replace only its bottom handler
+     * and its ticker.
+     *
+     * Everything above the bottom handler — the hardened option set and the
+     * `ssrf-dns-pin` middleware — is the production article, which is what makes
+     * tests 6 and 7 meaningful.
+     */
+    private function transportWith(StubbedTransfer $transfer, TransportTickerInterface $ticker): CancellableTransport
+    {
+        $real = $this->clientFactory->createCancellable();
+        self::assertInstanceOf(CancellableTransport::class, $real);
+
+        $client = $real->client();
+        self::assertInstanceOf(Client::class, $client);
+
+        $handler = $this->getGuzzleConfig($client)['handler'] ?? null;
+        self::assertInstanceOf(HandlerStack::class, $handler);
+        $handler->setHandler($transfer->handler());
+
+        return new CancellableTransport($client, $ticker, $real->wallClockBudgetSeconds());
+    }
+
+    private function clientWithTransport(CancellableTransport $transport): VaultHttpClient
+    {
+        // No inner client: the constructor builds one from the factory, which is
+        // what makes the instance factory-built. An injected transport is only
+        // honoured for such an instance — see
+        // `anInjectedTransportNeverDisplacesACallerSuppliedClient()` — so
+        // passing one here would be testing the degraded path by accident.
+        return new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            secureHttpClientFactory: $this->clientFactory,
+            cancellableTransport: $transport,
+        );
+    }
+
+    /**
+     * Record every audit row as `[action, success]`.
+     *
+     * @param list<array{0: string, 1: bool}> $actions
+     *
+     * @param-out list<array{0: string, 1: bool}> $actions
+     */
+    private function recordAuditActions(array &$actions): void
+    {
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->willReturnCallback(
+                static function (
+                    string $identifier,
+                    string $action,
+                    bool $success,
+                    ?string $error = null,
+                    ?string $reason = null,
+                    ?string $hashBefore = null,
+                    ?string $hashAfter = null,
+                    ?AuditContextInterface $context = null,
+                ) use (&$actions): void {
+                    $actions[] = [$action, $success];
+                },
+            );
+    }
+
+    /**
+     * Record every audit row as `[action, success, errorMessage]`.
+     *
+     * The message matters on this path: with a single cancellation action it is
+     * what tells an operator whether a credential was involved, and the audit
+     * module renders it in the row.
+     *
+     * @param list<array{0: string, 1: bool, 2: ?string}> $rows
+     *
+     * @param-out list<array{0: string, 1: bool, 2: ?string}> $rows
+     */
+    private function recordAuditRows(array &$rows): void
+    {
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->willReturnCallback(
+                static function (
+                    string $identifier,
+                    string $action,
+                    bool $success,
+                    ?string $error = null,
+                    ?string $reason = null,
+                    ?string $hashBefore = null,
+                    ?string $hashAfter = null,
+                    ?AuditContextInterface $context = null,
+                ) use (&$rows): void {
+                    $rows[] = [$action, $success, $error];
+                },
+            );
+    }
+}
+
+/**
+ * A DNS resolver that answers from a programmed table and never touches the
+ * network.
+ */
+final class ProgrammedDnsResolver implements DnsResolverInterface
+{
+    /** @var array<string, list<array{ip?: string, ipv6?: string}>> */
+    private array $programmed = [];
+
+    /** @var array<string, list<list<array{ip?: string, ipv6?: string}>>> */
+    private array $sequences = [];
+
+    /** @var array<string, int> */
+    private array $calls = [];
+
+    /**
+     * @param list<array{ip?: string, ipv6?: string}> $records
+     */
+    public function program(string $host, array $records): void
+    {
+        $this->programmed[$host] = $records;
+    }
+
+    /**
+     * Answer the same host differently on successive lookups.
+     *
+     * This is DNS rebinding: `isHostAllowed()` resolves the host once, the
+     * `ssrf-dns-pin` middleware resolves it again a moment later, and an
+     * attacker who controls the zone can answer the two lookups differently.
+     * The last programmed answer repeats for any further lookup.
+     *
+     * @param list<list<array{ip?: string, ipv6?: string}>> $answers
+     */
+    public function programSequence(string $host, array $answers): void
+    {
+        $this->sequences[$host] = $answers;
+        $this->calls[$host] = 0;
+    }
+
+    public function resolve(string $host): array
+    {
+        if (isset($this->sequences[$host])) {
+            $answers = $this->sequences[$host];
+            $index = min($this->calls[$host] ?? 0, \count($answers) - 1);
+            $this->calls[$host] = ($this->calls[$host] ?? 0) + 1;
+
+            return $answers[$index];
+        }
+
+        return $this->programmed[$host] ?? [];
+    }
+}
+
+/**
+ * The bottom handler of the stack under test.
+ *
+ * Returns a promise that never settles on its own — the only two ways out are
+ * the ticker settling it or the cancellation loop cancelling it, which is
+ * exactly the choice the loop is supposed to make.
+ */
+final class StubbedTransfer
+{
+    private ?RequestInterface $request = null;
+
+    /** @var array<int|string, mixed>|null */
+    private ?array $options = null;
+
+    private int $transferCount = 0;
+
+    private ?Promise $promise = null;
+
+    /**
+     * Incremented every time the promise's cancel function runs — the only
+     * in-process evidence that an abort reached the transport.
+     */
+    private int $cancelCalls = 0;
+
+    /**
+     * Incremented if anything ever forced the promise to settle by waiting on
+     * it — the one thing the loop must not do.
+     */
+    private int $waitCalls = 0;
+
+    /**
+     * @return Closure(RequestInterface, array<int|string, mixed>): PromiseInterface
+     */
+    public function handler(): Closure
+    {
+        return function (RequestInterface $request, array $options): PromiseInterface {
+            $this->request = $request;
+            /** @var array<int|string, mixed> $options */
+            $this->options = $options;
+            ++$this->transferCount;
+
+            $promise = new Promise(
+                function (): void {
+                    // Must stay at zero. Guzzle runs this from `wait()`, whose
+                    // implementation here is `CurlMultiHandler::execute()` —
+                    // it loops until every handle on the handler completes and
+                    // leaves no window in which the signal could be observed.
+                    // A loop that called wait() would still pass most of these
+                    // tests while being uncancellable in production.
+                    ++$this->waitCalls;
+                },
+                function (): void {
+                    ++$this->cancelCalls;
+                },
+            );
+            $this->promise = $promise;
+
+            return $promise;
+        };
+    }
+
+    public function settleWith(Response $response): void
+    {
+        $this->settleWithValue($response);
+    }
+
+    /**
+     * Settle with something that is not a PSR-7 response.
+     *
+     * No handler this package builds can do that; the branch exists so such a
+     * value can never be returned to a caller as if it were a response, and a
+     * branch with no test is a branch nobody has read.
+     */
+    public function settleWithValue(mixed $value): void
+    {
+        $this->promise?->resolve($value);
+        // Propagate through the middleware `then()` chain: Guzzle queues handler
+        // callbacks rather than running them inline, and it is normally
+        // CurlMultiHandler::tick() that drains that queue.
+        PromiseUtils::queue()->run();
+    }
+
+    /**
+     * Reject with a reason that is not a Throwable.
+     *
+     * Guzzle's own handlers reject with a `RequestException`, but the promise
+     * contract allows any value, and the branch that refuses one exists so such
+     * a reason can never be rethrown or copied into the row.
+     */
+    public function rejectWithValue(mixed $reason): void
+    {
+        $this->promise?->reject($reason);
+        PromiseUtils::queue()->run();
+    }
+
+    public function cancelCalls(): int
+    {
+        return $this->cancelCalls;
+    }
+
+    public function waitCalls(): int
+    {
+        return $this->waitCalls;
+    }
+
+    public function wasReached(): bool
+    {
+        return $this->transferCount > 0;
+    }
+
+    public function transferCount(): int
+    {
+        return $this->transferCount;
+    }
+
+    public function request(): ?RequestInterface
+    {
+        return $this->request;
+    }
+
+    /**
+     * @return array<int|string, mixed>|null
+     */
+    public function options(): ?array
+    {
+        return $this->options;
+    }
+}
+
+/**
+ * A transport client whose `sendAsync()` throws instead of returning a promise.
+ *
+ * Not a contrived shape: `Client::applyOptions()` raises
+ * `InvalidArgumentException` outside `Client::transfer()`'s own try/catch, so a
+ * real Guzzle client does exactly this for a bad option set — the throw escapes
+ * the call rather than becoming a rejected promise.
+ */
+final class ThrowingOnSendClient implements GuzzleClientInterface
+{
+    /**
+     * @param array<array-key, mixed> $options
+     */
+    public function send(RequestInterface $request, array $options = []): ResponseInterface
+    {
+        throw new InvalidArgumentException('sendAsync refused the option set', 1786579302);
+    }
+
+    /**
+     * @param array<array-key, mixed> $options
+     */
+    public function sendAsync(RequestInterface $request, array $options = []): PromiseInterface
+    {
+        throw new InvalidArgumentException('sendAsync refused the option set', 1786579302);
+    }
+
+    /**
+     * @param string|UriInterface $uri
+     * @param array<array-key, mixed> $options
+     */
+    public function request(string $method, $uri, array $options = []): ResponseInterface
+    {
+        throw new InvalidArgumentException('sendAsync refused the option set', 1786579302);
+    }
+
+    /**
+     * @param string|UriInterface $uri
+     * @param array<array-key, mixed> $options
+     */
+    public function requestAsync(string $method, $uri, array $options = []): PromiseInterface
+    {
+        throw new InvalidArgumentException('sendAsync refused the option set', 1786579302);
+    }
+
+    public function getConfig(?string $option = null): mixed
+    {
+        return null;
+    }
+}
+
+/**
+ * Drives the loop from a closure instead of a curl multi handle.
+ */
+final class ClosureTicker implements TransportTickerInterface
+{
+    private int $ticks = 0;
+
+    /**
+     * @param Closure(int): void $onTick Receives the 1-based tick number
+     */
+    public function __construct(private readonly Closure $onTick) {}
+
+    public function tick(): void
+    {
+        ++$this->ticks;
+        ($this->onTick)($this->ticks);
+    }
+
+    public function ticks(): int
+    {
+        return $this->ticks;
+    }
+}
+
+/**
+ * False for the first `$falseAnswers` questions, true from then on.
+ */
+final class CountdownSignal implements CancellationSignalInterface
+{
+    private int $asked = 0;
+
+    public function __construct(private readonly int $falseAnswers) {}
+
+    public function isCancelled(): bool
+    {
+        ++$this->asked;
+
+        return $this->asked > $this->falseAnswers;
+    }
+}
+
+final class NeverCancelledSignal implements CancellationSignalInterface
+{
+    public function isCancelled(): bool
+    {
+        return false;
+    }
+}
+
+final class AlreadyCancelledSignal implements CancellationSignalInterface
+{
+    public function isCancelled(): bool
+    {
+        return true;
+    }
+}
+
+/**
+ * Breaks the interface's "MUST NOT throw" contract on the Nth question.
+ *
+ * A caller-supplied object that misbehaves is not hypothetical, and the
+ * contract is a docblock, not an enforcement. What must hold anyway: the row
+ * still gets written, because the credential is already out by then.
+ */
+final class ThrowingSignal implements CancellationSignalInterface
+{
+    private int $asked = 0;
+
+    public function __construct(private readonly int $falseAnswers) {}
+
+    public function isCancelled(): bool
+    {
+        ++$this->asked;
+
+        if ($this->asked > $this->falseAnswers) {
+            throw new RuntimeException("the caller's signal blew up", 1786579301);
+        }
+
+        return false;
+    }
+}

--- a/Tests/Unit/Http/VaultHttpClientTest.php
+++ b/Tests/Unit/Http/VaultHttpClientTest.php
@@ -1246,6 +1246,285 @@ final class VaultHttpClientTest extends TestCase
         }
     }
 
+    // =========================================================================
+    // Characterization of the three refusals that happen before the send
+    //
+    // Written BEFORE those refusals were audited and unchanged since: an audit
+    // row is additive, and what a caller receives must be byte-for-byte the
+    // exception it received before. Each pins the concrete class, the code and
+    // the exact message. The rows themselves are asserted separately, below.
+    // =========================================================================
+
+    #[Test]
+    public function sendRequestRefusesAnUnsupportedSchemeWithAnUnchangedException(): void
+    {
+        $this->innerClient->expects(self::never())->method('sendRequest');
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        try {
+            $client->sendRequest(new Request('GET', 'ftp://files.example.com/data'));
+            self::fail('Expected the scheme guard to refuse an ftp:// URI.');
+        } catch (VaultException $e) {
+            self::assertSame(VaultException::class, $e::class);
+            self::assertSame(1735858523, $e->getCode());
+            self::assertSame(
+                'Unsupported URI scheme "ftp"; only https and http are allowed',
+                $e->getMessage(),
+            );
+        }
+    }
+
+    #[Test]
+    public function sendRequestRefusesAHostOutsideTheAllowlistWithAnUnchangedException(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'] = ['trusted.example.com'];
+
+        try {
+            $this->innerClient->expects(self::never())->method('sendRequest');
+
+            $client = new VaultHttpClient(
+                $this->vaultService,
+                $this->auditLogService,
+                $this->innerClient,
+            );
+
+            try {
+                $client->sendRequest(new Request('GET', 'https://untrusted.other.com/data'));
+                self::fail('Expected the allowlist to refuse the host.');
+            } catch (VaultException $e) {
+                self::assertSame(VaultException::class, $e::class);
+                self::assertSame(1735858522, $e->getCode());
+                self::assertSame(
+                    'Host "untrusted.other.com" is not in the allowed hosts list',
+                    $e->getMessage(),
+                );
+            }
+        } finally {
+            unset($GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts']);
+        }
+    }
+
+    #[Test]
+    public function sendRequestRefusesAMissingSecretWithAnUnchangedException(): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturn(null);
+
+        $this->innerClient->expects(self::never())->method('sendRequest');
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        try {
+            $client
+                ->withAuthentication('nonexistent_key', SecretPlacement::Bearer)
+                ->sendRequest(new Request('GET', self::API_URL));
+            self::fail('Expected the missing secret to refuse the send.');
+        } catch (SecretNotFoundException $e) {
+            // The catch type is half the assertion: a different exception class
+            // would leave this block unentered and hit the fail() above.
+            self::assertSame(1735858521, $e->getCode());
+            self::assertSame('nonexistent_key', $e->getMessage());
+        }
+    }
+
+    // =========================================================================
+    // The audit rows those three refusals now leave
+    // =========================================================================
+
+    #[Test]
+    public function aRefusedSchemeIsAuditedAsAFailedHttpCall(): void
+    {
+        // Somebody tried `file://` is exactly the row an operator goes looking
+        // for, and the scheme reaches the log only through this message:
+        // HttpCallContext records method, host, path and status, not the scheme.
+        $rows = [];
+        $this->recordAuditRows($rows);
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        try {
+            $client->sendRequest(new Request('GET', 'file:///etc/passwd'));
+            self::fail('Expected the scheme guard to refuse a file:// URI.');
+        } catch (VaultException) {
+        }
+
+        self::assertSame(
+            [[
+                'http_call',
+                false,
+                'Request refused before any secret was read: unsupported URI scheme "file"',
+            ]],
+            $rows,
+        );
+    }
+
+    #[Test]
+    public function aRefusedHostIsAuditedAsAFailedHttpCall(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'] = ['trusted.example.com'];
+
+        try {
+            $rows = [];
+            $this->recordAuditRows($rows);
+
+            $client = new VaultHttpClient(
+                $this->vaultService,
+                $this->auditLogService,
+                $this->innerClient,
+            );
+
+            try {
+                $client->sendRequest(new Request('GET', 'https://untrusted.other.com/data'));
+                self::fail('Expected the allowlist to refuse the host.');
+            } catch (VaultException) {
+            }
+
+            self::assertSame(
+                [[
+                    'http_call',
+                    false,
+                    'Request refused before any secret was read: host is not in the allowed hosts list',
+                ]],
+                $rows,
+            );
+        } finally {
+            unset($GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts']);
+        }
+    }
+
+    #[Test]
+    public function aFailedCredentialInjectionIsAuditedAsAFailedHttpCall(): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturn(null);
+
+        $rows = [];
+        $contexts = [];
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->willReturnCallback(
+                static function (
+                    string $identifier,
+                    string $action,
+                    bool $success,
+                    ?string $error = null,
+                    ?string $reason = null,
+                    ?string $hashBefore = null,
+                    ?string $hashAfter = null,
+                    ?AuditContextInterface $context = null,
+                ) use (&$rows, &$contexts): void {
+                    $rows[] = [$action, $success, $error];
+                    $contexts[] = $context;
+                },
+            );
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        try {
+            $client
+                ->withAuthentication('nonexistent_key', SecretPlacement::Bearer)
+                ->sendRequest(new Request('POST', self::API_URL));
+            self::fail('Expected the missing secret to refuse the send.');
+        } catch (SecretNotFoundException) {
+        }
+
+        self::assertCount(1, $rows);
+        self::assertSame('http_call', $rows[0][0]);
+        self::assertFalse($rows[0][1]);
+        self::assertSame(
+            'Credential injection failed; nothing was sent: nonexistent_key',
+            $rows[0][2],
+        );
+
+        // Status 0 says "nothing came back", which is the whole point of the
+        // row: the request was never sent. A real status here would read as a
+        // completed call in every count over the log.
+        self::assertInstanceOf(HttpCallContext::class, $contexts[0]);
+        self::assertSame(
+            [
+                'method' => 'POST',
+                'host' => 'api.example.com',
+                'path' => '/data',
+                'status_code' => 0,
+            ],
+            $contexts[0]->toArray(),
+        );
+    }
+
+    #[Test]
+    public function theRefusalRowCarriesTheRequestItRefused(): void
+    {
+        // The row has to be findable by what was attempted, or "who tried to
+        // reach a host nobody approved?" is unanswerable from the log.
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts'] = ['trusted.example.com'];
+
+        try {
+            $context = null;
+            $this->auditLogService
+                ->expects(self::once())
+                ->method('log')
+                ->willReturnCallback(
+                    static function (
+                        string $identifier,
+                        string $action,
+                        bool $success,
+                        ?string $error = null,
+                        ?string $reason = null,
+                        ?string $hashBefore = null,
+                        ?string $hashAfter = null,
+                        ?AuditContextInterface $auditContext = null,
+                    ) use (&$context): void {
+                        $context = $auditContext;
+                    },
+                );
+
+            $client = new VaultHttpClient(
+                $this->vaultService,
+                $this->auditLogService,
+                $this->innerClient,
+            );
+
+            try {
+                $client->sendRequest(new Request('POST', 'https://untrusted.other.com/data'));
+                self::fail('Expected the allowlist to refuse the host.');
+            } catch (VaultException) {
+            }
+
+            self::assertInstanceOf(HttpCallContext::class, $context);
+            self::assertSame(
+                [
+                    'method' => 'POST',
+                    'host' => 'untrusted.other.com',
+                    'path' => '/data',
+                    'status_code' => 0,
+                ],
+                $context->toArray(),
+            );
+        } finally {
+            unset($GLOBALS['TYPO3_CONF_VARS']['HTTP']['allowed_hosts']);
+        }
+    }
+
     #[Test]
     public function withReasonPreservesOtherConfiguration(): void
     {
@@ -1339,6 +1618,34 @@ final class VaultHttpClientTest extends TestCase
             $this->extractOAuthManager($afterChain),
             'withReason() (after withOAuth) must forward the same OAuthTokenManager — token cache is dead if this fails',
         );
+    }
+
+    /**
+     * Record every audit row as `[action, success, errorMessage]`.
+     *
+     * @param list<array{0: string, 1: bool, 2: ?string}> $rows
+     *
+     * @param-out list<array{0: string, 1: bool, 2: ?string}> $rows
+     */
+    private function recordAuditRows(array &$rows): void
+    {
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->willReturnCallback(
+                static function (
+                    string $identifier,
+                    string $action,
+                    bool $success,
+                    ?string $error = null,
+                    ?string $reason = null,
+                    ?string $hashBefore = null,
+                    ?string $hashAfter = null,
+                    ?AuditContextInterface $context = null,
+                ) use (&$rows): void {
+                    $rows[] = [$action, $success, $error];
+                },
+            );
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
         "typo3/cms-core": "^13.4 || ^14.3",
         "typo3/cms-backend": "^13.4 || ^14.3",
         "typo3/cms-install": "^13.4 || ^14.3",
+        "guzzlehttp/guzzle": "^7.10",
         "psr/http-client": "^1.0",
         "psr/http-factory": "^1.0"
     },
@@ -49,6 +50,7 @@
         "typo3/cms-scheduler": "^13.4 || ^14.3"
     },
     "suggest": {
+        "ext-curl": "Enables the CURLOPT_RESOLVE DNS pin and the cancellable outbound send (VaultHttpClient::sendCancellable()); without it both degrade, they do not fail",
         "typo3/cms-dashboard": "Adds vault secret count and audit activity widgets to the TYPO3 dashboard"
     },
     "autoload": {


### PR DESCRIPTION
## What this is

nr-llm cannot abort an in-flight MCP call: a cancelled run ends, the HTTP request keeps going to its timeout. PSR-18 hands back a response and never a handle, and Guzzle's synchronous send settles its promise before anyone could cancel it (`Client::sendRequest()` sets `RequestOptions::SYNCHRONOUS`, `Proxy::wrapSync` routes to `CurlHandler`, whose promise is already settled when it is built).

`VaultHttpClient` gains `sendCancellable()`, behind a separate `CancellableHttpClientInterface` so `VaultHttpClientInterface` is untouched and consumers feature-detect via `supportsCancellation()`. The send goes async so `Proxy::wrapSync` picks `CurlMultiHandler` — whose promise carries a real cancel function — and a ticker drives the loop while the signal is polled between passes. `create()` is byte-identical; `createCancellable()` re-composes the stack so the sync and streaming branches survive.

Closes the nr-llm side of netresearch/t3x-nr-llm#774.

## Why the primitive is a method here and not a factory that lends out a transport

Four of the protections this client exists for are **plain statements in `sendRequest()`**, not middleware: the scheme guard, the `allowed_hosts` gate, credential injection and the audit write. Only the SSRF reject and the `CURLOPT_RESOLVE` DNS pin live on the handler stack. Anything that hands a caller the inner client bypasses the first four — so no Guzzle type crosses the interface, and that is a structural requirement rather than a style choice.

**The invariant is stated at the width it holds, and not wider.** "No credential-bearing send exists outside `VaultHttpClient`" is **false** — `TransitMasterKeyProvider` sends `X-Vault-Token` on a plain client and `OAuthTokenManager` sends `client_secret`. Both are named in the ADR where a reader checks the invariant. What is true and enforced: nothing hands a caller a client that already carries a vault secret, and `VaultHttpClient` is the only place nr-vault attaches one to a *caller's* request.

## Three audit holes closed that this change found rather than introduced

A refused scheme, a refused host and a failed credential injection wrote **no** audit row — on the existing `sendRequest()` path too. All three now write one. The exceptions are unchanged: characterization tests written against the pre-change tree pin the class, code and exact message, and stayed green through the change.

**Two cancellations are told apart** because they are not the same event. Cancelled before the send: nothing egressed, no secret read. Cancelled mid-flight: the credential was injected and handed to the transport. Two actions rather than one, because overloading a single value would restore the ambiguity that already makes `http_call`/`0` mean both "connection refused" and "SSRF rejected".

## Every invariant names its test

Sentences that could not name one were **deleted**, not softened. That rule is what ended a loop: four earlier rounds each removed the absolute claims they were shown and wrote new ones while rephrasing.

It also caught the one finding that matters most here. Until this round, appending `(string) $request->getUri()` to either cancellation throw site kept the whole suite green — and for `SecretPlacement::QueryParam` that URI carries the secret. The messages are now asserted at every site, including exception code `1786579204`, which had no test of any kind. Re-running that mutation now produces four failures, each printing the leaked URI.

## Gates

Green on the final tree: `unit` (3652 tests, 12771 assertions), `phpstan` level 10, `cgl -n`, `rector -n`, `fuzz` (1612 tests), `composer validate`, `composer audit`.

**Four gates were red locally. CI disagrees with three of them, and that correction matters more than the original claim:**

| Gate | Locally | In CI |
| --- | --- | --- |
| Functional | 5 `OAuthIntegrationTest` `allowed_hosts` errors | **green across all 8 matrix cells** |
| Docs render | 47 warnings, exit 1 under `--fail-on-log` | **green** — CI does not pass that flag |
| Mutation | Covered MSI 70.73% vs a 72% ratchet over all of `Classes/` | **green** — CI runs a narrower "Security mutation ratchet" |
| `ci:test:php:doc-cli` | `Commands.rst:61` does not document `vault:store --as-provisioner` | **not run** — `ci / Repo checks` is skipping on this PR |

So the local functional red is an environment artefact, not a repository baseline, and my first phrasing implied otherwise. The one that stands is the doc-cli drift: it is pre-existing, it is unrelated to this change, and CI does not check it — so nothing but a local run would ever surface it.

69 checks pass, 0 fail, 10 skipping.

## Scope beyond the issue, named rather than buried

- `guzzlehttp/guzzle: ^7.10` is now a direct dependency (authorised): this change pins behaviour of `CurlMultiHandler` internals, and depending on that transitively means a Guzzle major arriving through a third path breaks us with no warning in our own manifest. An `ext-curl` suggest was added alongside.
- `SecureHttpClientFactory` carries a ~306-line refactor (`buildOptions()` extraction, `warnWhenTlsVerificationIsDisabled` / `warnWhenCurlIsMissing`). No review round asked for it. Behaviour was established rather than assumed: the TLS-warning condition moved from `array_key_exists` + `=== false` to `($typo3Config['verify'] ?? null) === false`, equivalent for the null, missing-key, false and true cases, and it now fires from `create()` only so the per-send transport does not repeat it.
- `Configuration/Services.yaml` pins one constructor argument. A `?self $clonedFrom` prototype made Symfony autowire `VaultHttpClient` into itself — `ServiceCircularReferenceException`, 384 of 384 functional tests erroring. The ADR records the fix and the two rejected alternatives.

## Known limit, documented rather than hidden

The `@internal $cancellableTransport` constructor parameter is public — PHP offers no way to make a constructor parameter unreachable while the constructor is. With it set, an instance that has no caller-supplied client can have its transport substituted. It needs a deliberate caller, so this is a documentation-versus-code boundary and it is stated as one, in the ADR and on the interface. A named constructor or a test-only subclass would close it; that is a reviewer's call.

## Commit convention

The subject is capitalized imperative, not a lowercase Conventional Commit: `captainhook.json` enforces `CapitalizeSubject` and would reject the latter. Worth noting because it contradicts the house preference elsewhere, and because 12 of the last 25 subjects on `main` are lowercase Conventional Commits — so either the hook is not installed for everyone, or it is being bypassed. Not resolved here.
