### PR TITLE
fix: make SecretMetadata::fromArray() honour the contract its docblock states

### DIFF
--- a/Classes/Domain/Dto/SecretMetadata.php
+++ b/Classes/Domain/Dto/SecretMetadata.php
@@ -51,7 +51,12 @@ readonly class SecretMetadata
             createdAt: $row['crdate'] ?? 0,
             updatedAt: $row['tstamp'] ?? 0,
             readCount: $row['read_count'] ?? 0,
-            lastReadAt: $row['last_read_at'] ?? null,
+            // The column is NOT NULL DEFAULT 0, so a real database row carries 0
+            // for "never read" and the coalesce above it never fires. Every
+            // consumer of $lastReadAt guards with `!== null`, so passing the 0
+            // through renders 1970-01-01 -- the same defect #313 fixed in
+            // VaultService::list(), at the factory this docblock points at.
+            lastReadAt: ($row['last_read_at'] ?? 0) === 0 ? null : $row['last_read_at'],
             description: $row['description'] ?? '',
             version: $row['version'] ?? 1,
             metadata: $row['metadata'] ?? [],

--- a/Tests/Unit/Domain/Dto/SecretMetadataTest.php
+++ b/Tests/Unit/Domain/Dto/SecretMetadataTest.php
@@ -168,6 +168,25 @@ final class SecretMetadataTest extends TestCase
         self::assertTrue(SecretMetadata::fromArray(['identifier' => 'live-key', 'hidden' => 0])->enabled);
     }
 
+    /**
+     * The docblock promises a database row, and `last_read_at` is
+     * NOT NULL DEFAULT 0 there -- so 0, not null, is what a secret nobody has
+     * read carries. Every consumer of $lastReadAt guards with `!== null`, so a
+     * 0 arriving here renders as 1970-01-01 on a screen about stale
+     * credentials. Same defect as #313, one construction site further in.
+     */
+    #[Test]
+    public function fromArrayReportsANeverReadSecretAsNullRatherThanTheEpoch(): void
+    {
+        $never = SecretMetadata::fromArray(['identifier' => 'never-read', 'last_read_at' => 0]);
+        $read = SecretMetadata::fromArray(['identifier' => 'has-been-read', 'last_read_at' => 1_700_000_000]);
+        $absent = SecretMetadata::fromArray(['identifier' => 'column-absent']);
+
+        self::assertNull($never->lastReadAt, 'a 0 from the database means never read');
+        self::assertSame(1_700_000_000, $read->lastReadAt, 'a real timestamp survives untouched');
+        self::assertNull($absent->lastReadAt, 'a missing column still means never read');
+    }
+
     #[Test]
     public function roundTripFromArrayToArray(): void
     {


### PR DESCRIPTION
Closes #317, but not the way that issue proposed — and the issue is wrong in two places, corrected there.

## What #317 got wrong

It named the method `SecretMetadata::fromDatabaseRow()`. There is no such method; it is `fromArray()`. I never verified the name and inferred it from the surrounding code, then searched the organisation for `SecretMetadata::fromDatabaseRow` and reported "zero callers anywhere". That search could not have matched anything.

It also proposed deleting the method as dead. The question asked in review — *was the purpose lost, or just never finished?* — turns out to be the right one, and the answer is the second.

## What the history says

`daee25b` (4 January) introduced the DTO "to replace array returns from `VaultServiceInterface::list()`". `toArray()` is the serialisation half and **is** used: `VaultListCommand:109` maps each `SecretMetadata` through it for JSON output. `fromArray()` is the mirror half, and its docblock states the contract explicitly:

```php
/**
 * Create from database row array.
 * @param array{... last_read_at?: int|null ...} $row
 */
```

Nothing calls it today because `VaultService::list()` builds the DTO from `Secret` entities rather than raw rows. So it is an unfinished half of a live pair, not a dead end — and deleting it would remove one side of a documented round trip that is part of the API surface.

## The defect

`last_read_at` is `NOT NULL DEFAULT 0`. A real database row therefore carries `0` for a secret nobody has read, `?? null` never fires, and the DTO receives `0`. Every consumer of `$lastReadAt` guards with `!== null` — the module listing, both CLI listings, the delete command — so all of them would render `1970-01-01` on a screen whose subject is stale credentials. It is the same defect #313 fixed in `VaultService::list()`, at the factory the docblock points at.

Fed its own `toArray()` output the round trip already worked, because that side emits `null`. It is the *database row* case — the one the docblock actually promises — that was broken.

## Verification

```
runTests.sh -s unit -p 8.4     → 3688 tests, 13216 assertions, no failures
runTests.sh -s cgl -p 8.4      → SUCCESS
phpstan Build/phpstan.no-plugins.neon → No errors
```

**The guard was seen to fail.** With the normalisation reverted:

```
a 0 from the database means never read
Failed asserting that 0 is null.
```

The test also covers the absent-column case and asserts a real timestamp passes through untouched.

One note on the environment rather than the change: the first run in this worktree failed with `Interface "TYPO3\CMS\Dashboard\Widgets\NumberWithIconDataProviderInterface" not found` from a `.Build` copied out of another checkout. `-s composerUpdate` resolved it properly and the figures above are from that tree. That step exits non-zero here while writing a correct `vendor/` — the dashboard package is present and the suite is green — so the exit code is from something after the resolve, not the resolve.
