### PR TITLE
Harden the Classes/Http assertions the mutation gate measures

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -2251,7 +2251,7 @@ parameters:
 		-
 			rawMessage: 'Call to an undefined method PHPUnit\Framework\MockObject\InvocationStubber::with().'
 			identifier: method.notFound
-			count: 19
+			count: 20
 			path: ../Tests/Unit/Http/VaultHttpClientTest.php
 
 		-
@@ -2269,7 +2269,7 @@ parameters:
 		-
 			rawMessage: 'Cannot call method willReturn() on mixed.'
 			identifier: method.nonObject
-			count: 19
+			count: 20
 			path: ../Tests/Unit/Http/VaultHttpClientTest.php
 
 		-

--- a/Tests/Unit/Http/OAuth/OAuthTokenTest.php
+++ b/Tests/Unit/Http/OAuth/OAuthTokenTest.php
@@ -78,6 +78,39 @@ final class OAuthTokenTest extends TestCase
         self::assertTrue($token->isExpired());
     }
 
+    /**
+     * The default buffer is zero, and the two tests above cannot show it: an
+     * expiry a minute away stays in the future even if the default silently
+     * became a second, and one a minute past stays past. Both assertions are
+     * therefore made against an expiry closer than one second, where a
+     * non-zero default flips the answer.
+     */
+    #[Test]
+    public function isExpiredAppliesNoBufferByDefault(): void
+    {
+        $expiringShortly = new OAuthToken(
+            accessToken: 'test-token',
+            tokenType: 'Bearer',
+            expiresAt: new DateTimeImmutable('+1 second'),
+        );
+
+        self::assertFalse(
+            $expiringShortly->isExpired(),
+            'A token still inside its lifetime must not be reported expired by the default buffer.',
+        );
+
+        $expiringNow = new OAuthToken(
+            accessToken: 'test-token',
+            tokenType: 'Bearer',
+            expiresAt: new DateTimeImmutable(),
+        );
+
+        self::assertTrue(
+            $expiringNow->isExpired(),
+            'A token whose expiry has been reached must be reported expired without an extension.',
+        );
+    }
+
     #[Test]
     public function isExpiredRespectsBufferTime(): void
     {

--- a/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
@@ -66,6 +66,21 @@ final class SecureHttpClientFactorySsrfTest extends TestCase
         yield 'reserved 240/4' => ['240.0.0.1'];
         yield 'benchmark 198.18/15' => ['198.18.0.1'];
 
+        // Upper edges of each explicitly checked range. The lower edge alone
+        // passes a check that has drifted to only match that one address —
+        // both ends have to be pinned for the range to mean anything.
+        yield 'cgnat upper edge 100.127.255.254' => ['100.127.255.254'];
+        yield 'cgnat odd second octet 100.65.0.1' => ['100.65.0.1'];
+        yield 'ietf protocol assignments 192.0.0/24' => ['192.0.0.1'];
+        yield 'ietf protocol assignments upper 192.0.0.254' => ['192.0.0.254'];
+        yield 'benchmark second half 198.19/16' => ['198.19.0.1'];
+        yield 'multicast upper edge 239.255.255.254' => ['239.255.255.254'];
+
+        // IPv6 range edges, same reasoning.
+        yield 'ipv6 ula second half fd00::/8' => ['fd00::1'];
+        yield 'ipv6 link-local upper edge febf::' => ['febf::1'];
+        yield 'ipv6 discard-only 100::/64' => ['100::1'];
+
         // IPv6 dangerous ranges
         yield 'ipv6 loopback' => ['::1'];
         yield 'ipv6 ula fc00::/7' => ['fc00::1'];
@@ -160,6 +175,62 @@ final class SecureHttpClientFactorySsrfTest extends TestCase
     {
         // parse_url returning no host means we fail closed.
         self::assertFalse($this->subject->isHostAllowed('://no-scheme-no-host'));
+    }
+
+    /**
+     * Addresses that sit just outside a denied range, or that merely resemble
+     * a transition form, and therefore must stay reachable.
+     *
+     * A deny check is only as good as the line it draws. Asserting the denied
+     * side alone cannot tell a correct range from one that swallows the whole
+     * internet, and the transition-form branches decode an embedded IPv4 at a
+     * fixed byte offset — reading one byte to either side still lands on
+     * plausible-looking bytes, so only an address that must be ALLOWED shows
+     * the offset moved.
+     *
+     * @return iterable<string, array{0: string}>
+     */
+    public static function publicNeighbourIpProvider(): iterable
+    {
+        // IPv4 — one step outside each explicitly checked range.
+        yield 'above cgnat 100.128.0.1' => ['100.128.0.1'];
+        yield 'below cgnat 99.64.0.1' => ['99.64.0.1'];
+        yield 'past ietf /24 192.0.1.1' => ['192.0.1.1'];
+        yield 'other 192 second octet 192.1.0.1' => ['192.1.0.1'];
+        yield 'below ietf block 191.0.0.1' => ['191.0.0.1'];
+        yield 'above benchmark 198.20.0.1' => ['198.20.0.1'];
+        yield 'below benchmark 198.17.0.1' => ['198.17.0.1'];
+        yield 'below multicast 223.255.255.254' => ['223.255.255.254'];
+        yield 'ordinary public 16.0.0.1' => ['16.0.0.1'];
+        yield 'ordinary public 9.9.9.9' => ['9.9.9.9'];
+
+        // IPv6 — outside the byte-0/byte-1 prefixes.
+        yield 'global unicast 2080::1' => ['2080::1'];
+
+        // IPv6 addresses that merely CONTAIN bytes a transition form would
+        // carry. ::ffff: in the middle of a global address is not an
+        // IPv4-mapped address, and the trailing bytes are not an embedded IPv4.
+        yield 'ffff bytes mid-address 2001:db8::ffff:7f00:1' => ['2001:db8::ffff:7f00:1'];
+
+        // Transition forms whose embedded IPv4 is public — these exercise the
+        // decode offsets: shift the window by a byte and a public embedded
+        // address reads as a reserved one.
+        yield 'ipv4-mapped public ::ffff:8.8.8.8' => ['::ffff:8.8.8.8'];
+        yield '6to4 public 2002:17f:1::' => ['2002:17f:1::'];
+        // Teredo with a public server (8.127.0.1, bytes 4-7) AND a public
+        // client (8.8.4.4, bytes 12-15 stored XOR 0xffffffff).
+        yield 'teredo public both legs' => ['2001:0:87f:1::f7f7:fbfb'];
+        yield 'ipv4-compatible public ::8.8.8.8' => ['::8.8.8.8'];
+    }
+
+    #[Test]
+    #[DataProvider('publicNeighbourIpProvider')]
+    public function isHostAllowedAllowsPublicNeighboursOfDeniedRanges(string $host): void
+    {
+        self::assertTrue(
+            $this->subject->isHostAllowed($host),
+            \sprintf('Expected public host %s to stay reachable, but it was blocked.', $host),
+        );
     }
 
     #[Test]

--- a/Tests/Unit/Http/SecureHttpClientFactoryTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryTest.php
@@ -328,6 +328,98 @@ final class SecureHttpClientFactoryTest extends TestCase
         }
     }
 
+    /**
+     * Environment proxy variables decide where outbound traffic — including
+     * every request carrying a vault secret — is actually sent, so the built
+     * client has to be inspected rather than merely constructed. The two tests
+     * above assert only that a client came back, which holds just as well for
+     * a client that silently dropped the proxy or read the wrong variable.
+     *
+     * `NO_PROXY` is a comma-separated list and Guzzle expects it split; the
+     * uppercase spelling wins over the lowercase one; and an empty value is
+     * not a proxy setting at all — an empty `proxy.https` would send requests
+     * to nowhere.
+     */
+    #[Test]
+    public function environmentProxyVariablesReachTheClientConfiguration(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP'] = [];
+
+        $this->withProxyEnvironment(
+            [
+                'HTTPS_PROXY' => 'http://https-proxy.example.com:8080',
+                'https_proxy' => 'http://lowercase-proxy.example.com:8080',
+                'HTTP_PROXY' => 'http://http-proxy.example.com:3128',
+                'NO_PROXY' => 'localhost,127.0.0.1,.local',
+            ],
+            function (): void {
+                $config = $this->getGuzzleConfig($this->factory->create());
+
+                self::assertSame(
+                    [
+                        'http' => 'http://http-proxy.example.com:3128',
+                        'https' => 'http://https-proxy.example.com:8080',
+                        'no' => ['localhost', '127.0.0.1', '.local'],
+                    ],
+                    $config['proxy'] ?? null,
+                );
+            },
+        );
+    }
+
+    #[Test]
+    public function emptyProxyEnvironmentVariablesAreNotTreatedAsAProxy(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP'] = [];
+
+        $this->withProxyEnvironment(
+            [
+                'HTTPS_PROXY' => '',
+                'https_proxy' => '',
+                'HTTP_PROXY' => '',
+                'http_proxy' => '',
+                'NO_PROXY' => '',
+                'no_proxy' => '',
+            ],
+            function (): void {
+                $config = $this->getGuzzleConfig($this->factory->create());
+
+                self::assertNull(
+                    $config['proxy'] ?? null,
+                    'An empty proxy variable must leave the client without a proxy, not with an empty one.',
+                );
+            },
+        );
+    }
+
+    #[Test]
+    public function lowercaseProxyVariablesAreUsedWhenTheUppercaseOnesAreUnset(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP'] = [];
+
+        $this->withProxyEnvironment(
+            [
+                'HTTPS_PROXY' => null,
+                'https_proxy' => 'http://lowercase-proxy.example.com:8080',
+                'HTTP_PROXY' => null,
+                'http_proxy' => null,
+                'NO_PROXY' => null,
+                'no_proxy' => 'example.org',
+            ],
+            function (): void {
+                $config = $this->getGuzzleConfig($this->factory->create());
+
+                self::assertSame(
+                    [
+                        'https' => 'http://lowercase-proxy.example.com:8080',
+                        'no' => ['example.org'],
+                    ],
+                    $config['proxy'] ?? null,
+                );
+            },
+        );
+    }
+
     #[Test]
     public function isHostAllowedReturnsFalseWhenNoPatternMatches(): void
     {
@@ -337,6 +429,46 @@ final class SecureHttpClientFactoryTest extends TestCase
 
         // Neither exact match nor wildcard match
         self::assertFalse($this->factory->isHostAllowed('different.domain.org'));
+    }
+
+    /**
+     * Apply proxy environment variables for the duration of one callable and
+     * restore whatever the environment held before, including variables the
+     * caller set to `null` (meaning: must be unset while the callable runs).
+     *
+     * @param array<string, string|null> $variables
+     * @param callable(): void $assertions
+     */
+    private function withProxyEnvironment(array $variables, callable $assertions): void
+    {
+        $originals = [];
+        foreach (array_keys($variables) as $name) {
+            $originals[$name] = getenv($name);
+        }
+
+        foreach ($variables as $name => $value) {
+            if ($value === null) {
+                putenv($name);
+
+                continue;
+            }
+
+            putenv($name . '=' . $value);
+        }
+
+        try {
+            $assertions();
+        } finally {
+            foreach ($originals as $name => $value) {
+                if ($value === false) {
+                    putenv($name);
+
+                    continue;
+                }
+
+                putenv($name . '=' . $value);
+            }
+        }
     }
 }
 

--- a/Tests/Unit/Http/VaultHttpClientTest.php
+++ b/Tests/Unit/Http/VaultHttpClientTest.php
@@ -32,6 +32,8 @@ use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Client\ClientExceptionInterface;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\StreamInterface;
 use ReflectionClass;
 
 #[CoversClass(VaultHttpClient::class)]
@@ -341,6 +343,52 @@ final class VaultHttpClientTest extends TestCase
 
         $request = new Request('GET', self::API_URL);
         $authenticatedClient->sendRequest($request);
+    }
+
+    /**
+     * The exact query string matters, not just that the pair is somewhere in
+     * it. `assertStringContainsString` passes on a query that dropped the `&`
+     * separator or emitted the pair before the caller's own parameters, and
+     * both of those silently change which request the server sees.
+     *
+     * @return iterable<string, array{0: string, 1: string}>
+     */
+    public static function queryParamInjectionProvider(): iterable
+    {
+        yield 'empty query gets no leading separator' => ['', 'api_key=query-key-value'];
+        yield 'existing query keeps its order and gains a separator' => [
+            '?page=2&sort=name',
+            'page=2&sort=name&api_key=query-key-value',
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('queryParamInjectionProvider')]
+    public function queryParamInjectionProducesTheExactQueryString(string $suffix, string $expected): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->with('my_api_key')
+            ->willReturn('query-key-value');
+
+        $this->innerClient
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturnCallback(function (RequestInterface $request) use ($expected): Response {
+                self::assertSame($expected, $request->getUri()->getQuery());
+
+                return new Response(200);
+            });
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::QueryParam);
+
+        $authenticatedClient->sendRequest(new Request('GET', self::API_URL . $suffix));
     }
 
     #[Test]
@@ -966,6 +1014,78 @@ final class VaultHttpClientTest extends TestCase
 
         $this->expectException(ClientExceptionInterface::class);
         $authenticatedClient->sendRequest($request);
+    }
+
+    /**
+     * The OAuth send path had no assertion on what it actually puts on the
+     * wire. Both halves are load-bearing and neither is observable from the
+     * `withOAuth()` construction tests: the header must be exactly
+     * `Bearer <token>` — a bare token, or the scheme without the token, is a
+     * request the API rejects or one that leaks nothing but also authenticates
+     * nothing — and the audit row must name the OAuth client-id secret under
+     * the `oauth2:` prefix, which is what separates an OAuth call from a
+     * static-secret call in the audit trail.
+     */
+    #[Test]
+    public function oauthSendSetsBearerHeaderAndAuditsUnderTheOauth2Identifier(): void
+    {
+        $tokenResponseBody = $this->createMock(StreamInterface::class);
+        $tokenResponseBody->method('__toString')->willReturn(json_encode([
+            'access_token' => 'issued-access-token',
+            'token_type' => 'Bearer',
+            'expires_in' => 3600,
+        ], JSON_THROW_ON_ERROR));
+
+        $tokenResponse = $this->createMock(ResponseInterface::class);
+        $tokenResponse->method('getStatusCode')->willReturn(200);
+        $tokenResponse->method('getBody')->willReturn($tokenResponseBody);
+
+        $tokenEndpointClient = $this->createMock(ClientInterface::class);
+        $tokenEndpointClient->method('sendRequest')->willReturn($tokenResponse);
+
+        $this->vaultService
+            ->method('retrieve')
+            ->willReturnCallback(fn (string $id): ?string => match ($id) {
+                'oauth_client_id' => 'my-client-id',
+                'oauth_client_secret' => 'my-client-secret',
+                default => null,
+            });
+
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->with('oauth2:oauth_client_id');
+
+        $this->innerClient
+            ->expects(self::once())
+            ->method('sendRequest')
+            ->willReturnCallback(function (RequestInterface $request): Response {
+                self::assertSame(
+                    'Bearer issued-access-token',
+                    $request->getHeaderLine('Authorization'),
+                );
+
+                return new Response(200);
+            });
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+            oauthManager: new OAuthTokenManager(
+                $this->vaultService,
+                $tokenEndpointClient,
+                new SecureHttpClientFactory(),
+            ),
+        );
+
+        $oauthClient = $client->withOAuth(OAuthConfig::clientCredentials(
+            tokenEndpoint: self::TOKEN_ENDPOINT,
+            clientIdSecret: 'oauth_client_id',
+            clientSecretSecret: 'oauth_client_secret',
+        ));
+
+        $oauthClient->sendRequest(new Request('GET', self::API_URL));
     }
 
     #[Test]

--- a/Tests/Unit/Http/VaultHttpResponseTest.php
+++ b/Tests/Unit/Http/VaultHttpResponseTest.php
@@ -70,6 +70,59 @@ final class VaultHttpResponseTest extends TestCase
         yield '299 boundary' => [299];
     }
 
+    /**
+     * The first code of the NEXT class, and the last code of the previous one.
+     * Each predicate is a half-open range, and asserting only the inside of it
+     * cannot tell a correct upper bound from one that has swallowed the
+     * neighbouring class — a 500 that also reports as a client error sends a
+     * caller down the retry-is-pointless branch for an error that is worth
+     * retrying.
+     *
+     * @return iterable<string, array{0: int, 1: string}>
+     */
+    public static function statusClassEdgeProvider(): iterable
+    {
+        yield '300 is not a success' => [300, 'isSuccessful'];
+        yield '199 is not a success' => [199, 'isSuccessful'];
+        yield '500 is not a client error' => [500, 'isClientError'];
+        yield '399 is not a client error' => [399, 'isClientError'];
+        yield '600 is not a server error' => [600, 'isServerError'];
+        yield '499 is not a server error' => [499, 'isServerError'];
+        yield '400 is not a redirect' => [400, 'isRedirect'];
+        yield '299 is not a redirect' => [299, 'isRedirect'];
+    }
+
+    #[Test]
+    #[DataProvider('statusClassEdgeProvider')]
+    public function statusClassPredicatesExcludeTheNeighbouringClass(int $statusCode, string $predicate): void
+    {
+        $psrResponse = $this->createMock(ResponseInterface::class);
+        $psrResponse->method('getStatusCode')->willReturn($statusCode);
+
+        $response = new VaultHttpResponse($psrResponse);
+
+        $actual = match ($predicate) {
+            'isSuccessful' => $response->isSuccessful(),
+            'isClientError' => $response->isClientError(),
+            'isServerError' => $response->isServerError(),
+            default => $response->isRedirect(),
+        };
+
+        self::assertFalse(
+            $actual,
+            \sprintf('%s() must not claim status %d.', $predicate, $statusCode),
+        );
+    }
+
+    #[Test]
+    public function isRedirectAcceptsTheFirstCodeOfItsClass(): void
+    {
+        $psrResponse = $this->createMock(ResponseInterface::class);
+        $psrResponse->method('getStatusCode')->willReturn(300);
+
+        self::assertTrue((new VaultHttpResponse($psrResponse))->isRedirect());
+    }
+
     #[Test]
     #[DataProvider('clientErrorStatusCodesProvider')]
     public function isClientErrorReturnsTrueFor4xxCodes(int $statusCode): void
@@ -282,6 +335,26 @@ final class VaultHttpResponseTest extends TestCase
         $response = new VaultHttpResponse($psrResponse);
 
         self::assertSame([self::CONTENT_TYPE_JSON, self::CONTENT_TYPE_HTML], $response->getHeaderValues('Accept'));
+    }
+
+    /**
+     * `application/json; charset=utf-8` splits into a media type that needs no
+     * trimming, so it cannot show whether the trim happens. A header written
+     * with the space before the separator can — and both spellings are legal
+     * per RFC 9110, so a caller comparing the media type must get the same
+     * answer for either.
+     */
+    #[Test]
+    public function getContentTypeTrimsWhitespaceAroundTheMediaType(): void
+    {
+        $psrResponse = $this->createMock(ResponseInterface::class);
+        $psrResponse
+            ->method('getHeader')
+            ->willReturn([' application/json ; charset=utf-8']);
+
+        $response = new VaultHttpResponse($psrResponse);
+
+        self::assertSame(self::CONTENT_TYPE_JSON, $response->getContentType());
     }
 
     #[Test]

--- a/infection-security.json5
+++ b/infection-security.json5
@@ -63,14 +63,16 @@
     //   * Deleting or excluding a file/directory from `source` above has the
     //     same effect as lowering the threshold and needs the same sign-off.
     //
-    // MEASUREMENT (2026-08-19, CI run 32220828311 — first four-directory
-    // baseline including Classes/Http, #307; ubuntu-latest, PHP 8.5, pcov,
+    // MEASUREMENT (2026-08-19, CI run 32262598788 — after the Classes/Http
+    // assertion-hardening pass, #328; ubuntu-latest, PHP 8.5, pcov,
     // Infection 0.35, Unit+Fuzz):
-    //   3503 mutants — 2910 killed, 566 escaped, 25 timed out, 2 errored,
+    //   3505 mutants — 2987 killed, 491 escaped, 25 timed out, 2 errored,
     //   0 skipped, 0 not covered
-    //   MSI 83.84 %, covered-code MSI 83.84 %, mutation code coverage 100 %
-    //   (previous 2026-08-02 three-directory baseline: 2338 mutants,
-    //   MSI 87.77 %; 2026-07-31: MSI 75.03 %)
+    //   MSI 85.99 %, covered-code MSI 85.99 %, mutation code coverage 100 %
+    //   (same day, before the hardening pass: 3503 mutants, MSI 83.84 % —
+    //   the first four-directory baseline from #307, CI run 32220828311;
+    //   2026-08-02 three-directory baseline: 2338 mutants, MSI 87.77 %;
+    //   2026-07-31: MSI 75.03 %)
     //
     //   CI is the authoritative environment for this number. On a slower host
     //   Infection drops a mutant from the MSI denominator when its covering
@@ -88,11 +90,18 @@
     // which is exactly the kind of weakness this gate is meant to hold the
     // line on.
     //
-    // Floor history: 86 -> 82 on 2026-08-19, the #307 scope re-baseline —
-    // lowered per the policy above, sign-off recorded in PR #327. The 566
-    // escapes (263 of them in Classes/Http) are the raise target for the
-    // assertion-hardening pass tracked in #328, aiming back above 86.
+    // Floor history, both on 2026-08-19: 86 -> 82 for the #307 scope
+    // re-baseline (lowered per the policy above, sign-off recorded in PR #327),
+    // then 82 -> 84 here, raised by the first Classes/Http assertion-hardening
+    // pass (PR #331), which killed 75 of the 566 escapes.
+    //
+    // 84 is what the measurement carries, not the 86 #328 set as its target:
+    // at MSI 85.99 a floor of 86 would fail on the spot, and even 85 would
+    // leave the gate tripping on a flake rather than on a regression — two
+    // runs of this same tree differed by one mutant (86.00 vs 85.99). #328
+    // stays open for the remaining 491 escapes, and the next pass raises the
+    // floor again.
     // ------------------------------------------------------------------------
-    "minMsi": 82,
-    "minCoveredMsi": 82
+    "minMsi": 84,
+    "minCoveredMsi": 84
 }


### PR DESCRIPTION
## Summary

The four-directory baseline from #307 measured MSI 83.84 % with 566 escaped mutants, 263 of them in `Classes/Http`, and the floor was re-baselined to 82 to admit them. Those escapes are assertion gaps rather than coverage gaps — mutation code coverage is 100 %, so every mutant is reached by a test that then fails to notice it. This PR closes the ones worth closing and raises the floor by what the result carries. Part of #328.

Every gap has the same shape: the tests asserted the denied side or the happy path only, which cannot pin a boundary.

- **SSRF ranges.** The provider held only "must be blocked" rows, so a check that widened to swallow the neighbouring range, or a transition form whose embedded-IPv4 window shifted by a byte, kept every assertion green. Adds the range edges that must stay blocked (CGNAT upper edge, `192.0.0.0/24`, `198.19/16`, multicast upper edge, `fd00::/8`, `febf::`, `100::/64`) and a new provider of public neighbours that must stay reachable — including 6to4, Teredo, IPv4-mapped and IPv4-compatible addresses whose embedded IPv4 is public.
- **Environment proxy resolution.** The two existing tests asserted only that a client came back, which holds equally for a client that dropped the proxy or read the wrong variable. The resolved configuration is now read off the built client: uppercase wins over lowercase, `NO_PROXY` is comma-split, and an empty variable is not a proxy setting.
- **OAuth send path.** Nothing asserted what it puts on the wire. Pins the exact `Bearer <token>` header and the `oauth2:` audit identifier that separates an OAuth call from a static-secret call in the audit trail.
- **Query-param placement** was asserted with `assertStringContainsString`, which survives a dropped separator or a reordered query. Now exact, with and without a pre-existing query string.
- **Status-class predicates, content-type trimming, default expiry buffer.** The neighbouring status class, the `media/type ; param` spelling and the sub-second expiry boundary were unasserted.

## Result, and why the floor lands on 84 rather than 86

CI run [32262598788](https://github.com/netresearch/t3x-nr-vault/actions/runs/32262598788) on this branch: **3505 mutants — 2987 killed, 491 escaped, 25 timed out, 2 errored, 0 skipped; MSI 85.99 %, mutation code coverage 100 %.** Against 83.84 % before the pass, that is **75 escapes killed, +2.15 points**.

The floor moves **82 → 84**. It does **not** reach the 86 that #328 named as its target, and this PR does not pretend otherwise: at a measured 85.99 a floor of 86 fails on the spot, and even 85 would leave the gate tripping on run-to-run variance rather than on regressions — two runs of this same tree differed by one mutant (86.00 on the pre-rebase head, 85.99 here). #328 therefore stays open for the remaining 491 escapes and the next pass raises the floor again.

Both figures are quoted from the CI `infection-security-report` artifact, and the config comment quotes the run on this PR's final head rather than an earlier one. Per the lesson recorded in #307, a local run of the same recipe is not comparable — on a slower host Infection drops slow-covered mutants from the MSI denominator and reads ~2.5 points high.

## Related Issues

Relates to #328 (partial: floor 82 → 84, target 86 not yet reached — do not auto-close). Follows #307.

## Checklist

- [x] Tests pass locally — full Unit+Fuzz suite: 5342 tests, 20475 assertions, no failures
- [x] PHPStan passes — `[OK] No errors`
- [x] Code style is correct — php-cs-fixer 0 of 510, Rector clean
- [x] Documentation updated — not applicable (tests, two baseline counts, and the gate config's own measurement comment)
- [x] CHANGELOG.md — not applicable; no user- or API-facing change

## Test Plan

Each new assertion was verified against the mutant it exists for rather than assumed to kill it: the mutant Infection reported as escaped was applied to the source by hand, the covering test was run and watched to fail, and the source restored. All 13 representative mutants across the five touched behaviours were caught:

```
caught  ipv4 192.0.0.0/24 first octet      caught  proxy result inversion
caught  ipv4 multicast mask                caught  proxy empty-value guard
caught  ipv6 ULA mask                      caught  oauth bearer scheme
caught  ipv6 teredo server offset          caught  oauth audit identifier prefix
caught  ipv6 discard prefix length         caught  query-param separator
caught  status class upper bound           caught  content-type trim
caught  token default buffer
```

The candidate addresses were also probed against the real `isHostAllowed()` before being written into a provider, so no row asserts a verdict the implementation does not actually produce. The gate itself then re-measured the whole scope on CI, which is the number the floor is set from.

## Threat-Model Delta

- **Trust boundaries**: none — tests plus the gate's threshold; no runtime code path was modified.
- **Attacker capability**: none made cheaper. The change removes the ability for a future edit to weaken the SSRF range checks, the proxy resolution or the OAuth header format without a red test, and raises the floor that would catch such an edit.
- **Invariants**: adds pinned invariants rather than changing any — the SSRF deny ranges are now pinned at both edges, the OAuth `Authorization` header format and audit identifier are pinned exactly, and environment proxy resolution is pinned to the configuration it produces. The gate invariant itself tightens from 82 to 84.