### PR TITLE
Record the worktree test-environment gotchas AGENTS.md was missing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,7 @@
 | Lint (syntax) | `make lint` | `php -l` across sources |
 | CS check | `make cgl` | php-cs-fixer --dry-run |
 | CS fix | `make fix` | alias of `make cgl-fix` |
-| PHPStan | `make phpstan` | Static analysis. In a fresh git worktree use `.Build/bin/phpstan analyse --configuration=Build/phpstan.no-plugins.neon` (the plugin config errors before `.Build/vendor` is populated) |
+| PHPStan | `make phpstan` | Static analysis. Locally use `.Build/bin/phpstan analyse --configuration=Build/phpstan.no-plugins.neon` — the plugin config dies on `Unexpected item 'parameters › ergebnis'` even with a fully populated `.Build`, because the ergebnis ruleset resolves only through the shared typo3-ci-workflows config on CI |
 | Rector (dry-run) | `make rector` | |
 | Unit tests | `make test-unit` | `composer ci:test:php:unit` |
 | Functional tests | `make test-functional` | `composer ci:test:php:functional` |
@@ -99,6 +99,9 @@ Build/           → phpunit.xml, FunctionalTests.xml
 - **Cross-worktree Rector/fixer runs produce false positives**: `main`'s `.Build/bin/rector` resolves classes via main's autoloader, not the branch's — signature changes misfire `RemoveExtraParametersRector`, and rules needing a new interface method fire only in CI. Judge each finding: real, or cross-worktree artifact?
 - **`RemoveDefaultArgumentValueRector` strips load-bearing trailing args** that equal the default (`verifyHashChain(null, null, 0)` → `verifyHashChain()`); keep them with a named argument (`verifyHashChain(minEpoch: 0)`), which the rule leaves alone.
 - **Opengrep vs Rector on `unlink`**: Rector's first-class-callable rewrite turns cleanup loops into `array_map(unlink(...), …)`, which Opengrep flags. Sidestep both — use `GeneralUtility::rmdir($path, true)` for tempdir cleanup.
+- **A `.Build` copied from a sibling worktree can predate a dev dependency**: the unit suite then dies with `Interface "TYPO3\CMS\Dashboard\Widgets\…" not found`-style errors that look like code breakage. Run `./Build/Scripts/runTests.sh -s composerUpdate` in the new worktree before trusting any red. (Observed: a copied `.Build` lacked `typo3/cms-dashboard`; 12 widget tests errored on pristine `main`.)
+- **CaptainHook cannot install its hooks in a git worktree** — composer install ends with `CaptainHook could not install yer git hooks! (invalid .git path)`. Harmless for the containerized test runner, but it means NO pre-commit/commit-msg checks run locally in that worktree: the subject-style and cgl gates you rely on elsewhere are silently absent, so run the checks by hand before pushing.
+- **`make ci` does not include Rector** (cgl + phpstan + unit + fuzz only), and CI's Rector dry-run is a required gate. `SimplifyQuoteEscapeRector` flags every `\'` escape in a single-quoted string — an assertion message with an apostrophe costs a full CI round trip. When adding or editing PHP files, run `make rector` before pushing. (Cost two round trips in one day, 2026-08-18.)
 
 ## Audit log invariants
 


### PR DESCRIPTION
## Summary

Four traps from the #303–#306 sweep (2026-08-18), each of which cost a diagnosis or a CI round trip and none of which AGENTS.md named:

- A `.Build` copied from a sibling worktree can predate a dev dependency — the unit suite then errors with "Interface … not found" on pristine `main` (observed: missing `typo3/cms-dashboard`, 12 widget tests red). New gotcha: run `runTests.sh -s composerUpdate` before trusting any red in a fresh worktree.
- CaptainHook cannot install its hooks in a git worktree ("invalid .git path") — harmless for the containerized runner, but the local pre-commit/commit-msg gates are silently absent there. New gotcha.
- The Commands table's phpstan row claimed the plugin config only errors "before `.Build/vendor` is populated" — it dies on `Unexpected item 'parameters › ergebnis'` even with a fully populated `.Build`, because the ergebnis ruleset resolves only through the shared typo3-ci-workflows config on CI. Row corrected.
- `make ci` carries no Rector while CI's Rector dry-run is a required gate; `SimplifyQuoteEscapeRector` flags every `\'` in a single-quoted string, which cost two CI round trips in one day. New gotcha: `make rector` before pushing when PHP files were added or edited.

## Related Issues

Follow-up hygiene from the #303–#306 sweep; no issue.

## Checklist

- [x] Tests pass locally — not applicable (docs-only)
- [x] PHPStan passes — not applicable (docs-only)
- [x] Code style is correct — not applicable (docs-only)
- [x] Documentation updated (this PR)
- [x] CHANGELOG.md updated — not applicable (agent instructions, not user-facing change)