### PR TITLE
fix: a never-read secret is null, not the epoch

### DIFF
--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -439,19 +439,21 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
                 continue;
             }
 
+            // 0 means "never read": last_read_at is NOT NULL DEFAULT 0.
+            $lastReadAt = $secret->getLastReadAt();
+
             $secrets[] = new SecretMetadata(
                 identifier: $secret->getIdentifier(),
                 ownerUid: $secret->getOwnerUid(),
                 createdAt: $secret->getCrdate(),
                 updatedAt: $secret->getTstamp(),
                 readCount: $secret->getReadCount(),
-                // 0 is what the column carries for a secret nobody has read:
-                // `last_read_at` is NOT NULL DEFAULT 0. Every consumer of this
-                // field guards with `!== null` -- the module list, both CLI
-                // listings and the delete command -- so passing 0 through made
-                // all four print 1970-01-01. SecretDetails, VaultAnalyticsService
-                // and StalenessEvaluator each normalise it; this one did not.
-                lastReadAt: $secret->getLastReadAt() ?: null,
+                // Every consumer of this field guards with `!== null` -- the
+                // module list, both CLI listings and the delete command -- so
+                // passing 0 through made all four print 1970-01-01.
+                // VaultAnalyticsService and StalenessEvaluator normalise it the
+                // same way; this construction site did not.
+                lastReadAt: $lastReadAt === 0 ? null : $lastReadAt,
                 description: $secret->getDescription(),
                 version: $secret->getVersion(),
                 metadata: $secret->getMetadata(),

--- a/Classes/Service/VaultService.php
+++ b/Classes/Service/VaultService.php
@@ -445,7 +445,13 @@ final readonly class VaultService implements VaultServiceInterface, SingletonInt
                 createdAt: $secret->getCrdate(),
                 updatedAt: $secret->getTstamp(),
                 readCount: $secret->getReadCount(),
-                lastReadAt: $secret->getLastReadAt(),
+                // 0 is what the column carries for a secret nobody has read:
+                // `last_read_at` is NOT NULL DEFAULT 0. Every consumer of this
+                // field guards with `!== null` -- the module list, both CLI
+                // listings and the delete command -- so passing 0 through made
+                // all four print 1970-01-01. SecretDetails, VaultAnalyticsService
+                // and StalenessEvaluator each normalise it; this one did not.
+                lastReadAt: $secret->getLastReadAt() ?: null,
                 description: $secret->getDescription(),
                 version: $secret->getVersion(),
                 metadata: $secret->getMetadata(),

--- a/Tests/Unit/Service/VaultServiceTest.php
+++ b/Tests/Unit/Service/VaultServiceTest.php
@@ -1452,6 +1452,34 @@ final class VaultServiceTest extends TestCase
         self::assertEquals('secret1', $result[0]->identifier);
     }
 
+    /**
+     * `last_read_at` is NOT NULL DEFAULT 0, so 0 -- not null -- is what a secret
+     * nobody has read carries. Every consumer of SecretMetadata::$lastReadAt
+     * guards with `!== null`: the module list, both CLI listings and the delete
+     * command. Passing 0 through made all four print the epoch, which on a
+     * screen about stale credentials reads as a very old read rather than none.
+     */
+    #[Test]
+    public function listReportsANeverReadSecretAsNullRatherThanTheEpoch(): void
+    {
+        $never = $this->createSecretEntity('never-read');
+        $read = $this->createSecretEntity('has-been-read', lastReadAt: 1_700_000_000);
+
+        $this->adapter
+            ->method('listSecrets')
+            ->willReturn([$never, $read]);
+
+        $this->accessControlService
+            ->method('canRead')
+            ->willReturn(true);
+
+        $result = $this->subject->list();
+
+        self::assertCount(2, $result);
+        self::assertNull($result[0]->lastReadAt, 'a secret nobody read has no last-read time');
+        self::assertSame(1_700_000_000, $result[1]->lastReadAt, 'a real timestamp survives untouched');
+    }
+
     #[Test]
     public function getMetadataReturnsSecretMetadata(): void
     {
@@ -1983,6 +2011,7 @@ final class VaultServiceTest extends TestCase
         array $metadata = [],
         bool $frontendAccessible = false,
         bool $hidden = false,
+        int $lastReadAt = 0,
     ): Secret {
         return new Secret(
             identifier: $identifier,
@@ -2001,6 +2030,7 @@ final class VaultServiceTest extends TestCase
             metadata: $metadata,
             crdate: $crdate,
             hidden: $hidden,
+            lastReadAt: $lastReadAt,
         );
     }
 }


### PR DESCRIPTION
`last_read_at` is `NOT NULL DEFAULT 0`, so **0 — not null — is what a secret nobody has read carries**. `VaultService::list()` passed that 0 straight into `SecretMetadata::$lastReadAt`, which is declared `?int` precisely so it can say *never*.

## Why one missing conversion showed up in four places

Every consumer of that field already guards with `!== null`:

| consumer | prints for "never" |
|---|---|
| `SecretsController:146` — the Secrets module list | `-` |
| `VaultListCommand:128` | `-` |
| `VaultListCommand:157` | *(empty)* |
| `VaultDeleteCommand:86` | `Never` |

All four were correct. All four printed `1970-01-01` anyway, because none of them ever received a null.

On a screen whose job is telling an operator which credentials are stale, the epoch reads as *a very old read* rather than *none at all* — the opposite meaning. And it disagreed with Analytics, which flags redaction candidates and says `never` for the same secret.

## The fix is the idiom the codebase already uses

Three other places normalise this: `SecretDetails::fromEntity` (`?: null`), `VaultAnalyticsService` twice (`=== 0 ? null :`), and `StalenessEvaluator` (`=== null || === 0`). `VaultService::list()` was the one construction site that did not. It now uses the same `?: null` as `SecretDetails`.

One line, plus a comment naming the four consumers so the next person does not have to rediscover why the nullability matters.

## Verification

```
runTests.sh -s unit -p 8.4  → 3653 tests, 12774 assertions, no failures
runTests.sh -s cgl   -p 8.4 → SUCCESS
```

The guard was seen to fail. With the conversion reverted and nothing else changed:

```
1) …VaultServiceTest::listReportsANeverReadSecretAsNullRatherThanTheEpoch
   a secret nobody read has no last-read time
   Failed asserting that 0 is null.
```

The test also asserts the other direction — a real timestamp survives untouched — so it cannot pass by turning everything into null.

**PHPStan was not run locally.** It aborts before analysing with `Invalid configuration: Unexpected item 'parameters › ergebnis'`, and a control run on unmodified `main` in a separate worktree produces the identical error. It is the local dependency resolution missing `ergebnis/phpstan-rules`, which CI installs — not this change. CI runs it.

Closes #313
