### PR TITLE
Cancel and audit the OAuth token round trip

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   inside `sendAsync()`, the caller's signal and the ticker can all throw, and
   none of them may be the one outbound call that leaves no trace.
 
+- **The OAuth token round trip is audited and cancellable** (#303). The
+  outbound POST that carries the `client_secret` used to leave no trace:
+  `VaultHttpClient` built its `OAuthTokenManager` without the audit service,
+  and the blocking token send ran before the cancellable transfer, out of the
+  signal's reach. Now every attempted round trip — completed, refused by the
+  `allowed_hosts` gate, failed in transport, or cancelled — writes exactly one
+  row under the new `oauth_token_request` action, carrying the endpoint, the
+  real HTTP status and a fixed literal (or redacted upstream message) naming
+  the outcome. The row is crash-safe like the manager's other audit writes: an
+  audit outage is reported loudly but never costs the caller a token the OAuth
+  server already issued.
+
+  On `sendCancellable()`, the signal now reaches the token leg exactly when
+  the call's own transfer runs cancellable: an already-cancelled call reads no
+  credential from the vault, a cancellation before the send never serialises
+  the `client_secret`, and an in-flight token POST is torn down through a
+  cancellable transport with the same hardening as the blocking client. On the
+  degraded blocking path the token leg blocks like everything else, so the two
+  legs never disagree on abortability. `getAccessToken()` gains an optional
+  trailing `$cancellationSignal` parameter; every existing call keeps
+  compiling.
+
 ### Changed
 
 - **One DNS lookup per outbound request instead of two** (#304). The

--- a/Classes/Audit/AuditAction.php
+++ b/Classes/Audit/AuditAction.php
@@ -79,6 +79,28 @@ enum AuditAction: string
     case MasterKeyRotateStart = 'master_key_rotate_start';
     case MasterKeyRotateEnd = 'master_key_rotate_end';
     case AuditChainRekey = 'audit_chain_rekey';
+    /**
+     * One OAuth token-endpoint round trip attempted by `OAuthTokenManager` —
+     * the outbound POST that carries the `client_secret` (issue #303).
+     *
+     * Written once per attempted round trip, success and failure alike, from
+     * the moment the credentials have been read from the vault: a completed
+     * fetch, a non-200 answer, a transport failure, the `allowed_hosts`
+     * rejection of the token endpoint, and a cancelled transfer each leave
+     * exactly one row. The row's context carries method, endpoint host/path
+     * and the HTTP status; which failure it was is a fixed literal (or the
+     * redacted upstream message) in `error_message`.
+     *
+     * Its own action rather than `http_call`: that action means "a caller's
+     * request through `VaultHttpClient`", and the token leg is an extra
+     * outbound call the manager makes on its own behalf — an auditor counting
+     * caller traffic must be able to exclude these rows by query, and one
+     * asking "when did the client credential go out?" must not have to parse
+     * messages. The `oauth_refresh_*` actions below record refresh-flow
+     * EVENTS (a rejected refresh token, the fallback, a failed store); this
+     * one records the round trip itself.
+     */
+    case OAuthTokenRequest = 'oauth_token_request';
     case OAuthRefreshFailed = 'oauth_refresh_failed';
     case OAuthFallbackClientCredentials = 'oauth_fallback_client_credentials';
     case OAuthRefreshStoreFailed = 'oauth_refresh_store_failed';

--- a/Classes/Http/CancellableHttpClientInterface.php
+++ b/Classes/Http/CancellableHttpClientInterface.php
@@ -55,9 +55,12 @@ use Psr\Http\Message\ResponseInterface;
  * not a caller's request and are not covered by the four: the `X-Vault-Token`
  * header in `TransitMasterKeyProvider::callTransit()`, on the plain Guzzle
  * client `MasterKeyProviderFactory` builds, and the `client_secret` form body
- * in `OAuthTokenManager::dispatchTokenRequest()`, which does apply the
- * `allowed_hosts` gate but writes no audit row. "No credential-bearing send
- * exists outside `VaultHttpClient`" would therefore be false; see ADR-037.
+ * in `OAuthTokenManager::dispatchTokenRequest()`, which applies the
+ * `allowed_hosts` gate and — since issue #303 — writes one
+ * `oauth_token_request` audit row per attempted round trip and honours this
+ * send's cancellation signal. "No credential-bearing send exists outside
+ * `VaultHttpClient`" would still be false (the transit leg remains); see
+ * ADR-037.
  *
  * The four are plain statements in the sending method, not middleware, so a
  * shape that handed a caller the promise for an authenticated send — or the

--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -13,16 +13,24 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Http\OAuth;
 
 use DateTimeImmutable;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
 use GuzzleHttp\Psr7\HttpFactory;
+use GuzzleHttp\RequestOptions;
 use JsonException;
+use Netresearch\NrVault\Audit\AuditAction;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\HttpCallContext;
 use Netresearch\NrVault\Exception\OAuthException;
+use Netresearch\NrVault\Exception\RequestCancelledException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
+use Netresearch\NrVault\Http\CancellableTransport;
+use Netresearch\NrVault\Http\CancellationSignalInterface;
 use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Service\VaultServiceInterface;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestFactoryInterface;
+use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\StreamFactoryInterface;
 use Psr\Log\LoggerInterface;
@@ -42,6 +50,55 @@ use Throwable;
 final class OAuthTokenManager
 {
     private const REDACT_REPLACEMENT = '$1[REDACTED]';
+
+    /**
+     * The `reason` on every `oauth_token_request` audit row. A fixed literal:
+     * the manager does not know the caller's reason, and the row records the
+     * manager's own outbound call, not the caller's.
+     */
+    private const TOKEN_REQUEST_REASON = 'OAuth2 token round trip';
+
+    /**
+     * Fixed literal for a token request cancelled before anything egressed —
+     * before the body carrying the credentials was even built. Fixed so the
+     * audit row and the exception a caller sees can never carry a credential.
+     */
+    private const TOKEN_CANCELLED_BEFORE_SEND_MESSAGE
+        = 'OAuth token request cancelled before send: nothing egressed';
+
+    /**
+     * Fixed literal for a token transfer aborted after it was handed to the
+     * transport: the `client_secret` must be treated as exposed.
+     */
+    private const TOKEN_CANCELLED_IN_FLIGHT_MESSAGE
+        = 'OAuth token request cancelled after send began: the client credential was handed to the transport';
+
+    /**
+     * Fixed literal for the tick loop's defensive wall-clock bound — a bug in
+     * the transport, not something a caller did. Mirrors
+     * `VaultHttpClient::TICK_BUDGET_EXHAUSTED_MESSAGE`.
+     */
+    private const TOKEN_TICK_BUDGET_EXHAUSTED_MESSAGE
+        = 'Cancellable OAuth token transfer exceeded its wall-clock budget and was aborted';
+
+    /**
+     * Fixed literal for a transport that settled with something that is not a
+     * PSR-7 response. Not reachable through any handler this package builds.
+     */
+    private const TOKEN_NON_RESPONSE_SETTLEMENT_MESSAGE
+        = 'Cancellable OAuth token transport settled with a value that is not an HTTP response';
+
+    /** Fixed literal for an async rejection reason that is not a throwable. */
+    private const TOKEN_TRANSFER_REJECTED_MESSAGE
+        = 'Cancellable OAuth token transfer was rejected';
+
+    /**
+     * Fixed literal for a throw the audit classification did not enumerate.
+     * Pre-set so an unexpected error can never be the one round trip missing
+     * from the log.
+     */
+    private const TOKEN_REQUEST_UNEXPECTED_MESSAGE
+        = 'OAuth token request aborted by an unexpected error';
 
     /**
      * Cached tokens indexed by config hash.
@@ -72,6 +129,13 @@ final class OAuthTokenManager
      *                                                         hostnames. Without this extra gate, an attacker-controlled
      *                                                         `tokenEndpoint` could reach any public host the IP guards consider
      *                                                         "safe" — defeating the allowlist on the OAuth leg only.
+     * @param CancellableTransport|null $cancellableTransport Explicit transport
+     *                                                        for a token request carrying a cancellation signal. Normally null:
+     *                                                        the transport is built on demand from `$secureHttpClientFactory`,
+     *                                                        so a manager whose callers never pass a signal pays nothing.
+     *                                                        `@internal` test seam, mirroring the parameter of the same name on
+     *                                                        `VaultHttpClient` — it is how the suite drives the token-leg tick
+     *                                                        loop deterministically. Trailing position preserves positional BC.
      */
     public function __construct(
         private readonly VaultServiceInterface $vaultService,
@@ -81,6 +145,7 @@ final class OAuthTokenManager
         ?RequestFactoryInterface $requestFactory = null,
         ?StreamFactoryInterface $streamFactory = null,
         private readonly ?AuditLogServiceInterface $auditLogService = null,
+        private readonly ?CancellableTransport $cancellableTransport = null,
     ) {
         $httpFactory = new HttpFactory();
         $this->requestFactory = $requestFactory ?? $httpFactory;
@@ -97,9 +162,25 @@ final class OAuthTokenManager
      *
      * Automatically refreshes the token if it's expired or about to expire.
      *
+     * @param CancellationSignalInterface|null $cancellationSignal When given,
+     *                                                             the token round trip honours it: an already-set signal aborts
+     *                                                             before any credential is read from the vault, and an in-flight
+     *                                                             token POST is torn down through a cancellable transport built by
+     *                                                             `SecureHttpClientFactory::createCancellable()` (issue #303).
+     *                                                             That transport carries the same hardening as the manager's own
+     *                                                             client but NOT a caller-supplied client's custom middleware —
+     *                                                             callers who handed this manager their own `$httpClient` and need
+     *                                                             its semantics must not pass a signal.
+     *                                                             `VaultHttpClient::sendCancellable()` passes its signal exactly
+     *                                                             when its own transfer runs cancellable, so the token leg and the
+     *                                                             API leg degrade together. A cached, still-valid token is returned
+     *                                                             without consulting the signal — it costs nothing and egresses
+     *                                                             nothing.
+     *
      * @throws OAuthException If token cannot be obtained
+     * @throws RequestCancelledException When the signal aborted the token round trip
      */
-    public function getAccessToken(OAuthConfig $config): string
+    public function getAccessToken(OAuthConfig $config, ?CancellationSignalInterface $cancellationSignal = null): string
     {
         $cacheKey = $this->getCacheKey($config);
 
@@ -115,8 +196,18 @@ final class OAuthTokenManager
             $this->logger?->debug('OAuth token expired or about to expire, refreshing');
         }
 
+        // Checked BEFORE the vault is read: an already-cancelled call must not
+        // retrieve the client credentials it will not use. No audit row here —
+        // the `oauth_token_request` row records round trips attempted with
+        // credentials in hand, and this abort never got that far. (On the
+        // `sendCancellable()` path the CALL's own row is still written by
+        // `VaultHttpClient::injectAuthenticationAudited()`.)
+        if ($cancellationSignal instanceof CancellationSignalInterface && $cancellationSignal->isCancelled()) {
+            throw new RequestCancelledException(self::TOKEN_CANCELLED_BEFORE_SEND_MESSAGE, 1786579301);
+        }
+
         // Fetch new token, with fallback to client_credentials on refresh failure.
-        $token = $this->fetchTokenWithFallback($config);
+        $token = $this->fetchTokenWithFallback($config, $cancellationSignal);
         $this->tokenCache[$cacheKey] = $token;
 
         return $token->accessToken;
@@ -169,14 +260,16 @@ final class OAuthTokenManager
      *
      * @throws OAuthException If both refresh and fallback fail
      */
-    private function fetchTokenWithFallback(OAuthConfig $config): OAuthToken
-    {
+    private function fetchTokenWithFallback(
+        OAuthConfig $config,
+        ?CancellationSignalInterface $cancellationSignal = null,
+    ): OAuthToken {
         if ($config->grantType !== 'refresh_token') {
-            return $this->fetchToken($config);
+            return $this->fetchToken($config, $cancellationSignal);
         }
 
         try {
-            return $this->fetchToken($config);
+            return $this->fetchToken($config, $cancellationSignal);
         } catch (OAuthException $e) {
             // Only fall back when the OAuth server specifically rejected
             // the refresh token. Everything else (5xx, 429, transport
@@ -216,7 +309,7 @@ final class OAuthTokenManager
                 additionalParams: $config->additionalParams,
             );
 
-            $token = $this->fetchToken($fallback);
+            $token = $this->fetchToken($fallback, $cancellationSignal);
 
             // Audit the successful fallback.
             $this->auditLogService?->log(
@@ -234,17 +327,36 @@ final class OAuthTokenManager
     /**
      * Fetch a new token from the OAuth server.
      *
+     * Every attempted round trip leaves exactly one `oauth_token_request`
+     * audit row (issue #303), written from the `finally` so no outcome can be
+     * the one missing from the log — the outbound POST here carries the
+     * `client_secret`, and until this row existed it left no trace at all.
+     * The row opens once the credentials have been read from the vault; the
+     * status is the endpoint's real answer where one arrived and `0` where
+     * nothing was received, and the message is a fixed literal (or the
+     * redacted upstream message) naming the failure. The vault's own rows
+     * about reading the credentials, and the `oauth_refresh_*` rows about the
+     * refresh flow, are unchanged — they answer different questions.
+     *
      * @throws OAuthException If token request fails
+     * @throws RequestCancelledException When the signal aborted the round trip
      */
-    private function fetchToken(OAuthConfig $config): OAuthToken
-    {
+    private function fetchToken(
+        OAuthConfig $config,
+        ?CancellationSignalInterface $cancellationSignal = null,
+    ): OAuthToken {
         // Build the request params VO (holds credentials/refresh_token from
         // vault). Plaintext is wiped via `wipeCredentials()` in the
         // `finally` block regardless of send success.
         $params = $this->buildTokenRequestParams($config);
 
+        $auditStatus = 0;
+        $auditSuccess = false;
+        $auditMessage = self::TOKEN_REQUEST_UNEXPECTED_MESSAGE;
+
         try {
-            $response = $this->dispatchTokenRequest($config, $params);
+            $response = $this->dispatchTokenRequest($config, $params, $cancellationSignal);
+            $auditStatus = $response->getStatusCode();
             $this->assertSuccessResponse($response);
             $body = $this->decodeTokenBody($response);
 
@@ -256,7 +368,25 @@ final class OAuthTokenManager
                 'token_type' => $token->tokenType,
             ]);
 
+            $auditSuccess = true;
+            $auditMessage = null;
+
             return $token;
+        } catch (RequestCancelledException $e) {
+            // Both cancellation literals are fixed constants of this class —
+            // safe on the row as-is, and they are what distinguishes "nothing
+            // egressed" from "the credential was handed to the transport".
+            $auditMessage = $e->getMessage();
+
+            throw $e;
+        } catch (OAuthException $e) {
+            // The host-gate rejection (nothing egressed), a non-200 answer
+            // (status recorded above), a missing access_token, the tick
+            // loop's wall-clock bound. Messages are built by this package;
+            // redaction is defence in depth.
+            $auditMessage = $this->redactCredentials($e->getMessage());
+
+            throw $e;
         } catch (ClientExceptionInterface $e) {
             $redacted = $this->redactCredentials($e->getMessage());
             $this->logger?->error('OAuth token request failed', [
@@ -264,13 +394,76 @@ final class OAuthTokenManager
                 'previous_class' => $e::class,
             ]);
 
+            $auditMessage = $redacted;
+
             throw OAuthException::requestFailed(
                 $redacted . \sprintf(' (caused by %s)', $e::class),
             );
         } catch (JsonException $e) {
+            // Fixed literal, not the JsonException message: the parser error
+            // quotes the response body, which nobody vetted for credentials.
+            $auditMessage = 'OAuth token response is not valid JSON';
+
             throw OAuthException::invalidJsonResponse($e);
+        } catch (Throwable $throwable) {
+            $auditMessage = self::TOKEN_REQUEST_UNEXPECTED_MESSAGE
+                . ': ' . $this->redactCredentials($throwable->getMessage());
+
+            throw $throwable;
         } finally {
             $params->wipeCredentials();
+            $this->auditTokenRoundTrip($config, $auditSuccess, $auditStatus, $auditMessage);
+        }
+    }
+
+    /**
+     * The one `oauth_token_request` row per attempted round trip.
+     *
+     * Written through the optional audit service: a manager constructed
+     * without one (a standalone consumer) keeps working, and the row's
+     * absence is that consumer's explicit choice. `VaultHttpClient` always
+     * passes its own audit service since issue #303.
+     */
+    private function auditTokenRoundTrip(
+        OAuthConfig $config,
+        bool $success,
+        int $statusCode,
+        ?string $errorMessage,
+    ): void {
+        if (!$this->auditLogService instanceof AuditLogServiceInterface) {
+            return;
+        }
+
+        try {
+            $this->auditLogService->log(
+                $config->clientIdSecret,
+                AuditAction::OAuthTokenRequest->value,
+                $success,
+                $errorMessage,
+                self::TOKEN_REQUEST_REASON,
+                null,
+                null,
+                HttpCallContext::fromRequest('POST', $config->tokenEndpoint, $statusCode),
+            );
+        } catch (Throwable $auditException) {
+            // Crash-safe like every other audit write in this class (see
+            // handleRefreshTokenStorageFailure(), and the test that pins the
+            // doctrine: getAccessTokenSurvivesAuditLogFailureDuringStorageFailure).
+            // The round trip already happened — a throw from the `finally`
+            // this is called from would cost the caller the token the OAuth
+            // server just issued, or mask the real failure, and un-send
+            // nothing. Fall back loudly instead.
+            try {
+                $this->logger?->error('OAuth token round trip could not be audited', [
+                    'token_endpoint' => $config->tokenEndpoint,
+                    'error' => $this->redactCredentials($auditException->getMessage()),
+                ]);
+            } catch (Throwable) {
+                error_log(
+                    'nr-vault: OAuth token round trip could not be audited: '
+                    . $this->redactCredentials($auditException->getMessage()),
+                );
+            }
         }
     }
 
@@ -324,8 +517,11 @@ final class OAuthTokenManager
      * exception propagates up and the outer finally wipes credentials
      * regardless.
      */
-    private function dispatchTokenRequest(OAuthConfig $config, OAuthTokenRequestParams $params): ResponseInterface
-    {
+    private function dispatchTokenRequest(
+        OAuthConfig $config,
+        OAuthTokenRequestParams $params,
+        ?CancellationSignalInterface $cancellationSignal = null,
+    ): ResponseInterface {
         // Gate the host BEFORE building the request body so the bearer
         // `client_secret` never gets serialised when the host is rejected
         // by the allowlist. The `$httpClient` middleware also rejects
@@ -344,6 +540,15 @@ final class OAuthTokenManager
             );
         }
 
+        // Checked BEFORE the body carrying the credentials is built: the
+        // credentials were already read from the vault (unavoidably — the
+        // pre-read check lives in getAccessToken()), but a cancelled call
+        // must not serialise or egress them. This also covers the degraded
+        // blocking send below.
+        if ($cancellationSignal instanceof CancellationSignalInterface && $cancellationSignal->isCancelled()) {
+            throw new RequestCancelledException(self::TOKEN_CANCELLED_BEFORE_SEND_MESSAGE, 1786579302);
+        }
+
         // `toHttpQuery()` builds a one-shot encoded body. Any throw from
         // the stream/request factories (or sendRequest) bubbles to the
         // outer `finally` in `fetchToken()` which calls
@@ -354,7 +559,121 @@ final class OAuthTokenManager
             ->withHeader('Accept', 'application/json')
             ->withBody($body);
 
+        if ($cancellationSignal instanceof CancellationSignalInterface) {
+            return $this->dispatchCancellable($request, $cancellationSignal);
+        }
+
         return $this->httpClient->sendRequest($request);
+    }
+
+    /**
+     * Send the token request through a cancellable transport, aborting when
+     * the signal says so (issue #303).
+     *
+     * The loop is the token-leg sibling of
+     * `VaultHttpClient::sendCancellably()` and follows the same mechanics for
+     * the same measured reasons documented there — `SYNCHRONOUS` deliberately
+     * absent (it would route back to the blocking handler whose cancel is a
+     * no-op), `ALLOW_REDIRECTS`/`HTTP_ERRORS` pinned per request, settlement
+     * observed through a `then()` handler rather than `getState()`, the
+     * global promise queue drained before the first tick and after every
+     * tick, and one teardown site: every abnormal exit cancels the promise,
+     * which is what closes the socket. It stays a private copy rather than a
+     * shared helper because the two callers classify outcomes differently —
+     * this one throws OAuth-flavoured exceptions and leaves the audit
+     * bookkeeping to `fetchToken()`'s wrapper, while `sendCancellably()`
+     * interleaves its own audit state with the loop.
+     *
+     * When no transport can be built (no `curl_multi_*` on this platform),
+     * the call degrades to the manager's blocking client — the same degraded
+     * mode `sendCancellable()` documents, and the pre-send signal check in
+     * `dispatchTokenRequest()` has already run.
+     *
+     * @throws RequestCancelledException When the signal aborted the transfer
+     * @throws OAuthException For the loop's own failure modes
+     * @throws ClientExceptionInterface When the transfer itself failed
+     */
+    private function dispatchCancellable(
+        RequestInterface $request,
+        CancellationSignalInterface $cancellationSignal,
+    ): ResponseInterface {
+        $transport = $this->cancellableTransport
+            ?? $this->secureHttpClientFactory->createCancellable();
+
+        if (!$transport instanceof CancellableTransport) {
+            return $this->httpClient->sendRequest($request);
+        }
+
+        $promise = null;
+
+        try {
+            $promise = $transport->client()->sendAsync($request, [
+                RequestOptions::ALLOW_REDIRECTS => false,
+                RequestOptions::HTTP_ERRORS => false,
+            ]);
+
+            $settled = false;
+            $rejected = false;
+            $settledValue = null;
+            $promise->then(
+                static function (mixed $value) use (&$settled, &$settledValue): void {
+                    $settled = true;
+                    $settledValue = $value;
+                },
+                static function (mixed $reason) use (&$settled, &$rejected, &$settledValue): void {
+                    $settled = true;
+                    $rejected = true;
+                    $settledValue = $reason;
+                },
+            );
+
+            $ticker = $transport->ticker();
+            $deadline = microtime(true) + $transport->wallClockBudgetSeconds();
+
+            // Drained before the first tick: an already-rejected promise (the
+            // SSRF middleware rejects synchronously) has its handler queued,
+            // not run inline.
+            PromiseUtils::queue()->run();
+
+            while (!$settled) {
+                if ($cancellationSignal->isCancelled()) {
+                    throw new RequestCancelledException(self::TOKEN_CANCELLED_IN_FLIGHT_MESSAGE, 1786579303);
+                }
+
+                if (microtime(true) >= $deadline) {
+                    throw new OAuthException(self::TOKEN_TICK_BUDGET_EXHAUSTED_MESSAGE, 1786579304);
+                }
+
+                $ticker->tick();
+                PromiseUtils::queue()->run();
+            }
+
+            if ($rejected) {
+                // A throwable reason (the SSRF middleware's RequestException,
+                // a connect failure) is rethrown as itself so fetchToken()'s
+                // ClientExceptionInterface handling treats it exactly like a
+                // blocking-path failure.
+                if ($settledValue instanceof Throwable) {
+                    throw $settledValue;
+                }
+
+                throw new OAuthException(self::TOKEN_TRANSFER_REJECTED_MESSAGE, 1786579305);
+            }
+
+            if (!$settledValue instanceof ResponseInterface) {
+                throw new OAuthException(self::TOKEN_NON_RESPONSE_SETTLEMENT_MESSAGE, 1786579306);
+            }
+
+            return $settledValue;
+        } catch (Throwable $throwable) {
+            // THE teardown: Promise::cancel() runs CurlMultiHandler's cancel
+            // function, which removes the easy handle and closes the socket.
+            // On a settled promise it returns immediately; null only when
+            // sendAsync() itself threw.
+            $promise?->cancel();
+
+            throw $throwable;
+        }
     }
 
     /**

--- a/Classes/Http/OAuth/OAuthTokenManager.php
+++ b/Classes/Http/OAuth/OAuthTokenManager.php
@@ -101,6 +101,33 @@ final class OAuthTokenManager
         = 'OAuth token request aborted by an unexpected error';
 
     /**
+     * The RFC 6749 §5.2 / RFC 6750 §3.1 error codes this class recognises.
+     *
+     * A whitelist rather than a passthrough on purpose: the `error` field is
+     * server-controlled free text, and since the `oauth_token_request` row
+     * exists it would travel — bounded only by pattern redaction — into the
+     * tamper-evident audit chain, where a row can never be deleted. A
+     * compromised endpoint echoing a bare credential in that field must not
+     * reach the chain. The only semantic consumer
+     * (`fetchTokenWithFallback()`) cares about `invalid_grant` /
+     * `invalid_token`; the rest exist so the exception message can still name
+     * a well-formed error. Anything outside the list collapses to null, which
+     * every consumer already handles.
+     */
+    private const KNOWN_OAUTH_ERROR_CODES = [
+        'invalid_request',
+        'invalid_client',
+        'invalid_grant',
+        'unauthorized_client',
+        'unsupported_grant_type',
+        'invalid_scope',
+        'invalid_token',
+        'insufficient_scope',
+        'server_error',
+        'temporarily_unavailable',
+    ];
+
+    /**
      * Cached tokens indexed by config hash.
      *
      * @var array<string, OAuthToken>
@@ -411,6 +438,12 @@ final class OAuthTokenManager
 
             throw $throwable;
         } finally {
+            // Wipe first (shortest plaintext residency during the DB write
+            // below), audit second. The row's unconditionality rests on
+            // wipeCredentials() never throwing — which its idempotence guard
+            // guarantees (OAuthTokenRequestParams wipes each buffer at most
+            // once); a throw here would both skip the row and mask the
+            // original exception.
             $params->wipeCredentials();
             $this->auditTokenRoundTrip($config, $auditSuccess, $auditStatus, $auditMessage);
         }
@@ -709,7 +742,12 @@ final class OAuthTokenManager
             return null;
         }
 
-        if (\is_array($errorBody) && isset($errorBody['error']) && \is_string($errorBody['error'])) {
+        if (
+            \is_array($errorBody)
+            && isset($errorBody['error'])
+            && \is_string($errorBody['error'])
+            && \in_array($errorBody['error'], self::KNOWN_OAUTH_ERROR_CODES, true)
+        ) {
             return $errorBody['error'];
         }
 

--- a/Classes/Http/VaultHttpClient.php
+++ b/Classes/Http/VaultHttpClient.php
@@ -309,11 +309,15 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface, Cancel
         // requests inherit the SSRF / DNS-rebinding / no-redirect defences.
         // The shared factory also lets the manager call `isHostAllowed()` on
         // the token endpoint — closes the allowed_hosts allowlist gap that
-        // the request-time middleware doesn't cover.
+        // the request-time middleware doesn't cover. The audit service is
+        // passed too (issue #303): the token round trip carries the
+        // `client_secret`, and a manager built without the service writes no
+        // `oauth_token_request` row for it.
         $this->oauthManager = $oauthManager ?? new OAuthTokenManager(
             $this->vaultService,
             $this->innerClient,
             $this->secureHttpClientFactory,
+            auditLogService: $this->auditLogService,
         );
     }
 
@@ -543,7 +547,17 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface, Cancel
         }
 
         $transport = $this->resolveCancellableTransportAudited($request, $secretForAudit);
-        $authenticatedRequest = $this->injectAuthenticationAudited($request, $secretForAudit);
+
+        // The signal reaches the OAuth token leg exactly when this call's own
+        // transfer runs cancellable (issue #303): with a transport in hand the
+        // token POST is torn down by the same signal, and on the degraded
+        // blocking path the token leg blocks like everything else — the two
+        // legs never disagree on whether the call is abortable.
+        $authenticatedRequest = $this->injectAuthenticationAudited(
+            $request,
+            $secretForAudit,
+            $transport instanceof CancellableTransport ? $signal : null,
+        );
 
         if (!$transport instanceof CancellableTransport) {
             // Degraded: this platform or this instance cannot tick a transport.
@@ -632,10 +646,13 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface, Cancel
      * The exception reaches the caller unchanged —
      * `VaultHttpClientTest::sendRequestRefusesAMissingSecretWithAnUnchangedException()`.
      */
-    private function injectAuthenticationAudited(RequestInterface $request, string $secretForAudit): RequestInterface
-    {
+    private function injectAuthenticationAudited(
+        RequestInterface $request,
+        string $secretForAudit,
+        ?CancellationSignalInterface $signal = null,
+    ): RequestInterface {
         try {
-            return $this->injectAuthentication($request);
+            return $this->injectAuthentication($request, $signal);
         } catch (Throwable $throwable) {
             $this->logHttpCall(
                 $secretForAudit,
@@ -1043,11 +1060,17 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface, Cancel
 
     /**
      * Inject authentication into the request based on configuration.
+     *
+     * `$signal` reaches only the OAuth leg: it is the one injection that
+     * performs its own outbound round trip (issue #303). Every other
+     * placement reads the vault locally and has nothing to abort.
      */
-    private function injectAuthentication(RequestInterface $request): RequestInterface
-    {
+    private function injectAuthentication(
+        RequestInterface $request,
+        ?CancellationSignalInterface $signal = null,
+    ): RequestInterface {
         if ($this->oauthConfig instanceof OAuthConfig) {
-            return $this->injectOAuth($request);
+            return $this->injectOAuth($request, $signal);
         }
 
         if ($this->secretIdentifier === null || !$this->placement instanceof SecretPlacement) {
@@ -1240,10 +1263,12 @@ final readonly class VaultHttpClient implements VaultHttpClientInterface, Cancel
         return $decoded;
     }
 
-    private function injectOAuth(RequestInterface $request): RequestInterface
-    {
+    private function injectOAuth(
+        RequestInterface $request,
+        ?CancellationSignalInterface $signal = null,
+    ): RequestInterface {
         \assert($this->oauthConfig instanceof OAuthConfig);
-        $accessToken = $this->oauthManager->getAccessToken($this->oauthConfig);
+        $accessToken = $this->oauthManager->getAccessToken($this->oauthConfig, $signal);
 
         try {
             return $request->withHeader('Authorization', 'Bearer ' . $accessToken);

--- a/Documentation/Developer/Api.rst
+++ b/Documentation/Developer/Api.rst
@@ -600,8 +600,10 @@ a configured clone, a PSR-7 response or a bool, and
 nr-vault sends two credentials of its own on paths that are not your request and
 do not carry all four: the ``X-Vault-Token`` header of the transit master-key
 provider, on a plain Guzzle client, and the ``client_secret`` of the OAuth token
-leg, which does apply the ``allowed_hosts`` gate but writes no audit row. They
-are listed in :ref:`adr-037-cancellable-outbound-send`.
+leg, which applies the ``allowed_hosts`` gate, writes one ``oauth_token_request``
+audit row per attempted round trip, and rides :php:`sendCancellable()`'s
+cancellation signal (issue #303). They are listed in
+:ref:`adr-037-cancellable-outbound-send`.
 
 Building a hardened transport *without* vault credentials remains a supported,
 public case: :php:`SecureHttpClientFactory::create()` and

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerCancellableTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerCancellableTest.php
@@ -1,0 +1,504 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Http\OAuth;
+
+use Closure;
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\RequestException;
+use GuzzleHttp\HandlerStack;
+use GuzzleHttp\Promise\Promise;
+use GuzzleHttp\Promise\PromiseInterface;
+use GuzzleHttp\Promise\Utils as PromiseUtils;
+use GuzzleHttp\Psr7\Request;
+use GuzzleHttp\Psr7\Response;
+use Netresearch\NrVault\Audit\AuditContextInterface;
+use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Exception\OAuthException;
+use Netresearch\NrVault\Exception\RequestCancelledException;
+use Netresearch\NrVault\Http\CancellableTransport;
+use Netresearch\NrVault\Http\CancellationSignalInterface;
+use Netresearch\NrVault\Http\DnsResolverInterface;
+use Netresearch\NrVault\Http\OAuth\OAuthConfig;
+use Netresearch\NrVault\Http\OAuth\OAuthTokenManager;
+use Netresearch\NrVault\Http\SecureHttpClientFactory;
+use Netresearch\NrVault\Http\TransportTickerInterface;
+use Netresearch\NrVault\Service\VaultServiceInterface;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use Psr\Http\Client\ClientInterface;
+use Psr\Http\Message\RequestInterface;
+
+/**
+ * The cancellable OAuth token round trip (issue #303).
+ *
+ * Mirrors the determinism rules of `VaultHttpClientCancellableTest`: no
+ * sockets, no sleeps — the transport's bottom handler is a stub whose promise
+ * nobody settles, and the ticker is a closure that settles it on the Nth call.
+ * The literals asserted below are copied from `OAuthTokenManager` rather than
+ * read from it, so a change to the subject is a change to a test.
+ *
+ * Not covered here, by the same in-process limitation the other cancellable
+ * suite documents: the degraded branch where `createCancellable()` returns
+ * null (no `curl_multi_*` on the platform) — `\function_exists()` cannot be
+ * faked, and the branch is a two-line fallback to the blocking client.
+ */
+#[CoversClass(OAuthTokenManager::class)]
+final class OAuthTokenManagerCancellableTest extends TestCase
+{
+    private const TOKEN_ENDPOINT = 'https://auth.example.com/token';
+
+    private const CLIENT_ID_SECRET = 'oauth/client-id';
+
+    private const CLIENT_SECRET_SECRET = 'oauth/client-secret';
+
+    /** Copied from OAuthTokenManager — see the class docblock above. */
+    private const CANCELLED_BEFORE_SEND_MESSAGE
+        = 'OAuth token request cancelled before send: nothing egressed';
+
+    private const CANCELLED_IN_FLIGHT_MESSAGE
+        = 'OAuth token request cancelled after send began: the client credential was handed to the transport';
+
+    private const TICK_BUDGET_EXHAUSTED_MESSAGE
+        = 'Cancellable OAuth token transfer exceeded its wall-clock budget and was aborted';
+
+    private VaultServiceInterface&MockObject $vaultService;
+
+    private ClientInterface&MockObject $blockingClient;
+
+    private mixed $originalGlobals;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->vaultService = $this->createMock(VaultServiceInterface::class);
+        $this->blockingClient = $this->createMock(ClientInterface::class);
+
+        $this->originalGlobals = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $GLOBALS['TYPO3_CONF_VARS'] = ['HTTP' => []];
+    }
+
+    protected function tearDown(): void
+    {
+        if ($this->originalGlobals === null) {
+            unset($GLOBALS['TYPO3_CONF_VARS']);
+        } else {
+            $GLOBALS['TYPO3_CONF_VARS'] = $this->originalGlobals;
+        }
+
+        parent::tearDown();
+    }
+
+    #[Test]
+    public function aCompletedCancellableTokenFetchReturnsTheTokenAndAuditsSuccess(): void
+    {
+        $this->programCredentialReads();
+
+        $transfer = new TokenTransfer();
+        $ticker = new TokenLoopTicker(static function (int $tick) use ($transfer): void {
+            if ($tick >= 1) {
+                $transfer->settleWith(self::tokenResponse('cancellable-access-token'));
+            }
+        });
+
+        $rows = [];
+        $subject = $this->managerWith($transfer, $ticker, $rows);
+
+        // The blocking client must not serve a signalled call — that it is
+        // never consulted IS the proof the signal routed the send through the
+        // cancellable transport.
+        $this->blockingClient->expects(self::never())->method('sendRequest');
+
+        $token = $subject->getAccessToken($this->config(), new TokenNeverCancelledSignal());
+
+        self::assertSame('cancellable-access-token', $token);
+        self::assertTrue($transfer->wasReached());
+        self::assertSame(0, $transfer->cancelCalls(), 'A completed transfer needs no teardown.');
+        self::assertSame(0, $transfer->waitCalls(), 'The loop must never wait() the promise settled.');
+        self::assertCount(1, $rows);
+        [, $action, $success] = $rows[0];
+        self::assertSame('oauth_token_request', $action);
+        self::assertTrue($success);
+    }
+
+    #[Test]
+    public function anInFlightCancellationAbortsTheTokenTransferAndAuditsIt(): void
+    {
+        $this->programCredentialReads();
+
+        $transfer = new TokenTransfer();
+        // Never settles: the only way out of the loop is the signal.
+        $ticker = new TokenLoopTicker(static function (): void {});
+
+        $rows = [];
+        $subject = $this->managerWith($transfer, $ticker, $rows);
+
+        // Question 1: the pre-read check in getAccessToken(). Question 2: the
+        // pre-send check in dispatchTokenRequest(). Question 3: the loop's
+        // first pass. Three falses put the abort on the loop's second pass —
+        // after the transfer was handed to the transport.
+        try {
+            $subject->getAccessToken($this->config(), new TokenCountdownSignal(3));
+            self::fail('Expected the in-flight cancellation to throw.');
+        } catch (RequestCancelledException $e) {
+            self::assertSame(self::CANCELLED_IN_FLIGHT_MESSAGE, $e->getMessage());
+            self::assertSame(1786579303, $e->getCode());
+        }
+
+        self::assertTrue($transfer->wasReached());
+        self::assertSame(1, $transfer->cancelCalls(), 'The abort must tear the transfer down exactly once.');
+        self::assertCount(1, $rows);
+        [, $action, $success, $error] = $rows[0];
+        self::assertSame('oauth_token_request', $action);
+        self::assertFalse($success);
+        self::assertSame(self::CANCELLED_IN_FLIGHT_MESSAGE, $error);
+    }
+
+    #[Test]
+    public function aPreSendCancellationReadsCredentialsButEgressesNothing(): void
+    {
+        $this->programCredentialReads();
+
+        $transfer = new TokenTransfer();
+        $rows = [];
+        $subject = $this->managerWith($transfer, new TokenLoopTicker(static function (): void {}), $rows);
+
+        $this->blockingClient->expects(self::never())->method('sendRequest');
+
+        // Question 1 (pre-read): false. Question 2 (pre-send): true.
+        try {
+            $subject->getAccessToken($this->config(), new TokenCountdownSignal(1));
+            self::fail('Expected the pre-send cancellation to throw.');
+        } catch (RequestCancelledException $e) {
+            self::assertSame(self::CANCELLED_BEFORE_SEND_MESSAGE, $e->getMessage());
+            self::assertSame(1786579302, $e->getCode());
+        }
+
+        self::assertFalse($transfer->wasReached(), 'Nothing may reach the transport.');
+        self::assertCount(1, $rows, 'The credentials were read, so the round trip leaves its row.');
+        [, $action, $success, $error] = $rows[0];
+        self::assertSame('oauth_token_request', $action);
+        self::assertFalse($success);
+        self::assertSame(self::CANCELLED_BEFORE_SEND_MESSAGE, $error);
+    }
+
+    #[Test]
+    public function anAlreadyCancelledCallReadsNoSecretAndLeavesNoRow(): void
+    {
+        $this->vaultService->expects(self::never())->method('retrieve');
+
+        $transfer = new TokenTransfer();
+        $rows = [];
+        $subject = $this->managerWith($transfer, new TokenLoopTicker(static function (): void {}), $rows);
+
+        try {
+            $subject->getAccessToken($this->config(), new TokenAlreadyCancelledSignal());
+            self::fail('Expected the pre-read cancellation to throw.');
+        } catch (RequestCancelledException $e) {
+            self::assertSame(self::CANCELLED_BEFORE_SEND_MESSAGE, $e->getMessage());
+            self::assertSame(1786579301, $e->getCode());
+        }
+
+        self::assertFalse($transfer->wasReached());
+        self::assertSame([], $rows, 'No credentials in hand, no round trip, no row.');
+    }
+
+    #[Test]
+    public function anExhaustedWallClockBudgetIsAFailureNotACancellation(): void
+    {
+        $this->programCredentialReads();
+
+        $transfer = new TokenTransfer();
+        $rows = [];
+        // Budget zero: the deadline has passed on the loop's first check.
+        $subject = $this->managerWith(
+            $transfer,
+            new TokenLoopTicker(static function (): void {}),
+            $rows,
+            wallClockBudgetSeconds: 0.0,
+        );
+
+        try {
+            $subject->getAccessToken($this->config(), new TokenNeverCancelledSignal());
+            self::fail('Expected the wall-clock bound to throw.');
+        } catch (OAuthException $e) {
+            self::assertSame(self::TICK_BUDGET_EXHAUSTED_MESSAGE, $e->getMessage());
+            self::assertSame(1786579304, $e->getCode());
+        }
+
+        self::assertSame(1, $transfer->cancelCalls(), 'The bound must still tear the transfer down.');
+        self::assertCount(1, $rows);
+        [, $action, $success, $error] = $rows[0];
+        self::assertSame('oauth_token_request', $action);
+        self::assertFalse($success);
+        self::assertSame(self::TICK_BUDGET_EXHAUSTED_MESSAGE, $error);
+    }
+
+    #[Test]
+    public function aRejectedTransferSurfacesLikeABlockingFailureWithRedaction(): void
+    {
+        $this->programCredentialReads();
+
+        $transfer = new TokenTransfer();
+        $ticker = new TokenLoopTicker(static function (int $tick) use ($transfer): void {
+            if ($tick >= 1) {
+                $transfer->rejectWith(new RequestException(
+                    'cURL error 7 while sending client_secret=super-secret-value',
+                    $transfer->request() ?? new Request('POST', self::TOKEN_ENDPOINT),
+                ));
+            }
+        });
+
+        $rows = [];
+        $subject = $this->managerWith($transfer, $ticker, $rows);
+
+        try {
+            $subject->getAccessToken($this->config(), new TokenNeverCancelledSignal());
+            self::fail('Expected the rejected transfer to throw.');
+        } catch (OAuthException $e) {
+            self::assertStringContainsString('[REDACTED]', $e->getMessage());
+            self::assertStringNotContainsString('super-secret-value', $e->getMessage());
+        }
+
+        self::assertCount(1, $rows);
+        [, $action, $success, $error] = $rows[0];
+        self::assertSame('oauth_token_request', $action);
+        self::assertFalse($success);
+        self::assertIsString($error);
+        self::assertStringContainsString('[REDACTED]', $error);
+        self::assertStringNotContainsString('super-secret-value', $error);
+    }
+
+    // =========================================================================
+    // Harness
+    // =========================================================================
+
+    private function config(): OAuthConfig
+    {
+        return OAuthConfig::clientCredentials(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+        );
+    }
+
+    private function programCredentialReads(): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(fn (string $id): ?string => match ($id) {
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
+                default => null,
+            });
+    }
+
+    /**
+     * A manager whose injected cancellable transport bottoms out in
+     * `$transfer` and whose audit rows are captured into `$rows` as
+     * `[identifier, action, success, error]`.
+     *
+     * @param list<array{0: string, 1: string, 2: bool, 3: ?string}> $rows
+     *
+     * @param-out list<array{0: string, 1: string, 2: bool, 3: ?string}> $rows
+     */
+    private function managerWith(
+        TokenTransfer $transfer,
+        TokenLoopTicker $ticker,
+        array &$rows,
+        float $wallClockBudgetSeconds = 45.0,
+    ): OAuthTokenManager {
+        $rows = [];
+        $auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $auditLogService
+            ->method('log')
+            ->willReturnCallback(
+                static function (
+                    string $identifier,
+                    string $action,
+                    bool $success,
+                    ?string $error = null,
+                    ?string $reason = null,
+                    ?string $hashBefore = null,
+                    ?string $hashAfter = null,
+                    ?AuditContextInterface $context = null,
+                ) use (&$rows): void {
+                    $rows[] = [$identifier, $action, $success, $error];
+                },
+            );
+
+        $transport = new CancellableTransport(
+            new Client(['handler' => HandlerStack::create($transfer->handler())]),
+            $ticker,
+            $wallClockBudgetSeconds,
+        );
+
+        return new OAuthTokenManager(
+            $this->vaultService,
+            $this->blockingClient,
+            new SecureHttpClientFactory(new AlwaysEmptyDnsResolver()),
+            null,
+            null,
+            null,
+            $auditLogService,
+            $transport,
+        );
+    }
+
+    private static function tokenResponse(string $accessToken): Response
+    {
+        return new Response(200, ['Content-Type' => 'application/json'], json_encode([
+            'access_token' => $accessToken,
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+        ], JSON_THROW_ON_ERROR));
+    }
+}
+
+/**
+ * Deterministic stand-in for DNS during the host gate: every host resolves to
+ * nothing, which the gate treats as "let the client surface the connection
+ * error" — no network, no real resolver.
+ */
+final class AlwaysEmptyDnsResolver implements DnsResolverInterface
+{
+    public function resolve(string $host): array
+    {
+        return [];
+    }
+}
+
+/**
+ * The bottom handler of the token transport under test — the token-leg
+ * sibling of `StubbedTransfer` in `VaultHttpClientCancellableTest`. Returns a
+ * promise that never settles on its own; the ticker settles it, or the loop
+ * cancels it.
+ */
+final class TokenTransfer
+{
+    private ?RequestInterface $request = null;
+
+    private ?Promise $promise = null;
+
+    private int $transferCount = 0;
+
+    private int $cancelCalls = 0;
+
+    private int $waitCalls = 0;
+
+    /**
+     * @return Closure(RequestInterface, array<int|string, mixed>): PromiseInterface
+     */
+    public function handler(): Closure
+    {
+        return function (RequestInterface $request, array $options): PromiseInterface {
+            $this->request = $request;
+            ++$this->transferCount;
+
+            $promise = new Promise(
+                function (): void {
+                    ++$this->waitCalls;
+                },
+                function (): void {
+                    ++$this->cancelCalls;
+                },
+            );
+            $this->promise = $promise;
+
+            return $promise;
+        };
+    }
+
+    public function settleWith(Response $response): void
+    {
+        $this->promise?->resolve($response);
+        PromiseUtils::queue()->run();
+    }
+
+    public function rejectWith(mixed $reason): void
+    {
+        $this->promise?->reject($reason);
+        PromiseUtils::queue()->run();
+    }
+
+    public function request(): ?RequestInterface
+    {
+        return $this->request;
+    }
+
+    public function wasReached(): bool
+    {
+        return $this->transferCount > 0;
+    }
+
+    public function cancelCalls(): int
+    {
+        return $this->cancelCalls;
+    }
+
+    public function waitCalls(): int
+    {
+        return $this->waitCalls;
+    }
+}
+
+/**
+ * Drives the token-leg loop from a closure instead of a curl multi handle.
+ */
+final class TokenLoopTicker implements TransportTickerInterface
+{
+    private int $ticks = 0;
+
+    /**
+     * @param Closure(int): void $onTick Receives the 1-based tick number
+     */
+    public function __construct(private readonly Closure $onTick) {}
+
+    public function tick(): void
+    {
+        ++$this->ticks;
+        ($this->onTick)($this->ticks);
+    }
+}
+
+/**
+ * False for the first `$falseAnswers` questions, true from then on.
+ */
+final class TokenCountdownSignal implements CancellationSignalInterface
+{
+    private int $asked = 0;
+
+    public function __construct(private readonly int $falseAnswers) {}
+
+    public function isCancelled(): bool
+    {
+        ++$this->asked;
+
+        return $this->asked > $this->falseAnswers;
+    }
+}
+
+final class TokenNeverCancelledSignal implements CancellationSignalInterface
+{
+    public function isCancelled(): bool
+    {
+        return false;
+    }
+}
+
+final class TokenAlreadyCancelledSignal implements CancellationSignalInterface
+{
+    public function isCancelled(): bool
+    {
+        return true;
+    }
+}

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerCancellableTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerCancellableTest.php
@@ -244,6 +244,49 @@ final class OAuthTokenManagerCancellableTest extends TestCase
     }
 
     #[Test]
+    public function aCancelledRefreshNeverFallsBackToClientCredentials(): void
+    {
+        // Cancellation must end the whole fetch, not read as "the refresh
+        // token was rejected": the fallback catch is typed OAuthException,
+        // and RequestCancelledException is its sibling under VaultException.
+        // One round trip, one row, no oauth_refresh_failed and no
+        // oauth_fallback_client_credentials.
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(fn (string $id): ?string => match ($id) {
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
+                'oauth/refresh-token' => 'old-refresh-token',
+                default => null,
+            });
+
+        $transfer = new TokenTransfer();
+        $rows = [];
+        $subject = $this->managerWith($transfer, new TokenLoopTicker(static function (): void {}), $rows);
+
+        $config = OAuthConfig::refreshToken(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            refreshTokenSecret: 'oauth/refresh-token',
+        );
+
+        try {
+            $subject->getAccessToken($config, new TokenCountdownSignal(3));
+            self::fail('Expected the in-flight cancellation to throw.');
+        } catch (RequestCancelledException $e) {
+            self::assertSame(1786579303, $e->getCode());
+        }
+
+        self::assertSame(1, $transfer->cancelCalls());
+        self::assertCount(1, $rows, 'Exactly one round trip was attempted — the fallback leg must not run.');
+        self::assertSame('oauth_token_request', $rows[0][1]);
+        $actions = array_column($rows, 1);
+        self::assertNotContains('oauth_refresh_failed', $actions);
+        self::assertNotContains('oauth_fallback_client_credentials', $actions);
+    }
+
+    #[Test]
     public function aRejectedTransferSurfacesLikeABlockingFailureWithRedaction(): void
     {
         $this->programCredentialReads();

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 namespace Netresearch\NrVault\Tests\Unit\Http\OAuth;
 
 use ArgumentCountError;
+use Netresearch\NrVault\Audit\AuditContextInterface;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\HttpCallContext;
 use Netresearch\NrVault\Exception\OAuthException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Http\OAuth\OAuthConfig;
@@ -1067,9 +1069,13 @@ final class OAuthTokenManagerTest extends TestCase
         // mimicking a full DB outage. The caller must still receive the
         // just-obtained access_token; neither secondary failure may
         // propagate.
+        // Two writes reach the audit service on this path — the
+        // `oauth_refresh_store_failed` row and the `oauth_token_request`
+        // round-trip row (issue #303) — and BOTH throw here. Neither may
+        // propagate.
         $auditLogService = $this->createMock(AuditLogServiceInterface::class);
         $auditLogService
-            ->expects(self::once())
+            ->expects(self::exactly(2))
             ->method('log')
             ->willThrowException(new RuntimeException('audit log also down'));
 
@@ -1117,6 +1123,184 @@ final class OAuthTokenManagerTest extends TestCase
         $token = $subject->getAccessToken($config);
 
         self::assertSame('new-access-token', $token);
+    }
+
+    // =========================================================================
+    // The oauth_token_request audit row — one per attempted round trip (#303)
+    // =========================================================================
+
+    #[Test]
+    public function aSuccessfulTokenRoundTripLeavesAnAuditRow(): void
+    {
+        $rows = [];
+        $subject = $this->managerAuditingInto($rows);
+
+        $config = OAuthConfig::clientCredentials(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+        );
+        $this->programCredentialReads();
+
+        $this->httpClient
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn($this->createSuccessfulTokenResponse([
+                'access_token' => 'new-access-token',
+                'token_type' => 'Bearer',
+                'expires_in' => 3600,
+            ]));
+
+        $subject->getAccessToken($config);
+
+        self::assertCount(1, $rows, 'Exactly one row per round trip.');
+        [$identifier, $action, $success, $error, $reason, $context] = $rows[0];
+        self::assertSame(self::CLIENT_ID_SECRET, $identifier);
+        self::assertSame('oauth_token_request', $action);
+        self::assertTrue($success);
+        self::assertNull($error);
+        self::assertSame('OAuth2 token round trip', $reason);
+        self::assertInstanceOf(HttpCallContext::class, $context);
+        self::assertSame('POST', $context->method);
+        self::assertSame('auth.example.com', $context->host);
+        self::assertSame(200, $context->statusCode);
+    }
+
+    #[Test]
+    public function aNon200AnswerLeavesAFailureRowCarryingTheRealStatus(): void
+    {
+        $rows = [];
+        $subject = $this->managerAuditingInto($rows);
+
+        $config = OAuthConfig::clientCredentials(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+        );
+        $this->programCredentialReads();
+
+        $errorResponse = $this->createMock(ResponseInterface::class);
+        $errorResponse->method('getStatusCode')->willReturn(401);
+        $errorBody = $this->createMock(StreamInterface::class);
+        $errorBody->method('__toString')->willReturn('{"error":"invalid_client"}');
+        $errorResponse->method('getBody')->willReturn($errorBody);
+        $this->httpClient->method('sendRequest')->willReturn($errorResponse);
+
+        try {
+            $subject->getAccessToken($config);
+            self::fail('Expected the non-200 answer to throw.');
+        } catch (OAuthException) {
+            // The exception itself is pinned elsewhere; the row is under test.
+        }
+
+        self::assertCount(1, $rows);
+        [, $action, $success, $error, , $context] = $rows[0];
+        self::assertSame('oauth_token_request', $action);
+        self::assertFalse($success);
+        self::assertIsString($error);
+        self::assertStringContainsString('401', $error);
+        self::assertInstanceOf(HttpCallContext::class, $context);
+        self::assertSame(401, $context->statusCode, 'The row must carry the endpoint\'s real answer, not 0.');
+    }
+
+    #[Test]
+    public function aTransportFailureLeavesAFailureRowWithStatusZero(): void
+    {
+        $rows = [];
+        $subject = $this->managerAuditingInto($rows);
+
+        $config = OAuthConfig::clientCredentials(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+        );
+        $this->programCredentialReads();
+
+        $this->httpClient
+            ->method('sendRequest')
+            ->willThrowException(
+                new class ('Connection refused for client_secret=super-secret-value') extends RuntimeException implements ClientExceptionInterface {},
+            );
+
+        try {
+            $subject->getAccessToken($config);
+            self::fail('Expected the transport failure to throw.');
+        } catch (OAuthException) {
+        }
+
+        self::assertCount(1, $rows);
+        [, $action, $success, $error, , $context] = $rows[0];
+        self::assertSame('oauth_token_request', $action);
+        self::assertFalse($success);
+        self::assertIsString($error);
+        self::assertStringContainsString('[REDACTED]', $error, 'The upstream message travels redacted.');
+        self::assertStringNotContainsString('super-secret-value', $error);
+        self::assertInstanceOf(HttpCallContext::class, $context);
+        self::assertSame(0, $context->statusCode);
+    }
+
+    #[Test]
+    public function aRejectedTokenEndpointHostLeavesARowBeforeAnythingEgressed(): void
+    {
+        $originalGlobals = $GLOBALS['TYPO3_CONF_VARS'] ?? null;
+        $GLOBALS['TYPO3_CONF_VARS'] = ['HTTP' => ['allowed_hosts' => ['api.partner.example']]];
+
+        try {
+            $rows = [];
+            $subject = $this->managerAuditingInto($rows);
+
+            $config = OAuthConfig::clientCredentials(
+                tokenEndpoint: self::TOKEN_ENDPOINT,
+                clientIdSecret: self::CLIENT_ID_SECRET,
+                clientSecretSecret: self::CLIENT_SECRET_SECRET,
+            );
+            $this->programCredentialReads();
+
+            $this->httpClient->expects(self::never())->method('sendRequest');
+
+            try {
+                $subject->getAccessToken($config);
+                self::fail('Expected the allowlist gate to refuse the token endpoint.');
+            } catch (OAuthException $e) {
+                self::assertStringContainsString('not in the allowed hosts list', $e->getMessage());
+            }
+
+            self::assertCount(1, $rows, 'The refused round trip is exactly the attempt an operator goes looking for.');
+            [, $action, $success, $error] = $rows[0];
+            self::assertSame('oauth_token_request', $action);
+            self::assertFalse($success);
+            self::assertIsString($error);
+            self::assertStringContainsString('not in the allowed hosts list', $error);
+        } finally {
+            if ($originalGlobals !== null) {
+                $GLOBALS['TYPO3_CONF_VARS'] = $originalGlobals;
+            } else {
+                unset($GLOBALS['TYPO3_CONF_VARS']);
+            }
+        }
+    }
+
+    #[Test]
+    public function aCredentialThatCannotBeReadLeavesNoRoundTripRow(): void
+    {
+        // The row records round trips attempted with credentials in hand; a
+        // failed vault read never got that far, and the vault writes its own
+        // rows about the read. (On the VaultHttpClient path the CALL's row is
+        // still written by injectAuthenticationAudited().)
+        $auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $auditLogService->expects(self::never())->method('log');
+        $subject = $this->managerWith($auditLogService);
+
+        $config = OAuthConfig::clientCredentials(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+        );
+
+        $this->vaultService->method('retrieve')->willReturn(null);
+
+        $this->expectException(SecretNotFoundException::class);
+        $subject->getAccessToken($config);
     }
 
     #[Test]
@@ -1372,6 +1556,62 @@ final class OAuthTokenManagerTest extends TestCase
             'rejected client_secret "topSecr3t"',
             'rejected client_secret "[REDACTED]"',
         ];
+    }
+
+    /**
+     * A manager whose audit writes are captured into `$rows` as
+     * `[identifier, action, success, error, reason, context]`.
+     *
+     * @param list<array{0: string, 1: string, 2: bool, 3: ?string, 4: ?string, 5: ?AuditContextInterface}> $rows
+     *
+     * @param-out list<array{0: string, 1: string, 2: bool, 3: ?string, 4: ?string, 5: ?AuditContextInterface}> $rows
+     */
+    private function managerAuditingInto(array &$rows): OAuthTokenManager
+    {
+        $rows = [];
+        $auditLogService = $this->createMock(AuditLogServiceInterface::class);
+        $auditLogService
+            ->method('log')
+            ->willReturnCallback(
+                static function (
+                    string $identifier,
+                    string $action,
+                    bool $success,
+                    ?string $error = null,
+                    ?string $reason = null,
+                    ?string $hashBefore = null,
+                    ?string $hashAfter = null,
+                    ?AuditContextInterface $context = null,
+                ) use (&$rows): void {
+                    $rows[] = [$identifier, $action, $success, $error, $reason, $context];
+                },
+            );
+
+        return $this->managerWith($auditLogService);
+    }
+
+    private function managerWith(AuditLogServiceInterface $auditLogService): OAuthTokenManager
+    {
+        return new OAuthTokenManager(
+            $this->vaultService,
+            $this->httpClient,
+            new SecureHttpClientFactory(),
+            $this->logger,
+            $this->requestFactory,
+            $this->streamFactory,
+            $auditLogService,
+        );
+    }
+
+    private function programCredentialReads(): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(fn (string $id): ?string => match ($id) {
+                self::CLIENT_ID_SECRET => 'my-client-id',
+                self::CLIENT_SECRET_SECRET => 'my-client-secret',
+                default => null,
+            });
     }
 
     /**

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -1200,7 +1200,7 @@ final class OAuthTokenManagerTest extends TestCase
         self::assertIsString($error);
         self::assertStringContainsString('401', $error);
         self::assertInstanceOf(HttpCallContext::class, $context);
-        self::assertSame(401, $context->statusCode, 'The row must carry the endpoint\'s real answer, not 0.');
+        self::assertSame(401, $context->statusCode, "The row must carry the endpoint's real answer, not 0.");
     }
 
     #[Test]

--- a/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenManagerTest.php
@@ -1204,6 +1204,44 @@ final class OAuthTokenManagerTest extends TestCase
     }
 
     #[Test]
+    public function anUnknownErrorCodeFromTheEndpointNeverReachesTheRowOrTheException(): void
+    {
+        // The `error` field is server-controlled free text. A compromised
+        // endpoint echoing a credential there must not reach the
+        // tamper-evident audit chain, where a row can never be deleted —
+        // only RFC 6749/6750 error codes pass the whitelist.
+        $rows = [];
+        $subject = $this->managerAuditingInto($rows);
+
+        $config = OAuthConfig::clientCredentials(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: self::CLIENT_ID_SECRET,
+            clientSecretSecret: self::CLIENT_SECRET_SECRET,
+        );
+        $this->programCredentialReads();
+
+        $errorResponse = $this->createMock(ResponseInterface::class);
+        $errorResponse->method('getStatusCode')->willReturn(400);
+        $errorBody = $this->createMock(StreamInterface::class);
+        $errorBody->method('__toString')->willReturn('{"error":"echoed-bare-credential-value"}');
+        $errorResponse->method('getBody')->willReturn($errorBody);
+        $this->httpClient->method('sendRequest')->willReturn($errorResponse);
+
+        try {
+            $subject->getAccessToken($config);
+            self::fail('Expected the non-200 answer to throw.');
+        } catch (OAuthException $e) {
+            self::assertNull($e->oauthError, 'An unlisted error code must collapse to null.');
+            self::assertStringNotContainsString('echoed-bare-credential-value', $e->getMessage());
+        }
+
+        self::assertCount(1, $rows);
+        [, , , $error] = $rows[0];
+        self::assertIsString($error);
+        self::assertStringNotContainsString('echoed-bare-credential-value', $error, 'The echoed value must not reach the audit chain.');
+    }
+
+    #[Test]
     public function aTransportFailureLeavesAFailureRowWithStatusZero(): void
     {
         $rows = [];

--- a/Tests/Unit/Http/VaultHttpClientCancellableTest.php
+++ b/Tests/Unit/Http/VaultHttpClientCancellableTest.php
@@ -31,6 +31,8 @@ use Netresearch\NrVault\Http\CancellableHttpClientInterface;
 use Netresearch\NrVault\Http\CancellableTransport;
 use Netresearch\NrVault\Http\CancellationSignalInterface;
 use Netresearch\NrVault\Http\DnsResolverInterface;
+use Netresearch\NrVault\Http\OAuth\OAuthConfig;
+use Netresearch\NrVault\Http\OAuth\OAuthTokenManager;
 use Netresearch\NrVault\Http\SecretPlacement;
 use Netresearch\NrVault\Http\SecureHttpClientFactory;
 use Netresearch\NrVault\Http\TransportTickerInterface;
@@ -1346,6 +1348,167 @@ final class VaultHttpClientCancellableTest extends TestCase
             [['http_call', false, self::TRANSPORT_RESOLUTION_FAILED_MESSAGE . ': ' . $thrown]],
             $auditedRows,
             'A call whose transport could not be built still gets exactly one row.',
+        );
+    }
+
+    // =========================================================================
+    // 16 — the OAuth token leg rides the same signal (issue #303)
+    // =========================================================================
+
+    #[Test]
+    public function theSignalRoutesTheOAuthTokenLegThroughACancellableTransport(): void
+    {
+        // Credentials for the token leg: the manager reads client id + secret.
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(static fn (string $id): ?string => match ($id) {
+                'oauth/cid' => 'client-id-value',
+                'oauth/csec' => 'client-secret-value',
+                default => null,
+            });
+
+        // The manager's own cancellable transport: the token POST settles with
+        // a token on the first tick of ITS ticker.
+        $tokenTransfer = new StubbedTransfer();
+        $tokenTicker = new ClosureTicker(static function (int $tick) use ($tokenTransfer): void {
+            if ($tick >= 1) {
+                $tokenTransfer->settleWith(new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
+                    'access_token' => 'token-from-cancellable-leg',
+                    'token_type' => 'Bearer',
+                    'expires_in' => 3600,
+                ])));
+            }
+        });
+        $tokenTransport = new CancellableTransport(
+            new Client(['handler' => HandlerStack::create($tokenTransfer->handler())]),
+            $tokenTicker,
+            45.0,
+        );
+
+        // The manager's BLOCKING client must not serve a signalled call: that
+        // it stays untouched is the proof the signal reached the token leg.
+        $tokenBlockingClient = $this->createMock(ClientInterface::class);
+        $tokenBlockingClient->expects(self::never())->method('sendRequest');
+
+        $manager = new OAuthTokenManager(
+            $this->vaultService,
+            $tokenBlockingClient,
+            $this->clientFactory,
+            auditLogService: $this->auditLogService,
+            cancellableTransport: $tokenTransport,
+        );
+
+        // The API transfer settles on the first tick of its own ticker.
+        $apiTransfer = new StubbedTransfer();
+        $apiTicker = new ClosureTicker(static function (int $tick) use ($apiTransfer): void {
+            if ($tick >= 1) {
+                $apiTransfer->settleWith(new Response(200, [], 'api-payload'));
+            }
+        });
+        $apiTransport = $this->transportWith($apiTransfer, $apiTicker);
+
+        $rows = [];
+        $this->auditLogService
+            ->method('log')
+            ->willReturnCallback(
+                static function (
+                    string $identifier,
+                    string $action,
+                    bool $success,
+                ) use (&$rows): void {
+                    $rows[] = [$action, $success];
+                },
+            );
+
+        $client = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            oauthConfig: OAuthConfig::clientCredentials(
+                tokenEndpoint: 'https://auth.example.com/token',
+                clientIdSecret: 'oauth/cid',
+                clientSecretSecret: 'oauth/csec',
+            ),
+            oauthManager: $manager,
+            secureHttpClientFactory: $this->clientFactory,
+            cancellableTransport: $apiTransport,
+        );
+
+        $response = $client->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertTrue($tokenTransfer->wasReached(), 'The token POST must ride the cancellable transport when a signal is in play.');
+        self::assertTrue($apiTransfer->wasReached());
+        self::assertSame(
+            [['oauth_token_request', true], ['http_call', true]],
+            $rows,
+            'The token leg and the call each leave their own row, in send order.',
+        );
+    }
+
+    #[Test]
+    public function theOAuthTokenLegStaysBlockingWhenTheCallItselfIsDegraded(): void
+    {
+        // A caller-supplied inner client degrades the whole call to blocking —
+        // and the token leg with it: the signal is deliberately NOT passed to
+        // the manager, so the two legs cannot disagree on abortability.
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(static fn (string $id): ?string => match ($id) {
+                'oauth/cid' => 'client-id-value',
+                'oauth/csec' => 'client-secret-value',
+                default => null,
+            });
+
+        $tokenTransfer = new StubbedTransfer();
+        $tokenTransport = new CancellableTransport(
+            new Client(['handler' => HandlerStack::create($tokenTransfer->handler())]),
+            new ClosureTicker(static function (): void {}),
+            45.0,
+        );
+
+        $tokenBlockingClient = $this->createMock(ClientInterface::class);
+        $tokenBlockingClient
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn(new Response(200, ['Content-Type' => 'application/json'], (string) json_encode([
+                'access_token' => 'token-from-blocking-leg',
+                'token_type' => 'Bearer',
+                'expires_in' => 3600,
+            ])));
+
+        $manager = new OAuthTokenManager(
+            $this->vaultService,
+            $tokenBlockingClient,
+            $this->clientFactory,
+            auditLogService: $this->auditLogService,
+            cancellableTransport: $tokenTransport,
+        );
+
+        $callerSuppliedClient = $this->createMock(ClientInterface::class);
+        $callerSuppliedClient
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturn(new Response(200, [], 'api-payload'));
+
+        $client = new VaultHttpClient(
+            vaultService: $this->vaultService,
+            auditLogService: $this->auditLogService,
+            innerClient: $callerSuppliedClient,
+            oauthConfig: OAuthConfig::clientCredentials(
+                tokenEndpoint: 'https://auth.example.com/token',
+                clientIdSecret: 'oauth/cid',
+                clientSecretSecret: 'oauth/csec',
+            ),
+            oauthManager: $manager,
+            secureHttpClientFactory: $this->clientFactory,
+        );
+
+        $response = $client->sendCancellable(new Request('GET', self::API_URL), new NeverCancelledSignal());
+
+        self::assertSame(200, $response->getStatusCode());
+        self::assertFalse(
+            $tokenTransfer->wasReached(),
+            'A degraded call must not route its token leg through a cancellable transport the API leg does not have.',
         );
     }
 


### PR DESCRIPTION
## Summary

The outbound POST that carries the `client_secret` left no trace and could not be aborted: `VaultHttpClient` built its `OAuthTokenManager` with 3 of 7 constructor arguments, leaving `$auditLogService` null, and the blocking token send ran before the cancellable transfer, out of the signal's reach. Deferred from #302 / ADR-037, which named both halves.

**Audit half.** `VaultHttpClient` now passes its audit service into the manager, and the manager writes exactly one row per attempted round trip under the new `oauth_token_request` action, from a `finally` that opens once the credentials have been read from the vault. A completed fetch, a non-200 answer (the endpoint's real status lands on the row), a transport failure, the `allowed_hosts` rejection of the token endpoint, and a cancelled transfer each leave their row; the message is a fixed literal or the redacted upstream message. Its own action rather than `http_call` so an auditor counting caller traffic can exclude the manager's own calls by query — the `oauth_refresh_*` actions record refresh-flow events, this one records the round trip itself. The write is crash-safe like the manager's other audit writes (pinned by the pre-existing `getAccessTokenSurvivesAuditLogFailureDuringStorageFailure`, updated to cover both throwing writes): an audit outage is reported loudly but never costs the caller a token the OAuth server already issued.

**Cancellation half.** `getAccessToken()` gains an optional trailing `$cancellationSignal` parameter (additive; every existing call keeps compiling), threaded from `sendCancellable()` exactly when the call's own transfer runs cancellable — with a caller-supplied inner client the whole call degrades to blocking, token leg included, so the two legs never disagree on abortability. An already-cancelled call reads no credential from the vault; a cancellation between the vault read and the send never serialises the `client_secret`; an in-flight token POST runs on a cancellable transport from `SecureHttpClientFactory::createCancellable()` and is torn down through its promise's cancel function. The tick loop is the token-leg sibling of `sendCancellably()` and follows its documented mechanics (no `SYNCHRONOUS`, pinned `ALLOW_REDIRECTS`/`HTTP_ERRORS`, settlement via `then()`, queue drained before the first tick, one teardown site); it stays a private copy rather than a shared helper because the two callers classify outcomes differently — extracting a common driver would mean restructuring the freshly reviewed `sendCancellably()` for symmetry alone.

## Related Issues

Fixes #303

## Changes

- `Classes/Http/OAuth/OAuthTokenManager.php` — the `oauth_token_request` row (crash-safe), the signal parameter with pre-read and pre-send checks, the cancellable dispatch with tick loop, `@internal` `$cancellableTransport` test seam (trailing, positional BC preserved)
- `Classes/Http/VaultHttpClient.php` — audit service wired into the constructed manager; signal threaded through `injectAuthenticationAudited()` → `injectAuthentication()` → `injectOAuth()` (all private), passed exactly when a cancellable transport was resolved
- `Classes/Audit/AuditAction.php` — new case `OAuthTokenRequest = 'oauth_token_request'` (additive; historical rows unaffected, filter dropdown and label derive automatically, badge falls to the same grey default as the other `oauth_*` actions)
- `Classes/Http/CancellableHttpClientInterface.php`, `Documentation/Developer/Api.rst` — the "writes no audit row" claims about the token leg were true when written and are now updated; ADR-037's "Where the guarantee stops" section is left as the historical record, with #303's closure visible on the linked issue
- Tests: 5 audit-row tests in `OAuthTokenManagerTest`, 6 in the new `OAuthTokenManagerCancellableTest` (self-contained stub transfer/ticker/signals mirroring the `VaultHttpClientCancellableTest` determinism rules), 2 threading tests in `VaultHttpClientCancellableTest` (signal routes the token leg through the cancellable transport; a degraded call keeps the token leg blocking)
- `CHANGELOG.md` — entry under `### Added`

## Checklist

- [x] Tests pass locally (`runTests.sh -s unit`: 3666 tests SUCCESS; `-s fuzz`: 1612 tests OK)
- [x] PHPStan passes (`Build/phpstan.no-plugins.neon` locally: "No errors"; the ergebnis ruleset only resolves on CI)
- [x] Code style is correct (`runTests.sh -s cgl`: SUCCESS)
- [x] Documentation updated (`Api.rst`, interface docblock)
- [x] CHANGELOG.md updated

## Threat-Model Delta

- **Trust boundaries**: none new — the token POST goes to the same operator-configured `tokenEndpoint` as before, through the same `allowed_hosts` gate and (cancellable path) a factory-built transport carrying the same SSRF/DNS-pin hardening as the blocking client. The new audit rows put the endpoint host/path and status into the audit log; the row never carries a credential (fixed literals, `redactCredentials()` on upstream messages, defence-in-depth before `AuditLogService::sanitizeErrorMessage()`).
- **Attacker capability**: none gained. No comparison, grant or zeroisation changed; `wipeCredentials()` still runs in the same `finally`. One nuance made explicit: when a signal is passed, the token request is sent through a factory-built cancellable transport instead of the injected `$httpClient` — for `VaultHttpClient` both are factory-built (the signal is only threaded when the instance is), and a standalone consumer who hands the manager a custom client is told on the parameter not to pass a signal if they need that client's semantics.
- **Invariants**: adds "every attempted token round trip leaves exactly one `oauth_token_request` row" (pinned by the five audit tests plus the cancellable suite's row assertions), "a cancelled token call never reads a credential it will not use / never serialises one it will not send" (`anAlreadyCancelledCallReadsNoSecretAndLeavesNoRow`, `aPreSendCancellationReadsCredentialsButEgressesNothing`), and "the token leg is abortable exactly when the API leg is" (`theSignalRoutesTheOAuthTokenLegThroughACancellableTransport`, `theOAuthTokenLegStaysBlockingWhenTheCallItselfIsDegraded`). Removes none: blocking-path behaviour without a signal is byte-identical, and the crash-safety invariant of the manager's audit writes now covers the new row too.

## Test Plan

Guard seen to fail: reverting the conditional signal pass in `sendCancellable()` to a hard `null` turns `theSignalRoutesTheOAuthTokenLegThroughACancellableTransport` red — the token POST falls back to the blocking client its mock forbids (`expects(never())` violated) — and restoring it turns the test green again (1 test, 10 assertions OK).

Not covered in-process, as in the existing cancellable suite: the degraded branch where `createCancellable()` returns null (no `curl_multi_*`) — `\function_exists()` cannot be faked; the branch is a two-line fallback to the blocking client, and the pre-send signal check runs before it.

Note for whichever of this and #319 merges second: the api-surface snapshot freezes `AuditAction` (new enum case) — an additive diff, resolved by regenerating `Tests/Unit/Api/api-surface.txt` on rebase.

## Review round

The independent review (Copilot quota exhausted; see the review-note comment) verified every premise of this description against the code and led to the changes in [455ffae](https://github.com/netresearch/t3x-nr-vault/commit/455ffae7) (now [38315dd](https://github.com/netresearch/t3x-nr-vault/commit/38315dd) after the rebase onto #320): the RFC 6749 `error` field is whitelisted against the known error codes before it can reach the tamper-evident audit chain — a compromised endpoint echoing a bare credential there now collapses to null (test: `anUnknownErrorCodeFromTheEndpointNeverReachesTheRowOrTheException`); a test pins that a cancelled refresh never triggers the `client_credentials` fallback; and a comment makes visible that the audit row's unconditionality rests on `wipeCredentials()` never throwing.
