### PR TITLE
docs(agents): sync AGENTS.md files and adopt agent-harness verification

### DIFF
--- a/.ddev/AGENTS.md
+++ b/.ddev/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Managed by agent: keep sections and order; edit content, not structure -->
-<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
 
 # AGENTS.md — .ddev
 
@@ -33,9 +33,8 @@ Invoke skill **`typo3-ddev`** for setup and multi-version testing patterns.
 ## Build/Tests
 | Task | Command |
 |------|---------|
-| Run unit tests in container | `ddev composer ci:test:php:unit` |
-| Run functional tests in container | `ddev composer ci:test:php:functional` |
-| Run single test | `ddev exec vendor/bin/phpunit -c Build/phpunit.xml <path>` |
+| Run tests | NOT in DDEV — use `make test-unit` / `make test-functional` (containerized `Build/Scripts/runTests.sh`, own ephemeral containers) |
+| Run single test | `Build/Scripts/runTests.sh -s unit Tests/Unit/Path/ToTest.php` |
 | DB export | `ddev export-db --file=dump.sql.gz` |
 | DB import | `ddev import-db --file=dump.sql.gz` |
 

--- a/.github/workflows/AGENTS.md
+++ b/.github/workflows/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Managed by agent: keep sections and order; edit content, not structure -->
-<!-- Last updated: 2026-08-02 | Last verified: 2026-08-02 -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
 
 # AGENTS.md — .github/workflows
 
@@ -14,6 +14,7 @@ GitHub Actions workflows for nr-vault. CI, releases, auto-merge, and community a
 | `security-gates.yml` | Mutation ratchet over `Classes/Crypto`, `Classes/Security`, `Classes/Audit`, `Classes/Http` (`infection-security.json5`). Standalone precisely because `checks.yml` is drift-locked |
 | `check-template-drift.yml` | Verifies this repo still matches the `typo3-extension` template |
 | `docs.yml` | Renders `Documentation/` on PRs touching it |
+| `harness-verify.yml` | Agent-harness consistency check (`Build/Scripts/verify-harness.sh`) via the shared `script-check.yml` reusable; exit 2 (warnings) passes |
 | `release.yml` | Tag-triggered TER publish + GitHub release assets |
 | `release-evidence.yml` | Publishes the security release-evidence bundle for a tag |
 | `republish.yml` | Manual re-run of a publish target (ter / docs / packagist) for an existing tag |
@@ -54,6 +55,7 @@ GitHub Actions workflows for nr-vault. CI, releases, auto-merge, and community a
 │   ├── check-template-drift.yml
 │   ├── security-gates.yml
 │   ├── docs.yml
+│   ├── harness-verify.yml
 │   ├── release.yml
 │   ├── release-evidence.yml
 │   ├── republish.yml

--- a/.github/workflows/harness-verify.yml
+++ b/.github/workflows/harness-verify.yml
@@ -1,0 +1,23 @@
+name: Harness Verification
+
+# Verifies agent-harness consistency (AGENTS.md line budget, dead references,
+# documented commands vs composer.json/Makefile, docs/ structure) via
+# Build/Scripts/verify-harness.sh. Thin caller of the shared script-check
+# reusable, so the checkout pin and harden-runner are maintained centrally.
+# Exit 2 means warnings only and passes; exit 1 (errors) fails the check.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions: {}
+
+jobs:
+  harness-verify:
+    uses: netresearch/.github/.github/workflows/script-check.yml@main
+    permissions:
+      contents: read
+    with:
+      check-cmd: bash Build/Scripts/verify-harness.sh || [ $? -eq 2 ]

--- a/.gitignore
+++ b/.gitignore
@@ -36,8 +36,13 @@ package-lock.json
 /rust/target/
 *.so
 
-# Generated / internal docs
-/docs/
+# Generated / internal docs — but the agent-harness files are tracked:
+# docs/ARCHITECTURE.md and docs/exec-plans/README.md (exec-plan contents stay ignored)
+/docs/*
+!/docs/ARCHITECTURE.md
+!/docs/exec-plans/
+/docs/exec-plans/*
+!/docs/exec-plans/README.md
 /claudedocs/
 /.conformance-reports/
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 <!-- FOR AI AGENTS - Human readability is a side effect, not a goal -->
 <!-- Managed by agent: keep sections and order; edit content, not structure -->
-<!-- Last updated: 2026-08-02 | Last verified: 2026-08-02 -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
 
 # AGENTS.md — nr-vault
 
@@ -10,11 +10,10 @@
 
 ## Project Overview
 
-- **Stack:** PHP 8.2+, TYPO3 ^13.4 || ^14.3, libsodium (XChaCha20-Poly1305 / AES-256-GCM envelope encryption)
-- **Environment:** DDEV for local development
-- **License:** GPL-2.0-or-later
-- **Namespace:** `Netresearch\NrVault\` (PSR-4 from `Classes/`)
-- **Extension key:** `nr_vault`
+- **Stack:** PHP 8.2+, TYPO3 ^13.4 || ^14.3, libsodium (XChaCha20-Poly1305 / AES-256-GCM envelope encryption). Version: see `ext_emconf.php`.
+- **Environment:** DDEV for local development · **License:** GPL-2.0-or-later
+- **Namespace:** `Netresearch\NrVault\` (PSR-4 from `Classes/`) · **Extension key:** `nr_vault`
+- **Component map + key interfaces + CLI command list:** `docs/ARCHITECTURE.md`
 
 ## Commands
 > Source: `Makefile` (primary) and `composer.json` scripts
@@ -36,49 +35,29 @@
 | All CI | `make ci` | cgl + phpstan + unit + fuzz (no lint/rector/functional) |
 | Docs render | `make docs` | |
 
-**Test execution ALWAYS goes through `Build/Scripts/runTests.sh`** (or the `composer test:*` scripts that wrap it) — the TYPO3 core-style containerized runner with its own ephemeral containers. NEVER run tests inside DDEV (`ddev exec phpunit`, DDEV-prefixed make targets); DDEV is the dev *environment*, not the test runner.
+**Test execution ALWAYS goes through `Build/Scripts/runTests.sh`** (or the composer wrappers around it, e.g. `composer test:unit` / `test:functional`) — the TYPO3 core-style containerized runner with its own ephemeral containers. NEVER run tests inside DDEV (`ddev exec phpunit`); DDEV is the dev *environment*, not the test runner. Single file: `Build/Scripts/runTests.sh -s unit Tests/Unit/Path/ToTest.php`.
 
-Direct composer (without make):
-- `composer ci` — unit + fuzz + phpstan + cgl
-- `composer ci:test:php:functional` — functional suite
-- `composer ci:cgl` — fix code style
-
-## Response Style
-- Answer first, elaborate only if needed. No sycophantic openers.
-- For yes/no or status questions, lead with the answer.
-- Skip preamble. Match response length to task complexity.
+Direct composer (without make): `composer ci` — unit + fuzz + phpstan + arch (phpat) + doc-cli drift + evidence + cgl; `composer ci:test:php:functional` — functional suite; `composer ci:cgl` — fix code style.
 
 ## Workflow
-1. **Before coding**: Read nearest `AGENTS.md` + inspect Golden Samples.
+1. **Before coding**: Read nearest `AGENTS.md` + inspect its Golden Samples (`Classes/AGENTS.md`, `Tests/AGENTS.md`, …).
 2. **After each change**: Run the smallest relevant check (`make lint` → `make phpstan` → single test).
 3. **Before committing**: `make ci` when changes affect >2 files or touch shared code.
 4. **Before claiming done**: Run verification and **paste output as evidence** — never say "should work now" / "tested" / "all green" without showing output.
+5. **Response style**: answer first, skip preamble, match length to task; no sycophantic openers.
 
 ## File Map
 ```
-Classes/         → PHP sources (Adapter, Audit, Command, Configuration, Controller, Crypto, Domain,
-                   Event, EventListener, Exception, Form, Hook, Http, Secret, Security, Seeder,
-                   Service, TCA, Task, Upgrades, Utility, Widgets)
+Classes/         → PHP sources (see Classes/AGENTS.md + docs/ARCHITECTURE.md for the component map)
 Configuration/   → TYPO3 config (TCA, Backend routes, Services.yaml)
-Documentation/   → reStructuredText docs + ADRs
+Documentation/   → reStructuredText docs + ADRs (Documentation/Developer/Adr/)
 Resources/       → Templates (Fluid), JS/CSS, XLIFF language files
-Tests/           → Unit + Functional + E2E (Playwright)
-Build/           → phpunit.xml, FunctionalTests.xml
+Tests/           → Unit + Functional + Fuzz + Architecture + E2E (Playwright)
+Build/           → runTests.sh, phpunit.xml, FunctionalTests.xml, verify-harness.sh
+docs/            → Agent-facing docs: ARCHITECTURE.md, exec-plans/
 .ddev/           → DDEV environment (mock-oauth sidecar, phpunit extras)
 .github/         → workflows, CODEOWNERS, renovate, labeler
 ```
-
-## Golden Samples
-| For | Reference |
-|-----|-----------|
-| Domain service | `Classes/Service/VaultService.php` |
-| Crypto boundary | `Classes/Crypto/EncryptionService.php` |
-| Controller (backend module) | `Classes/Controller/SecretsController.php` |
-| AJAX controller | `Classes/Controller/AjaxController.php` |
-| TYPO3 hook | `Classes/Hook/FlexFormVaultHook.php` |
-| Audit writer | `Classes/Audit/AuditLogService.php` |
-| Upgrade wizard | `Classes/Upgrades/AuditHmacMigrationWizard.php` |
-| Functional test | `Tests/Functional/Crypto/MasterKeyRotationTest.php` |
 
 ## Heuristics
 | When | Do |
@@ -86,8 +65,8 @@ Build/           → phpunit.xml, FunctionalTests.xml
 | Adding class | PSR-4 under `Classes/`, namespace `Netresearch\NrVault\*` |
 | New command | `Classes/Command/` + register in `Configuration/Services.yaml` |
 | AJAX route | Add to `Configuration/Backend/AjaxRoutes.php` + controller in `Classes/Controller/` |
-| New backend submodule | (1) register in `Configuration/Backend/Modules.php` (with its dedicated labels XLF); (2) add a card to the `submodules` list in `OverviewController::indexAction` (with localized title/description in `locallang_mod.xlf`); (3) add a `Documentation/Usage/Index.rst` section + a `Documentation/Images/*.png` screenshot; (4) exclude the controller in `Build/phpunit.xml` coverage (backend module render is E2E-covered) **or** unit-test its extractable logic. Not done = incomplete feature. |
-| Touching secrets | Audit log every read/write via `AuditLogServiceInterface::log()` |
+| New backend submodule | Follow the 4-step completeness recipe in `Classes/AGENTS.md` (module registration, overview card, docs + screenshot, coverage). Not done = incomplete feature. |
+| Touching secrets | Audit log every read/write via `AuditLogServiceInterface::log()`; invariants in `Classes/AGENTS.md` |
 | Running locally | `make up` then `make shell` |
 | Committing | Subject-style enforced by `captainhook.json`: capitalized, imperative mood, length-limited, no trailing period (NOT lowercase `feat:`/`fix:` prefixes). Sign off with `git commit -s`. See CONTRIBUTING.md |
 | Merging PRs | Merge commit (not squash, not rebase) — preserves GPG signatures |
@@ -103,12 +82,6 @@ Build/           → phpunit.xml, FunctionalTests.xml
 - **CaptainHook cannot install its hooks in a git worktree** — composer install ends with `CaptainHook could not install yer git hooks! (invalid .git path)`. Harmless for the containerized test runner, but it means NO pre-commit/commit-msg checks run locally in that worktree: the subject-style and cgl gates you rely on elsewhere are silently absent, so run the checks by hand before pushing.
 - **`make ci` does not include Rector** (cgl + phpstan + unit + fuzz only), and CI's Rector dry-run is a required gate. `SimplifyQuoteEscapeRector` flags every `\'` escape in a single-quoted string — an assertion message with an apostrophe costs a full CI round trip. When adding or editing PHP files, run `make rector` before pushing. (Cost two round trips in one day, 2026-08-18.)
 
-## Audit log invariants
-
-- `crdate` is bound into the entry hash and `log()` hardcodes `time()` — you cannot `log()` then `UPDATE crdate` without breaking `verifyHashChain()`. Backdated/historic rows require chain reconstruction in time order via the public static hashing API (`calculateHash()`/`calculateHashV2()`/`extractHashRow()`/`deriveHmacKey()`), mirroring `insertAndUpdateHash`; never delete rows (uid gaps are detected).
-- Audit retention (`getAuditLogRetention()`, default 365d) is configured but has **zero consumers** — nothing purges audit rows; `OrphanCleanupTask` touches only orphaned secrets. Audit-derived metrics are safe for windows ≤365d.
-- `actor_type` separates manual reveals (`backend`) from automated (`cli`/`api`/`scheduler`); `AuditLogFilter` cannot filter on it — query the table directly.
-
 ## Security Requirements
 This extension handles sensitive data. Non-negotiable rules:
 
@@ -118,127 +91,8 @@ This extension handles sensitive data. Non-negotiable rules:
 4. **No plaintext storage** — all secrets via envelope encryption (master key wraps per-secret DEK).
 5. **Audit every access** — reads/writes/rotations/deletes all create audit log entries.
 6. **Access control** — respect backend user groups & ownership via `AccessControlServiceInterface`.
-7. **Tamper-evident audit log** — HMAC hash chain plus an in-DB tip anchor (ADR-034); verify
-   on schedule (`vault:audit-verify` / `AuditVerifyTask`, `vault:audit --verify` interactively).
-   A mutation and its audit entry are all-or-nothing — a write that cannot be audited must not
-   land, and that includes the MM ACL tiers written alongside it.
-8. **One admin-bypass seam** — every "admins may do anything" decision goes through the private
-   `AccessControlService::adminBypassActive()`. Never inline `isAdmin()`/`isSystemMaintainer()` in a
-   caller, and never route a grant lookup through `BackendUserAuthentication::check()` (core
-   short-circuits it to `true` for admins). The hardened profile can disable the bypass
-   (`disableAdminOverride`); a half-disabled override is worse than none.
-
-## Key Interfaces
-> Authoritative source: the `*Interface.php` files. This is a cheat-sheet — read the PHP for full docblocks.
-
-```php
-// Core vault operations — Classes/Service/VaultServiceInterface.php
-VaultServiceInterface::store(string $identifier, string $secret, array $options = []): void
-VaultServiceInterface::retrieve(string $identifier): ?string
-VaultServiceInterface::retrieveForFrontend(string $identifier): ?string
-VaultServiceInterface::exists(string $identifier): bool
-VaultServiceInterface::delete(string $identifier, string $reason = ''): void
-// Runs delete()'s permission gates WITHOUT deleting, so a record delete spanning
-// several vault fields can fail closed before the first (unrestorable) deletion.
-// An absent secret passes.
-VaultServiceInterface::assertDeletable(string $identifier): void
-VaultServiceInterface::rotate(string $identifier, string $newSecret, string $reason = ''): void
-// The single write path for a secret's availability. Disabling withdraws it from
-// every read path at once (TCA `disabled` enable column), so it is gated by
-// canWrite() AND secret.manage_policy, audited as `metadata_update`, and
-// compensated on a failed audit write. Absolute, not a toggle: setting the
-// current state is a no-op. A disabled secret stays administrable — it can be
-// re-enabled, rotated, deleted, and its metadata read.
-VaultServiceInterface::setEnabled(string $identifier, bool $enabled, string $reason = ''): void
-// `$includeDisabled` widens the listing to secrets that are out of service;
-// off by default, passed by the management surfaces only. Each SecretMetadata
-// reports its state in `$enabled`.
-VaultServiceInterface::list(?string $pattern = null, bool $includeDisabled = false): array
-VaultServiceInterface::getMetadata(string $identifier): SecretDetails
-VaultServiceInterface::http(): VaultHttpClientInterface
-
-// Encryption — Classes/Crypto/EncryptionServiceInterface.php
-EncryptionServiceInterface::encrypt(string $plaintext, string $identifier): EncryptedData
-EncryptionServiceInterface::decrypt(
-    string $encryptedValue, string $encryptedDek,
-    string $dekNonce, string $valueNonce, string $identifier
-): string
-EncryptionServiceInterface::generateDek(): string
-EncryptionServiceInterface::calculateChecksum(string $plaintext): string
-
-// Master key — Classes/Crypto/MasterKeyProviderInterface.php
-MasterKeyProviderInterface::getMasterKey(): string
-// Static: wipes the request-lifetime key cache (ADR-020). Long-running processes
-// (workers, scheduler tasks) must call it to bound key residency.
-MasterKeyProviderInterface::clearCachedKey(): void
-
-// Operation permissions — Classes/Security/AccessControlServiceInterface.php
-// Every privileged operation resolves through isGranted(); the VaultPermission
-// enum (Classes/Security/VaultPermission.php) is the single list of operations
-// (secret.create, secret.rotate, secret.delete, secret.manage_policy, …).
-// A technical actor has no live session, so its grants are read straight from
-// the `tx_nrvault:<permission>` custom options on its be_groups rows — never
-// from BackendUserAuthentication::check(). Fail-closed: no groups, no grant.
-AccessControlServiceInterface::isGranted(VaultPermission $permission): bool
-AccessControlServiceInterface::canRead(Secret $secret): bool
-AccessControlServiceInterface::canWrite(Secret $secret): bool
-AccessControlServiceInterface::canDelete(Secret $secret): bool
-AccessControlServiceInterface::canCreate(): bool
-
-// Technical actor (headless runAs) — Classes/Security/TechnicalActorContextInterface.php
-TechnicalActorContextInterface::runAs(int $beUserUid, callable $fn): mixed
-TechnicalActorContextInterface::getCurrentActor(): ?TechnicalActor
-
-// Break-glass (time-boxed restore of the admin override) — Classes/Security/BreakGlassServiceInterface.php
-BreakGlassServiceInterface::activate(string $reason, int $minutes = 15): BreakGlassSession
-BreakGlassServiceInterface::deactivate(string $reason): void
-// Read-only seam consumed by AccessControlService — Classes/Security/BreakGlassStateInterface.php
-BreakGlassStateInterface::getActiveSession(): ?BreakGlassSession
-BreakGlassStateInterface::isActive(): bool
-
-// Audit logging — Classes/Audit/AuditLogServiceInterface.php
-AuditLogServiceInterface::log(
-    string $secretIdentifier, string $action, bool $success,
-    ?string $errorMessage = null, ?string $reason = null,
-    ?string $hashBefore = null, ?string $hashAfter = null,
-    ?AuditContextInterface $context = null,
-): void
-AuditLogServiceInterface::query(?AuditLogFilter $filter = null, int $limit = 100, int $offset = 0): array
-AuditLogServiceInterface::count(?AuditLogFilter $filter = null): int
-AuditLogServiceInterface::export(?AuditLogFilter $filter = null): array
-AuditLogServiceInterface::verifyHashChain(
-    ?int $fromUid = null, ?int $toUid = null, ?int $minEpoch = null,
-): HashChainVerificationResult
-AuditLogServiceInterface::getLatestHash(): ?string
-
-// In-DB chain-tip anchor (ADR-034) — Classes/Audit/AuditChainAnchorStoreInterface.php
-// Persists the tip in sys_registry under `tx_nrvault_audit_anchor`, so a full
-// truncation of the audit table is still detected. `auditAnchorRequired` decides
-// whether a missing anchor is a warning or a critical finding.
-```
-
-## CLI Commands (TYPO3 `vendor/bin/typo3`)
-> All 17 registered `vault:*` commands. Full options/examples in
-> `Documentation/Developer/Commands.rst`.
-```
-vault:init                 # Initialize the vault (generate master key, verify configuration)
-vault:store                # Store a secret in the vault
-vault:retrieve             # Retrieve a secret from the vault
-vault:list                 # List all secrets in the vault
-vault:rotate               # Rotate (replace) a secret value
-vault:delete               # Delete a secret from the vault
-vault:scan                 # Scan database content for exposed secrets
-vault:migrate-field        # Migrate a database field value into the vault
-vault:audit                # View / export audit entries; --verify checks the hash chain and the in-DB anchor, --reset-anchor clears the anchor after a legitimate wipe
-vault:audit-anchor         # Publish the audit chain tip to the external audit sinks (scheduled task wrapper)
-vault:audit-verify         # Verify the hash chain AND the external chain-tip anchor (scheduled task wrapper)
-vault:audit-migrate-hmac   # Migrate audit log hash chain from SHA-256 to HMAC-SHA256
-vault:rotate-master-key    # Re-encrypt all secrets with a new master key
-vault:cleanup-orphans      # Clean up orphaned vault entries (scheduled task wrapper)
-vault:break-glass          # Open/close/inspect a time-boxed break-glass window (restores the admin override)
-vault:doctor               # Check the configuration for deployment/audit readiness (exit 0 clean / 1 warnings / 2 critical)
-vault:seed-demo            # Seed demo secrets + audit history (development only)
-```
+7. **Tamper-evident audit log** — HMAC hash chain plus an in-DB tip anchor (ADR-034); verify on schedule (`vault:audit-verify` / `AuditVerifyTask`, `vault:audit --verify` interactively). A mutation and its audit entry are all-or-nothing — a write that cannot be audited must not land, and that includes the MM ACL tiers written alongside it.
+8. **One admin-bypass seam** — every "admins may do anything" decision goes through the private `AccessControlService::adminBypassActive()`. Never inline `isAdmin()`/`isSystemMaintainer()` in a caller, and never route a grant lookup through `BackendUserAuthentication::check()` (core short-circuits it to `true` for admins). The hardened profile can disable the bypass (`disableAdminOverride`); a half-disabled override is worse than none.
 
 ## Boundaries
 
@@ -247,20 +101,16 @@ vault:seed-demo            # Seed demo secrets + audit history (development only
 - Dependency injection via `Configuration/Services.yaml` — not `GeneralUtility::makeInstance()`.
 - Run `make fix && make phpstan && make test` before pushing.
 - Use atomic commits (one logical change per commit); preserve GPG signatures.
-- Force-push only with `--force-with-lease`.
-- Follow PSR-12 + TYPO3 CGL.
+- Force-push only with `--force-with-lease`. Follow PSR-12 + TYPO3 CGL.
 
 ### Ask First
-- Adding new dependencies (composer / npm).
-- Modifying CI/CD configuration.
-- Changing public API signatures of `*Interface.php`.
-- Rotating / regenerating cryptographic keys in fixtures.
+- Adding new dependencies (composer / npm). Modifying CI/CD configuration.
+- Changing public API signatures of `*Interface.php`. Rotating / regenerating cryptographic keys in fixtures.
 
 ### Never Do
 - Commit secrets, credentials, or real master keys (test fixtures only — synthetic values; `.gitleaks.toml` tunes the `gitleaks` job in `.github/workflows/checks.yml`, so a new fixture that trips a rule fails CI).
 - Commit `composer.lock` (extension, not application).
-- Push directly to `main` — open a PR.
-- Merge a PR before all review threads are resolved.
+- Push directly to `main` — open a PR. Merge a PR before all review threads are resolved.
 - Squash or rebase-merge (loses GPG signatures — use merge commits).
 - Use `secrets: inherit` in reusable GitHub Actions workflows (pass secrets explicitly).
 - Modify `.Build/`, `vendor/`, `Documentation-GENERATED-temp/`, `.php-cs-fixer.cache`.
@@ -268,7 +118,7 @@ vault:seed-demo            # Seed demo secrets + audit history (development only
 
 ## Index of scoped AGENTS.md
 MUST read when working in these directories:
-- `./Classes/AGENTS.md` — PHP sources, crypto, services, hooks
+- `./Classes/AGENTS.md` — PHP sources, crypto, services, hooks, audit invariants
 - `./Configuration/AGENTS.md` — TCA, Services.yaml, routes
 - `./Documentation/AGENTS.md` — RST docs + ADRs
 - `./Resources/AGENTS.md` — Fluid templates, JS/CSS, XLIFF
@@ -280,17 +130,15 @@ MUST read when working in these directories:
 > **Agents**: When you read or edit files in a listed directory, load its AGENTS.md first.
 
 ## Repository Settings
-- **Default branch:** `main`
-- **Merge strategy:** merge commit (required for GPG signature preservation)
+- **Default branch:** `main` · **Merge strategy:** merge commit (GPG signature preservation)
 - **Signed commits:** required (GPG/SSH)
 - **DCO:** required (`Signed-off-by:` trailer on every commit — use `git commit -s`). Enforced at the PR gate; the local commit-msg hook does NOT check it.
 
 ## When Stuck
-1. TYPO3 v14 docs: <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/>
-2. Review ADRs in `Documentation/Developer/Adr/`
-3. Run `make phpstan` for type hints
-4. Check audit logs (`vault:audit`) for access issues
-5. Root AGENTS.md for project-wide conventions
+1. `docs/ARCHITECTURE.md` — component map, dependency rules, key interfaces, CLI commands
+2. TYPO3 v14 docs: <https://docs.typo3.org/m/typo3/reference-coreapi/main/en-us/>
+3. Review ADRs in `Documentation/Developer/Adr/`
+4. Run `make phpstan` for type hints; check audit logs (`vault:audit`) for access issues
 
 ---
 *© Netresearch DTT GmbH — GPL-2.0-or-later*

--- a/Build/Scripts/verify-harness.sh
+++ b/Build/Scripts/verify-harness.sh
@@ -1,0 +1,756 @@
+#!/usr/bin/env bash
+# verify-harness.sh — Portable harness consistency checker
+# Checks AGENTS.md and related files for agent harness maturity.
+# Dependencies: coreutils + git (jq optional, graceful fallback)
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Globals
+# ---------------------------------------------------------------------------
+ERRORS=0
+WARNINGS=0
+FORMAT=""
+MAX_LEVEL=3
+SINGLE_CHECK=""
+STATUS_ONLY=false
+PLATFORM="${PLATFORM:-}"
+
+# Collected output lines (for final rendering)
+declare -a OUTPUT_LINES=()
+declare -a GITHUB_LINES=()
+declare -a GITLAB_LINES=()
+
+# Per-level pass/total counters
+declare -A LEVEL_PASS=( [1]=0 [2]=0 [3]=0 )
+declare -A LEVEL_TOTAL=( [1]=0 [2]=0 [3]=0 )
+
+# Track the first failing level-1 suggestion for --status
+NEXT_STEP=""
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+usage() {
+    cat <<'USAGE'
+Usage: verify-harness.sh [OPTIONS]
+
+Verify agent harness consistency in the current repository.
+Must be run from the repo root.
+
+Options:
+  --format=text     Plain text output (default for terminals)
+  --format=github   GitHub Actions annotations (auto-detected in CI)
+  --format=gitlab   GitLab CI section annotations (auto-detected in CI)
+  --platform=P      Target platform: github, gitlab or forgejo (auto-detected
+                    from CI environment or git remote URL if not specified)
+  --level=N         Only check up to level N (1, 2, or 3; default: all)
+  --check=NAME      Run single check category: refs, commands, drift, structure
+  --status          Show current maturity level summary only
+  --help            Show this help message
+
+Exit codes:
+  0  All checks pass
+  1  Errors found (Level 1/2 failures)
+  2  Only warnings (Level 3 suggestions)
+USAGE
+    exit 0
+}
+
+# Detect output format: github if running in CI, otherwise text
+detect_format() {
+    if [[ -n "$FORMAT" ]]; then
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        FORMAT="github"
+    elif [[ "${GITLAB_CI:-}" == "true" ]]; then
+        FORMAT="gitlab"
+    else
+        FORMAT="text"
+    fi
+}
+
+# Detect hosting platform from CI env, git remote, or flag
+detect_platform() {
+    if [[ -n "$PLATFORM" ]]; then
+        if [[ "$PLATFORM" != "github" && "$PLATFORM" != "gitlab" && "$PLATFORM" != "forgejo" ]]; then
+            echo "Error: Unsupported PLATFORM '${PLATFORM}'. Expected 'github', 'gitlab' or 'forgejo'." >&2
+            exit 1
+        fi
+        return
+    fi
+    if [[ "${GITHUB_ACTIONS:-}" == "true" ]]; then
+        # Forgejo/Gitea Actions also export GITHUB_ACTIONS=true; tell them apart
+        # by the server URL — github.com (or a *.github.* Enterprise host) is real
+        # GitHub, anything else is a self-hosted Forgejo/Gitea instance.
+        if [[ -n "${GITHUB_SERVER_URL:-}" && "${GITHUB_SERVER_URL}" != *"github."* ]]; then
+            PLATFORM="forgejo"
+        else
+            PLATFORM="github"
+        fi
+        return
+    fi
+    if [[ "${GITLAB_CI:-}" == "true" ]]; then
+        PLATFORM="gitlab"
+        return
+    fi
+    local remote_url=""
+    remote_url=$(git remote get-url origin 2>/dev/null || true)
+    if [[ "$remote_url" == *"forgejo"* || "$remote_url" == *"gitea"* ]]; then
+        PLATFORM="forgejo"
+    elif [[ "$remote_url" == *"github"* ]]; then
+        PLATFORM="github"
+    elif [[ "$remote_url" == *"gitlab"* ]]; then
+        PLATFORM="gitlab"
+    elif [[ -f ".gitlab-ci.yml" ]]; then
+        # Infer GitLab from CI config presence (e.g. self-hosted GitLab)
+        PLATFORM="gitlab"
+    elif [[ -d ".forgejo" || -d ".gitea" ]]; then
+        # Infer Forgejo/Gitea from config presence (self-hosted)
+        PLATFORM="forgejo"
+    elif [[ -d ".github" ]]; then
+        PLATFORM="github"
+    else
+        PLATFORM="github"
+    fi
+}
+
+# Record a passing check
+pass() {
+    local level="$1"
+    local msg="$2"
+    (( LEVEL_PASS[$level]++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  PASS|${level}|${msg}")
+}
+
+# Record a failing check (error)
+fail() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( ERRORS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  FAIL|${level}|${msg}")
+    GITHUB_LINES+=("::error file=${file}::${msg} -- required for Level ${level} harness maturity")
+    GITLAB_LINES+=("ERROR: [Level ${level}] ${msg}${file:+ (${file})}")
+    # Capture first actionable suggestion for --status
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# Record a warning
+warn() {
+    local level="$1"
+    local msg="$2"
+    local file="${3-AGENTS.md}"
+    (( WARNINGS++ )) || true
+    (( LEVEL_TOTAL[$level]++ )) || true
+    OUTPUT_LINES+=("  WARN|${level}|${msg}")
+    GITHUB_LINES+=("::warning file=${file}::${msg}")
+    GITLAB_LINES+=("WARNING: [Level ${level}] ${msg}${file:+ (${file})}")
+    if [[ -z "$NEXT_STEP" ]]; then
+        NEXT_STEP="$msg"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Level 1 checks — Basic
+# ---------------------------------------------------------------------------
+check_agents_md_exists() {
+    if [[ -f "AGENTS.md" ]]; then
+        pass 1 "AGENTS.md exists"
+    else
+        fail 1 "AGENTS.md missing at repo root"
+    fi
+}
+
+check_agents_md_length() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "AGENTS.md length check skipped (file missing)"
+        return
+    fi
+    local lines
+    lines=$(wc -l < "AGENTS.md")
+    if (( lines < 150 )); then
+        pass 1 "AGENTS.md is index-format (${lines} lines)"
+    else
+        fail 1 "AGENTS.md is ${lines} lines (should be under 150)"
+    fi
+}
+
+check_agents_md_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 1 "Commands section check skipped (AGENTS.md missing)"
+        return
+    fi
+    if grep -qi '^## *\(available \)\?commands' "AGENTS.md"; then
+        pass 1 "Commands section found"
+    else
+        fail 1 "AGENTS.md missing ## Commands section"
+    fi
+}
+
+check_docs_exists() {
+    if [[ -d "docs" ]]; then
+        pass 1 "docs/ directory exists"
+    else
+        fail 1 "docs/ directory missing" ""
+    fi
+}
+
+run_level1() {
+    check_agents_md_exists
+    check_agents_md_length
+    check_agents_md_commands
+    check_docs_exists
+}
+
+# ---------------------------------------------------------------------------
+# Level 2 checks — Verified
+# ---------------------------------------------------------------------------
+
+# Check that all local file references in AGENTS.md resolve
+check_refs() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Reference check skipped (AGENTS.md missing)"
+        return
+    fi
+    local has_broken=false
+    # Extract markdown links: [text](path) — skip http(s):// and #anchors
+    while IFS= read -r ref; do
+        # Strip anchor (#...) and query string (?...)
+        local clean
+        clean="${ref%%#*}"
+        clean="${clean%%\?*}"
+        # Skip empty after stripping
+        [[ -z "$clean" ]] && continue
+        # Skip URLs
+        [[ "$clean" =~ ^https?:// ]] && continue
+        # Check if file/dir exists
+        if [[ ! -e "$clean" ]]; then
+            warn 2 "Broken reference in AGENTS.md: ${ref} -> ${clean} not found"
+            has_broken=true
+        fi
+    done < <(grep -oP '\]\(\K[^)]+' "AGENTS.md" 2>/dev/null || true)
+
+    if [[ "$has_broken" == false ]]; then
+        pass 2 "All references resolve"
+    fi
+}
+
+# Check that documented commands have matching targets/scripts
+check_commands() {
+    if [[ ! -f "AGENTS.md" ]]; then
+        fail 2 "Command check skipped (AGENTS.md missing)"
+        return
+    fi
+
+    local found_any=false
+
+    # -- Makefile targets --
+    if [[ -f "Makefile" ]]; then
+        found_any=true
+        local has_make_issue=false
+        while IFS= read -r target; do
+            # Check if Makefile defines this target (pattern: "target:" at start of line)
+            if ! grep -qE "^${target}[[:space:]]*:" "Makefile"; then
+                warn 2 "make ${target}: no matching Makefile target (warning)"
+                has_make_issue=true
+            fi
+        done < <(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_make_issue" == false ]]; then
+            local make_count
+            make_count=$(grep -oP '`make\s+\K[a-zA-Z0-9_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$make_count" -gt 0 ]]; then
+                pass 2 "All make targets verified (${make_count} targets)"
+            fi
+        fi
+    fi
+
+    # -- composer.json scripts --
+    if [[ -f "composer.json" ]]; then
+        found_any=true
+        local has_composer_issue=false
+        # Built-in composer commands that are NOT user-defined scripts
+        local composer_builtins="install|update|require|remove|dump-autoload|dumpautoload|clear-cache|clearcache|config|create-project|exec|global|init|outdated|prohibits|why|why-not|search|self-update|selfupdate|show|status|validate|archive|browse|check-platform-reqs|diagnose|fund|licenses|run-script|suggests|upgrade"
+        while IFS= read -r script; do
+            # Skip built-in composer commands
+            if echo "$script" | grep -qE "^(${composer_builtins})$"; then
+                continue
+            fi
+            # Look for the script name in composer.json's scripts section
+            # Using grep since jq is optional
+            if ! grep -qE "\"${script}\"" "composer.json"; then
+                warn 2 "composer ${script}: no matching composer.json script (warning)"
+                has_composer_issue=true
+            fi
+        done < <(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_composer_issue" == false ]]; then
+            local composer_count
+            composer_count=$(grep -oP '`composer\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$composer_count" -gt 0 ]]; then
+                pass 2 "All composer scripts verified (${composer_count} scripts)"
+            fi
+        fi
+    fi
+
+    # -- package.json scripts --
+    if [[ -f "package.json" ]]; then
+        found_any=true
+        local has_npm_issue=false
+        while IFS= read -r script; do
+            if ! grep -qE "\"${script}\"" "package.json"; then
+                warn 2 "npm run ${script}: no matching package.json script (warning)"
+                has_npm_issue=true
+            fi
+        done < <(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null || true)
+        if [[ "$has_npm_issue" == false ]]; then
+            local npm_count
+            npm_count=$(grep -oP '`npm run\s+\K[a-zA-Z0-9:_-]+' "AGENTS.md" 2>/dev/null | wc -l || true)
+            if [[ "$npm_count" -gt 0 ]]; then
+                pass 2 "All npm scripts verified (${npm_count} scripts)"
+            fi
+        fi
+    fi
+
+    if [[ "$found_any" == false ]]; then
+        pass 2 "No build system files found to check commands against"
+    fi
+}
+
+check_architecture_doc() {
+    if [[ -f "docs/ARCHITECTURE.md" ]]; then
+        pass 2 "docs/ARCHITECTURE.md exists"
+    else
+        fail 2 "docs/ARCHITECTURE.md missing" ""
+    fi
+}
+
+check_ci_workflow() {
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -f ".gitlab-ci.yml" ]]; then
+            # Search root file and all include:local files for harness job
+            local found_harness=false
+            if grep -qE "harness-verify|verify-harness" ".gitlab-ci.yml"; then
+                found_harness=true
+            else
+                # Check files referenced via include:local (supports globs).
+                # Portable parser using sed/awk — handles common GitLab CI forms:
+                #   include: { local: 'path' }
+                #   include:
+                #     - local: 'path'
+                #   include:
+                #     - local:
+                #         - path1
+                #         - path2
+                # Skips PCRE (-P) and lookaround for BSD/macOS grep portability.
+                while IFS= read -r inc_pattern; do
+                    [[ -z "$inc_pattern" ]] && continue
+                    # shellcheck disable=SC2086
+                    for inc_file in $inc_pattern; do
+                        if [[ -f "$inc_file" ]] && grep -qE "harness-verify|verify-harness" "$inc_file"; then
+                            found_harness=true
+                            break 2
+                        fi
+                    done
+                done < <(awk '
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*\[/ {
+                        # inline list form: local: [a.yml, b.yml]
+                        s=$0; sub(/.*local:[[:space:]]*\[/,"",s); sub(/\].*/,"",s);
+                        n=split(s, a, /[[:space:]]*,[[:space:]]*/);
+                        for (i=1;i<=n;i++) print a[i]; next
+                    }
+                    /^[[:space:]]*-?[[:space:]]*local:[[:space:]]*[^[:space:]\[]/ {
+                        # scalar form: local: path or - local: path
+                        s=$0; sub(/.*local:[[:space:]]*/,"",s); print s; next
+                    }
+                ' ".gitlab-ci.yml" 2>/dev/null | tr -d "'\"" || true)
+            fi
+            if [[ "$found_harness" == true ]]; then
+                pass 2 "CI harness job found in GitLab CI config"
+            else
+                warn 2 "CI config exists (.gitlab-ci.yml) but no harness-verify job found"
+            fi
+        else
+            fail 2 "CI harness workflow missing -- create .gitlab-ci.yml with a harness-verify job" ""
+        fi
+    elif [[ "$PLATFORM" == "forgejo" ]]; then
+        if [[ -f ".forgejo/workflows/harness-verify.yml" || -f ".gitea/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .forgejo/workflows/harness-verify.yml" ""
+        fi
+    else
+        if [[ -f ".github/workflows/harness-verify.yml" ]]; then
+            pass 2 "CI harness workflow exists"
+        else
+            fail 2 "CI harness workflow missing -- create .github/workflows/harness-verify.yml" ""
+        fi
+    fi
+}
+
+run_level2() {
+    check_refs
+    check_commands
+    check_architecture_doc
+    check_ci_workflow
+}
+
+# ---------------------------------------------------------------------------
+# Level 3 checks — Enforced
+# ---------------------------------------------------------------------------
+
+check_hooks_autosetup() {
+    local found=false
+    local via=""
+
+    # Check .envrc for hooksPath
+    if [[ -f ".envrc" ]] && grep -q "hooksPath" ".envrc"; then
+        found=true
+        via=".envrc"
+    fi
+
+    # Check for Husky
+    if [[ -d ".husky" ]]; then
+        found=true
+        via=".husky"
+    fi
+
+    # Check composer.json for post-install-cmd with hooks
+    if [[ -f "composer.json" ]] && grep -q "post-install-cmd" "composer.json"; then
+        if grep -q "hook" "composer.json"; then
+            found=true
+            via="composer.json post-install-cmd"
+        fi
+    fi
+
+    if [[ "$found" == true ]]; then
+        pass 3 "Git hooks auto-setup via ${via}"
+    else
+        warn 3 "No git hooks auto-setup detected (.envrc hooksPath, .husky/, or composer.json post-install-cmd)"
+    fi
+}
+
+check_pr_template() {
+    if [[ "$PLATFORM" == "forgejo" ]]; then
+        # Forgejo/Gitea honour PR templates under .forgejo/, .gitea/ or .github/
+        local f
+        for f in .forgejo/pull_request_template.md .gitea/pull_request_template.md \
+                 .forgejo/PULL_REQUEST_TEMPLATE.md .gitea/PULL_REQUEST_TEMPLATE.md \
+                 .github/pull_request_template.md; do
+            if [[ -f "$f" ]]; then
+                pass 3 "PR template exists ($f)"
+                return
+            fi
+        done
+        warn 3 "PR template missing (create .forgejo/pull_request_template.md)"
+        return
+    fi
+    if [[ "$PLATFORM" == "gitlab" ]]; then
+        if [[ -d ".gitlab/merge_request_templates" ]]; then
+            local tmpl_count
+            tmpl_count=$(find .gitlab/merge_request_templates -maxdepth 1 -type f -name '*.md' 2>/dev/null | wc -l)
+            if (( tmpl_count > 0 )); then
+                pass 3 "MR template exists (.gitlab/merge_request_templates/, ${tmpl_count} template(s))"
+                return
+            fi
+        fi
+        warn 3 "MR template missing (create .gitlab/merge_request_templates/Default.md)"
+    else
+        if [[ -f ".github/pull_request_template.md" ]]; then
+            pass 3 "PR template exists (repo-level)"
+            return
+        fi
+        if [[ -d ".github/PULL_REQUEST_TEMPLATE" ]]; then
+            pass 3 "PR template exists (directory form)"
+            return
+        fi
+        local org=""
+        org=$(git remote get-url origin 2>/dev/null | sed -n 's|.*github\.com[:/]\([^/]*\)/.*|\1|p')
+        if [[ -n "$org" ]]; then
+            local api_result=""
+            api_result=$(gh api "repos/${org}/.github/contents/pull_request_template.md" --jq '.name' 2>/dev/null || true)
+            if [[ "$api_result" == "pull_request_template.md" ]]; then
+                pass 3 "PR template exists (org-level via ${org}/.github)"
+                return
+            fi
+        fi
+        warn 3 "PR template missing (.github/pull_request_template.md or org-level)"
+    fi
+}
+
+check_drift() {
+    # Skip if git is not available
+    if ! command -v git &>/dev/null; then
+        pass 3 "Drift check skipped (git not available)"
+        return
+    fi
+
+    # Skip if not in a git repo
+    if ! git rev-parse --git-dir &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (not a git repository)"
+        return
+    fi
+
+    # Skip if no parent commit (initial commit)
+    if ! git rev-parse HEAD~1 &>/dev/null 2>&1; then
+        pass 3 "Drift check skipped (no parent commit)"
+        return
+    fi
+
+    # Check if build/CI files changed in last commit
+    local build_files_changed=false
+    local agents_changed=false
+
+    while IFS= read -r changed_file; do
+        case "$changed_file" in
+            Makefile|composer.json|package.json|.github/workflows/*|.gitlab-ci.yml|.forgejo/workflows/*|.gitea/workflows/*)
+                build_files_changed=true
+                ;;
+            AGENTS.md)
+                agents_changed=true
+                ;;
+        esac
+    done < <(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+
+    if [[ "$build_files_changed" == true && "$agents_changed" == false ]]; then
+        warn 3 "Potential drift: build/CI files changed in last commit but AGENTS.md was not updated"
+    else
+        pass 3 "No drift detected"
+    fi
+}
+
+run_level3() {
+    check_hooks_autosetup
+    check_pr_template
+    check_drift
+}
+
+# ---------------------------------------------------------------------------
+# Output rendering
+# ---------------------------------------------------------------------------
+
+render_text() {
+    echo "Agent Harness Verification"
+    echo "=========================="
+    echo ""
+
+    local current_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for line in "${OUTPUT_LINES[@]}"; do
+        local kind level msg
+        kind="${line%%|*}"
+        local rest="${line#*|}"
+        level="${rest%%|*}"
+        msg="${rest#*|}"
+        kind="${kind#"${kind%%[![:space:]]*}"}" # trim leading whitespace
+
+        # Print level header when level changes
+        if (( level != current_level )); then
+            if (( current_level != 0 )); then
+                echo ""
+            fi
+            echo "Level ${level} -- ${level_names[$level]}"
+            current_level=$level
+        fi
+
+        case "$kind" in
+            PASS) echo "  ✓ ${msg}" ;;
+            FAIL) echo "  ✗ ${msg}" ;;
+            WARN) echo "  ! ${msg}" ;;
+        esac
+    done
+
+    echo ""
+
+    # Summary line
+    local maturity_level=0
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status="COMPLETE"
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        maturity_level=1
+    elif (( maturity_level < 3 )); then
+        # Check if next level is partially done
+        local next_lvl=$(( maturity_level + 1 ))
+        if (( ${LEVEL_TOTAL[$next_lvl]} > 0 && ${LEVEL_PASS[$next_lvl]} < ${LEVEL_TOTAL[$next_lvl]} )); then
+            status="PARTIAL"
+        fi
+    fi
+
+    echo "Summary: Level ${maturity_level} ${status} | ${ERRORS} error(s), ${WARNINGS} warning(s)"
+}
+
+render_github() {
+    if (( ${#GITHUB_LINES[@]} > 0 )); then
+        for line in "${GITHUB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+}
+
+render_gitlab() {
+    local ts
+    ts=$(date +%s)
+    echo -e "\e[0Ksection_start:${ts}:harness_verify[collapsed=false]\r\e[0KAgent Harness Verification"
+    if (( ${#GITLAB_LINES[@]} > 0 )); then
+        for line in "${GITLAB_LINES[@]}"; do
+            echo "$line"
+        done
+    fi
+    echo ""
+    echo "Summary: ${ERRORS} error(s), ${WARNINGS} warning(s)"
+    echo -e "\e[0Ksection_end:${ts}:harness_verify\r\e[0K"
+}
+
+render_status() {
+    # Determine highest fully-passing level
+    local maturity_level=0
+    local level_names=( [1]="Basic" [2]="Verified" [3]="Enforced" )
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 && ${LEVEL_PASS[$lvl]} == ${LEVEL_TOTAL[$lvl]} )); then
+            maturity_level=$lvl
+        else
+            break
+        fi
+    done
+
+    local status
+    if (( maturity_level == 0 )); then
+        if (( LEVEL_TOTAL[1] > 0 && LEVEL_PASS[1] > 0 )); then
+            status="PARTIAL"
+        else
+            status="NONE"
+        fi
+        # Display as Level 1 when no level is fully complete
+        local display_level=1
+        echo "Harness Maturity: Level ${display_level} (${level_names[$display_level]}) -- ${status}"
+    else
+        echo "Harness Maturity: Level ${maturity_level} (${level_names[$maturity_level]}) -- COMPLETE"
+    fi
+
+    for lvl in 1 2 3; do
+        if (( ${LEVEL_TOTAL[$lvl]} > 0 )); then
+            echo "  Level ${lvl}: ${LEVEL_PASS[$lvl]}/${LEVEL_TOTAL[$lvl]} checks pass"
+        fi
+    done
+
+    if [[ -n "$NEXT_STEP" ]]; then
+        echo "Next step: ${NEXT_STEP}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+main() {
+    # Parse arguments
+    while [[ $# -gt 0 ]]; do
+        case "$1" in
+            --format=*)
+                FORMAT="${1#--format=}"
+                ;;
+            --platform=*)
+                PLATFORM="${1#--platform=}"
+                if [[ ! "$PLATFORM" =~ ^(github|gitlab|forgejo)$ ]]; then
+                    echo "Error: --platform must be 'github', 'gitlab' or 'forgejo'" >&2
+                    exit 1
+                fi
+                ;;
+            --level=*)
+                MAX_LEVEL="${1#--level=}"
+                if [[ ! "$MAX_LEVEL" =~ ^[123]$ ]]; then
+                    echo "Error: --level must be 1, 2, or 3" >&2
+                    exit 1
+                fi
+                ;;
+            --check=*)
+                SINGLE_CHECK="${1#--check=}"
+                ;;
+            --status)
+                STATUS_ONLY=true
+                ;;
+            --help|-h)
+                usage
+                ;;
+            *)
+                echo "Unknown option: $1" >&2
+                echo "Run with --help for usage info" >&2
+                exit 1
+                ;;
+        esac
+        shift
+    done
+
+    detect_format
+    detect_platform
+
+    # Run single check category if requested
+    if [[ -n "$SINGLE_CHECK" ]]; then
+        case "$SINGLE_CHECK" in
+            refs)       check_refs ;;
+            commands)   check_commands ;;
+            drift)      check_drift ;;
+            structure)
+                check_agents_md_exists
+                check_docs_exists
+                check_architecture_doc
+                check_ci_workflow
+                check_pr_template
+                ;;
+            *)
+                echo "Unknown check: ${SINGLE_CHECK}" >&2
+                echo "Valid checks: refs, commands, drift, structure" >&2
+                exit 1
+                ;;
+        esac
+    else
+        # Run all checks up to MAX_LEVEL
+        if (( MAX_LEVEL >= 1 )); then
+            run_level1
+        fi
+        if (( MAX_LEVEL >= 2 )); then
+            run_level2
+        fi
+        if (( MAX_LEVEL >= 3 )); then
+            run_level3
+        fi
+    fi
+
+    # Render output
+    if [[ "$STATUS_ONLY" == true ]]; then
+        render_status
+    elif [[ "$FORMAT" == "github" ]]; then
+        render_github
+    elif [[ "$FORMAT" == "gitlab" ]]; then
+        render_gitlab
+    else
+        render_text
+    fi
+
+    # Exit code
+    if (( ERRORS > 0 )); then
+        exit 1
+    elif (( WARNINGS > 0 )); then
+        exit 2
+    else
+        exit 0
+    fi
+}
+
+main "$@"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,6 +147,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Agent documentation synced and put under CI verification** (#325). Root
+  `AGENTS.md` shrank from 296 to 144 lines: the Key-Interfaces cheat-sheet, the
+  `vault:*` CLI list, the component map and the phpat dependency rules now live
+  in the new agent-facing `docs/ARCHITECTURE.md`; the audit-log invariants and
+  the backend-submodule completeness recipe moved into `Classes/AGENTS.md`.
+  Drifted claims were corrected (`composer ci` scope, `make ci` scope in the
+  `Classes/` checklist, stale `ddev exec phpunit` instructions in `Tests/` and
+  `.ddev/` that contradicted the `runTests.sh` mandate), and
+  `Documentation/CLAUDE.md` was added as a regular file (the docs renderer
+  rejects symlinks). A new `harness-verify` workflow runs
+  `Build/Scripts/verify-harness.sh` on every PR so this class of drift fails CI.
+
 - **One DNS lookup per outbound request instead of two** (#304). The
   caller-side `isHostAllowed()` gate and the `ssrf-dns-pin` middleware each
   ran their own `dns_get_record()`; a short-lived memo (5 s, per host) inside

--- a/Classes/AGENTS.md
+++ b/Classes/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Managed by agent: keep sections and order; edit content, not structure -->
-<!-- Last updated: 2026-08-02 | Last verified: 2026-08-02 -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
 
 # AGENTS.md — Classes
 
@@ -37,6 +37,8 @@ Strict types, final classes, readonly properties, constructor promotion. DI via 
 |---------|-----------|
 | Service with DI + interface | `Classes/Service/VaultService.php` |
 | Crypto boundary (libsodium) | `Classes/Crypto/EncryptionService.php` |
+| Controller (backend module) | `Classes/Controller/SecretsController.php` |
+| Audit writer | `Classes/Audit/AuditLogService.php` |
 | TYPO3 hook integration | `Classes/Hook/FlexFormVaultHook.php` |
 | AJAX controller | `Classes/Controller/AjaxController.php` |
 | Symfony Console command | `Classes/Command/VaultMigrateFieldCommand.php` |
@@ -117,8 +119,16 @@ This directory contains the crypto + audit core. Review bar is high:
 - **Access control** — per-secret tiers via `AccessControlServiceInterface::canRead/canWrite/canDelete/canCreate`; privileged *operations* (create, rotate, delete, manage_policy) additionally go through `isGranted(VaultPermission::…)`. Both before the mutation, never after
 - **Mutation and audit are atomic** — if the audit write fails, compensate the mutation (`VaultService::compensateAuditFailure()`, `SecretTcaHook`'s MM-relation restore). A change that persists unaudited is a control failure, not a degraded success
 
+### Audit log invariants
+- `crdate` is bound into the entry hash and `log()` hardcodes `time()` — you cannot `log()` then `UPDATE crdate` without breaking `verifyHashChain()`. Backdated/historic rows require chain reconstruction in time order via the public static hashing API (`calculateHash()`/`calculateHashV2()`/`extractHashRow()`/`deriveHmacKey()`), mirroring `insertAndUpdateHash`; never delete rows (uid gaps are detected).
+- Audit retention (`getAuditLogRetention()`, default 365d) is configured but has **zero consumers** — nothing purges audit rows; `OrphanCleanupTask` touches only orphaned secrets. Audit-derived metrics are safe for windows ≤365d.
+- `actor_type` separates manual reveals (`backend`) from automated (`cli`/`api`/`scheduler`); `AuditLogFilter` cannot filter on it — query the table directly.
+
+### New backend submodule — completeness recipe
+(1) register in `Configuration/Backend/Modules.php` (with its dedicated labels XLF); (2) add a card to the `submodules` list in `OverviewController::indexAction` (with localized title/description in `locallang_mod.xlf`); (3) add a `Documentation/Usage/Index.rst` section + a `Documentation/Images/*.png` screenshot; (4) exclude the controller in `Build/phpunit.xml` coverage (backend module render is E2E-covered) **or** unit-test its extractable logic. Not done = incomplete feature.
+
 ## Checklist
-- [ ] `make ci` passes (lint + cs + phpstan + rector + tests)
+- [ ] `make ci` passes (cgl + phpstan + unit + fuzz) — and `make rector` run separately (not part of `make ci`, but a required CI gate)
 - [ ] New public methods have interfaces + tests
 - [ ] Audit log entry for any new secret operation
 - [ ] TCA changes accompanied by `ext_tables.sql` update

--- a/Configuration/AGENTS.md
+++ b/Configuration/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Managed by agent: keep sections and order; edit content, not structure -->
-<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
 
 # AGENTS.md — Configuration
 

--- a/Documentation/AGENTS.md
+++ b/Documentation/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Managed by agent: keep sections and order; edit content, not structure -->
-<!-- Last updated: 2026-08-02 | Last verified: 2026-08-02 -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
 
 # AGENTS.md — Documentation
 

--- a/Documentation/CLAUDE.md
+++ b/Documentation/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- Regular file, not a symlink: the TYPO3 docs renderer (Flysystem) rejects symbolic links inside Documentation/. -->
+
+@AGENTS.md

--- a/Resources/AGENTS.md
+++ b/Resources/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Managed by agent: keep sections and order; edit content, not structure -->
-<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
 
 # AGENTS.md — Resources
 

--- a/Tests/AGENTS.md
+++ b/Tests/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Managed by agent: keep sections and order; edit content, not structure -->
-<!-- Last updated: 2026-08-02 | Last verified: 2026-08-02 -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
 
 # AGENTS.md — Tests
 
@@ -8,9 +8,8 @@ Unit, Functional, Fuzz, and Architecture tests for nr-vault.
 Invoke skill **`typo3-testing`** for deeper guidance on fixtures, mocking, and CI setup.
 
 ## Setup
-- Local: `make up` to start DDEV, then `make test-unit` / `make test-functional`.
-- CI-only config at `Build/phpunit.xml` (unit + fuzz) and `Build/FunctionalTests.xml` (functional).
-- Functional tests need DB — run inside DDEV (`ddev exec ...`).
+- All suites run through `Build/Scripts/runTests.sh` (containerized, brings its own ephemeral DB) — `make test-unit` / `make test-functional` wrap it. NEVER run tests inside DDEV; DDEV is the dev environment only.
+- PHPUnit config at `Build/phpunit.xml` (unit + fuzz) and `Build/FunctionalTests.xml` (functional).
 
 ## Key Files
 | File | Purpose |
@@ -43,10 +42,10 @@ Invoke skill **`typo3-testing`** for deeper guidance on fixtures, mocking, and C
 | Unit only | `make test-unit` (or `composer ci:test:php:unit`) |
 | Functional only | `make test-functional` (or `composer ci:test:php:functional`) |
 | Fuzz | `composer ci:test:php:fuzz` |
-| All CI (unit+fuzz+phpstan+cgl) | `composer ci` |
+| All CI (unit+fuzz+phpstan+arch+doc-cli+evidence+cgl) | `composer ci` |
 | Mutation (Infection) | `make test-mutation` |
-| Single file | `ddev exec vendor/bin/phpunit -c Build/phpunit.xml Tests/Unit/Path/ToTest.php` |
-| Coverage | `ddev exec vendor/bin/phpunit -c Build/phpunit.xml --coverage-html .Build/coverage` |
+| Single file | `Build/Scripts/runTests.sh -s unit Tests/Unit/Path/ToTest.php` |
+| Coverage | `make test-coverage` (line) / `make test-coverage-path` (path+branch) / `make test-coverage-functional` |
 | Test-base convention check | `php Tests/scripts/check-test-base-class.php` |
 | Regenerate legacy allow-list | `php Tests/scripts/check-test-base-class.php --update-allowlist` |
 

--- a/Tests/E2E/AGENTS.md
+++ b/Tests/E2E/AGENTS.md
@@ -1,5 +1,5 @@
 <!-- Managed by agent: keep sections and order; edit content, not structure -->
-<!-- Last updated: 2026-04-20 | Last verified: 2026-04-20 -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
 
 # AGENTS.md — Tests/E2E
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,169 @@
+<!-- Managed by agent: keep sections and order; edit content, not structure -->
+<!-- Last updated: 2026-08-19 | Last verified: 2026-08-19 -->
+
+# Architecture — nr-vault
+
+Agent-facing component map. Human-facing documentation lives in `Documentation/` (rendered to docs.typo3.org); design decisions live in `Documentation/Developer/Adr/`. Nothing here duplicates those — this file locates code and states the enforced boundaries.
+
+## System Overview
+
+nr-vault is a TYPO3 extension (key `nr_vault`, namespace `Netresearch\NrVault\`) providing secrets management inside a TYPO3 instance: envelope encryption via libsodium (a master key wraps a per-secret DEK), per-secret and per-operation access control, and a tamper-evident audit log (HMAC hash chain with an in-DB chain-tip anchor, ADR-034). Consumers reach it through the PHP API (`VaultServiceInterface`), 17 `vault:*` CLI commands, a backend module, TCA/FlexForm field integration, and placeholder resolution in TypoScript/site config.
+
+## Components
+
+| Component | Location | Responsibility |
+|-----------|----------|----------------|
+| Vault service | `Classes/Service/VaultService.php` | Core secret CRUD + rotation; binds vault adapters; compensates mutations on failed audit writes |
+| Crypto | `Classes/Crypto/` | `EncryptionService` (libsodium envelope), master-key providers (file / env / TYPO3 encryptionKey) behind `MasterKeyProviderInterface` |
+| Access control | `Classes/Security/AccessControlService.php` | Per-secret tiers + operation permissions (`VaultPermission` enum); sole admin-bypass seam |
+| Technical actor | `Classes/Security/TechnicalActorContext.php` | Headless `runAs()` for CLI/scheduler/API actors without a live session |
+| Break-glass | `Classes/Security/BreakGlassService.php` | Time-boxed restore of the admin override |
+| Audit log | `Classes/Audit/AuditLogService.php` | HMAC hash-chain writer/verifier; fans out to external sinks (`Classes/Audit/Sink/`) after the chain write |
+| Audit anchor | `Classes/Audit/AuditChainAnchorStore.php`, `Classes/Audit/Anchor/` | In-DB chain tip in `sys_registry` (ADR-034) + external chain-tip anchoring |
+| Persistence | `Classes/Domain/Repository/SecretRepository.php` | Doctrine QueryBuilder access to `tx_nrvault_secret` |
+| Adapters | `Classes/Adapter/` | Vault backend adapters behind `VaultAdapterInterface` (local encryption, external) |
+| HTTP client | `Classes/Http/` | `VaultHttpClient` + OAuth token manager for secure outbound calls (ADR-010, ADR-027) |
+| Backend UI | `Classes/Controller/`, `Resources/` | Backend module (Overview/Secrets/Audit/Migration) + AJAX endpoints (reveal, verify-chain) |
+| TYPO3 integration | `Classes/Hook/`, `Classes/Form/`, `Classes/TCA/`, `Classes/EventListener/` | DataHandler/FlexForm/TCA hooks, FormEngine render types, TypoScript placeholder listener |
+| CLI | `Classes/Command/` | 17 `vault:*` Symfony Console commands (list below) |
+| Scheduler | `Classes/Task/` | OrphanCleanup, AuditAnchor, AuditVerify tasks |
+| Doctor | `Classes/Service/Doctor/` | `vault:doctor` readiness checks, one class per control group |
+| Events | `Classes/Event/` | PSR-14 events (SecretAccessed/Created/Rotated, BreakGlass*, …) |
+| Config wrapper | `Classes/Configuration/` | ExtensionConfiguration accessor (settings documented in `Documentation/Configuration/Index.rst`) |
+
+## Dependency Rules
+
+Enforced by phpat via `Tests/Architecture/ArchitectureTest.php` (`composer ci:test:php:arch`; config `phpat.neon`). The test is authoritative — the summary below mirrors its 25 rules:
+
+- **Immutability/finality**: events, `AuditLogEntry`, OAuth value objects, and `VaultHttpClient` must be readonly; exceptions, enums, and Crypto/Security implementations must be final.
+- **Interface seams**: `*Service` classes and adapters must implement their interface (`VaultAdapterInterface` for adapters).
+- **Layering**: services must not depend on controllers or commands; hooks and commands must not depend on controllers; commands must not depend on the repository; controllers must not depend on Crypto; Domain must not depend on infrastructure; Configuration must not depend on services; event listeners must not depend on presentation; utilities must not depend on services.
+- **Isolation locks**: Crypto is isolated; Security must not depend on Http; only `SecureHttpClientFactory` may instantiate a Guzzle `Client` (ADR-028); the audit anchor never uses TYPO3's core `Registry`; shared test infrastructure must not leak into production code.
+
+## Data Flow
+
+Write path: caller (controller / CLI / hook / API) → `VaultServiceInterface::store()/rotate()/delete()/setEnabled()` → `AccessControlService` gate (`isGranted()` + `canWrite()`/`canDelete()`) → `EncryptionService` envelope encryption → `SecretRepository` persist → `AuditLogService::log()` (HMAC chain + sinks). Mutation and audit entry are all-or-nothing: a failed audit write triggers compensation (`VaultService::compensateAuditFailure()`, `SecretTcaHook` MM-relation restore, ADR-036).
+
+Read path: `retrieve()`/`retrieveForFrontend()` → access-control gate → decrypt (DEK unwrapped with the master key, request-lifetime key cache per ADR-020) → audit read entry (configurable, ADR-019) → plaintext to the caller; `sodium_memzero()` after processing.
+
+## Key Interfaces (cheat-sheet)
+
+Authoritative source: the `*Interface.php` files — read the PHP for full docblocks.
+
+```php
+// Core vault operations — Classes/Service/VaultServiceInterface.php
+VaultServiceInterface::store(string $identifier, string $secret, array $options = []): void
+VaultServiceInterface::retrieve(string $identifier): ?string
+VaultServiceInterface::retrieveForFrontend(string $identifier): ?string
+VaultServiceInterface::exists(string $identifier): bool
+VaultServiceInterface::delete(string $identifier, string $reason = ''): void
+// Runs delete()'s permission gates WITHOUT deleting, so a record delete spanning
+// several vault fields can fail closed before the first (unrestorable) deletion.
+// An absent secret passes.
+VaultServiceInterface::assertDeletable(string $identifier): void
+VaultServiceInterface::rotate(string $identifier, string $newSecret, string $reason = ''): void
+// The single write path for a secret's availability. Disabling withdraws it from
+// every read path at once (TCA `disabled` enable column), so it is gated by
+// canWrite() AND secret.manage_policy, audited as `metadata_update`, and
+// compensated on a failed audit write. Absolute, not a toggle: setting the
+// current state is a no-op. A disabled secret stays administrable — it can be
+// re-enabled, rotated, deleted, and its metadata read.
+VaultServiceInterface::setEnabled(string $identifier, bool $enabled, string $reason = ''): void
+// `$includeDisabled` widens the listing to secrets that are out of service;
+// off by default, passed by the management surfaces only. Each SecretMetadata
+// reports its state in `$enabled`.
+VaultServiceInterface::list(?string $pattern = null, bool $includeDisabled = false): array
+VaultServiceInterface::getMetadata(string $identifier): SecretDetails
+VaultServiceInterface::http(): VaultHttpClientInterface
+
+// Encryption — Classes/Crypto/EncryptionServiceInterface.php
+EncryptionServiceInterface::encrypt(string $plaintext, string $identifier): EncryptedData
+EncryptionServiceInterface::decrypt(
+    string $encryptedValue, string $encryptedDek,
+    string $dekNonce, string $valueNonce, string $identifier
+): string
+EncryptionServiceInterface::generateDek(): string
+EncryptionServiceInterface::calculateChecksum(string $plaintext): string
+
+// Master key — Classes/Crypto/MasterKeyProviderInterface.php
+MasterKeyProviderInterface::getMasterKey(): string
+// Static: wipes the request-lifetime key cache (ADR-020). Long-running processes
+// (workers, scheduler tasks) must call it to bound key residency.
+MasterKeyProviderInterface::clearCachedKey(): void
+
+// Operation permissions — Classes/Security/AccessControlServiceInterface.php
+// Every privileged operation resolves through isGranted(); the VaultPermission
+// enum (Classes/Security/VaultPermission.php) is the single list of operations
+// (secret.create, secret.rotate, secret.delete, secret.manage_policy, …).
+// A technical actor has no live session, so its grants are read straight from
+// the `tx_nrvault:<permission>` custom options on its be_groups rows — never
+// from BackendUserAuthentication::check(). Fail-closed: no groups, no grant.
+AccessControlServiceInterface::isGranted(VaultPermission $permission): bool
+AccessControlServiceInterface::canRead(Secret $secret): bool
+AccessControlServiceInterface::canWrite(Secret $secret): bool
+AccessControlServiceInterface::canDelete(Secret $secret): bool
+AccessControlServiceInterface::canCreate(): bool
+
+// Technical actor (headless runAs) — Classes/Security/TechnicalActorContextInterface.php
+TechnicalActorContextInterface::runAs(int $beUserUid, callable $fn): mixed
+TechnicalActorContextInterface::getCurrentActor(): ?TechnicalActor
+
+// Break-glass (time-boxed restore of the admin override) — Classes/Security/BreakGlassServiceInterface.php
+BreakGlassServiceInterface::activate(string $reason, int $minutes = 15): BreakGlassSession
+BreakGlassServiceInterface::deactivate(string $reason): void
+// Read-only seam consumed by AccessControlService — Classes/Security/BreakGlassStateInterface.php
+BreakGlassStateInterface::getActiveSession(): ?BreakGlassSession
+BreakGlassStateInterface::isActive(): bool
+
+// Audit logging — Classes/Audit/AuditLogServiceInterface.php
+AuditLogServiceInterface::log(
+    string $secretIdentifier, string $action, bool $success,
+    ?string $errorMessage = null, ?string $reason = null,
+    ?string $hashBefore = null, ?string $hashAfter = null,
+    ?AuditContextInterface $context = null,
+): void
+AuditLogServiceInterface::query(?AuditLogFilter $filter = null, int $limit = 100, int $offset = 0): array
+AuditLogServiceInterface::count(?AuditLogFilter $filter = null): int
+AuditLogServiceInterface::export(?AuditLogFilter $filter = null): array
+AuditLogServiceInterface::verifyHashChain(
+    ?int $fromUid = null, ?int $toUid = null, ?int $minEpoch = null,
+): HashChainVerificationResult
+AuditLogServiceInterface::getLatestHash(): ?string
+
+// In-DB chain-tip anchor (ADR-034) — Classes/Audit/AuditChainAnchorStoreInterface.php
+// Persists the tip in sys_registry under `tx_nrvault_audit_anchor`, so a full
+// truncation of the audit table is still detected. `auditAnchorRequired` decides
+// whether a missing anchor is a warning or a critical finding.
+```
+
+## CLI Commands (TYPO3 `vendor/bin/typo3`)
+
+All 17 registered `vault:*` commands (`Classes/Command/`). Full options/examples in `Documentation/Developer/Commands.rst`.
+
+```
+vault:init                 # Initialize the vault (generate master key, verify configuration)
+vault:store                # Store a secret in the vault
+vault:retrieve             # Retrieve a secret from the vault
+vault:list                 # List all secrets in the vault
+vault:rotate               # Rotate (replace) a secret value
+vault:delete               # Delete a secret from the vault
+vault:scan                 # Scan database content for exposed secrets
+vault:migrate-field        # Migrate a database field value into the vault
+vault:audit                # View / export audit entries; --verify checks the hash chain and the in-DB anchor, --reset-anchor clears the anchor after a legitimate wipe
+vault:audit-anchor         # Publish the audit chain tip to the external audit sinks (scheduled task wrapper)
+vault:audit-verify         # Verify the hash chain AND the external chain-tip anchor (scheduled task wrapper)
+vault:audit-migrate-hmac   # Migrate audit log hash chain from SHA-256 to HMAC-SHA256
+vault:rotate-master-key    # Re-encrypt all secrets with a new master key
+vault:cleanup-orphans      # Clean up orphaned vault entries (scheduled task wrapper)
+vault:break-glass          # Open/close/inspect a time-boxed break-glass window (restores the admin override)
+vault:doctor               # Check the configuration for deployment/audit readiness (exit 0 clean / 1 warnings / 2 critical)
+vault:seed-demo            # Seed demo secrets + audit history (development only)
+```
+
+## CI
+
+`.github/workflows/ci.yml` is a thin caller of `netresearch/typo3-ci-workflows/.github/workflows/ci.yml@main` with matrix PHP 8.2/8.3/8.4/8.5 × TYPO3 ^13.4/^14.3, functional tests and coverage upload enabled. `checks.yml` (security/quality jobs) is drift-locked across all netresearch TYPO3 extensions; the mutation ratchet for `Classes/Crypto|Security|Audit` lives in `security-gates.yml`. See `.github/workflows/AGENTS.md`.
+
+## Key Decisions
+
+37 ADRs in `Documentation/Developer/Adr/` (index: `Documentation/Developer/Adr/Index.rst`). Load-bearing for agents: ADR-002 (envelope encryption), ADR-003 (master-key management), ADR-005 (access control), ADR-006/ADR-023/ADR-024 (audit logging + HMAC chain + forensic fields), ADR-020 (master-key request-lifetime caching), ADR-028 (phpat HTTP-client lock), ADR-029 (technical actor context), ADR-034 (audit chain-tip anchor), ADR-035 (frontend placeholder allow-set), ADR-036 (mutation/audit atomicity).

--- a/docs/exec-plans/README.md
+++ b/docs/exec-plans/README.md
@@ -1,0 +1,11 @@
+# Execution Plans
+
+Working directory for multi-step agent execution plans (design docs, task breakdowns, migration plans) that are too large for a PR description but not durable enough for `Documentation/`.
+
+- `active/` — plans currently being executed. One Markdown file per plan, named `YYYY-MM-DD-<slug>.md`.
+- `completed/` — plans whose work has merged; keep for archaeology, prune freely.
+
+Rules:
+
+- A plan is a scratchpad, not documentation — the merged PR and `Documentation/` (ADRs included) are the durable record. Never cite an exec plan from code or docs.
+- Directories are created on first use; do not commit empty placeholder files.


### PR DESCRIPTION
## Summary

Syncs every AGENTS.md against the actual repo state and adopts the agent-harness verification infrastructure (docs/ARCHITECTURE.md, exec-plans scaffold, `Build/Scripts/verify-harness.sh`, `harness-verify` CI workflow), following the pattern established in t3x-rte_ckeditor_image.

## Related Issues

Closes #325.

## Changes

- Root `AGENTS.md` shrunk 296 → 144 lines (harness budget is under 150) with no curated content deleted: the Key-Interfaces cheat-sheet, the 17-command `vault:*` CLI list, the component map and the phpat dependency-rule summary moved to the new agent-facing `docs/ARCHITECTURE.md`; the audit-log invariants and the backend-submodule completeness recipe moved to `Classes/AGENTS.md`.
- Drift fixes: `composer ci` scope corrected (it also runs arch, doc-cli, doc-cli self-test and evidence — root and `Tests/AGENTS.md` claimed unit+fuzz+phpstan+cgl); `Classes/AGENTS.md` checklist no longer claims `make ci` covers lint+rector; `Tests/AGENTS.md` and `.ddev/AGENTS.md` no longer instruct `ddev exec vendor/bin/phpunit` (contradicted the root `runTests.sh` mandate — single-file runs now documented as `Build/Scripts/runTests.sh -s unit <path>`); phantom verifier tokens removed ("make targets", "`composer test:`").
- `Documentation/CLAUDE.md` added as a **regular file** (`@AGENTS.md` include), not a symlink — the TYPO3 docs renderer (Flysystem) rejects symlinks inside `Documentation/`.
- Harness Level 2/3: `Build/Scripts/verify-harness.sh` (verbatim copy from the agent-harness skill) + `.github/workflows/harness-verify.yml` as a thin caller of the shared `netresearch/.github` script-check reusable (exit 2 = warnings passes); `docs/exec-plans/README.md` scaffold; `/docs/` gitignore narrowed so exactly `docs/ARCHITECTURE.md` and `docs/exec-plans/README.md` are tracked while exec-plan contents stay ignored.
- Managed headers bumped to 2026-08-19 on all nine AGENTS.md files after verifying their claims against Makefile, composer.json, `runTests.sh -h`, `Classes/Command/`, `Tests/Architecture/ArchitectureTest.php` and `.github/workflows/ci.yml`.

## Test plan

- `validate-structure.sh`: 1 error / 0 warnings → **0 / 0**
- `verify-content.sh`: 1 warning → **0**
- `verify-harness.sh`: Level 1 PARTIAL, 3 errors / 2 warnings → **Level 2 PARTIAL, 0 errors / 1 warning** (remaining warning: no git-hooks auto-setup; CaptainHook is configured via `captainhook.json` but not wired through `post-install-cmd`, and adding that would change composer install behaviour — out of scope here)
- `score-agents.sh`: average 80/100 (root 66) → **average 98/100** (root 90, seven files at 100)
- Root line count: 296 → 144

## Checklist

- [x] Tests pass locally — docs-only change, no PHP touched
- [x] PHPStan passes — not affected (no PHP touched)
- [x] Code style is correct — not affected (no PHP touched)
- [x] Documentation updated (if applicable)
- [x] CHANGELOG.md updated
