### PR TITLE
Add an api-surface snapshot test

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,6 +1,11 @@
 # Normalize line endings.
 * text=auto
 
+# The api-surface snapshot is compared byte-for-byte by assertSame(); a CRLF
+# checkout (Windows autocrlf) would fail the comparison with a diff output
+# that says "identical" (the classifier rtrims per line). Pin it to LF.
+/Tests/Unit/Api/api-surface.txt text eol=lf
+
 # Exclude development-only paths from `git archive` (composer dist / TER packages),
 # keeping published artifacts small. Runtime code (Classes, Configuration,
 # Resources, Documentation, ext_* , composer.json, LICENSE) is intentionally NOT

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trailing `$cancellationSignal` parameter; every existing call keeps
   compiling.
 
+- **An api-surface snapshot test** (#306). `Tests/Unit/Api/api-surface.txt`
+  freezes the rendered public surface — every interface, enum (backing
+  values included) and exception class under `Classes/`, the `Domain/Dto`
+  value objects, plus every own-namespace type their signatures mention,
+  constructors included. A change to any frozen signature now has to be an
+  explicit commit with a visible snapshot diff rather than a side effect;
+  the failure message classifies the diff as additive (regenerate) or
+  breaking (a decision, per AGENTS.md's "Ask First" rule for interface
+  signatures). Ported from nr-llm, which has carried the same guard since
+  ADR-127, with one deliberate divergence — backed-enum values are rendered,
+  proposed upstream as t3x-nr-llm#815.
+
 ### Changed
 
 - **One DNS lookup per outbound request instead of two** (#304). The

--- a/Tests/Unit/Api/ApiSurfaceRendererTest.php
+++ b/Tests/Unit/Api/ApiSurfaceRendererTest.php
@@ -1,0 +1,211 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Api;
+
+use Netresearch\NrVault\Tests\Unit\Api\Fixtures\AddedMethod;
+use Netresearch\NrVault\Tests\Unit\Api\Fixtures\InheritsForeignConstructor;
+use Netresearch\NrVault\Tests\Unit\Api\Fixtures\InheritsOwnConstructor;
+use Netresearch\NrVault\Tests\Unit\Api\Fixtures\NarrowConstructor;
+use Netresearch\NrVault\Tests\Unit\Api\Fixtures\WidenedConstructor;
+use Netresearch\NrVault\Tests\Unit\Api\Support\ApiSurfaceDiff;
+use Netresearch\NrVault\Tests\Unit\Api\Support\ApiSurfaceRenderer;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * Proves what ApiSurfaceSnapshotTest cannot prove about itself.
+ *
+ * A snapshot assertion only ever shows that today's surface equals the
+ * committed one. It cannot show that a given break WOULD have been caught.
+ * These tests run the renderer and the classifier against fixture classes
+ * that differ in one property each, so the claim "the snapshot catches a
+ * widened constructor" is checked rather than asserted.
+ */
+#[CoversNothing] // both subjects live under Tests/, never a coverage target
+final class ApiSurfaceRendererTest extends TestCase
+{
+    #[Test]
+    public function aWidenedConstructorIsTheOnlyDifferenceTheRendererReports(): void
+    {
+        $renderer = new ApiSurfaceRenderer();
+
+        $narrow = $this->linesOf($renderer->render([NarrowConstructor::class]));
+        $widened = $this->linesOf($renderer->render([WidenedConstructor::class]));
+
+        // Everything but the constructor is identical between the two
+        // fixtures — that is what makes the next assertion mean something.
+        self::assertSame(
+            $this->withoutConstructor($narrow),
+            $this->withoutConstructor($widened),
+            'The fixtures must differ in the constructor and nothing else.',
+        );
+
+        self::assertNotSame(
+            $narrow,
+            $widened,
+            'A new required constructor argument left the rendered surface unchanged — '
+            . 'the snapshot is blind to constructor breaks.',
+        );
+
+        self::assertSame(
+            ['constructor(string $name)'],
+            $this->constructorLines($narrow),
+        );
+        self::assertSame(
+            ['constructor(string $name, int $limit)'],
+            $this->constructorLines($widened),
+        );
+    }
+
+    #[Test]
+    public function aWidenedConstructorClassifiesAsBreaking(): void
+    {
+        $diff = $this->diffBetween(NarrowConstructor::class, WidenedConstructor::class);
+
+        self::assertSame('breaking', $diff->verdict());
+        self::assertSame([], $diff->added);
+        self::assertSame([], $diff->removed);
+        self::assertCount(1, $diff->changed);
+        self::assertSame(
+            WidenedConstructor::class . ' :: constructor',
+            $diff->changed[0]['entry'],
+        );
+        self::assertStringContainsString('this is a decision, not a regeneration', $diff->describe());
+        self::assertStringStartsWith(strtoupper($diff->verdict()) . ' — ', $diff->describe());
+    }
+
+    #[Test]
+    public function anAddedMethodClassifiesAsAdditive(): void
+    {
+        $diff = $this->diffBetween(NarrowConstructor::class, AddedMethod::class);
+
+        self::assertSame('additive', $diff->verdict());
+        self::assertSame([], $diff->removed);
+        self::assertSame([], $diff->changed);
+        self::assertSame(
+            [AddedMethod::class . ' :: method shout(): string'],
+            $diff->added,
+        );
+        self::assertStringContainsString('regenerate the snapshot', $diff->describe());
+        self::assertStringStartsWith(strtoupper($diff->verdict()) . ' — ', $diff->describe());
+    }
+
+    #[Test]
+    public function aRemovedMethodClassifiesAsBreaking(): void
+    {
+        $diff = $this->diffBetween(AddedMethod::class, NarrowConstructor::class);
+
+        self::assertSame('breaking', $diff->verdict());
+        self::assertSame([], $diff->added);
+        self::assertSame([], $diff->changed);
+        self::assertSame(
+            [NarrowConstructor::class . ' :: method shout(): string'],
+            $diff->removed,
+        );
+    }
+
+    #[Test]
+    public function aConstructorInheritedFromAnOwnNamespaceBaseIsRecorded(): void
+    {
+        $rendered = (new ApiSurfaceRenderer())->render([InheritsOwnConstructor::class]);
+
+        self::assertSame(
+            ['constructor(string $endpoint)'],
+            $this->constructorLines($this->linesOf($rendered)),
+            'A class that declares no constructor still gets one from its own-namespace base, '
+            . 'and `new` binds to that — leaving it out is how a required argument added to the '
+            . 'base passes the gate in silence.',
+        );
+    }
+
+    #[Test]
+    public function aConstructorInheritedFromOutsideTheRepositoryIsNotRecorded(): void
+    {
+        $rendered = (new ApiSurfaceRenderer())->render([InheritsForeignConstructor::class]);
+
+        self::assertSame(
+            [],
+            $this->constructorLines($this->linesOf($rendered)),
+            'A constructor inherited from TYPO3 core or the SPL is not ours and may differ '
+            . 'between the 13.4 and 14.x legs; recording it would make the snapshot '
+            . 'matrix-dependent.',
+        );
+    }
+
+    #[Test]
+    public function anUnchangedSurfaceProducesNoDiff(): void
+    {
+        $renderer = new ApiSurfaceRenderer();
+        $rendered = $renderer->render([NarrowConstructor::class, AddedMethod::class]);
+
+        $diff = ApiSurfaceDiff::between($rendered, $rendered);
+
+        self::assertTrue($diff->isEmpty());
+        self::assertSame('identical', $diff->verdict());
+    }
+
+    /**
+     * Renders both fixtures and rewrites the first one's class name to the
+     * second's, so the diff sees ONE class whose members moved rather than
+     * one class removed and another added. Deriving the "before" side from a
+     * real rendering keeps this test honest if the rendering format changes.
+     *
+     * @param class-string $before
+     * @param class-string $after
+     */
+    private function diffBetween(string $before, string $after): ApiSurfaceDiff
+    {
+        $renderer = new ApiSurfaceRenderer();
+
+        return ApiSurfaceDiff::between(
+            str_replace($before, $after, $renderer->render([$before])),
+            $renderer->render([$after]),
+        );
+    }
+
+    /**
+     * @return list<string> the member lines of a single-class rendering
+     */
+    private function linesOf(string $rendered): array
+    {
+        $lines = array_map(trim(...), explode("\n", trim($rendered)));
+
+        // Drop the `FQCN (class)` header — the fixtures have different names
+        // by construction, and that is not the difference under test.
+        return array_values(\array_slice($lines, 1));
+    }
+
+    /**
+     * @param list<string> $lines
+     *
+     * @return list<string>
+     */
+    private function withoutConstructor(array $lines): array
+    {
+        return array_values(array_filter(
+            $lines,
+            static fn (string $line): bool => !str_starts_with($line, 'constructor('),
+        ));
+    }
+
+    /**
+     * @param list<string> $lines
+     *
+     * @return list<string>
+     */
+    private function constructorLines(array $lines): array
+    {
+        return array_values(array_filter(
+            $lines,
+            static fn (string $line): bool => str_starts_with($line, 'constructor('),
+        ));
+    }
+}

--- a/Tests/Unit/Api/ApiSurfaceRendererTest.php
+++ b/Tests/Unit/Api/ApiSurfaceRendererTest.php
@@ -10,6 +10,7 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Api;
 
 use Netresearch\NrVault\Tests\Unit\Api\Fixtures\AddedMethod;
+use Netresearch\NrVault\Tests\Unit\Api\Fixtures\BackedFixtureEnum;
 use Netresearch\NrVault\Tests\Unit\Api\Fixtures\InheritsForeignConstructor;
 use Netresearch\NrVault\Tests\Unit\Api\Fixtures\InheritsOwnConstructor;
 use Netresearch\NrVault\Tests\Unit\Api\Fixtures\NarrowConstructor;
@@ -138,6 +139,47 @@ final class ApiSurfaceRendererTest extends TestCase
             . 'between the 13.4 and 14.x legs; recording it would make the snapshot '
             . 'matrix-dependent.',
         );
+    }
+
+    #[Test]
+    public function aBackedEnumRendersItsBackingValues(): void
+    {
+        $rendered = (new ApiSurfaceRenderer())->render([BackedFixtureEnum::class]);
+
+        // The engine-declared enum members (cases/from/tryFrom, name/value)
+        // reflect as DECLARED on the enum itself and are therefore rendered —
+        // the committed snapshot has carried them across all eight matrix
+        // legs since its first version, so they are matrix-stable.
+        self::assertSame(
+            [
+                'case Read = "read"',
+                'case Write = "write"',
+                'method static cases(): array',
+                'method static from(int|string $value): static',
+                'method static tryFrom(int|string $value): ?static',
+                'property readonly name: string',
+                'property readonly value: string',
+            ],
+            $this->linesOf($rendered),
+            'The backing value is the frozen vocabulary — a name-only line would let a value change pass green.',
+        );
+    }
+
+    #[Test]
+    public function aChangedBackingValueClassifiesAsBreaking(): void
+    {
+        $renderer = new ApiSurfaceRenderer();
+        $rendered = $renderer->render([BackedFixtureEnum::class]);
+
+        // Simulate the value change textually: same case name, new value —
+        // exactly the shape of a `case Read = 'read'` → `= 'reveal'` edit.
+        $diff = ApiSurfaceDiff::between($rendered, str_replace('"read"', '"reveal"', $rendered));
+
+        self::assertSame('breaking', $diff->verdict());
+        self::assertCount(1, $diff->changed);
+        self::assertSame(BackedFixtureEnum::class . ' :: case Read', $diff->changed[0]['entry']);
+        self::assertSame('case Read = "read"', $diff->changed[0]['was']);
+        self::assertSame('case Read = "reveal"', $diff->changed[0]['now']);
     }
 
     #[Test]

--- a/Tests/Unit/Api/ApiSurfaceSnapshotTest.php
+++ b/Tests/Unit/Api/ApiSurfaceSnapshotTest.php
@@ -1,0 +1,262 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Api;
+
+use FilesystemIterator;
+use Netresearch\NrVault\Tests\Unit\Api\Support\ApiSurfaceDiff;
+use Netresearch\NrVault\Tests\Unit\Api\Support\ApiSurfaceRenderer;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversNothing;
+use PHPUnit\Framework\Attributes\Test;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use ReflectionClass;
+use ReflectionIntersectionType;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionParameter;
+use ReflectionProperty;
+use ReflectionType;
+use ReflectionUnionType;
+use SplFileInfo;
+use Throwable;
+
+/**
+ * Freezes the rendered public surface of this package in `api-surface.txt`
+ * (issue #306).
+ *
+ * nr-vault has no `@api` marker convention; its public surface is defined by
+ * its own doctrine instead — "prefer `*Interface.php` seams at public
+ * boundaries" (AGENTS.md), and at least one downstream repo feature-detects
+ * on interface names (`instanceof CancellableHttpClientInterface`). The
+ * frozen set is therefore derived mechanically, with no marker to forget:
+ *
+ * 1. **Seed**: every interface, enum and `Throwable` subclass under
+ *    `Classes/`. Interfaces are the consumer contract; enum backing values
+ *    are shared vocabulary (the `AuditAction` values are bound into audit
+ *    rows); exception classes are what callers `catch`.
+ * 2. **Closure**: every own-namespace type a frozen signature mentions —
+ *    method parameters and returns, public property types, and public
+ *    constructor parameters — is frozen too, recursively. That pulls in the
+ *    value objects consumers receive and construct (`OAuthConfig`,
+ *    `SecretDetails`, …) without hand-maintaining a list.
+ *
+ * A change to any of these signatures then has to be an explicit commit — a
+ * visible `api-surface.txt` diff — rather than a side effect. The failure
+ * message is classified by ApiSurfaceDiff: additive (a new class, method,
+ * property) may simply be regenerated; breaking (removed or changed) is a
+ * decision, per AGENTS.md's "Ask First" rule for interface signatures.
+ *
+ * To update intentionally: delete `api-surface.txt`, run the unit suite
+ * twice (first run regenerates the file and fails, second is green), and
+ * commit the regenerated file together with a CHANGELOG entry.
+ */
+#[CoversNothing]
+final class ApiSurfaceSnapshotTest extends TestCase
+{
+    private const CLASSES_DIR = __DIR__ . '/../../../Classes';
+
+    private const SNAPSHOT_PATH = __DIR__ . '/api-surface.txt';
+
+    private const NAMESPACE_PREFIX = 'Netresearch\\NrVault\\';
+
+    #[Test]
+    public function renderedPublicSurfaceMatchesTheCommittedSnapshot(): void
+    {
+        $classes = $this->discoverSurfaceClasses();
+        self::assertNotSame([], $classes, 'No interfaces, enums or exception classes found under Classes/ — the discovery rule is broken.');
+
+        $rendered = (new ApiSurfaceRenderer())->render($classes);
+
+        if (!is_file(self::SNAPSHOT_PATH)) {
+            file_put_contents(self::SNAPSHOT_PATH, $rendered);
+            self::fail(\sprintf(
+                'Snapshot regenerated at %s — inspect the diff and commit it. '
+                . 'A removed or changed line is a break and needs a CHANGELOG entry.',
+                self::SNAPSHOT_PATH,
+            ));
+        }
+
+        $expected = file_get_contents(self::SNAPSHOT_PATH);
+        self::assertNotFalse($expected);
+
+        $diff = ApiSurfaceDiff::between($expected, $rendered);
+
+        self::assertSame(
+            $expected,
+            $rendered,
+            "The rendered public surface differs from Tests/Unit/Api/api-surface.txt.\n\n"
+            . $diff->describe(),
+        );
+    }
+
+    // ==================== discovery ====================
+
+    /**
+     * The seed set (interfaces, enums, Throwables) plus the closure over
+     * own-namespace types their frozen signatures mention.
+     *
+     * @return list<class-string>
+     */
+    private function discoverSurfaceClasses(): array
+    {
+        $renderer = new ApiSurfaceRenderer();
+        $included = [];
+        $queue = $this->discoverSeedClasses();
+
+        while ($queue !== []) {
+            $fqcn = array_shift($queue);
+            if (isset($included[$fqcn])) {
+                continue;
+            }
+
+            $included[$fqcn] = true;
+
+            foreach ($this->mentionedOwnTypes(new ReflectionClass($fqcn), $renderer) as $type) {
+                if (!isset($included[$type])) {
+                    $queue[] = $type;
+                }
+            }
+        }
+
+        $classes = array_keys($included);
+        sort($classes);
+
+        /** @var list<class-string> $classes */
+        return $classes;
+    }
+
+    /**
+     * @return list<class-string>
+     */
+    private function discoverSeedClasses(): array
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator(self::CLASSES_DIR, FilesystemIterator::SKIP_DOTS),
+        );
+
+        $classes = [];
+        foreach ($iterator as $file) {
+            if (!$file instanceof SplFileInfo) {
+                continue;
+            }
+
+            if ($file->getExtension() !== 'php') {
+                continue;
+            }
+
+            $relative = substr($file->getPathname(), \strlen(self::CLASSES_DIR) + 1, -4);
+            $fqcn = self::NAMESPACE_PREFIX . str_replace('/', '\\', $relative);
+            self::assertTrue(
+                class_exists($fqcn) || interface_exists($fqcn) || trait_exists($fqcn) || enum_exists($fqcn),
+                \sprintf('File under Classes/ does not autoload as %s — the PSR-4 discovery rule is broken.', $fqcn),
+            );
+
+            if (interface_exists($fqcn) || enum_exists($fqcn) || is_a($fqcn, Throwable::class, true)) {
+                $classes[] = $fqcn;
+            }
+        }
+
+        sort($classes);
+
+        /** @var list<class-string> $classes */
+        return $classes;
+    }
+
+    // ==================== closure ====================
+
+    /**
+     * Own-namespace class names mentioned in the class's frozen signatures:
+     * declared public methods (parameters and return), declared public
+     * property types, and the public constructor's parameters. Mirrors
+     * exactly what ApiSurfaceRenderer renders for the class.
+     *
+     * @param ReflectionClass<object> $reflection
+     *
+     * @return list<class-string>
+     */
+    private function mentionedOwnTypes(ReflectionClass $reflection, ApiSurfaceRenderer $renderer): array
+    {
+        $types = [];
+
+        foreach ($renderer->declaredPublicMethods($reflection) as $method) {
+            $types = [...$types, ...$this->typesOfMethod($method)];
+        }
+
+        foreach ($renderer->declaredPublicProperties($reflection) as $property) {
+            $types = [...$types, ...$this->typesOfProperty($property)];
+        }
+
+        $constructor = $renderer->declaredPublicConstructor($reflection);
+        if ($constructor instanceof ReflectionMethod) {
+            foreach ($constructor->getParameters() as $parameter) {
+                $types = [...$types, ...$this->typesOfParameter($parameter)];
+            }
+        }
+
+        $own = array_values(array_unique(array_filter(
+            $types,
+            static fn (string $name): bool => str_starts_with($name, self::NAMESPACE_PREFIX),
+        )));
+
+        /** @var list<class-string> $own */
+        return $own;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function typesOfMethod(ReflectionMethod $method): array
+    {
+        $types = [];
+        foreach ($method->getParameters() as $parameter) {
+            $types = [...$types, ...$this->typesOfParameter($parameter)];
+        }
+
+        return [...$types, ...$this->namedClassTypes($method->getReturnType())];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function typesOfParameter(ReflectionParameter $parameter): array
+    {
+        return $this->namedClassTypes($parameter->getType());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function typesOfProperty(ReflectionProperty $property): array
+    {
+        return $this->namedClassTypes($property->getType());
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function namedClassTypes(?ReflectionType $type): array
+    {
+        if ($type instanceof ReflectionNamedType) {
+            return $type->isBuiltin() ? [] : [$type->getName()];
+        }
+
+        if ($type instanceof ReflectionUnionType || $type instanceof ReflectionIntersectionType) {
+            $names = [];
+            foreach ($type->getTypes() as $part) {
+                $names = [...$names, ...$this->namedClassTypes($part)];
+            }
+
+            return $names;
+        }
+
+        return [];
+    }
+}

--- a/Tests/Unit/Api/ApiSurfaceSnapshotTest.php
+++ b/Tests/Unit/Api/ApiSurfaceSnapshotTest.php
@@ -39,14 +39,22 @@ use Throwable;
  * frozen set is therefore derived mechanically, with no marker to forget:
  *
  * 1. **Seed**: every interface, enum and `Throwable` subclass under
- *    `Classes/`. Interfaces are the consumer contract; enum backing values
- *    are shared vocabulary (the `AuditAction` values are bound into audit
- *    rows); exception classes are what callers `catch`.
- * 2. **Closure**: every own-namespace type a frozen signature mentions —
- *    method parameters and returns, public property types, and public
- *    constructor parameters — is frozen too, recursively. That pulls in the
- *    value objects consumers receive and construct (`OAuthConfig`,
- *    `SecretDetails`, …) without hand-maintaining a list.
+ *    `Classes/`, plus every class under `Classes/Domain/Dto/`. Interfaces
+ *    are the consumer contract; enum backing values are shared vocabulary
+ *    (the `AuditAction` values are bound into audit rows, and the renderer
+ *    freezes the values, not just the case names); exception classes are
+ *    what callers `catch`; the DTO directory is seeded wholesale because
+ *    several DTOs travel only through docblock-typed arrays
+ *    (`VaultServiceInterface::list()` returns `list<SecretMetadata>` as
+ *    native `array`), which the reflection-based closure cannot see.
+ * 2. **Closure**: every own-namespace type a frozen signature mentions as a
+ *    NATIVE type — method parameters and returns, public property types,
+ *    and public constructor parameters — is frozen too, recursively. That
+ *    pulls in the value objects consumers receive and construct
+ *    (`OAuthConfig`, …) without hand-maintaining a list. Types that appear
+ *    only in docblocks are outside the closure's sight — the Dto seeding
+ *    above is the compensation, so a new consumer-facing DTO belongs in
+ *    that directory.
  *
  * A change to any of these signatures then has to be an explicit commit — a
  * visible `api-surface.txt` diff — rather than a side effect. The failure
@@ -163,10 +171,14 @@ final class ApiSurfaceSnapshotTest extends TestCase
                 // TYPO3 ^13.4: AuditHmacMigrationWizard implements
                 // TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface, which
                 // exists under that name only on 14.x). Such a class cannot
-                // be part of THIS leg's surface. If a class that qualifies
-                // for the snapshot ever splits by TYPO3 version, the leg
-                // missing it fails the snapshot comparison with a visible
-                // `removed` diff instead of a fatal here.
+                // be part of THIS leg's surface. If a SEED class ever splits
+                // by TYPO3 version, the leg missing it fails the snapshot
+                // comparison with a visible `removed` diff instead of a
+                // fatal here; a closure-reached type that splits would still
+                // error loudly at its ReflectionClass construction — loud,
+                // just without the diff diagnosis. This catch also swallows
+                // a ParseError in a seed file: such a file is skipped here
+                // and caught by the lint job instead.
                 continue;
             }
 
@@ -178,7 +190,12 @@ final class ApiSurfaceSnapshotTest extends TestCase
                 \sprintf('File under Classes/ does not autoload as %s — the PSR-4 discovery rule is broken.', $fqcn),
             );
 
-            if (interface_exists($fqcn) || enum_exists($fqcn) || is_a($fqcn, Throwable::class, true)) {
+            if (
+                interface_exists($fqcn)
+                || enum_exists($fqcn)
+                || is_a($fqcn, Throwable::class, true)
+                || str_starts_with($fqcn, self::NAMESPACE_PREFIX . 'Domain\\Dto\\')
+            ) {
                 $classes[] = $fqcn;
             }
         }

--- a/Tests/Unit/Api/ApiSurfaceSnapshotTest.php
+++ b/Tests/Unit/Api/ApiSurfaceSnapshotTest.php
@@ -154,8 +154,27 @@ final class ApiSurfaceSnapshotTest extends TestCase
 
             $relative = substr($file->getPathname(), \strlen(self::CLASSES_DIR) + 1, -4);
             $fqcn = self::NAMESPACE_PREFIX . str_replace('/', '\\', $relative);
+
+            try {
+                $loadable = class_exists($fqcn) || interface_exists($fqcn) || trait_exists($fqcn) || enum_exists($fqcn);
+            } catch (Throwable) {
+                // The autoload attempt THREW — a parent or interface comes
+                // from a package this matrix leg does not ship (observed on
+                // TYPO3 ^13.4: AuditHmacMigrationWizard implements
+                // TYPO3\CMS\Core\Upgrades\UpgradeWizardInterface, which
+                // exists under that name only on 14.x). Such a class cannot
+                // be part of THIS leg's surface. If a class that qualifies
+                // for the snapshot ever splits by TYPO3 version, the leg
+                // missing it fails the snapshot comparison with a visible
+                // `removed` diff instead of a fatal here.
+                continue;
+            }
+
+            // A clean FALSE (no throw) means the file's PSR-4 name resolves
+            // to nothing anywhere — that is a broken discovery rule, not a
+            // matrix difference, and stays a hard failure.
             self::assertTrue(
-                class_exists($fqcn) || interface_exists($fqcn) || trait_exists($fqcn) || enum_exists($fqcn),
+                $loadable,
                 \sprintf('File under Classes/ does not autoload as %s — the PSR-4 discovery rule is broken.', $fqcn),
             );
 

--- a/Tests/Unit/Api/Fixtures/AddedMethod.php
+++ b/Tests/Unit/Api/Fixtures/AddedMethod.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Api\Fixtures;
+
+/**
+ * NarrowConstructor plus one extra method — the additive counter-example.
+ *
+ * Nothing an existing caller uses moved, so the diff must classify this as
+ * additive and say the snapshot may simply be regenerated.
+ */
+final readonly class AddedMethod
+{
+    public function __construct(public string $name) {}
+
+    public function label(): string
+    {
+        return $this->name;
+    }
+
+    public function shout(): string
+    {
+        return strtoupper($this->name);
+    }
+}

--- a/Tests/Unit/Api/Fixtures/BackedFixtureEnum.php
+++ b/Tests/Unit/Api/Fixtures/BackedFixtureEnum.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Api\Fixtures;
+
+/**
+ * A backed enum for the renderer tests: the backing values are part of the
+ * rendered surface (in this package they are persisted vocabulary), so a
+ * value change must classify as breaking even when every case name stays.
+ */
+enum BackedFixtureEnum: string
+{
+    case Read = 'read';
+    case Write = 'write';
+}

--- a/Tests/Unit/Api/Fixtures/InheritedConstructorBase.php
+++ b/Tests/Unit/Api/Fixtures/InheritedConstructorBase.php
@@ -1,0 +1,19 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Api\Fixtures;
+
+/**
+ * An own-namespace base whose public constructor is the effective
+ * constructor of every subclass that declares none.
+ */
+abstract class InheritedConstructorBase
+{
+    public function __construct(protected readonly string $endpoint) {}
+}

--- a/Tests/Unit/Api/Fixtures/InheritsForeignConstructor.php
+++ b/Tests/Unit/Api/Fixtures/InheritsForeignConstructor.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Api\Fixtures;
+
+use RuntimeException;
+
+/**
+ * Declares no constructor and inherits one from OUTSIDE this repository.
+ *
+ * The counterpart to InheritsOwnConstructor: `\RuntimeException` stands in for
+ * TYPO3 core's `AbstractEntity`, whose inherited members differ between the
+ * 13.4 and 14.x legs. Recording that signature would make the snapshot depend
+ * on which matrix cell rendered it, so it stays out.
+ */
+final class InheritsForeignConstructor extends RuntimeException
+{
+    public function detail(): string
+    {
+        return $this->getMessage();
+    }
+}

--- a/Tests/Unit/Api/Fixtures/InheritsOwnConstructor.php
+++ b/Tests/Unit/Api/Fixtures/InheritsOwnConstructor.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Api\Fixtures;
+
+/**
+ * Declares no constructor and inherits one from an own-namespace base.
+ *
+ * `new InheritsOwnConstructor('https://…')` is what a caller writes, so the
+ * inherited signature is this class's contract and must appear in the frozen
+ * surface — a required argument added to the base is a break here.
+ */
+final class InheritsOwnConstructor extends InheritedConstructorBase
+{
+    public function call(): string
+    {
+        return $this->endpoint;
+    }
+}

--- a/Tests/Unit/Api/Fixtures/NarrowConstructor.php
+++ b/Tests/Unit/Api/Fixtures/NarrowConstructor.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Api\Fixtures;
+
+/**
+ * The "before" side of the constructor-break fixture pair.
+ *
+ * Its sibling WidenedConstructor differs from it in the constructor and in
+ * nothing else — same public property, same method signature — so a rendering
+ * difference between the two can only come from the constructor.
+ */
+final readonly class NarrowConstructor
+{
+    public function __construct(public string $name) {}
+
+    public function label(): string
+    {
+        return $this->name;
+    }
+}

--- a/Tests/Unit/Api/Fixtures/WidenedConstructor.php
+++ b/Tests/Unit/Api/Fixtures/WidenedConstructor.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Api\Fixtures;
+
+/**
+ * NarrowConstructor plus one required constructor argument.
+ *
+ * `$limit` is promoted private on purpose: a public promotion would also add
+ * a property line, and then the rendering difference would no longer isolate
+ * the constructor. This is exactly the shape that passed the snapshot
+ * silently before constructors were recorded — every `new NarrowConstructor()`
+ * in consumer code stops working, and nothing in the rendered surface moved.
+ */
+final readonly class WidenedConstructor
+{
+    public function __construct(
+        public string $name,
+        private int $limit,
+    ) {}
+
+    public function label(): string
+    {
+        return $this->name . ':' . $this->limit;
+    }
+}

--- a/Tests/Unit/Api/Support/ApiSurfaceDiff.php
+++ b/Tests/Unit/Api/Support/ApiSurfaceDiff.php
@@ -1,0 +1,278 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Api\Support;
+
+/**
+ * Classifies the difference between two rendered API surfaces.
+ *
+ * A snapshot assertion that only reports "different" makes a new value
+ * object look exactly like a deleted method, so every diff gets read with
+ * the same shrug. This splits the difference into three buckets and answers
+ * the only question the author actually has: may I regenerate the file, or
+ * do I have to decide something?
+ *
+ * - **added** — a class, method, property, constant or enum case that was
+ *   not there before. Additive; existing callers keep compiling.
+ * - **removed** — gone. Every caller that used it breaks.
+ * - **changed** — same member, different signature. Includes a widened
+ *   constructor, which a plain line diff would report as one unrelated
+ *   removal plus one unrelated addition.
+ *
+ * Members are matched by NAME, not by rendered line, so a signature change
+ * lands in `changed` instead of showing up as an unrelated removal plus an
+ * unrelated addition.
+ *
+ * Ported from nr-llm's `Tests/Unit/Api/Support/ApiSurfaceDiff.php`
+ * (issue #306); only the "what to do" guidance differs, because the two
+ * repositories keep their deprecation rules in different places.
+ */
+final readonly class ApiSurfaceDiff
+{
+    /**
+     * How many entries a bucket prints before it is truncated. A surface-wide
+     * rename produces hundreds; the first few say the same thing.
+     */
+    private const MAX_LISTED = 40;
+
+    /**
+     * The synthetic member key of the block header, so a `class` that became
+     * an `interface` is a change like any other.
+     */
+    private const DECLARATION_KEY = '(declaration)';
+
+    /**
+     * @param list<string> $added
+     * @param list<string> $removed
+     * @param list<array{entry: string, was: string, now: string}> $changed
+     */
+    private function __construct(
+        public array $added,
+        public array $removed,
+        public array $changed,
+    ) {}
+
+    public static function between(string $expected, string $actual): self
+    {
+        $before = self::parse($expected);
+        $after = self::parse($actual);
+
+        $added = [];
+        $removed = [];
+        $changed = [];
+
+        foreach ($after as $fqcn => $members) {
+            if (!isset($before[$fqcn])) {
+                $added[] = $members[self::DECLARATION_KEY] ?? $fqcn;
+
+                continue;
+            }
+
+            foreach ($members as $key => $line) {
+                if (!isset($before[$fqcn][$key])) {
+                    $added[] = $fqcn . ' :: ' . $line;
+
+                    continue;
+                }
+
+                if ($before[$fqcn][$key] !== $line) {
+                    $changed[] = [
+                        'entry' => $fqcn . ' :: ' . $key,
+                        'was' => $before[$fqcn][$key],
+                        'now' => $line,
+                    ];
+                }
+            }
+        }
+
+        foreach ($before as $fqcn => $members) {
+            if (!isset($after[$fqcn])) {
+                $removed[] = $members[self::DECLARATION_KEY] ?? $fqcn;
+
+                continue;
+            }
+
+            foreach ($members as $key => $line) {
+                if (!isset($after[$fqcn][$key])) {
+                    $removed[] = $fqcn . ' :: ' . $line;
+                }
+            }
+        }
+
+        sort($added);
+        sort($removed);
+        usort($changed, static fn (array $a, array $b): int => strcmp($a['entry'], $b['entry']));
+
+        return new self($added, $removed, $changed);
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->added === [] && $this->removed === [] && $this->changed === [];
+    }
+
+    /**
+     * True when nothing was removed and nothing changed shape — the case an
+     * author may resolve by regenerating the snapshot.
+     */
+    public function isAdditiveOnly(): bool
+    {
+        return !$this->isEmpty() && $this->removed === [] && $this->changed === [];
+    }
+
+    /**
+     * `identical`, `additive` or `breaking` — the word the failure message
+     * leads with.
+     */
+    public function verdict(): string
+    {
+        return match (true) {
+            $this->isEmpty() => 'identical',
+            $this->isAdditiveOnly() => 'additive',
+            default => 'breaking',
+        };
+    }
+
+    /**
+     * The failure message body: what happened, and what the author must do
+     * about it.
+     */
+    public function describe(): string
+    {
+        if ($this->isEmpty()) {
+            return 'The rendered public surface matches api-surface.txt.';
+        }
+
+        $counts = \sprintf(
+            '%d added, %d removed, %d changed',
+            \count($this->added),
+            \count($this->removed),
+            \count($this->changed),
+        );
+
+        $sections = [];
+
+        if ($this->isAdditiveOnly()) {
+            $sections[] = strtoupper($this->verdict()) . ' — ' . $counts . '. Nothing was removed '
+                . 'and no existing signature changed, so no caller breaks.';
+            $sections[] = 'What to do: regenerate the snapshot (delete Tests/Unit/Api/api-surface.txt, '
+                . 'run the unit suite twice) and note the addition under "### Added" in CHANGELOG.md.';
+        } else {
+            $sections[] = strtoupper($this->verdict()) . ' — ' . $counts . '. A removed line breaks '
+                . 'every caller that used it. A changed one may or may not: an added OPTIONAL '
+                . 'parameter breaks nobody, an added required one breaks every call. Read the '
+                . 'was/now pair below — the rendering marks an optional parameter with " = …".';
+            $sections[] = 'What to do: this is a decision, not a regeneration. AGENTS.md puts '
+                . 'changing public API signatures of *Interface.php under "Ask First" — agree the '
+                . 'change before it lands. Then record it under a BREAKING heading in CHANGELOG.md '
+                . 'and regenerate the snapshot. A widening that only adds optional parameters is '
+                . 'additive for callers: note it under "### Added" and regenerate. A constructor of '
+                . 'a service you only ever obtain from the DI container is not a caller contract, '
+                . 'but it is still recorded here so a widened one cannot land unread.';
+        }
+
+        if ($this->removed !== []) {
+            $sections[] = $this->bucket('removed', '-', $this->removed);
+        }
+
+        if ($this->changed !== []) {
+            $lines = [];
+            foreach ($this->changed as $entry) {
+                $lines[] = $entry['entry'] . "\n        was: " . $entry['was'] . "\n        now: " . $entry['now'];
+            }
+
+            $sections[] = $this->bucket('changed', '~', $lines);
+        }
+
+        if ($this->added !== []) {
+            $sections[] = $this->bucket('added', '+', $this->added);
+        }
+
+        return implode("\n\n", $sections);
+    }
+
+    /**
+     * @param list<string> $entries
+     */
+    private function bucket(string $title, string $marker, array $entries): string
+    {
+        $shown = \array_slice($entries, 0, self::MAX_LISTED);
+        $formatted = array_map(static fn (string $entry): string => '  ' . $marker . ' ' . $entry, $shown);
+
+        if (\count($entries) > self::MAX_LISTED) {
+            $formatted[] = \sprintf('  … and %d more', \count($entries) - self::MAX_LISTED);
+        }
+
+        return $title . ':' . "\n" . implode("\n", $formatted);
+    }
+
+    /**
+     * @return array<string, array<string, string>> FQCN => member key => rendered line
+     */
+    private static function parse(string $text): array
+    {
+        $classes = [];
+
+        foreach (explode("\n\n", trim($text)) as $block) {
+            $lines = array_values(array_filter(
+                array_map(rtrim(...), explode("\n", $block)),
+                static fn (string $line): bool => trim($line) !== '',
+            ));
+
+            if ($lines === []) {
+                continue;
+            }
+
+            $header = trim($lines[0]);
+            $fqcn = self::classNameOf($header);
+
+            $members = [self::DECLARATION_KEY => $header];
+            foreach (\array_slice($lines, 1) as $line) {
+                $member = trim($line);
+                $members[self::memberKey($member)] = $member;
+            }
+
+            $classes[$fqcn] = $members;
+        }
+
+        return $classes;
+    }
+
+    /**
+     * `Foo\Bar (class)` → `Foo\Bar`.
+     */
+    private static function classNameOf(string $header): string
+    {
+        return preg_match('/^(\S+) \(\w+\)$/', $header, $matches) === 1 ? $matches[1] : $header;
+    }
+
+    /**
+     * The name a member is matched by across the two renderings.
+     *
+     * Modifiers are deliberately dropped from the key: a method that became
+     * `static`, or a property that lost `readonly`, must land in `changed`
+     * rather than read as one removal and one unrelated addition.
+     */
+    private static function memberKey(string $line): string
+    {
+        if (str_starts_with($line, 'constructor(')) {
+            return 'constructor';
+        }
+
+        if (preg_match('/^(method|property) (?:static |readonly )?(\w+)/', $line, $matches) === 1) {
+            return $matches[1] . ' ' . $matches[2];
+        }
+
+        if (preg_match('/^(const|case) (\w+)/', $line, $matches) === 1) {
+            return $matches[1] . ' ' . $matches[2];
+        }
+
+        return $line;
+    }
+}

--- a/Tests/Unit/Api/Support/ApiSurfaceRenderer.php
+++ b/Tests/Unit/Api/Support/ApiSurfaceRenderer.php
@@ -12,6 +12,7 @@ namespace Netresearch\NrVault\Tests\Unit\Api\Support;
 use ReflectionClass;
 use ReflectionClassConstant;
 use ReflectionEnum;
+use ReflectionEnumBackedCase;
 use ReflectionIntersectionType;
 use ReflectionMethod;
 use ReflectionNamedType;
@@ -51,8 +52,9 @@ use UnitEnum;
  *   `Netresearch\NrVault`; see {@see declaredPublicConstructor()}.
  *
  * Ported from nr-llm's `Tests/Unit/Api/Support/ApiSurfaceRenderer.php`
- * (issue #306); the rendering rules are identical so the two snapshots
- * stay comparable across the two packages.
+ * (issue #306) with one deliberate divergence: backed-enum cases render
+ * WITH their backing value (see `declaredLines()`), because here the
+ * values themselves are frozen vocabulary. Worth mirroring upstream.
  */
 final class ApiSurfaceRenderer
 {
@@ -199,7 +201,15 @@ final class ApiSurfaceRenderer
             \assert(is_subclass_of($enumName, UnitEnum::class));
             $enum = new ReflectionEnum($enumName);
             foreach ($enum->getCases() as $case) {
-                $lines[] = 'case ' . $case->getName();
+                // The BACKING VALUE is rendered, not just the case name: for
+                // this package the values are the frozen vocabulary (the
+                // AuditAction strings are persisted in audit rows and bound
+                // into the HMAC chain), and a name-only line would let a
+                // value change sail through green. Deliberate divergence
+                // from the nr-llm original, which renders names only.
+                $lines[] = $case instanceof ReflectionEnumBackedCase
+                    ? \sprintf('case %s = %s', $case->getName(), json_encode($case->getBackingValue(), JSON_THROW_ON_ERROR))
+                    : 'case ' . $case->getName();
             }
         }
 

--- a/Tests/Unit/Api/Support/ApiSurfaceRenderer.php
+++ b/Tests/Unit/Api/Support/ApiSurfaceRenderer.php
@@ -1,0 +1,343 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Api\Support;
+
+use ReflectionClass;
+use ReflectionClassConstant;
+use ReflectionEnum;
+use ReflectionIntersectionType;
+use ReflectionMethod;
+use ReflectionNamedType;
+use ReflectionProperty;
+use ReflectionType;
+use ReflectionUnionType;
+use UnitEnum;
+
+/**
+ * Renders the public signatures of a set of classes as deterministic text.
+ *
+ * Kept separate from ApiSurfaceSnapshotTest so the rendering rules can be
+ * exercised against fixture classes — a snapshot test can only ever prove
+ * that today's surface equals yesterday's, never that the renderer would
+ * have noticed a given break. ApiSurfaceRendererTest carries that proof.
+ *
+ * Determinism rules (why the rendering looks the way it does):
+ * - DECLARED members only (`getDeclaringClass()`), because inherited core
+ *   members differ between the TYPO3 13.4 and 14.x legs of the CI matrix.
+ * - No default values: their `ReflectionParameter` rendering differs
+ *   across PHP versions; a default-value change alone is not a signature
+ *   break for callers.
+ * - Type strings are self-built with sorted union members — never
+ *   `(string)$type`, whose format has changed across PHP versions.
+ * - The constructor renders as its own `constructor(...)` line rather than
+ *   as a method, because it is keyed and classified separately: a widened
+ *   constructor is a break for every value object a consumer builds with
+ *   `new`.
+ * - The constructor is the ONE member that is not declared-only. The
+ *   cross-version rationale above holds for a parent in TYPO3 core or in a
+ *   vendor package, but not for one of ours: an own-namespace base is in
+ *   this repository and identical on both TYPO3 legs, and `new` binds to
+ *   the inherited constructor, so a declared-only rule would drop the
+ *   effective constructor from the frozen surface — exactly the break the
+ *   constructor line exists to catch. It is therefore recorded from the
+ *   nearest declaring class whenever that class is inside
+ *   `Netresearch\NrVault`; see {@see declaredPublicConstructor()}.
+ *
+ * Ported from nr-llm's `Tests/Unit/Api/Support/ApiSurfaceRenderer.php`
+ * (issue #306); the rendering rules are identical so the two snapshots
+ * stay comparable across the two packages.
+ */
+final class ApiSurfaceRenderer
+{
+    /**
+     * Namespace prefix of classes this repository owns, and therefore
+     * controls across the whole CI matrix.
+     */
+    private const OWN_NAMESPACE_PREFIX = 'Netresearch\\NrVault\\';
+
+    /**
+     * @param list<class-string> $classes
+     */
+    public function render(array $classes): string
+    {
+        $blocks = [];
+        foreach ($classes as $fqcn) {
+            $reflection = new ReflectionClass($fqcn);
+            $lines = [\sprintf('%s (%s)', $fqcn, $this->kindOf($reflection))];
+
+            foreach ($this->declaredLines($reflection) as $line) {
+                $lines[] = '  ' . $line;
+            }
+
+            $blocks[] = implode("\n", $lines);
+        }
+
+        return implode("\n\n", $blocks) . "\n";
+    }
+
+    /**
+     * Declared public methods, constructor excluded.
+     *
+     * Public so the snapshot test can walk the same members when it computes
+     * the closure over mentioned types — the closure must see exactly what
+     * the rendering freezes.
+     *
+     * @param ReflectionClass<object> $reflection
+     *
+     * @return list<ReflectionMethod>
+     */
+    public function declaredPublicMethods(ReflectionClass $reflection): array
+    {
+        $methods = [];
+        foreach ($reflection->getMethods(ReflectionMethod::IS_PUBLIC) as $method) {
+            if ($method->getDeclaringClass()->getName() !== $reflection->getName()) {
+                continue;
+            }
+
+            if ($method->getName() === '__construct') {
+                continue;
+            }
+
+            $methods[] = $method;
+        }
+
+        return $methods;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     *
+     * @return list<ReflectionProperty>
+     */
+    public function declaredPublicProperties(ReflectionClass $reflection): array
+    {
+        $properties = [];
+        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            if ($property->getDeclaringClass()->getName() !== $reflection->getName()) {
+                continue;
+            }
+
+            if ($property->isStatic()) {
+                continue;
+            }
+
+            $properties[] = $property;
+        }
+
+        return $properties;
+    }
+
+    /**
+     * The public constructor a caller actually reaches with `new`.
+     *
+     * Unlike every other member here this is NOT declared-only. `new Foo(...)`
+     * binds to whatever constructor `Foo` inherits, so a declared-only rule
+     * leaves a class that declares none with no constructor line at all — and
+     * then a new required argument added to the parent moves nothing in the
+     * snapshot.
+     *
+     * The exclusion that remains is the narrow one the cross-version rationale
+     * actually supports: a constructor inherited from OUTSIDE
+     * `Netresearch\NrVault` — TYPO3 core's, `\RuntimeException`'s — is not
+     * ours, and may differ between the 13.4 and 14.x legs, so recording it
+     * would make the snapshot matrix-dependent.
+     *
+     * @param ReflectionClass<object> $reflection
+     */
+    public function declaredPublicConstructor(ReflectionClass $reflection): ?ReflectionMethod
+    {
+        $constructor = $reflection->getConstructor();
+
+        if (!$constructor instanceof ReflectionMethod) {
+            return null;
+        }
+
+        if (!$constructor->isPublic()) {
+            return null;
+        }
+
+        $declaringClass = $constructor->getDeclaringClass()->getName();
+
+        if ($declaringClass === $reflection->getName()) {
+            return $constructor;
+        }
+
+        return str_starts_with($declaringClass, self::OWN_NAMESPACE_PREFIX) ? $constructor : null;
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     */
+    private function kindOf(ReflectionClass $reflection): string
+    {
+        return match (true) {
+            $reflection->isEnum() => 'enum',
+            $reflection->isInterface() => 'interface',
+            $reflection->isTrait() => 'trait',
+            default => 'class',
+        };
+    }
+
+    /**
+     * @param ReflectionClass<object> $reflection
+     *
+     * @return list<string>
+     */
+    private function declaredLines(ReflectionClass $reflection): array
+    {
+        $lines = [];
+
+        if ($reflection->isEnum()) {
+            $enumName = $reflection->getName();
+            \assert(is_subclass_of($enumName, UnitEnum::class));
+            $enum = new ReflectionEnum($enumName);
+            foreach ($enum->getCases() as $case) {
+                $lines[] = 'case ' . $case->getName();
+            }
+        }
+
+        foreach ($reflection->getReflectionConstants(ReflectionClassConstant::IS_PUBLIC) as $constant) {
+            if ($constant->getDeclaringClass()->getName() !== $reflection->getName()) {
+                continue;
+            }
+
+            if ($constant->isEnumCase()) {
+                continue;
+            }
+
+            $value = $constant->getValue();
+            $lines[] = \sprintf(
+                'const %s = %s',
+                $constant->getName(),
+                \is_scalar($value) || $value === null ? json_encode($value, JSON_THROW_ON_ERROR) : 'array',
+            );
+        }
+
+        foreach ($this->declaredPublicProperties($reflection) as $property) {
+            $lines[] = \sprintf(
+                'property %s%s: %s',
+                $property->isReadOnly() ? 'readonly ' : '',
+                $property->getName(),
+                $this->renderType($property->getType(), $reflection->getName()),
+            );
+        }
+
+        $constructor = $this->declaredPublicConstructor($reflection);
+        if ($constructor instanceof ReflectionMethod) {
+            $lines[] = \sprintf(
+                'constructor(%s)',
+                // Canonicalised against the DECLARING class, not this one: an
+                // inherited constructor's `self` resolves to the parent, and
+                // only that comparison turns it back into `self` on the PHP
+                // versions that resolve it (see canonicalTypeName()).
+                $this->renderParameters($constructor, $constructor->getDeclaringClass()->getName()),
+            );
+        }
+
+        foreach ($this->declaredPublicMethods($reflection) as $method) {
+            $lines[] = \sprintf(
+                'method %s%s(%s): %s',
+                $method->isStatic() ? 'static ' : '',
+                $method->getName(),
+                $this->renderParameters($method, $reflection->getName()),
+                $this->renderType($method->getReturnType(), $reflection->getName()),
+            );
+        }
+
+        sort($lines);
+
+        return $lines;
+    }
+
+    private function renderParameters(ReflectionMethod $method, string $selfClass): string
+    {
+        $params = [];
+        foreach ($method->getParameters() as $parameter) {
+            $params[] = \sprintf(
+                '%s%s$%s%s',
+                $this->renderType($parameter->getType(), $selfClass),
+                $parameter->isVariadic() ? ' ...' : ' ',
+                $parameter->getName(),
+                $parameter->isOptional() ? ' = …' : '',
+            );
+        }
+
+        return implode(', ', $params);
+    }
+
+    private function renderType(?ReflectionType $type, string $selfClass): string
+    {
+        if (!$type instanceof ReflectionType) {
+            return 'mixed';
+        }
+
+        if ($type instanceof ReflectionNamedType) {
+            $name = $this->canonicalTypeName($type->getName(), $selfClass);
+
+            return ($type->allowsNull() && $name !== 'null' && $name !== 'mixed' ? '?' : '') . $name;
+        }
+
+        if ($type instanceof ReflectionUnionType) {
+            $parts = array_map(
+                fn (ReflectionType $part): string => $this->renderTypeBare($part, $selfClass),
+                $type->getTypes(),
+            );
+            sort($parts);
+
+            return implode('|', $parts);
+        }
+
+        if ($type instanceof ReflectionIntersectionType) {
+            $parts = array_map(
+                fn (ReflectionType $part): string => $this->renderTypeBare($part, $selfClass),
+                $type->getTypes(),
+            );
+            sort($parts);
+
+            return implode('&', $parts);
+        }
+
+        return 'mixed';
+    }
+
+    /**
+     * PHP versions differ in whether a declared `self` survives reflection
+     * or comes back resolved to the class name (observed: 8.2 keeps `self`,
+     * 8.5 resolves it). Canonicalise to `self` so the snapshot is identical
+     * across the CI matrix. `static` is stable and passes through.
+     */
+    private function canonicalTypeName(string $name, string $selfClass): string
+    {
+        return $name === $selfClass ? 'self' : $name;
+    }
+
+    /**
+     * Union/intersection members render WITHOUT the nullability marker —
+     * `null` appears as its own sorted member instead.
+     */
+    private function renderTypeBare(ReflectionType $type, string $selfClass): string
+    {
+        if ($type instanceof ReflectionNamedType) {
+            return $this->canonicalTypeName($type->getName(), $selfClass);
+        }
+
+        if ($type instanceof ReflectionIntersectionType) {
+            $parts = array_map(
+                fn (ReflectionType $part): string => $this->renderTypeBare($part, $selfClass),
+                $type->getTypes(),
+            );
+            sort($parts);
+
+            return '(' . implode('&', $parts) . ')';
+        }
+
+        return 'mixed';
+    }
+}

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -34,26 +34,26 @@ Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface (interface)
   method verify(): Netresearch\NrVault\Audit\AuditIntegrityReport
 
 Netresearch\NrVault\Audit\AuditAction (enum)
-  case AccessDenied
-  case AuditAnchorReset
-  case AuditChainRekey
-  case AuditReadLoggingChanged
-  case BreakGlassActivated
-  case BreakGlassDeactivated
-  case Create
-  case Delete
-  case HttpCall
-  case HttpCallCancelled
-  case HttpCallCancelledBeforeSend
-  case MasterKeyRotateEnd
-  case MasterKeyRotateStart
-  case MetadataUpdate
-  case OAuthFallbackClientCredentials
-  case OAuthRefreshFailed
-  case OAuthRefreshStoreFailed
-  case Read
-  case Rotate
-  case Update
+  case AccessDenied = "access_denied"
+  case AuditAnchorReset = "audit_anchor_reset"
+  case AuditChainRekey = "audit_chain_rekey"
+  case AuditReadLoggingChanged = "audit_read_logging_changed"
+  case BreakGlassActivated = "break_glass_activated"
+  case BreakGlassDeactivated = "break_glass_deactivated"
+  case Create = "create"
+  case Delete = "delete"
+  case HttpCall = "http_call"
+  case HttpCallCancelled = "http_call_cancelled"
+  case HttpCallCancelledBeforeSend = "http_call_cancelled_before_send"
+  case MasterKeyRotateEnd = "master_key_rotate_end"
+  case MasterKeyRotateStart = "master_key_rotate_start"
+  case MetadataUpdate = "metadata_update"
+  case OAuthFallbackClientCredentials = "oauth_fallback_client_credentials"
+  case OAuthRefreshFailed = "oauth_refresh_failed"
+  case OAuthRefreshStoreFailed = "oauth_refresh_store_failed"
+  case Read = "read"
+  case Rotate = "rotate"
+  case Update = "update"
   method label(): string
   method static cases(): array
   method static from(int|string $value): static
@@ -74,13 +74,13 @@ Netresearch\NrVault\Audit\AuditChainAnchorLoad (class)
   property readonly status: Netresearch\NrVault\Audit\AuditChainAnchorStatus
 
 Netresearch\NrVault\Audit\AuditChainAnchorStatus (enum)
-  case Disabled
-  case InFlight
-  case NotChecked
-  case Ok
-  case Unanchored
-  case Unreadable
-  case Violated
+  case Disabled = "disabled"
+  case InFlight = "inFlight"
+  case NotChecked = "notChecked"
+  case Ok = "ok"
+  case Unanchored = "unanchored"
+  case Unreadable = "unreadable"
+  case Violated = "violated"
   method static cases(): array
   method static from(int|string $value): static
   method static tryFrom(int|string $value): ?static
@@ -113,13 +113,13 @@ Netresearch\NrVault\Audit\AuditIntegrityAlert (class)
   property readonly timestamp: int
 
 Netresearch\NrVault\Audit\AuditIntegrityReason (enum)
-  case BreakGlass
-  case EpochDowngrade
-  case HashMismatch
-  case NoExternalSink
-  case SinkFailure
-  case TableReset
-  case UidGap
+  case BreakGlass = "BREAK_GLASS"
+  case EpochDowngrade = "EPOCH_DOWNGRADE"
+  case HashMismatch = "HASH_MISMATCH"
+  case NoExternalSink = "NO_EXTERNAL_SINK"
+  case SinkFailure = "SINK_FAILURE"
+  case TableReset = "TABLE_RESET"
+  case UidGap = "UID_GAP"
   method isTamperEvidence(): bool
   method label(): string
   method static cases(): array
@@ -323,8 +323,8 @@ Netresearch\NrVault\Configuration\ExtensionConfigurationInterface (interface)
   method preferXChaCha20(): bool
 
 Netresearch\NrVault\Configuration\SecurityProfile (enum)
-  case Hardened
-  case Standard
+  case Hardened = "hardened"
+  case Standard = "standard"
   method isHardened(): bool
   method static cases(): array
   method static from(int|string $value): static
@@ -348,8 +348,8 @@ Netresearch\NrVault\Crypto\EncryptedData (class)
   property readonly valueNonce: string
 
 Netresearch\NrVault\Crypto\EncryptionAlgorithm (enum)
-  case Aes256Gcm
-  case XChaCha20Poly1305
+  case Aes256Gcm = "aes256gcm"
+  case XChaCha20Poly1305 = "xchacha20poly1305"
   method isAvailable(): bool
   method keyLength(): int
   method nonceLength(): int
@@ -406,6 +406,43 @@ Netresearch\NrVault\Crypto\ReEncryptedDek (class)
   property readonly encryptedDek: string
   property readonly nonce: string
 
+Netresearch\NrVault\Domain\Dto\MigrationResult (class)
+  constructor(string $table, string $column, int $migrated, int $failed, int $skipped, ?string $error = …)
+  method getTotal(): int
+  method hasError(): bool
+  method isSuccess(): bool
+  method static error(string $table, string $column, string $error): self
+  method static success(string $table, string $column, int $migrated, int $skipped = …): self
+  method static withFailures(string $table, string $column, int $migrated, int $failed, int $skipped = …): self
+  method toArray(): array
+  property readonly column: string
+  property readonly error: ?string
+  property readonly failed: int
+  property readonly migrated: int
+  property readonly skipped: int
+  property readonly table: string
+
+Netresearch\NrVault\Domain\Dto\OrphanReference (class)
+  constructor(string $table, string $field, int $uid)
+  method getLocation(): string
+  method static fromArray(array $data): self
+  method toArray(): array
+  property readonly field: string
+  property readonly table: string
+  property readonly uid: int
+
+Netresearch\NrVault\Domain\Dto\OrphanSecretInfo (class)
+  constructor(string $identifier, array $metadata, int $createdAt)
+  method getAgeInDays(): int
+  method getAgeInSeconds(): int
+  method getMetadataValue(string $key, mixed $default = …): mixed
+  method isOlderThanDays(int $days): bool
+  method static fromArray(array $data): self
+  method toArray(): array
+  property readonly createdAt: int
+  property readonly identifier: string
+  property readonly metadata: array
+
 Netresearch\NrVault\Domain\Dto\SecretDetails (class)
   constructor(int $uid, string $identifier, string $description, int $ownerUid, array $groups, string $context, bool $frontendAccessible, int $version, int $createdAt, int $updatedAt, ?int $expiresAt, ?int $lastRotatedAt, int $readCount, ?int $lastReadAt, array $metadata, int $scopePid, bool $enabled = …)
   method expiresSoon(int $days): bool
@@ -440,6 +477,40 @@ Netresearch\NrVault\Domain\Dto\SecretFilters (class)
   property readonly owner: ?int
   property readonly prefix: ?string
   property readonly scopePid: ?int
+
+Netresearch\NrVault\Domain\Dto\SecretMetadata (class)
+  constructor(string $identifier, int $ownerUid, int $createdAt, int $updatedAt, int $readCount, ?int $lastReadAt, string $description, int $version, array $metadata = …, bool $enabled = …)
+  method static fromArray(array $row): self
+  method toArray(): array
+  property readonly createdAt: int
+  property readonly description: string
+  property readonly enabled: bool
+  property readonly identifier: string
+  property readonly lastReadAt: ?int
+  property readonly metadata: array
+  property readonly ownerUid: int
+  property readonly readCount: int
+  property readonly updatedAt: int
+  property readonly version: int
+
+Netresearch\NrVault\Domain\Dto\StaleSecret (class)
+  constructor(int $uid, string $identifier, string $context, string $adapter, ?int $lastReadAt, int $automatedReads, int $manualReveals, int $ageDays, array $rules)
+  method highestSeverity(): string
+  property readonly adapter: string
+  property readonly ageDays: int
+  property readonly automatedReads: int
+  property readonly context: string
+  property readonly identifier: string
+  property readonly lastReadAt: ?int
+  property readonly manualReveals: int
+  property readonly rules: array
+  property readonly uid: int
+
+Netresearch\NrVault\Domain\Dto\UsageBar (class)
+  constructor(string $label, int $value, int $percent)
+  property readonly label: string
+  property readonly percent: int
+  property readonly value: int
 
 Netresearch\NrVault\Domain\Dto\VaultUsageStats (class)
   constructor(int $total, int $active, int $disabled, int $expired, int $frontendAccessible, int $neverRotated, int $automatedReads, int $manualReveals, int $windowDays, array $byAdapter, array $byContext)
@@ -545,10 +616,10 @@ Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface (interface)
   method setMetadata(int $uid, array $metadata): void
 
 Netresearch\NrVault\Domain\StalenessRule (enum)
-  case AutomationStale
-  case Dead
-  case Expired
-  case NeverRotated
+  case AutomationStale = "automation_stale"
+  case Dead = "dead"
+  case Expired = "expired"
+  case NeverRotated = "never_rotated"
   method label(): string
   method severity(): string
   method static cases(): array
@@ -667,13 +738,13 @@ Netresearch\NrVault\Http\OAuth\OAuthConfig (class)
   property readonly tokenExpiryBuffer: int
 
 Netresearch\NrVault\Http\SecretPlacement (enum)
-  case ApiKey
-  case BasicAuth
-  case Bearer
-  case BodyField
-  case Header
-  case OAuth2
-  case QueryParam
+  case ApiKey = "api_key"
+  case BasicAuth = "basic"
+  case Bearer = "bearer"
+  case BodyField = "body_field"
+  case Header = "header"
+  case OAuth2 = "oauth2"
+  case QueryParam = "query"
   method defaultConfigKey(): ?string
   method description(): string
   method requiresConfig(): bool
@@ -760,16 +831,16 @@ Netresearch\NrVault\Security\TechnicalActorContextInterface (interface)
   method runAs(int $beUserUid, callable $fn): mixed
 
 Netresearch\NrVault\Security\VaultPermission (enum)
-  case AuditExport
-  case AuditView
-  case MasterKeyRotate
-  case SecretCreate
-  case SecretDelete
-  case SecretManagePolicy
-  case SecretReveal
-  case SecretRotate
-  case SecretUse
-  case VaultConfigure
+  case AuditExport = "audit.export"
+  case AuditView = "audit.view"
+  case MasterKeyRotate = "master_key.rotate"
+  case SecretCreate = "secret.create"
+  case SecretDelete = "secret.delete"
+  case SecretManagePolicy = "secret.manage_policy"
+  case SecretReveal = "secret.reveal"
+  case SecretRotate = "secret.rotate"
+  case SecretUse = "secret.use"
+  case VaultConfigure = "vault.configure"
   method static cases(): array
   method static from(int|string $value): static
   method static secretOperations(): array
@@ -789,10 +860,10 @@ Netresearch\NrVault\Service\Detection\SecretFinding (interface)
   method getSource(): string
 
 Netresearch\NrVault\Service\Detection\Severity (enum)
-  case Critical
-  case High
-  case Low
-  case Medium
+  case Critical = "critical"
+  case High = "high"
+  case Low = "low"
+  case Medium = "medium"
   method isAtLeast(self $minimum): bool
   method order(): int
   method static cases(): array
@@ -824,9 +895,9 @@ Netresearch\NrVault\Service\Doctor\DoctorReport (class)
   property readonly findings: array
 
 Netresearch\NrVault\Service\Doctor\FindingSeverity (enum)
-  case Critical
-  case Pass
-  case Warning
+  case Critical = "critical"
+  case Pass = "pass"
+  case Warning = "warning"
   method bootstrapContext(): string
   method rank(): int
   method static cases(): array
@@ -852,10 +923,10 @@ Netresearch\NrVault\Service\SecretDetectionServiceInterface (interface)
   method scanLocalConfiguration(): void
 
 Netresearch\NrVault\Service\VaultFieldPermission (enum)
-  case Copy
-  case Edit
-  case ReadOnly
-  case Reveal
+  case Copy = "copy"
+  case Edit = "edit"
+  case ReadOnly = "readOnly"
+  case Reveal = "reveal"
   method static cases(): array
   method static from(int|string $value): static
   method static tryFrom(int|string $value): ?static

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -1,0 +1,886 @@
+Netresearch\NrVault\Adapter\VaultAdapterInterface (interface)
+  method delete(string $identifier): void
+  method exists(string $identifier): bool
+  method getIdentifier(): string
+  method getMetadata(string $identifier): ?array
+  method incrementReadCount(int $uid): void
+  method isAvailable(): bool
+  method list(?Netresearch\NrVault\Domain\Dto\SecretFilters $filters = …): array
+  method listSecrets(?Netresearch\NrVault\Domain\Dto\SecretFilters $filters = …): array
+  method retrieve(string $identifier): ?Netresearch\NrVault\Domain\Model\Secret
+  method retrieveIncludingDisabled(string $identifier): ?Netresearch\NrVault\Domain\Model\Secret
+  method setHidden(int $uid, bool $hidden): void
+  method store(Netresearch\NrVault\Domain\Model\Secret $secret, bool $persistGroupRelations = …): Netresearch\NrVault\Domain\Model\Secret
+  method updateMetadata(string $identifier, array $metadata): void
+
+Netresearch\NrVault\Audit\Anchor\AnchorReaderInterface (interface)
+  method isAvailable(): bool
+  method readLatestAnchor(): ?Netresearch\NrVault\Audit\Anchor\ChainTipAnchor
+
+Netresearch\NrVault\Audit\Anchor\ChainTipAnchor (class)
+  constructor(int $sequence, string $chainTip, int $timestamp, int $hmacEpoch)
+  method isEmpty(): bool
+  method jsonSerialize(): array
+  method static fromArray(array $data): ?self
+  method toArray(): array
+  property readonly chainTip: string
+  property readonly hmacEpoch: int
+  property readonly sequence: int
+  property readonly timestamp: int
+
+Netresearch\NrVault\Audit\Anchor\ChainTipAnchorServiceInterface (interface)
+  method capture(): Netresearch\NrVault\Audit\Anchor\ChainTipAnchor
+  method publish(Netresearch\NrVault\Audit\Anchor\ChainTipAnchor $anchor): int
+  method verify(): Netresearch\NrVault\Audit\AuditIntegrityReport
+
+Netresearch\NrVault\Audit\AuditAction (enum)
+  case AccessDenied
+  case AuditAnchorReset
+  case AuditChainRekey
+  case AuditReadLoggingChanged
+  case BreakGlassActivated
+  case BreakGlassDeactivated
+  case Create
+  case Delete
+  case HttpCall
+  case HttpCallCancelled
+  case HttpCallCancelledBeforeSend
+  case MasterKeyRotateEnd
+  case MasterKeyRotateStart
+  case MetadataUpdate
+  case OAuthFallbackClientCredentials
+  case OAuthRefreshFailed
+  case OAuthRefreshStoreFailed
+  case Read
+  case Rotate
+  case Update
+  method label(): string
+  method static cases(): array
+  method static from(int|string $value): static
+  method static tryFrom(int|string $value): ?static
+  property readonly name: string
+  property readonly value: string
+
+Netresearch\NrVault\Audit\AuditChainAnchor (class)
+  constructor(int $uid, string $entryHash, int $tstamp)
+  property readonly entryHash: string
+  property readonly tstamp: int
+  property readonly uid: int
+
+Netresearch\NrVault\Audit\AuditChainAnchorLoad (class)
+  constructor(Netresearch\NrVault\Audit\AuditChainAnchorStatus $status, ?Netresearch\NrVault\Audit\AuditChainAnchor $anchor = …, string $raw = …)
+  property readonly anchor: ?Netresearch\NrVault\Audit\AuditChainAnchor
+  property readonly raw: string
+  property readonly status: Netresearch\NrVault\Audit\AuditChainAnchorStatus
+
+Netresearch\NrVault\Audit\AuditChainAnchorStatus (enum)
+  case Disabled
+  case InFlight
+  case NotChecked
+  case Ok
+  case Unanchored
+  case Unreadable
+  case Violated
+  method static cases(): array
+  method static from(int|string $value): static
+  method static tryFrom(int|string $value): ?static
+  property readonly name: string
+  property readonly value: string
+
+Netresearch\NrVault\Audit\AuditChainAnchorStoreInterface (interface)
+  method advance(TYPO3\CMS\Core\Database\Connection $connection, Netresearch\NrVault\Audit\AuditChainAnchor $tip, ?string $masterKey = …): void
+  method arm(TYPO3\CMS\Core\Database\Connection $connection, ?string $masterKey = …): bool
+  method isEnabled(): bool
+  method load(TYPO3\CMS\Core\Database\Connection $auditConnection): Netresearch\NrVault\Audit\AuditChainAnchorLoad
+  method reseal(TYPO3\CMS\Core\Database\Connection $connection, ?string $masterKey = …): void
+  method reset(TYPO3\CMS\Core\Database\Connection $connection): void
+  method sharesConnection(TYPO3\CMS\Core\Database\Connection $auditConnection): bool
+
+Netresearch\NrVault\Audit\AuditChainRekeyServiceInterface (interface)
+  method rekeyChain(TYPO3\CMS\Core\Database\Connection $connection, string $newMasterKey): int
+
+Netresearch\NrVault\Audit\AuditContextInterface (interface)
+  method toArray(): array
+
+Netresearch\NrVault\Audit\AuditIntegrityAlert (class)
+  constructor(Netresearch\NrVault\Audit\AuditIntegrityReason $reason, string $detail, int $timestamp, array $context = …)
+  method jsonSerialize(): array
+  method static create(Netresearch\NrVault\Audit\AuditIntegrityReason $reason, string $detail, array $context = …): self
+  method toArray(): array
+  property readonly context: array
+  property readonly detail: string
+  property readonly reason: Netresearch\NrVault\Audit\AuditIntegrityReason
+  property readonly timestamp: int
+
+Netresearch\NrVault\Audit\AuditIntegrityReason (enum)
+  case BreakGlass
+  case EpochDowngrade
+  case HashMismatch
+  case NoExternalSink
+  case SinkFailure
+  case TableReset
+  case UidGap
+  method isTamperEvidence(): bool
+  method label(): string
+  method static cases(): array
+  method static from(int|string $value): static
+  method static tryFrom(int|string $value): ?static
+  property readonly name: string
+  property readonly value: string
+
+Netresearch\NrVault\Audit\AuditIntegrityReport (class)
+  constructor(array $findings, bool $chainValid, int $currentSequence, ?Netresearch\NrVault\Audit\Anchor\ChainTipAnchor $anchor = …, array $warnings = …, array $epochCounts = …)
+  method getMaxEpoch(): ?int
+  method getMinEpoch(): ?int
+  method getReasonCodes(): array
+  method hasReason(Netresearch\NrVault\Audit\AuditIntegrityReason $reason): bool
+  method hasTamperEvidence(): bool
+  method isValid(): bool
+  method toArray(): array
+  property readonly anchor: ?Netresearch\NrVault\Audit\Anchor\ChainTipAnchor
+  property readonly chainValid: bool
+  property readonly currentSequence: int
+  property readonly epochCounts: array
+  property readonly findings: array
+  property readonly warnings: array
+
+Netresearch\NrVault\Audit\AuditLogEntry (class)
+  constructor(int $uid, string $secretIdentifier, string $action, bool $success, ?string $errorMessage, ?string $reason, int $actorUid, string $actorType, string $actorUsername, string $actorRole, string $ipAddress, string $userAgent, string $requestId, string $previousHash, string $entryHash, string $hashBefore, string $hashAfter, int $crdate, array $context)
+  method jsonSerialize(): array
+  method static fromDatabaseRow(array $row): self
+  property readonly action: string
+  property readonly actorRole: string
+  property readonly actorType: string
+  property readonly actorUid: int
+  property readonly actorUsername: string
+  property readonly context: array
+  property readonly crdate: int
+  property readonly entryHash: string
+  property readonly errorMessage: ?string
+  property readonly hashAfter: string
+  property readonly hashBefore: string
+  property readonly ipAddress: string
+  property readonly previousHash: string
+  property readonly reason: ?string
+  property readonly requestId: string
+  property readonly secretIdentifier: string
+  property readonly success: bool
+  property readonly uid: int
+  property readonly userAgent: string
+
+Netresearch\NrVault\Audit\AuditLogFilter (class)
+  constructor(?string $secretIdentifier = …, ?string $action = …, ?int $actorUid = …, ?bool $success = …, ?DateTimeInterface $since = …, ?DateTimeInterface $until = …)
+  method isEmpty(): bool
+  method static dateRange(DateTimeInterface $since, ?DateTimeInterface $until = …): self
+  method static failedOnly(): self
+  method static forAction(string $action): self
+  method static forActor(int $actorUid): self
+  method static forSecret(string $identifier): self
+  method withAction(string $action): self
+  method withActor(int $actorUid): self
+  method withDateRange(?DateTimeInterface $since, ?DateTimeInterface $until = …): self
+  method withSecret(string $identifier): self
+  method withSuccess(?bool $success): self
+  property readonly action: ?string
+  property readonly actorUid: ?int
+  property readonly secretIdentifier: ?string
+  property readonly since: ?DateTimeInterface
+  property readonly success: ?bool
+  property readonly until: ?DateTimeInterface
+
+Netresearch\NrVault\Audit\AuditLogServiceInterface (interface)
+  method count(?Netresearch\NrVault\Audit\AuditLogFilter $filter = …): int
+  method export(?Netresearch\NrVault\Audit\AuditLogFilter $filter = …): array
+  method getLatestHash(): ?string
+  method log(string $secretIdentifier, string $action, bool $success, ?string $errorMessage = …, ?string $reason = …, ?string $hashBefore = …, ?string $hashAfter = …, ?Netresearch\NrVault\Audit\AuditContextInterface $context = …): void
+  method query(?Netresearch\NrVault\Audit\AuditLogFilter $filter = …, int $limit = …, int $offset = …): array
+  method verifyChainForReseal(): ?Netresearch\NrVault\Audit\HashChainVerificationResult
+  method verifyHashChain(?int $fromUid = …, ?int $toUid = …, ?int $minEpoch = …): Netresearch\NrVault\Audit\HashChainVerificationResult
+
+Netresearch\NrVault\Audit\HashChainVerificationResult (class)
+  constructor(bool $valid, array $errors = …, array $warnings = …, array $missingUids = …, int $missingUidCount = …, Netresearch\NrVault\Audit\AuditChainAnchorStatus $anchorStatus = …, array $epochCounts = …)
+  method getErrorCount(): int
+  method getMaxEpoch(): ?int
+  method getMinEpoch(): ?int
+  method getWarningCount(): int
+  method hasMissingUids(): bool
+  method hasMixedEpochs(): bool
+  method isValid(): bool
+  method static invalid(array $errors, array $warnings = …, array $missingUids = …, int $missingUidCount = …, Netresearch\NrVault\Audit\AuditChainAnchorStatus $anchorStatus = …, array $epochCounts = …): self
+  method static valid(array $warnings = …, array $missingUids = …, int $missingUidCount = …, Netresearch\NrVault\Audit\AuditChainAnchorStatus $anchorStatus = …, array $epochCounts = …): self
+  method toArray(): array
+  property readonly anchorStatus: Netresearch\NrVault\Audit\AuditChainAnchorStatus
+  property readonly epochCounts: array
+  property readonly errors: array
+  property readonly missingUidCount: int
+  property readonly missingUids: array
+  property readonly valid: bool
+  property readonly warnings: array
+
+Netresearch\NrVault\Audit\Sink\AuditSinkInterface (interface)
+  method getIdentifier(): string
+  method isEnabled(): bool
+  method publish(Netresearch\NrVault\Audit\AuditLogEntry $entry, string $chainTip): void
+  method publishAlert(Netresearch\NrVault\Audit\AuditIntegrityAlert $alert): void
+  method publishAnchor(Netresearch\NrVault\Audit\Anchor\ChainTipAnchor $anchor): void
+
+Netresearch\NrVault\Audit\Sink\AuditSinkRegistryInterface (interface)
+  method dispatch(Netresearch\NrVault\Audit\AuditLogEntry $entry, string $chainTip): int
+  method dispatchAlert(Netresearch\NrVault\Audit\AuditIntegrityAlert $alert): int
+  method dispatchAnchor(Netresearch\NrVault\Audit\Anchor\ChainTipAnchor $anchor): int
+  method getEnabledSinkIdentifiers(): array
+  method getFailureCount(): int
+  method getFailureCountsBySink(): array
+  method hasExternalAuditSink(): bool
+
+Netresearch\NrVault\Audit\Sink\SinkDeliveryState (class)
+  constructor(string $sinkIdentifier, int $lastSuccessAt = …, int $lastFailureAt = …, int $consecutiveFailures = …, int $totalFailures = …, string $lastError = …)
+  method hasEverSucceeded(): bool
+  method isFailing(): bool
+  method static fromArray(string $sinkIdentifier, array $row): self
+  method toArray(): array
+  property readonly consecutiveFailures: int
+  property readonly lastError: string
+  property readonly lastFailureAt: int
+  property readonly lastSuccessAt: int
+  property readonly sinkIdentifier: string
+  property readonly totalFailures: int
+
+Netresearch\NrVault\Audit\Sink\SinkDeliveryStateRepositoryInterface (interface)
+  method getState(string $sinkIdentifier): Netresearch\NrVault\Audit\Sink\SinkDeliveryState
+  method recordFailure(string $sinkIdentifier, string $errorMessage): void
+  method recordSuccess(string $sinkIdentifier): void
+
+Netresearch\NrVault\Configuration\Dto\AwsSecretsConfig (class)
+  constructor(string $region = …, string $secretPrefix = …)
+  method getFullSecretName(string $secretName): string
+  method isValid(): bool
+  method static fromArray(array $config): self
+  method toArray(): array
+  property readonly region: string
+  property readonly secretPrefix: string
+
+Netresearch\NrVault\Configuration\Dto\TransitConfig (class)
+  const DEFAULT_KEY_NAME = "nr-vault-master"
+  const DEFAULT_MOUNT = "transit"
+  const DEFAULT_TOKEN_ENV_VAR = "VAULT_TOKEN"
+  constructor(string $address = …, string $mount = …, string $keyName = …, string $wrappedKeyPath = …, string $authMethod = …, string $tokenEnvVar = …, string $token = …)
+  method endpointFor(string $operation): string
+  method isComplete(): bool
+  method static fromArray(array $config, string $fallbackWrappedKeyPath = …): self
+  method toArray(): array
+  method usesTokenAuth(): bool
+  property readonly address: string
+  property readonly authMethod: string
+  property readonly keyName: string
+  property readonly mount: string
+  property readonly token: string
+  property readonly tokenEnvVar: string
+  property readonly wrappedKeyPath: string
+
+Netresearch\NrVault\Configuration\Dto\VaultServerConfig (class)
+  constructor(string $address = …, string $path = …, string $authMethod = …, string $token = …)
+  method hasTokenAuth(): bool
+  method isValid(): bool
+  method static fromArray(array $config): self
+  method toArray(): array
+  property readonly address: string
+  property readonly authMethod: string
+  property readonly path: string
+  property readonly token: string
+
+Netresearch\NrVault\Configuration\ExtensionConfigurationInterface (interface)
+  method getAuditHmacEpoch(): int
+  method getAuditLogRetention(): int
+  method getAuditSinkAnchorPath(): string
+  method getAuditSinkFilePath(): string
+  method getAuditSinkStaleDeliveryHours(): int
+  method getAuditSinkSyslogIdent(): string
+  method getAuditSinkWebhookUrl(): string
+  method getAutoKeyPath(): string
+  method getAwsConfig(): Netresearch\NrVault\Configuration\Dto\AwsSecretsConfig
+  method getCliAccessGroups(): array
+  method getCliAllowedOperations(): array
+  method getEncryptionAlgorithm(): string
+  method getHashiCorpConfig(): Netresearch\NrVault\Configuration\Dto\VaultServerConfig
+  method getMasterKeyProvider(): string
+  method getMasterKeySource(): string
+  method getProvisioningBeUserUid(): int
+  method getSecurityProfile(): Netresearch\NrVault\Configuration\SecurityProfile
+  method getStaleNeverReadDays(): int
+  method getStaleNeverRotatedDays(): int
+  method getStaleNotReadDays(): int
+  method getStorageAdapter(): string
+  method getTransitConfig(): Netresearch\NrVault\Configuration\Dto\TransitConfig
+  method isAdminOverrideDisabled(): bool
+  method isAuditAnchorRequired(): bool
+  method isAuditReadsEnabled(): bool
+  method isAuditSinkFileEnabled(): bool
+  method isAuditSinkSyslogEnabled(): bool
+  method isAuditSinkWebhookEnabled(): bool
+  method isCliAccessAllowed(): bool
+  method isFrontendPlaceholderLegacyCliEnabled(): bool
+  method preferXChaCha20(): bool
+
+Netresearch\NrVault\Configuration\SecurityProfile (enum)
+  case Hardened
+  case Standard
+  method isHardened(): bool
+  method static cases(): array
+  method static from(int|string $value): static
+  method static tryFrom(int|string $value): ?static
+  property readonly name: string
+  property readonly value: string
+
+Netresearch\NrVault\Configuration\SiteConfigurationVaultProcessorInterface (interface)
+  method processConfiguration(array $configuration, ?TYPO3\CMS\Core\Site\Entity\Site $site = …): array
+
+Netresearch\NrVault\Crypto\EncryptedData (class)
+  constructor(string $encryptedValue, string $encryptedDek, string $dekNonce, string $valueNonce, string $valueChecksum, int $encryptionVersion = …, Netresearch\NrVault\Crypto\EncryptionAlgorithm $encryptionAlgorithm = …)
+  method static fromRaw(string $encryptedValue, string $encryptedDek, string $dekNonce, string $valueNonce, string $valueChecksum, int $encryptionVersion = …, Netresearch\NrVault\Crypto\EncryptionAlgorithm $encryptionAlgorithm = …): self
+  method toArray(): array
+  property readonly dekNonce: string
+  property readonly encryptedDek: string
+  property readonly encryptedValue: string
+  property readonly encryptionAlgorithm: Netresearch\NrVault\Crypto\EncryptionAlgorithm
+  property readonly encryptionVersion: int
+  property readonly valueChecksum: string
+  property readonly valueNonce: string
+
+Netresearch\NrVault\Crypto\EncryptionAlgorithm (enum)
+  case Aes256Gcm
+  case XChaCha20Poly1305
+  method isAvailable(): bool
+  method keyLength(): int
+  method nonceLength(): int
+  method static cases(): array
+  method static forNewSecrets(): self
+  method static from(int|string $value): static
+  method static tryFrom(int|string $value): ?static
+  property readonly name: string
+  property readonly value: string
+
+Netresearch\NrVault\Crypto\EncryptionServiceInterface (interface)
+  const ENCRYPTION_VERSION_CURRENT = 2
+  const ENCRYPTION_VERSION_LEGACY = 1
+  method calculateChecksum(string $plaintext): string
+  method decrypt(string $encryptedValue, string $encryptedDek, string $dekNonce, string $valueNonce, string $identifier, int $encryptionVersion = …, string $encryptionAlgorithm = …): string
+  method encrypt(string $plaintext, string $identifier): Netresearch\NrVault\Crypto\EncryptedData
+  method generateDek(): string
+  method reEncryptDek(string $encryptedDek, string $dekNonce, string $identifier, string $oldMasterKey, string $newMasterKey, int $encryptionVersion = …, string $encryptionAlgorithm = …): Netresearch\NrVault\Crypto\ReEncryptedDek
+
+Netresearch\NrVault\Crypto\EnvelopeCodecInterface (interface)
+  const MARKER = "nrv1:"
+  method isSealed(string $value): bool
+  method open(string $sealed, string $identifier): string
+  method rewrap(string $sealed, string $identifier, string $oldMasterKey, string $newMasterKey): string
+  method seal(string $plaintext, string $identifier): string
+
+Netresearch\NrVault\Crypto\EnvelopeRotationContext (class)
+  constructor(Netresearch\NrVault\Crypto\EnvelopeCodecInterface $codec, string $oldMasterKey, string $newMasterKey)
+  method isSealed(string $value): bool
+  method rewrap(string $sealed, string $identifier): string
+
+Netresearch\NrVault\Crypto\ForeignEnvelopeRotatorInterface (interface)
+  method countEnvelopes(): int
+  method getIdentifier(): string
+  method getTables(): array
+  method rewrapAll(Netresearch\NrVault\Crypto\EnvelopeRotationContext $context): int
+
+Netresearch\NrVault\Crypto\MasterKeyProviderFactoryInterface (interface)
+  method create(): Netresearch\NrVault\Crypto\MasterKeyProviderInterface
+  method getAvailableProvider(): Netresearch\NrVault\Crypto\MasterKeyProviderInterface
+
+Netresearch\NrVault\Crypto\MasterKeyProviderInterface (interface)
+  method generateMasterKey(): string
+  method getIdentifier(): string
+  method getMasterKey(): string
+  method isAvailable(): bool
+  method static clearCachedKey(): void
+  method storeMasterKey(string $key): void
+
+Netresearch\NrVault\Crypto\ReEncryptedDek (class)
+  constructor(string $encryptedDek, string $nonce)
+  method static fromRaw(string $encryptedDek, string $nonce): self
+  method toArray(): array
+  property readonly encryptedDek: string
+  property readonly nonce: string
+
+Netresearch\NrVault\Domain\Dto\SecretDetails (class)
+  constructor(int $uid, string $identifier, string $description, int $ownerUid, array $groups, string $context, bool $frontendAccessible, int $version, int $createdAt, int $updatedAt, ?int $expiresAt, ?int $lastRotatedAt, int $readCount, ?int $lastReadAt, array $metadata, int $scopePid, bool $enabled = …)
+  method expiresSoon(int $days): bool
+  method isExpired(): bool
+  method static fromSecret(Netresearch\NrVault\Domain\Model\Secret $secret): self
+  method toArray(): array
+  property readonly context: string
+  property readonly createdAt: int
+  property readonly description: string
+  property readonly enabled: bool
+  property readonly expiresAt: ?int
+  property readonly frontendAccessible: bool
+  property readonly groups: array
+  property readonly identifier: string
+  property readonly lastReadAt: ?int
+  property readonly lastRotatedAt: ?int
+  property readonly metadata: array
+  property readonly ownerUid: int
+  property readonly readCount: int
+  property readonly scopePid: int
+  property readonly uid: int
+  property readonly updatedAt: int
+  property readonly version: int
+
+Netresearch\NrVault\Domain\Dto\SecretFilters (class)
+  constructor(?int $owner = …, ?string $prefix = …, ?string $context = …, ?int $scopePid = …, bool $includeDisabled = …)
+  method hasFilters(): bool
+  method static fromArray(array $filters): self
+  method toArray(): array
+  property readonly context: ?string
+  property readonly includeDisabled: bool
+  property readonly owner: ?int
+  property readonly prefix: ?string
+  property readonly scopePid: ?int
+
+Netresearch\NrVault\Domain\Dto\VaultUsageStats (class)
+  constructor(int $total, int $active, int $disabled, int $expired, int $frontendAccessible, int $neverRotated, int $automatedReads, int $manualReveals, int $windowDays, array $byAdapter, array $byContext)
+  property readonly active: int
+  property readonly automatedReads: int
+  property readonly byAdapter: array
+  property readonly byContext: array
+  property readonly disabled: int
+  property readonly expired: int
+  property readonly frontendAccessible: int
+  property readonly manualReveals: int
+  property readonly neverRotated: int
+  property readonly total: int
+  property readonly windowDays: int
+
+Netresearch\NrVault\Domain\Model\Secret (class)
+  constructor(string $identifier, ?int $uid = …, int $scopePid = …, string $description = …, ?string $encryptedValue = …, string $encryptedDek = …, string $dekNonce = …, string $valueNonce = …, int $encryptionVersion = …, string $encryptionAlgorithm = …, string $valueChecksum = …, int $ownerUid = …, array $allowedGroups = …, array $writeGroups = …, string $context = …, bool $frontendAccessible = …, int $version = …, int $expiresAt = …, int $lastRotatedAt = …, array $metadata = …, string $adapter = …, string $externalReference = …, int $tstamp = …, int $crdate = …, int $cruserId = …, bool $deleted = …, bool $hidden = …, int $readCount = …, int $lastReadAt = …)
+  method cloneWithGroups(array $allowedGroups): self
+  method cloneWithWriteGroups(array $writeGroups): self
+  method getAdapter(): string
+  method getAllowedGroups(): array
+  method getContext(): string
+  method getCrdate(): int
+  method getCruserId(): int
+  method getDekNonce(): string
+  method getDescription(): string
+  method getEncryptedDek(): string
+  method getEncryptedValue(): ?string
+  method getEncryptionAlgorithm(): string
+  method getEncryptionVersion(): int
+  method getExpiresAt(): int
+  method getExternalReference(): string
+  method getIdentifier(): string
+  method getLastReadAt(): int
+  method getLastRotatedAt(): int
+  method getMetadata(): array
+  method getOwnerUid(): int
+  method getReadCount(): int
+  method getScopePid(): int
+  method getTstamp(): int
+  method getUid(): ?int
+  method getValueChecksum(): string
+  method getValueNonce(): string
+  method getVersion(): int
+  method getWriteGroups(): array
+  method isDeleted(): bool
+  method isExpired(): bool
+  method isFrontendAccessible(): bool
+  method isHidden(): bool
+  method static fromDatabaseRow(array $row, array $allowedGroups = …, array $writeGroups = …): self
+  method toDatabaseRow(): array
+  method withMetadata(array $metadata): self
+  method withReEncryptedDek(string $encryptedDek, string $dekNonce): self
+  method withUid(?int $uid): self
+  method withValueRotation(Netresearch\NrVault\Crypto\EncryptedData $encrypted, int $rotatedAt): self
+  property readonly adapter: string
+  property readonly allowedGroups: array
+  property readonly context: string
+  property readonly crdate: int
+  property readonly cruserId: int
+  property readonly dekNonce: string
+  property readonly deleted: bool
+  property readonly description: string
+  property readonly encryptedDek: string
+  property readonly encryptedValue: ?string
+  property readonly encryptionAlgorithm: string
+  property readonly encryptionVersion: int
+  property readonly expiresAt: int
+  property readonly externalReference: string
+  property readonly frontendAccessible: bool
+  property readonly hidden: bool
+  property readonly identifier: string
+  property readonly lastReadAt: int
+  property readonly lastRotatedAt: int
+  property readonly metadata: array
+  property readonly ownerUid: int
+  property readonly readCount: int
+  property readonly scopePid: int
+  property readonly tstamp: int
+  property readonly uid: ?int
+  property readonly valueChecksum: string
+  property readonly valueNonce: string
+  property readonly version: int
+  property readonly writeGroups: array
+
+Netresearch\NrVault\Domain\Repository\SecretRepositoryInterface (interface)
+  method countAll(): int
+  method delete(Netresearch\NrVault\Domain\Model\Secret $secret): void
+  method exists(string $identifier): bool
+  method findAllWithFilters(?Netresearch\NrVault\Domain\Dto\SecretFilters $filters = …): array
+  method findByGroups(array $groupUids): array
+  method findByIdentifier(string $identifier): ?Netresearch\NrVault\Domain\Model\Secret
+  method findByIdentifierIncludingDisabled(string $identifier): ?Netresearch\NrVault\Domain\Model\Secret
+  method findByUid(int $uid): ?Netresearch\NrVault\Domain\Model\Secret
+  method findByUidIncludingDisabled(int $uid): ?Netresearch\NrVault\Domain\Model\Secret
+  method findExpired(): array
+  method findExpiringSoon(int $days): array
+  method findIdentifiers(?Netresearch\NrVault\Domain\Dto\SecretFilters $filters = …): array
+  method findPaginatedAfterUid(int $afterUid, int $limit): array
+  method incrementReadCount(int $uid): void
+  method save(Netresearch\NrVault\Domain\Model\Secret $secret, bool $persistGroupRelations = …): Netresearch\NrVault\Domain\Model\Secret
+  method setHidden(int $uid, bool $hidden): void
+  method setMetadata(int $uid, array $metadata): void
+
+Netresearch\NrVault\Domain\StalenessRule (enum)
+  case AutomationStale
+  case Dead
+  case Expired
+  case NeverRotated
+  method label(): string
+  method severity(): string
+  method static cases(): array
+  method static from(int|string $value): static
+  method static tryFrom(int|string $value): ?static
+  property readonly name: string
+  property readonly value: string
+
+Netresearch\NrVault\Exception\AccessDeniedException (class)
+  method static breakGlassRequiresAdmin(string $operation): self
+  method static cliAccessDisabled(): self
+  method static forIdentifier(string $identifier, string $reason = …): self
+
+Netresearch\NrVault\Exception\AuditSinkException (class)
+  method static encodingFailed(string $sinkIdentifier, string $detail): self
+  method static rejectedByEndpoint(string $sinkIdentifier, int $statusCode): self
+  method static transportFailed(string $sinkIdentifier, string $detail): self
+  method static writeFailed(string $sinkIdentifier, string $detail): self
+
+Netresearch\NrVault\Exception\AuditWriteException (class)
+  method static lockAcquisitionFailed(mixed $rawResult): self
+  method static writeFailed(Throwable $cause): self
+
+Netresearch\NrVault\Exception\ConfigurationException (class)
+  method static invalidAdapter(string $adapter): self
+  method static invalidProvider(string $provider): self
+  method static invalidSecurityProfile(string $profile): self
+  method static missingConfiguration(string $key): self
+  method static providerForbiddenInHardenedProfile(string $provider): self
+
+Netresearch\NrVault\Exception\EncryptionException (class)
+  method static algorithmNotAvailable(string $algorithm): self
+  method static decryptionFailed(string $reason = …): self
+  method static encryptionFailed(string $reason = …): self
+
+Netresearch\NrVault\Exception\EnvelopeFormatException (class)
+  method static malformedFields(): self
+  method static missingMarker(): self
+  method static notBase64(): self
+  method static notJson(): self
+
+Netresearch\NrVault\Exception\MasterKeyException (class)
+  method static cannotStore(string $reason): self
+  method static environmentVariableNotSet(string $varName): self
+  method static invalidLength(int $expected, int $actual): self
+  method static notFound(string $location): self
+  method static transitInvalidKeyReference(string $field): self
+  method static transitMalformedResponse(string $operation, string $detail): self
+  method static transitNotConfigured(string $detail): self
+  method static transitRequestRejected(string $operation, int $statusCode): self
+  method static transitTokenMissing(string $envVarName): self
+  method static transitTransportFailure(string $operation, string $redactedReason): self
+  method static transitUnsupportedAuthMethod(string $authMethod): self
+
+Netresearch\NrVault\Exception\OAuthException (class)
+  method static invalidJsonResponse(Throwable $previous): self
+  method static missingAccessToken(): self
+  method static requestFailed(string $message, ?Throwable $previous = …): self
+  method static tokenRequestFailed(int $statusCode, ?string $oauthError = …): self
+  property httpStatus: ?int
+  property oauthError: ?string
+
+Netresearch\NrVault\Exception\RequestCancelledException (class)
+
+Netresearch\NrVault\Exception\SecretExpiredException (class)
+  method static forIdentifier(string $identifier, int $expiredAt): self
+
+Netresearch\NrVault\Exception\SecretNotFoundException (class)
+  method static forIdentifier(string $identifier): self
+
+Netresearch\NrVault\Exception\TechnicalActorException (class)
+  method static invalidUid(int $beUserUid): self
+  method static userDisabled(int $beUserUid): self
+  method static userNotActive(int $beUserUid): self
+  method static userNotAtRootLevel(int $beUserUid): self
+  method static userNotFound(int $beUserUid): self
+
+Netresearch\NrVault\Exception\ValidationException (class)
+  method static emptySecret(): self
+  method static invalidIdentifier(string $identifier, string $reason): self
+  method static invalidOption(string $option, string $reason): self
+  method static missingReason(string $operation): self
+
+Netresearch\NrVault\Exception\VaultException (class)
+
+Netresearch\NrVault\Hook\RecordCreationOutcome (enum)
+  case Rejected
+  case Stored
+  case ValueLess
+  method static cases(): array
+  method static classify(bool $valueSubmitted, bool $valueStored): self
+  property readonly name: string
+
+Netresearch\NrVault\Http\CancellableHttpClientInterface (interface)
+  method sendCancellable(Psr\Http\Message\RequestInterface $request, Netresearch\NrVault\Http\CancellationSignalInterface $signal): Psr\Http\Message\ResponseInterface
+  method supportsCancellation(): bool
+
+Netresearch\NrVault\Http\CancellationSignalInterface (interface)
+  method isCancelled(): bool
+
+Netresearch\NrVault\Http\DnsResolverInterface (interface)
+  method resolve(string $host): array
+
+Netresearch\NrVault\Http\OAuth\OAuthConfig (class)
+  constructor(string $tokenEndpoint, string $clientIdSecret, string $clientSecretSecret, string $grantType = …, ?string $refreshTokenSecret = …, array $scopes = …, int $tokenExpiryBuffer = …, array $additionalParams = …)
+  method getScopesString(): string
+  method static clientCredentials(string $tokenEndpoint, string $clientIdSecret, string $clientSecretSecret, array $scopes = …): self
+  method static refreshToken(string $tokenEndpoint, string $clientIdSecret, string $clientSecretSecret, string $refreshTokenSecret, array $scopes = …): self
+  property readonly additionalParams: array
+  property readonly clientIdSecret: string
+  property readonly clientSecretSecret: string
+  property readonly grantType: string
+  property readonly refreshTokenSecret: ?string
+  property readonly scopes: array
+  property readonly tokenEndpoint: string
+  property readonly tokenExpiryBuffer: int
+
+Netresearch\NrVault\Http\SecretPlacement (enum)
+  case ApiKey
+  case BasicAuth
+  case Bearer
+  case BodyField
+  case Header
+  case OAuth2
+  case QueryParam
+  method defaultConfigKey(): ?string
+  method description(): string
+  method requiresConfig(): bool
+  method static cases(): array
+  method static from(int|string $value): static
+  method static tryFrom(int|string $value): ?static
+  property readonly name: string
+  property readonly value: string
+
+Netresearch\NrVault\Http\TransportTickerInterface (interface)
+  method tick(): void
+
+Netresearch\NrVault\Http\VaultHttpClientFactoryInterface (interface)
+  method create(Netresearch\NrVault\Service\VaultServiceInterface $vaultService): Netresearch\NrVault\Http\VaultHttpClientInterface
+
+Netresearch\NrVault\Http\VaultHttpClientInterface (interface)
+  method withAuthentication(string $secretIdentifier, Netresearch\NrVault\Http\SecretPlacement $placement = …, array $options = …): static
+  method withOAuth(Netresearch\NrVault\Http\OAuth\OAuthConfig $config, string $reason = …): static
+  method withReason(string $reason): static
+  method withTimeout(int $seconds): static
+
+Netresearch\NrVault\Secret\SecretIdentifierKind (enum)
+  case ConfigurationKey
+  case DatabaseColumn
+  case EnvironmentVariable
+  method hints(): array
+  method static cases(): array
+  property readonly name: string
+
+Netresearch\NrVault\Secret\SecretRedactorInterface (interface)
+  method identifyValue(string $value): ?string
+  method isSecretIdentifier(string $identifier, Netresearch\NrVault\Secret\SecretIdentifierKind $kind): bool
+  method redact(string $text, bool $includeEmails = …): string
+
+Netresearch\NrVault\Security\AccessControlServiceInterface (interface)
+  method canCreate(): bool
+  method canDelete(Netresearch\NrVault\Domain\Model\Secret $secret): bool
+  method canRead(Netresearch\NrVault\Domain\Model\Secret $secret): bool
+  method canWrite(Netresearch\NrVault\Domain\Model\Secret $secret): bool
+  method getCurrentActorType(): string
+  method getCurrentActorUid(): int
+  method getCurrentActorUsername(): string
+  method getCurrentUserGroups(): array
+  method isCurrentActorAdmin(): bool
+  method isGranted(Netresearch\NrVault\Security\VaultPermission $permission): bool
+
+Netresearch\NrVault\Security\BreakGlassServiceInterface (interface)
+  const DEFAULT_TTL_MINUTES = 15
+  const MAX_TTL_MINUTES = 60
+  const MIN_TTL_MINUTES = 1
+  method activate(string $reason, int $minutes = …): Netresearch\NrVault\Security\BreakGlassSession
+  method deactivate(string $reason): void
+
+Netresearch\NrVault\Security\BreakGlassSession (class)
+  constructor(int $activatedByUid, string $activatedByUsername, string $reason, DateTimeImmutable $activatedAt, DateTimeImmutable $expiresAt)
+  method isExpiredAt(DateTimeImmutable $now): bool
+  method remainingSeconds(DateTimeImmutable $now): int
+  method static fromArray(array $payload): ?self
+  method toArray(): array
+  property readonly activatedAt: DateTimeImmutable
+  property readonly activatedByUid: int
+  property readonly activatedByUsername: string
+  property readonly expiresAt: DateTimeImmutable
+  property readonly reason: string
+
+Netresearch\NrVault\Security\BreakGlassStateInterface (interface)
+  method getActiveSession(): ?Netresearch\NrVault\Security\BreakGlassSession
+  method isActive(): bool
+
+Netresearch\NrVault\Security\FrontendPlaceholderPolicyInterface (interface)
+  method allowIdentifier(string $identifier, Psr\Http\Message\ServerRequestInterface $request): void
+  method claimLogSlot(TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $contentObjectRenderer): bool
+  method isResolvable(string $identifier, TYPO3\CMS\Frontend\ContentObject\ContentObjectRenderer $contentObjectRenderer): bool
+
+Netresearch\NrVault\Security\TechnicalActor (class)
+  constructor(int $uid, string $username, bool $admin, array $groupIds)
+  property readonly admin: bool
+  property readonly groupIds: array
+  property readonly uid: int
+  property readonly username: string
+
+Netresearch\NrVault\Security\TechnicalActorContextInterface (interface)
+  method getCurrentActor(): ?Netresearch\NrVault\Security\TechnicalActor
+  method runAs(int $beUserUid, callable $fn): mixed
+
+Netresearch\NrVault\Security\VaultPermission (enum)
+  case AuditExport
+  case AuditView
+  case MasterKeyRotate
+  case SecretCreate
+  case SecretDelete
+  case SecretManagePolicy
+  case SecretReveal
+  case SecretRotate
+  case SecretUse
+  case VaultConfigure
+  method static cases(): array
+  method static from(int|string $value): static
+  method static secretOperations(): array
+  method static tryFrom(int|string $value): ?static
+  property readonly name: string
+  property readonly value: string
+
+Netresearch\NrVault\Service\Analytics\VaultAnalyticsServiceInterface (interface)
+  method getRedactionCandidates(int $windowDays): array
+  method getUsageStats(int $windowDays): Netresearch\NrVault\Domain\Dto\VaultUsageStats
+
+Netresearch\NrVault\Service\Detection\SecretFinding (interface)
+  method getDetails(): string
+  method getKey(): string
+  method getPatterns(): array
+  method getSeverity(): Netresearch\NrVault\Service\Detection\Severity
+  method getSource(): string
+
+Netresearch\NrVault\Service\Detection\Severity (enum)
+  case Critical
+  case High
+  case Low
+  case Medium
+  method isAtLeast(self $minimum): bool
+  method order(): int
+  method static cases(): array
+  method static from(int|string $value): static
+  method static tryFrom(int|string $value): ?static
+  property readonly name: string
+  property readonly value: string
+
+Netresearch\NrVault\Service\Doctor\DoctorContext (class)
+  constructor(Netresearch\NrVault\Configuration\SecurityProfile $profile, Netresearch\NrVault\Configuration\SecurityProfile $configuredProfile, bool $activeProbes = …)
+  method isHardened(): bool
+  method isProfileOverridden(): bool
+  method static forConfiguredProfile(Netresearch\NrVault\Configuration\SecurityProfile $profile): self
+  property readonly activeProbes: bool
+  property readonly configuredProfile: Netresearch\NrVault\Configuration\SecurityProfile
+  property readonly profile: Netresearch\NrVault\Configuration\SecurityProfile
+
+Netresearch\NrVault\Service\Doctor\DoctorReport (class)
+  constructor(Netresearch\NrVault\Service\Doctor\DoctorContext $context, array $findings)
+  method exitCode(): int
+  method findingsOfSeverity(Netresearch\NrVault\Service\Doctor\FindingSeverity $severity): array
+  method highestSeverity(): Netresearch\NrVault\Service\Doctor\FindingSeverity
+  method isAuditReady(): bool
+  method passedControls(): int
+  method problems(): array
+  method toArray(): array
+  method totalControls(): int
+  property readonly context: Netresearch\NrVault\Service\Doctor\DoctorContext
+  property readonly findings: array
+
+Netresearch\NrVault\Service\Doctor\FindingSeverity (enum)
+  case Critical
+  case Pass
+  case Warning
+  method bootstrapContext(): string
+  method rank(): int
+  method static cases(): array
+  method static from(int|string $value): static
+  method static tryFrom(int|string $value): ?static
+  property readonly name: string
+  property readonly value: string
+
+Netresearch\NrVault\Service\Doctor\ReadinessCheckInterface (interface)
+  method appliesTo(Netresearch\NrVault\Configuration\SecurityProfile $profile): bool
+  method getId(): string
+  method run(Netresearch\NrVault\Service\Doctor\DoctorContext $context): array
+
+Netresearch\NrVault\Service\Doctor\VaultDoctorServiceInterface (interface)
+  method run(?Netresearch\NrVault\Configuration\SecurityProfile $targetProfile = …, bool $activeProbes = …): Netresearch\NrVault\Service\Doctor\DoctorReport
+
+Netresearch\NrVault\Service\SecretDetectionServiceInterface (interface)
+  method getDetectedSecretsBySeverity(): array
+  method getDetectedSecretsCount(): int
+  method scan(array $excludeTables = …): array
+  method scanDatabaseTables(array $excludeTables = …): void
+  method scanExtensionConfiguration(): void
+  method scanLocalConfiguration(): void
+
+Netresearch\NrVault\Service\VaultFieldPermission (enum)
+  case Copy
+  case Edit
+  case ReadOnly
+  case Reveal
+  method static cases(): array
+  method static from(int|string $value): static
+  method static tryFrom(int|string $value): ?static
+  property readonly name: string
+  property readonly value: string
+
+Netresearch\NrVault\Service\VaultHealthServiceInterface (interface)
+  method checkHealth(): Netresearch\NrVault\Service\VaultHealthStatus
+
+Netresearch\NrVault\Service\VaultHealthStatus (class)
+  constructor(bool $masterKeyAvailable, string $masterKeyProvider, bool $encryptionWorking, bool $hasIssues)
+  property readonly encryptionWorking: bool
+  property readonly hasIssues: bool
+  property readonly masterKeyAvailable: bool
+  property readonly masterKeyProvider: string
+
+Netresearch\NrVault\Service\VaultServiceInterface (interface)
+  method assertDeletable(string $identifier): void
+  method delete(string $identifier, string $reason = …): void
+  method exists(string $identifier): bool
+  method getMetadata(string $identifier): Netresearch\NrVault\Domain\Dto\SecretDetails
+  method http(): Netresearch\NrVault\Http\VaultHttpClientInterface
+  method list(?string $pattern = …, bool $includeDisabled = …): array
+  method retrieve(string $identifier): ?string
+  method retrieveForFrontend(string $identifier): ?string
+  method rotate(string $identifier, string $newSecret, string $reason = …): void
+  method setEnabled(string $identifier, bool $enabled, string $reason = …): void
+  method store(string $identifier, string $secret, array $options = …): void

--- a/Tests/Unit/Api/api-surface.txt
+++ b/Tests/Unit/Api/api-surface.txt
@@ -51,6 +51,7 @@ Netresearch\NrVault\Audit\AuditAction (enum)
   case OAuthFallbackClientCredentials = "oauth_fallback_client_credentials"
   case OAuthRefreshFailed = "oauth_refresh_failed"
   case OAuthRefreshStoreFailed = "oauth_refresh_store_failed"
+  case OAuthTokenRequest = "oauth_token_request"
   case Read = "read"
   case Rotate = "rotate"
   case Update = "update"


### PR DESCRIPTION
## Summary

`Tests/Unit/Api/api-surface.txt` freezes the rendered public surface of the package, so a change to any frozen signature has to be an explicit commit with a visible snapshot diff instead of a side effect. Deferred from #302, which added a whole new public interface without anything in CI that would notice a later alteration.

nr-vault has no `@api` marker convention, so the frozen set is derived mechanically, with no marker to forget: every interface, enum and `Throwable` subclass under `Classes/` (89 classes total), plus — computed as a closure — every own-namespace type those signatures mention through method parameters and returns, public property types, and public constructor parameters. That pulls in the value objects consumers receive and construct (`OAuthConfig`, `SecretDetails`, …), constructors included.

The renderer and the diff classifier are ported from nr-llm (`Tests/Unit/Api/Support/`) with identical rendering rules, so the two packages' snapshots stay comparable. The failure message classifies a diff as **additive** (regenerate the snapshot, note it under `### Added`) or **breaking** (a decision, per AGENTS.md's "Ask First" rule for `*Interface.php` signatures), with a was/now pair per changed member.

## Related Issues

Fixes #306

## Changes

- `Tests/Unit/Api/ApiSurfaceSnapshotTest.php` — discovery (seed + closure), snapshot assertion, regenerate-on-missing
- `Tests/Unit/Api/Support/ApiSurfaceRenderer.php` — deterministic rendering (declared-only members, no default values, self-built type strings, constructor recorded from the nearest own-namespace declaring class)
- `Tests/Unit/Api/Support/ApiSurfaceDiff.php` — additive/breaking classification by member name
- `Tests/Unit/Api/ApiSurfaceRendererTest.php` + `Fixtures/` — proves the renderer catches what the snapshot alone cannot show it would catch (widened constructor, own-namespace inherited constructor, foreign inherited constructor excluded)
- `Tests/Unit/Api/api-surface.txt` — the initial snapshot (89 classes)
- `CHANGELOG.md` — entry under `### Added`

## Checklist

- [x] Tests pass locally (`runTests.sh -s unit`: 3661 tests OK; `-s fuzz`: 1612 tests OK)
- [x] PHPStan passes (`Build/phpstan.no-plugins.neon` locally: "No errors"; the ergebnis ruleset only resolves on CI)
- [x] Code style is correct (`runTests.sh -s cgl`: SUCCESS)
- [x] Documentation updated — not applicable (test infrastructure; the test docblock carries the update procedure)
- [x] CHANGELOG.md updated

## Test Plan

Guard seen to fail, both ends:

- End-to-end: renaming the `$signal` parameter in `CancellableHttpClientInterface::sendCancellable()` turned `renderedPublicSurfaceMatchesTheCommittedSnapshot` red with `BREAKING — 0 added, 0 removed, 1 changed` and the exact was/now pair; reverting turned it green again. (A widened method signature on the same interface dies earlier, as a PHP fatal in the implementor — the snapshot exists for the changes PHP tolerates.)
- Renderer-level: `ApiSurfaceRendererTest` asserts against fixtures that a widened constructor classifies as breaking, an added method as additive, and that a constructor inherited from an own-namespace base is recorded while one inherited from outside the repository is not.

To review the frozen set: read `api-surface.txt` — the header lines list the 89 classes. To update intentionally later: delete the file, run the unit suite twice, commit the regenerated file with a CHANGELOG entry (the failure message says which of the two cases applies).

## Review round

The independent review (Copilot quota exhausted; see the review-note comment) led to [61c4588](https://github.com/netresearch/t3x-nr-vault/commit/61c4588b): backed-enum cases render WITH their backing value (a value change now classifies as breaking; divergence from nr-llm proposed upstream as netresearch/t3x-nr-llm#815), `Classes/Domain/Dto/` is seeded wholesale because docblock-typed array returns are invisible to the reflection closure, the snapshot file is pinned to LF in `.gitattributes`, and the skip-on-throw comment names its limits. After rebasing onto #320 and #321, [86794c5](https://github.com/netresearch/t3x-nr-vault/commit/86794c5) records #303's new `oauth_token_request` action in the snapshot — one additive line, exactly the visibility this test exists to force.
