### PR TITLE
Collapse the double DNS resolve per outbound request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inside `sendAsync()`, the caller's signal and the ticker can all throw, and
   none of them may be the one outbound call that leaves no trace.
 
+### Changed
+
+- **One DNS lookup per outbound request instead of two** (#304). The
+  caller-side `isHostAllowed()` gate and the `ssrf-dns-pin` middleware each
+  ran their own `dns_get_record()`; a short-lived memo (5 s, per host) inside
+  `SecureHttpClientFactory` now lets the middleware reuse the gate's answer.
+  The sharing is bounded by issue #304's security constraint: it only applies
+  where every memoised IP is still range-checked and then pinned via
+  `CURLOPT_RESOLVE` (the ext-curl path), so a memoised answer can never admit
+  an address a fresh one would have rejected — a rebind inside the TTL just
+  means curl connects to the address that was actually vetted. Without
+  ext-curl there is no pin and the middleware's resolve IS the rebind
+  defence, so that path keeps resolving fresh. Failed resolutions are never
+  memoised; every failure-path behaviour is unchanged.
+
 ### Fixed
 
 - **A refused scheme, a host outside `allowed_hosts`, and a credential that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -108,12 +108,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `SecureHttpClientFactory` now lets the middleware reuse the gate's answer.
   The sharing is bounded by issue #304's security constraint: it only applies
   where every memoised IP is still range-checked and then pinned via
-  `CURLOPT_RESOLVE` (the ext-curl path), so a memoised answer can never admit
-  an address a fresh one would have rejected — a rebind inside the TTL just
-  means curl connects to the address that was actually vetted. Without
-  ext-curl there is no pin and the middleware's resolve IS the rebind
-  defence, so that path keeps resolving fresh. Failed resolutions are never
-  memoised; every failure-path behaviour is unchanged.
+  `CURLOPT_RESOLVE`, so a memoised answer can never admit an address a fresh
+  one would have rejected — a rebind inside the TTL just means curl connects
+  to the address that was actually vetted. Where no pin takes effect — no
+  ext-curl, or a `stream => true` transfer, which Guzzle routes to the
+  StreamHandler that ignores the curl options — the middleware's own resolve
+  IS the rebind defence and keeps resolving fresh, decided per hop. (The
+  `isHostAllowed()` gate itself may share answers within the TTL in every
+  mode; its check was always advisory relative to connect time, and the
+  middleware re-validates.) Failed resolutions are never memoised; every
+  failure-path behaviour is unchanged.
 
 ### Fixed
 

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -77,6 +77,40 @@ final class SecureHttpClientFactory
      */
     private const CANCELLABLE_WALL_CLOCK_MARGIN_SECONDS = 5.0;
 
+    /**
+     * How long one resolver answer may be reused (issue #304).
+     *
+     * Sized to span the gap between the caller-side `isHostAllowed()` gate and
+     * the `ssrf-dns-pin` middleware within ONE outbound request — normally
+     * milliseconds — so the common case pays one `dns_get_record()` instead of
+     * two. It is deliberately NOT sized to span an OAuth token leg: when the
+     * gap exceeds the TTL the only cost is one extra lookup.
+     *
+     * The ceiling this places on staleness matters because the factory is a
+     * shared DI service: under PHP-FPM it dies with the request anyway, but a
+     * long-running CLI process (scheduler, worker) keeps one instance across
+     * many operations, and the TTL is what bounds how old an answer the
+     * `isHostAllowed()` gate may accept there. The middleware's own use is
+     * bounded differently — see `buildResolveEntries()` for why a memoised
+     * answer is only ever consumed where the resolved IPs are re-checked and
+     * pinned.
+     */
+    private const DNS_MEMO_TTL_SECONDS = 5.0;
+
+    /**
+     * Upper bound on memoised hosts, so a long-running process that talks to
+     * many endpoints cannot grow the memo without limit. Eviction is
+     * oldest-first; with a 5-second TTL the cap is theoretical.
+     */
+    private const DNS_MEMO_MAX_HOSTS = 32;
+
+    /**
+     * Short-lived per-host memo of resolver answers.
+     *
+     * @var array<string, array{expiresAt: float, records: list<array{ip?: string, ipv6?: string}>}>
+     */
+    private array $dnsMemo = [];
+
     public function __construct(
         private readonly DnsResolverInterface $dnsResolver = new DefaultDnsResolver(),
     ) {}
@@ -526,7 +560,19 @@ final class SecureHttpClientFactory
             return [];
         }
 
-        $records = $this->dnsResolver->resolve($host);
+        // Which resolve this hop may share is a security decision, not a
+        // performance one (issue #304). WITH ext-curl, every IP taken from the
+        // answer is range-checked below and then pinned via CURLOPT_RESOLVE,
+        // so curl can only connect to addresses this method vetted — a
+        // memoised answer is exactly as safe as a fresh one, and reusing the
+        // gate's lookup is what collapses the double resolve. WITHOUT
+        // ext-curl there is no pin: this resolve-and-check is itself the
+        // rebind defence, and its whole value is being the freshest answer
+        // before the connect. Consuming a memo there would widen the
+        // check-to-connect window by up to the TTL, so that path stays fresh.
+        $records = \function_exists('curl_init')
+            ? $this->memoisedResolve($host)
+            : $this->freshResolve($host);
         if ($records === []) {
             // Resolution failed — let curl produce the usual connection error.
             return [];
@@ -888,7 +934,7 @@ final class SecureHttpClientFactory
             return false;
         }
 
-        foreach ($this->dnsResolver->resolve($host) as $record) {
+        foreach ($this->memoisedResolve($host) as $record) {
             $ip = $record['ip'] ?? $record['ipv6'] ?? null;
             if (\is_string($ip) && $this->isDangerousIpLiteral($ip)) {
                 return true;
@@ -896,6 +942,73 @@ final class SecureHttpClientFactory
         }
 
         return false;
+    }
+
+    /**
+     * The resolver answer for `$host`, reused for up to
+     * `DNS_MEMO_TTL_SECONDS` after a fresh lookup.
+     *
+     * Serves the two callers issue #304 established MAY share an answer: the
+     * `isHostAllowed()` gate (via `resolvesToDangerousIp()`), and the
+     * `ssrf-dns-pin` middleware when — and only when — ext-curl will pin the
+     * resolved IPs (`buildResolveEntries()` decides that per hop, and takes a
+     * fresh answer otherwise). Every consumer re-checks each IP it reads, so
+     * a memoised answer can never admit an address a fresh one would have
+     * rejected — the sharing changes WHEN the answer was resolved, never
+     * whether it is checked.
+     *
+     * @return list<array{ip?: string, ipv6?: string}>
+     */
+    private function memoisedResolve(string $host): array
+    {
+        $entry = $this->dnsMemo[$host] ?? null;
+        if ($entry !== null && microtime(true) < $entry['expiresAt']) {
+            return $entry['records'];
+        }
+
+        return $this->freshResolve($host);
+    }
+
+    /**
+     * One real resolver lookup, memoised for `memoisedResolve()`.
+     *
+     * A failed resolution (the empty list) is never memoised — today an empty
+     * answer means "no pin, let the HTTP client surface the connection error",
+     * and a transient DNS failure frozen for the TTL would also blind the
+     * middleware's re-resolve where a fresh attempt might have succeeded.
+     * Memoising only non-empty answers keeps every failure-path behaviour
+     * byte-identical to the un-memoised code.
+     *
+     * @return list<array{ip?: string, ipv6?: string}>
+     */
+    private function freshResolve(string $host): array
+    {
+        $records = $this->dnsResolver->resolve($host);
+
+        if ($records === []) {
+            unset($this->dnsMemo[$host]);
+
+            return [];
+        }
+
+        $now = microtime(true);
+        foreach ($this->dnsMemo as $memoHost => $memoEntry) {
+            if ($now >= $memoEntry['expiresAt']) {
+                unset($this->dnsMemo[$memoHost]);
+            }
+        }
+
+        unset($this->dnsMemo[$host]);
+        while (\count($this->dnsMemo) >= self::DNS_MEMO_MAX_HOSTS) {
+            array_shift($this->dnsMemo);
+        }
+
+        $this->dnsMemo[$host] = [
+            'expiresAt' => $now + self::DNS_MEMO_TTL_SECONDS,
+            'records' => $records,
+        ];
+
+        return $records;
     }
 
     /**

--- a/Classes/Http/SecureHttpClientFactory.php
+++ b/Classes/Http/SecureHttpClientFactory.php
@@ -469,7 +469,21 @@ final class SecureHttpClientFactory
                     );
                 }
 
-                $resolveEntries = $this->buildResolveEntries($host, $port, $allowlisted);
+                // Whether curl will actually honour a CURLOPT_RESOLVE pin for
+                // THIS transfer — per hop, not per process: even with ext-curl
+                // loaded, Guzzle routes a request carrying `stream => true` to
+                // the StreamHandler, which ignores `$options['curl']` entirely.
+                // The memo may only be consumed where the pin is honoured (see
+                // buildResolveEntries()); on a pinless transfer the fresh
+                // resolve below IS the rebind defence. No in-repo caller sets
+                // `stream`, but the factory's clients are a public seam.
+                // The truthiness cast mirrors Guzzle's own routing check
+                // (`Proxy::wrapStreaming()` tests `empty($options['stream'])`),
+                // so this predicate and the handler choice cannot disagree.
+                $pinWillBeHonoured = \function_exists('curl_init')
+                    && !(bool) ($options['stream'] ?? false);
+
+                $resolveEntries = $this->buildResolveEntries($host, $port, $allowlisted, $pinWillBeHonoured);
 
                 if ($resolveEntries === null) {
                     throw new RequestException(
@@ -488,7 +502,7 @@ final class SecureHttpClientFactory
                 // option anyway. The dangerous-IP rejections above still ran —
                 // this is exactly the degraded-but-working posture create()'s
                 // missing-ext-curl warning documents.
-                if ($resolveEntries !== [] && \function_exists('curl_init')) {
+                if ($resolveEntries !== [] && $pinWillBeHonoured) {
                     $curlOptions = \is_array($options['curl'] ?? null) ? $options['curl'] : [];
                     /** @var list<string> $existing */
                     $existing = \is_array($curlOptions[\CURLOPT_RESOLVE] ?? null)
@@ -540,11 +554,22 @@ final class SecureHttpClientFactory
      *                          operator has explicitly opted in. The pin is
      *                          still added so rebinding to a *different*
      *                          address stays blocked.
+     * @param bool $pinWillBeHonoured Whether curl will honour a
+     *                                `CURLOPT_RESOLVE` pin for THIS transfer — ext-curl present AND the
+     *                                request not routed to the StreamHandler (`stream => true` ignores
+     *                                the curl options). Only then may the resolve consume the DNS memo;
+     *                                otherwise this method resolves fresh, because on a pinless transfer
+     *                                its own resolve-and-check is the rebind defence. Defaults to false
+     *                                (fresh), the safe side.
      *
      * @return list<string>|null
      */
-    private function buildResolveEntries(string $host, int $port, bool $allowlisted = false): ?array
-    {
+    private function buildResolveEntries(
+        string $host,
+        int $port,
+        bool $allowlisted = false,
+        bool $pinWillBeHonoured = false,
+    ): ?array {
         // IP literal — no DNS to pin, but the literal itself is still
         // range-checked HERE. The middleware must be self-sufficient: it runs
         // below Guzzle's RedirectMiddleware, so EVERY redirect hop re-enters
@@ -561,16 +586,20 @@ final class SecureHttpClientFactory
         }
 
         // Which resolve this hop may share is a security decision, not a
-        // performance one (issue #304). WITH ext-curl, every IP taken from the
-        // answer is range-checked below and then pinned via CURLOPT_RESOLVE,
-        // so curl can only connect to addresses this method vetted — a
-        // memoised answer is exactly as safe as a fresh one, and reusing the
-        // gate's lookup is what collapses the double resolve. WITHOUT
-        // ext-curl there is no pin: this resolve-and-check is itself the
-        // rebind defence, and its whole value is being the freshest answer
-        // before the connect. Consuming a memo there would widen the
-        // check-to-connect window by up to the TTL, so that path stays fresh.
-        $records = \function_exists('curl_init')
+        // performance one (issue #304). When the pin will be HONOURED, every
+        // IP taken from the answer is range-checked below and then pinned via
+        // CURLOPT_RESOLVE, so curl can only connect to addresses this method
+        // vetted — a memoised answer is exactly as safe as a fresh one, and
+        // reusing the gate's lookup is what collapses the double resolve.
+        // Where no pin takes effect — no ext-curl, or a `stream => true`
+        // transfer that Guzzle routes to the StreamHandler, which ignores the
+        // curl options — this resolve-and-check is itself the rebind defence,
+        // and its whole value is being the freshest answer before the
+        // connect. Consuming a memo there would widen the check-to-connect
+        // window by up to the TTL, so those paths stay fresh. The caller (the
+        // middleware closure) decides per hop and defaults to fresh, so a
+        // forgotten caller degrades to the safe side.
+        $records = $pinWillBeHonoured
             ? $this->memoisedResolve($host)
             : $this->freshResolve($host);
         if ($records === []) {
@@ -950,9 +979,11 @@ final class SecureHttpClientFactory
      *
      * Serves the two callers issue #304 established MAY share an answer: the
      * `isHostAllowed()` gate (via `resolvesToDangerousIp()`), and the
-     * `ssrf-dns-pin` middleware when — and only when — ext-curl will pin the
-     * resolved IPs (`buildResolveEntries()` decides that per hop, and takes a
-     * fresh answer otherwise). Every consumer re-checks each IP it reads, so
+     * `ssrf-dns-pin` middleware when — and only when — the `CURLOPT_RESOLVE`
+     * pin will actually be honoured for the transfer (the middleware closure
+     * decides that per hop — ext-curl present and no `stream => true` — and
+     * `buildResolveEntries()` takes a fresh answer otherwise). Every consumer
+     * re-checks each IP it reads, so
      * a memoised answer can never admit an address a fresh one would have
      * rejected — the sharing changes WHEN the answer was resolved, never
      * whether it is checked.
@@ -1000,7 +1031,15 @@ final class SecureHttpClientFactory
 
         unset($this->dnsMemo[$host]);
         while (\count($this->dnsMemo) >= self::DNS_MEMO_MAX_HOSTS) {
-            array_shift($this->dnsMemo);
+            // Not array_shift(): PHP casts a purely-numeric hostname to an
+            // int key, and array_shift() would renumber the remaining int
+            // keys — a later lookup could then hit a foreign entry's records.
+            $oldest = array_key_first($this->dnsMemo);
+            if ($oldest === null) {
+                break;
+            }
+
+            unset($this->dnsMemo[$oldest]);
         }
 
         $this->dnsMemo[$host] = [

--- a/Tests/Unit/Http/SecureHttpClientFactoryDnsMemoTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryDnsMemoTest.php
@@ -158,6 +158,60 @@ final class SecureHttpClientFactoryDnsMemoTest extends TestCase
     }
 
     #[Test]
+    public function aStreamTransferNeverConsumesTheMemo(): void
+    {
+        // Even with ext-curl loaded, Guzzle routes `stream => true` to the
+        // StreamHandler, which ignores the curl options — a pin attached to
+        // such a transfer is inert. The middleware must therefore resolve
+        // fresh (its own resolve-and-check IS the rebind defence there) and
+        // attach no pin at all.
+        $this->dnsResolver->answer(self::HOST, [['ip' => self::PUBLIC_IP]]);
+
+        self::assertTrue($this->subject->isHostAllowed(self::HOST));
+
+        $client = $this->buildCapturingClient($capturedOptions);
+        $client->get('https://' . self::HOST . '/v1/data', ['stream' => true]);
+
+        self::assertSame(2, $this->dnsResolver->queryCount(self::HOST), 'A pinless transfer must resolve fresh, not reuse the memo.');
+        self::assertIsArray($capturedOptions);
+        self::assertArrayNotHasKey('curl', $capturedOptions, 'No pin may be attached to a transfer that cannot honour it.');
+    }
+
+    #[Test]
+    public function theOldestEntryIsEvictedWhenTheMemoIsFull(): void
+    {
+        for ($i = 0; $i < 33; ++$i) {
+            $host = \sprintf('host-%02d.example', $i);
+            $this->dnsResolver->answer($host, [['ip' => self::PUBLIC_IP]]);
+            self::assertTrue($this->subject->isHostAllowed($host));
+        }
+
+        // host-00 was evicted by host-32's insert; host-32 is still memoised.
+        self::assertTrue($this->subject->isHostAllowed('host-00.example'));
+        self::assertSame(2, $this->dnsResolver->queryCount('host-00.example'), 'The oldest entry must have been evicted at the cap.');
+        self::assertTrue($this->subject->isHostAllowed('host-32.example'));
+        self::assertSame(1, $this->dnsResolver->queryCount('host-32.example'), 'A newer entry must survive the eviction.');
+    }
+
+    #[Test]
+    public function anExpiredForeignEntryIsPrunedOnTheNextFreshResolve(): void
+    {
+        $this->dnsResolver->answer(self::HOST, [['ip' => self::PUBLIC_IP]]);
+        $this->dnsResolver->answer('other.example', [['ip' => self::PUBLIC_IP_SECONDARY]]);
+
+        self::assertTrue($this->subject->isHostAllowed(self::HOST));
+        $this->expireMemoEntry(self::HOST);
+
+        self::assertTrue($this->subject->isHostAllowed('other.example'));
+
+        $property = (new ReflectionClass(SecureHttpClientFactory::class))->getProperty('dnsMemo');
+        /** @var array<string, mixed> $memo */
+        $memo = $property->getValue($this->subject);
+        self::assertArrayNotHasKey(self::HOST, $memo, 'A fresh resolve must prune expired foreign entries.');
+        self::assertArrayHasKey('other.example', $memo);
+    }
+
+    #[Test]
     public function anExpiredMemoEntryIsResolvedAgain(): void
     {
         $this->dnsResolver->answer(

--- a/Tests/Unit/Http/SecureHttpClientFactoryDnsMemoTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryDnsMemoTest.php
@@ -90,7 +90,7 @@ final class SecureHttpClientFactoryDnsMemoTest extends TestCase
         $client = $this->buildCapturingClient($capturedOptions);
         $client->get('https://' . self::HOST . '/v1/data');
 
-        self::assertSame(1, $this->dnsResolver->queryCount(self::HOST), 'The middleware must reuse the gate\'s answer, not resolve again.');
+        self::assertSame(1, $this->dnsResolver->queryCount(self::HOST), "The middleware must reuse the gate's answer, not resolve again.");
         self::assertIsArray($capturedOptions);
         self::assertSame(
             [self::HOST . ':443:' . self::PUBLIC_IP],

--- a/Tests/Unit/Http/SecureHttpClientFactoryDnsMemoTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryDnsMemoTest.php
@@ -1,0 +1,280 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Http;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\Create;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Psr7\Response;
+use Netresearch\NrVault\Http\DnsResolverInterface;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Psr\Http\Message\RequestInterface;
+use ReflectionClass;
+use TypeError;
+
+/**
+ * The short-lived DNS memo that collapses the double resolve per outbound
+ * request (issue #304).
+ *
+ * Before the memo, every request resolved its host twice: once in the
+ * caller-side `isHostAllowed()` gate and again in the `ssrf-dns-pin`
+ * middleware. The memo lets the middleware reuse the gate's answer — but only
+ * where issue #304's security constraint allows it: on the curl path every
+ * memoised IP is still range-checked and then pinned, so the sharing changes
+ * WHEN the answer was resolved, never whether it is checked. These tests pin
+ * both halves: the lookup count, and that a memoised answer keeps being
+ * checked.
+ *
+ * The ext-curl-less branch of `buildResolveEntries()` (fresh resolve, no
+ * memo) cannot be exercised here — `\function_exists('curl_init')` cannot be
+ * faked in-process, the same limitation the pin-attachment guard itself has.
+ * The branch is three lines whose reasoning lives in the method's comment.
+ */
+#[CoversClass(SecureHttpClientFactory::class)]
+final class SecureHttpClientFactoryDnsMemoTest extends TestCase
+{
+    private const PUBLIC_IP = '93.184.216.34';
+
+    private const PUBLIC_IP_SECONDARY = '93.184.216.35';
+
+    private const DOCKER_IP = '172.18.0.5';
+
+    private const HOST = 'api.example';
+
+    private SecureHttpClientFactory $subject;
+
+    private SequencedDnsResolver $dnsResolver;
+
+    private mixed $originalGlobals;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->dnsResolver = new SequencedDnsResolver();
+        $this->subject = new SecureHttpClientFactory($this->dnsResolver);
+        $this->originalGlobals = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $GLOBALS['TYPO3_CONF_VARS'] = ['HTTP' => []];
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+        if ($this->originalGlobals !== null) {
+            $GLOBALS['TYPO3_CONF_VARS'] = $this->originalGlobals;
+        } else {
+            unset($GLOBALS['TYPO3_CONF_VARS']);
+        }
+    }
+
+    #[Test]
+    public function theGateAndThePinShareOneResolverAnswer(): void
+    {
+        // The headline of issue #304: gate first, middleware second, ONE
+        // dns_get_record between them.
+        $this->dnsResolver->answer(self::HOST, [['ip' => self::PUBLIC_IP]]);
+
+        self::assertTrue($this->subject->isHostAllowed(self::HOST));
+
+        $client = $this->buildCapturingClient($capturedOptions);
+        $client->get('https://' . self::HOST . '/v1/data');
+
+        self::assertSame(1, $this->dnsResolver->queryCount(self::HOST), 'The middleware must reuse the gate\'s answer, not resolve again.');
+        self::assertIsArray($capturedOptions);
+        self::assertSame(
+            [self::HOST . ':443:' . self::PUBLIC_IP],
+            $capturedOptions['curl'][\CURLOPT_RESOLVE] ?? null,
+            'The reused answer must still be pinned — sharing the lookup must not drop the pin.',
+        );
+    }
+
+    #[Test]
+    public function twoGateChecksInsideTheTtlShareOneAnswer(): void
+    {
+        $this->dnsResolver->answer(self::HOST, [['ip' => self::PUBLIC_IP]]);
+
+        self::assertTrue($this->subject->isHostAllowed(self::HOST));
+        self::assertTrue($this->subject->isHostAllowed(self::HOST));
+
+        self::assertSame(1, $this->dnsResolver->queryCount(self::HOST));
+    }
+
+    #[Test]
+    public function aMemoisedAnswerIsStillCheckedBeforeThePin(): void
+    {
+        // "Resolved once, compared" must not become "resolved once, trusted":
+        // the middleware re-checks every IP it takes from the memo. A host the
+        // gate already rejected is rejected again on the send path, from the
+        // same single resolver answer.
+        $this->dnsResolver->answer(self::HOST, [['ip' => self::DOCKER_IP]]);
+
+        self::assertFalse($this->subject->isHostAllowed(self::HOST));
+
+        $client = $this->buildCapturingClient($capturedOptions);
+
+        try {
+            $client->get('https://' . self::HOST . '/v1/data');
+            self::fail('The middleware must reject a memoised dangerous answer.');
+        } catch (RequestException $e) {
+            self::assertStringContainsString('disallowed IP range', $e->getMessage());
+        }
+
+        self::assertSame(1, $this->dnsResolver->queryCount(self::HOST), 'Both rejections must come from one resolver answer.');
+        self::assertNull($capturedOptions, 'Nothing may reach the transport.');
+    }
+
+    #[Test]
+    public function aRebindInsideTheTtlConnectsToTheVettedAddressNotTheNewOne(): void
+    {
+        // An attacker who rebinds between the gate and the send gains nothing
+        // on the curl path: the memo means the middleware pins the address the
+        // gate CHECKED — the rebound answer is never even fetched, and curl
+        // cannot connect anywhere else.
+        $this->dnsResolver->answer(self::HOST, [['ip' => self::PUBLIC_IP]], [['ip' => self::DOCKER_IP]]);
+
+        self::assertTrue($this->subject->isHostAllowed(self::HOST));
+
+        $client = $this->buildCapturingClient($capturedOptions);
+        $client->get('https://' . self::HOST . '/v1/data');
+
+        self::assertSame(1, $this->dnsResolver->queryCount(self::HOST));
+        self::assertIsArray($capturedOptions);
+        self::assertSame(
+            [self::HOST . ':443:' . self::PUBLIC_IP],
+            $capturedOptions['curl'][\CURLOPT_RESOLVE] ?? null,
+            'The pin must carry the vetted address, not the rebound one.',
+        );
+    }
+
+    #[Test]
+    public function anExpiredMemoEntryIsResolvedAgain(): void
+    {
+        $this->dnsResolver->answer(
+            self::HOST,
+            [['ip' => self::PUBLIC_IP]],
+            [['ip' => self::PUBLIC_IP_SECONDARY]],
+        );
+
+        self::assertTrue($this->subject->isHostAllowed(self::HOST));
+        $this->expireMemoEntry(self::HOST);
+        self::assertTrue($this->subject->isHostAllowed(self::HOST));
+
+        self::assertSame(2, $this->dnsResolver->queryCount(self::HOST), 'An expired entry must trigger a fresh lookup.');
+    }
+
+    #[Test]
+    public function aFailedResolutionIsNotMemoised(): void
+    {
+        // Sequence: first NXDOMAIN, then a dangerous answer. If the failure
+        // were memoised, the second gate check would reuse the empty answer
+        // and pass a host whose fresh answer is dangerous.
+        $this->dnsResolver->answer(self::HOST, [], [['ip' => self::DOCKER_IP]]);
+
+        self::assertTrue($this->subject->isHostAllowed(self::HOST), 'An unresolvable host passes the gate (connection error surfaces later).');
+        self::assertFalse($this->subject->isHostAllowed(self::HOST), 'The second check must see the fresh, dangerous answer.');
+
+        self::assertSame(2, $this->dnsResolver->queryCount(self::HOST));
+    }
+
+    /**
+     * Backdate the memo entry for `$host` so the next lookup sees it expired.
+     * Reflection instead of sleeping: the TTL is seconds, and a sleeping test
+     * is a flake generator.
+     */
+    private function expireMemoEntry(string $host): void
+    {
+        $property = (new ReflectionClass(SecureHttpClientFactory::class))->getProperty('dnsMemo');
+        /** @var array<string, array{expiresAt: float, records: list<array{ip?: string, ipv6?: string}>}> $memo */
+        $memo = $property->getValue($this->subject);
+        self::assertArrayHasKey($host, $memo, 'Expected a memo entry to expire.');
+        $memo[$host]['expiresAt'] = microtime(true) - 1.0;
+        $property->setValue($this->subject, $memo);
+    }
+
+    /**
+     * Build a Client whose factory-installed middleware stack is intact, but
+     * the BOTTOM handler is replaced with a capturing stub — the same seam as
+     * in SecureHttpClientFactoryRebindingTest.
+     *
+     * @param array<string, mixed>|null $capturedOptions
+     *
+     * @param-out array<string, mixed>|null $capturedOptions
+     */
+    private function buildCapturingClient(?array &$capturedOptions): Client
+    {
+        $capturedOptions = null;
+
+        $client = $this->subject->create();
+        self::assertInstanceOf(Client::class, $client);
+        // The deprecated getConfig() seam is the suite's only in-process way
+        // to reach the handler stack — same usage as in
+        // SecureHttpClientFactoryRebindingTest (there via the baseline).
+        /** @phpstan-ignore method.deprecated */
+        $handler = $client->getConfig('handler');
+        if (!$handler instanceof HandlerStack) {
+            throw new TypeError('Factory must build a HandlerStack-backed client.', 7093840416);
+        }
+
+        $handler->setHandler(
+            static function (RequestInterface $request, array $options) use (&$capturedOptions): PromiseInterface {
+                $capturedOptions = $options;
+
+                return Create::promiseFor(new Response(200, [], ''));
+            },
+        );
+
+        return $client;
+    }
+}
+
+/**
+ * Test double returning a programmed SEQUENCE of answers per host — the
+ * rebinding scenarios need the second lookup to answer differently from the
+ * first, which `InMemoryDnsResolver`'s static programming cannot express.
+ * The last programmed answer repeats once the sequence is exhausted.
+ */
+final class SequencedDnsResolver implements DnsResolverInterface
+{
+    /** @var array<string, list<list<array{ip?: string, ipv6?: string}>>> */
+    private array $sequences = [];
+
+    /** @var array<string, int> */
+    private array $queries = [];
+
+    /**
+     * @param list<array{ip?: string, ipv6?: string}> ...$answers
+     */
+    public function answer(string $host, array ...$answers): void
+    {
+        $this->sequences[$host] = array_values($answers);
+    }
+
+    public function resolve(string $host): array
+    {
+        $index = $this->queries[$host] ?? 0;
+        $this->queries[$host] = $index + 1;
+
+        $sequence = $this->sequences[$host] ?? [];
+        if ($sequence === []) {
+            return [];
+        }
+
+        return $sequence[min($index, \count($sequence) - 1)];
+    }
+
+    public function queryCount(string $host): int
+    {
+        return $this->queries[$host] ?? 0;
+    }
+}

--- a/Tests/Unit/Http/VaultHttpClientCancellableTest.php
+++ b/Tests/Unit/Http/VaultHttpClientCancellableTest.php
@@ -1079,9 +1079,14 @@ final class VaultHttpClientCancellableTest extends TestCase
     #[Test]
     public function anSsrfRejectionSettlesBeforeTheFirstTickAndStillWritesItsRow(): void
     {
-        // The host answers a public address to the allowlist gate and a loopback
-        // address to the middleware a moment later — DNS rebinding, which is the
-        // attack the pin exists for. The middleware throws inside
+        // The host gives the allowlist gate no usable answer and the middleware
+        // a loopback one a moment later. (Until the DNS memo of #304 this
+        // scenario answered the gate with a PUBLIC address — but a non-empty
+        // gate answer is now memoised and reused by the middleware, whose
+        // re-check then pins the vetted address instead of rejecting; that
+        // behaviour has its own test in SecureHttpClientFactoryDnsMemoTest.
+        // A FAILED resolution is never memoised, so the middleware still
+        // resolves fresh here and still rejects.) The middleware throws inside
         // Client::transfer(), so sendAsync() returns an ALREADY-REJECTED promise
         // whose handler is merely QUEUED. Two things must hold and neither is
         // free: the loop must drain that queue before it ticks (there is no
@@ -1089,7 +1094,7 @@ final class VaultHttpClientCancellableTest extends TestCase
         // produce an audit row, because this is a call that was refused after
         // the credential had been injected.
         $this->dnsResolver->programSequence(self::API_HOST, [
-            [['ip' => self::PUBLIC_IP]],
+            [],
             [['ip' => '127.0.0.1']],
         ]);
 


### PR DESCRIPTION
## Summary

Every outbound request through `VaultHttpClient` resolved its host twice — once in the caller-side `isHostAllowed()` gate (`resolvesToDangerousIp()`) and again in the `ssrf-dns-pin` middleware — both synchronous `dns_get_record()` calls ahead of the socket, and part of the floor under the abort latency `sendCancellable()` can offer. A short-lived per-host memo (5 s TTL, 32-host cap) inside `SecureHttpClientFactory` lets the middleware reuse the gate's answer, so the common case pays one lookup.

The sharing follows the constraint #304 stated — establish which caller may share before writing the cache:

- **With ext-curl** (the pin path): every IP taken from a memoised answer is still range-checked in `buildResolveEntries()` and then pinned via `CURLOPT_RESOLVE`, so curl can only connect to addresses that were vetted. A rebind inside the TTL means the pin carries the checked address and the rebound answer is never fetched — the sharing changes WHEN the answer was resolved, never whether it is checked.
- **Without ext-curl**: there is no pin, the middleware's own resolve IS the rebind defence, and its value is being the freshest answer before the connect — that branch keeps resolving fresh, always.
- **Failed resolutions are never memoised**: negative caching would freeze a transient DNS failure for the TTL and blind the middleware's re-resolve where a fresh attempt might have succeeded. Every failure-path behaviour is byte-identical to the un-memoised code.

## Related Issues

Fixes #304

## Changes

- `Classes/Http/SecureHttpClientFactory.php` — `DNS_MEMO_TTL_SECONDS` / `DNS_MEMO_MAX_HOSTS`, the `$dnsMemo` property, `memoisedResolve()` / `freshResolve()`; `resolvesToDangerousIp()` and `buildResolveEntries()` route through them (the latter picking memo vs fresh per the curl condition above)
- `Tests/Unit/Http/SecureHttpClientFactoryDnsMemoTest.php` — six tests: the one-lookup collapse (gate→pin and gate→gate), a memoised dangerous answer still rejected on the send path, a rebind inside the TTL pinning the vetted address, TTL expiry re-resolving, failed resolutions not memoised
- `Tests/Unit/Http/VaultHttpClientCancellableTest.php` — one characterization test updated: `anSsrfRejectionSettlesBeforeTheFirstTickAndStillWritesItsRow()` built its synchronous middleware rejection from a gate-sees-public / middleware-sees-loopback rebind, which the memo now (by design) resolves to a pin instead of a rejection; the test keeps its actual subject (drain before the first tick + audit row) and triggers the same rejection through a failed gate resolution, which is never memoised. The old scenario's new behaviour is pinned by `aRebindInsideTheTtlConnectsToTheVettedAddressNotTheNewOne()`.
- `CHANGELOG.md` — entry under `### Changed`

## Checklist

- [x] Tests pass locally (`runTests.sh -s unit`: 3659 tests SUCCESS; `-s fuzz`: 1612 tests OK)
- [x] PHPStan passes (`Build/phpstan.no-plugins.neon` locally: "No errors"; the ergebnis ruleset only resolves on CI)
- [x] Code style is correct (`runTests.sh -s cgl`: SUCCESS)
- [x] Documentation updated — the security reasoning lives as comments at the two decision points (`buildResolveEntries()`, `memoisedResolve()`); no RST surface documents the resolve count
- [x] CHANGELOG.md updated

## Threat-Model Delta

- **Trust boundaries**: none — the memo lives inside `SecureHttpClientFactory` and holds resolver answers (host → IP list), never secrets; nothing new leaves the process.
- **Attacker capability**: none gained. On the pin path an attacker who rebinds inside the TTL gets the vetted address pinned, not the rebound one (`aRebindInsideTheTtlConnectsToTheVettedAddressNotTheNewOne`); a dangerous answer is rejected identically whether it comes from the memo or fresh (`aMemoisedAnswerIsStillCheckedBeforeThePin`). On the no-ext-curl path nothing changed — that branch never consumes the memo. What DID change: on the pin path the middleware no longer performs an independent second lookup, so a rebind inside the TTL is no longer *observed* there — it is *neutralised* by the pin instead of *detected* by a re-resolve. The one visible consequence is the updated characterization test.
- **Invariants**: adds "a memoised answer is checked exactly like a fresh one before any pin" (pinned by `aMemoisedAnswerIsStillCheckedBeforeThePin`) and "failed resolutions are never memoised" (pinned by `aFailedResolutionIsNotMemoised`). Removes no existing invariant: the no-pin rebind defence keeps its fresh resolve by construction.

## Test Plan

Guard seen to fail: reverting `buildResolveEntries()` to a direct `$this->dnsResolver->resolve($host)` turns `theGateAndThePinShareOneResolverAnswer` red on its query-count assertion ("The middleware must reuse the gate's answer, not resolve again") and the rebind test red; restoring the memo turns all six green. The ext-curl-less branch cannot be exercised in-process (`\function_exists('curl_init')` cannot be faked) — the same limitation the pin-attachment guard itself has; its reasoning lives in the inline comment.

## Review round

The independent review (Copilot quota exhausted; see the review-note comment) led to three changes in [4a7f870](https://github.com/netresearch/t3x-nr-vault/commit/4a7f8708): the memo-vs-fresh choice is decided **per transfer**, not per process — a `stream => true` request routes to the StreamHandler, which ignores the pin, so such a transfer always resolves fresh and carries no pin (test: `aStreamTransferNeverConsumesTheMemo`); the eviction logic is now covered by a cap test and an expired-prune test; and eviction uses `array_key_first()` + `unset` instead of `array_shift()`, which would renumber int-cast purely-numeric hostname keys.
