### PR TITLE
Document vault:store --as-provisioner and let CI run the repo checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ jobs:
       php-versions: '["8.2","8.3","8.4","8.5"]'
       typo3-versions: '["^13.4","^14.3"]'
       run-functional-tests: true
+      # Repo-specific checks (composer ci:test:repo: arch + doc-cli + its
+      # self-test). All three are static file scans needing no dependency
+      # tree, which is the shared job's contract — without this input they
+      # ran only when someone invoked the full gate set by hand, which is
+      # how the vault:store doc drift went unnoticed (#308).
+      run-repo-checks: true
       upload-coverage: true
       upload-test-results: true
       coverage-tool: 'xdebug'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,10 +22,11 @@ jobs:
       typo3-versions: '["^13.4","^14.3"]'
       run-functional-tests: true
       # Repo-specific checks (composer ci:test:repo: arch + doc-cli + its
-      # self-test). All three are static file scans needing no dependency
-      # tree, which is the shared job's contract — without this input they
-      # ran only when someone invoked the full gate set by hand, which is
-      # how the vault:store doc drift went unnoticed (#308).
+      # self-test + the evidence-collector self-test). All four are static
+      # file scans needing no dependency tree, which is the shared job's
+      # contract — without this input they ran only when someone invoked
+      # the full gate set by hand, which is how the vault:store doc drift
+      # went unnoticed (#308).
       run-repo-checks: true
       upload-coverage: true
       upload-test-results: true

--- a/Documentation/Developer/Commands.rst
+++ b/Documentation/Developer/Commands.rst
@@ -102,6 +102,15 @@ Options
    ``--groups="1,2"`` is *not* split: it is read as a single non-numeric value
    and becomes group 0.
 
+--as-provisioner
+   Write as the configured provisioning backend user instead of the
+   unattributed CLI actor, so the stored secret is owned and audited under a
+   real account.
+   The user comes from the ``provisioningBeUserUid`` extension setting —
+   never from this command line — and its group must carry the
+   ``tx_nrvault:secret.create`` permission option.
+   The command aborts before storing anything when the setting is unset.
+
 .. _command-store-example:
 
 Example

--- a/composer.json
+++ b/composer.json
@@ -99,6 +99,11 @@
         ],
         "ci:audit": "@composer audit --locked --format=plain --abandoned=fail",
         "ci:evidence": "@php Build/Scripts/collect-evidence.php",
+        "ci:test:repo": [
+            "@ci:test:php:arch",
+            "@ci:test:php:doc-cli",
+            "@ci:test:php:doc-cli:self-test"
+        ],
         "ci:test:evidence": "@php Build/Scripts/collect-evidence.php --self-test",
         "ci:test:php:arch": "@php Tests/scripts/check-test-base-class.php",
         "ci:test:php:doc-cli": "@php Tests/scripts/check-cli-docs.php",

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,8 @@
         "ci:test:repo": [
             "@ci:test:php:arch",
             "@ci:test:php:doc-cli",
-            "@ci:test:php:doc-cli:self-test"
+            "@ci:test:php:doc-cli:self-test",
+            "@ci:test:evidence"
         ],
         "ci:test:evidence": "@php Build/Scripts/collect-evidence.php --self-test",
         "ci:test:php:arch": "@php Tests/scripts/check-test-base-class.php",


### PR DESCRIPTION
## Summary

Two findings, one cause (#308). `--as-provisioner` existed on `vault:store` since 1b120f3 but `Commands.rst` never documented it — and nothing could have noticed, because the doc-cli drift check (like the arch check) ran only inside the hand-invoked `composer ci` aggregate: the shared CI workflow runs its repo-checks job only when `run-repo-checks` is passed, and this repo neither passed it nor named its checks `ci:test:repo`.

The option is now documented against the command's actual behaviour (the uid comes from the `provisioningBeUserUid` extension setting, never the command line; the command aborts before storing anything when the setting is unset — verified in `VaultStoreCommand`). The new `ci:test:repo` composer script bundles arch + doc-cli + the doc-cli self-test + the evidence-collector self-test (`ci:test:evidence`, which sat in the same never-run-by-CI position — review finding, second commit); all four are static file scans needing no dependency tree, which is the shared repo-checks job's stated contract (it deliberately skips `composer install`). `ci.yml` passes `run-repo-checks: true`, so the next drift fails the PR that causes it instead of waiting for someone to run the full gate set by hand.

## Related Issues

Fixes #308

## Checklist

- [x] Tests pass locally — `composer ci:test:repo`: arch 0 violations, doc-cli exit 0 ("206 documented vault:* example(s) and 66 documented option(s) match"), doc-cli self-test 16/16, evidence self-checks OK
- [x] PHPStan — not applicable (no PHP changes)
- [x] Code style — not applicable (RST + JSON + YAML); `actionlint` clean, zizmor findings unchanged before/after (the one HIGH is the `@main` netresearch reusable, mandated by the workflows AGENTS.md)
- [x] Documentation updated (this PR)
- [x] CHANGELOG.md — not applicable per repo convention for docs/CI wiring; say if it should carry an entry anyway

## Test Plan

`composer ci:test:php:doc-cli` failed on pristine `main` with exactly the drift the issue quotes, and exits 0 after the doc addition — the checker itself is the guard, and it was seen failing before the fix. CI's new repo-checks job runs the same four commands on every PR from now on; the shared job's no-install contract was verified empirically (`composer ci:test:repo` exits 0 on a copy with `.git`, `.Build` and `vendor` deleted).