### PR TITLE
Reconcile the process surfaces with the widened security scope

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,5 +9,6 @@
 /Classes/Crypto/        @CybotTM
 /Classes/Security/      @CybotTM
 /Classes/Audit/         @CybotTM
+/Classes/Http/          @CybotTM
 /SECURITY.md            @CybotTM
 /.github/workflows/     @CybotTM

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -24,9 +24,9 @@
 
 <!--
 REQUIRED when this PR touches Classes/Crypto, Classes/Security, Classes/Audit,
-the security gates, the release-evidence pipeline, or SECURITY.md — and whenever
-it changes how a secret, key, or audit record is produced, stored, transported
-or compared. Otherwise delete this section.
+Classes/Http, the security gates, the release-evidence pipeline, or SECURITY.md
+— and whenever it changes how a secret, key, or audit record is produced,
+stored, transported or compared. Otherwise delete this section.
 
 "No change" is a valid answer; leaving it blank is not — see CONTRIBUTING.md.
 Security-critical PRs also need TWO approvals, one from a code owner.

--- a/Build/Scripts/collect-evidence.php
+++ b/Build/Scripts/collect-evidence.php
@@ -44,8 +44,9 @@ const SCHEMA_VERSION = 1;
 /**
  * Security-relevant source directories that get their own coverage line in
  * the manifest. Mirrors the source scope of the security mutation ratchet
- * (infection-security.json5); CODEOWNERS still lists only the first three —
- * reconciling that is #329.
+ * (infection-security.json5), the codecov security components, the
+ * security-critical path table in CONTRIBUTING.md and the `Classes/`
+ * entries in CODEOWNERS.
  */
 const SECURITY_DIRS = ['Classes/Crypto', 'Classes/Security', 'Classes/Audit', 'Classes/Http'];
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -166,6 +166,7 @@ extra requirements on top of the normal PR process.
 | `Classes/Crypto/` | Envelope encryption, key wrapping, master-key providers |
 | `Classes/Security/` | Access control, permissions, technical-actor context |
 | `Classes/Audit/` | Tamper-evident audit log and its hash chain |
+| `Classes/Http/` | Outbound credential path, SSRF/DNS-pin middleware, host allow-list, OAuth token leg |
 | `infection-security.json5`, `.github/workflows/security-gates.yml` | The mutation ratchet that guards the above |
 | `.github/workflows/release-evidence.yml`, `Build/Scripts/collect-evidence.php` | The release evidence bundle |
 | `SECURITY.md` | The published security policy and its SLAs |

--- a/codecov.yml
+++ b/codecov.yml
@@ -41,9 +41,10 @@ coverage:
 # Security-critical components.
 #
 # Patch coverage on these paths must be 90%: envelope encryption and master-key
-# handling (Crypto), authorization and technical-actor context (Security), and
-# the tamper-evident audit chain (Audit). The 1% threshold absorbs rounding on
-# small diffs without opening a meaningful gap.
+# handling (Crypto), authorization and technical-actor context (Security), the
+# tamper-evident audit chain (Audit), and the outbound credential path (Http).
+# The 1% threshold absorbs rounding on small diffs without opening a meaningful
+# gap.
 #
 # Raising a target is always fine. LOWERING one — or dropping a path from a
 # component — needs security-team sign-off recorded in the PR description, the
@@ -72,6 +73,11 @@ component_management:
       name: audit
       paths:
         - Classes/Audit/**
+
+    - component_id: http
+      name: http
+      paths:
+        - Classes/Http/**
 
 flags:
   unit:


### PR DESCRIPTION
## Summary

#307 widened the *measurement* surfaces to `Classes/Http` (mutation ratchet, release-evidence manifest, SECURITY.md, developer docs) and deliberately left the *process* surfaces enumerating three directories, recorded as #329. The result was a repo that named the outbound credential path security-critical in one half of its own documentation and not the other. This PR closes that split.

## Changes

- `.github/CODEOWNERS` — `/Classes/Http/` gets the entry the other three security paths have.
- `CONTRIBUTING.md` — `Classes/Http/` joins the security-critical path table, which is what the two-approval rule and the threat-model requirement read.
- `.github/PULL_REQUEST_TEMPLATE.md` — `Classes/Http` joins the Threat-Model Delta trigger list. The functional catch-all ("changes how a secret … is transported") already covered it; the mechanical list now says so instead of requiring the reader to derive it.
- `codecov.yml` — a fourth `http` component reports Http patches against the same 90% patch target. The file's own comment already promised this by naming the mutation ratchet's scope as the rule it follows.
- `Build/Scripts/collect-evidence.php` — the `SECURITY_DIRS` comment no longer points at this issue as open work.

## What this does and does not enforce

Stated precisely, because the first version of this description overstated it on two counts:

- **CODEOWNERS**: no mechanical change. `*  @CybotTM` already resolved every file under `Classes/Http/` to the same owner set, CODEOWNERS is last-match-wins, and neither the ruleset nor classic protection sets `require_code_owner_review` — verified against `repos/…/rules/branches/main` and `/branches/main/protection`, both `false`, for `Classes/Crypto/` as much as for `Classes/Http/`. The entry is what the file's own comment says it is: explicit for visibility, and consistent with its three siblings. Turning the enforcement on is a ruleset change, and it cannot be a drive-by: with a single code owner who is also the usual author, `require_code_owner_review: true` would block every PR they open, so it needs a second code owner first.
- **codecov**: advisory, not a merge gate. The required contexts on `main` are `All security checks, CodeQL, DCO, Detect security-critical changes, Opengrep OSS, Security gates, betterleaks, ci / All CI checks, scorecard, zizmor` plus the two classic `security / …` contexts; no codecov context appears in either list. `codecov/patch/http` will post alongside the existing `codecov/patch/{crypto,security,audit}` statuses and show red below the bar without blocking the merge.
- **CONTRIBUTING.md and the PR template** are the surfaces that do change something today: they are what a reviewer reads to decide whether a PR needs two approvals and a threat-model delta.

Patch coverage measures the diff, not the file, so the new component sets the bar for future Http changes rather than retroactively failing anything. `Classes/Http/SecretPlacement.php` sits in the top-level `ignore` list, so the component covers 17 of the directory's 18 files.

## Related Issues

Fixes #329

## Checklist

- [x] Tests pass locally — `composer ci:test:repo` (arch, doc-cli, doc-cli self-test, evidence self-test) all OK
- [x] PHPStan — not applicable (one docblock in a Build script; `php -l` clean)
- [x] Code style is correct — php-cs-fixer dry-run 0 of 510
- [x] Documentation updated (CONTRIBUTING.md is the documentation for this rule)
- [x] CHANGELOG.md — not applicable; no user- or API-facing change, and the gate-semantics entry landed with #307
- [x] `codecov.yml` validated against `https://codecov.io/validate` → `Valid!`

## Two-person review

This PR edits `Build/Scripts/collect-evidence.php`, which its own table lists as a security-critical path, so CONTRIBUTING.md Rule 1 applies: two approvals, author excluded, one from a code owner. That is not available here and the deviation is recorded per CONTRIBUTING.md's own instruction rather than passed over. Copilot is out of review quota for 2026-08 (monthly, account-wide), the only approval on this PR is the `github-actions` bot, and the repository has one code owner, who is the author. The diff was instead reviewed by an independent adversarial agent pass whose findings are applied here — including the two enforcement claims corrected above and the wording of the two comments.

## Threat-Model Delta

- **Trust boundaries**: none — review-process configuration and documentation only; no code path changes.
- **Attacker capability**: none made cheaper. The change makes the review requirements for the outbound credential path legible in the places a reviewer actually consults, and adds an advisory 90% patch-coverage signal there.
- **Invariants**: extends the documented "security-critical paths need two approvals and a threat-model delta" from `Classes/{Crypto,Security,Audit}` to also name `Classes/Http` — carried by CONTRIBUTING.md and the PR template, and reported (not enforced) by the codecov component.

## Test Plan

The repo checks cover the evidence collector. The widened rules take effect on the next PR that changes production code under `Classes/Http/` — note that #328 is a test-only change, so it exercises neither the CODEOWNERS path match nor the `codecov/patch/http` component.