### PR TITLE
Harden the remaining Classes/Http assertion gaps

### DIFF
--- a/Build/phpstan-baseline.neon
+++ b/Build/phpstan-baseline.neon
@@ -2251,7 +2251,7 @@ parameters:
 		-
 			rawMessage: 'Call to an undefined method PHPUnit\Framework\MockObject\InvocationStubber::with().'
 			identifier: method.notFound
-			count: 20
+			count: 22
 			path: ../Tests/Unit/Http/VaultHttpClientTest.php
 
 		-
@@ -2269,7 +2269,7 @@ parameters:
 		-
 			rawMessage: 'Cannot call method willReturn() on mixed.'
 			identifier: method.nonObject
-			count: 20
+			count: 22
 			path: ../Tests/Unit/Http/VaultHttpClientTest.php
 
 		-

--- a/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryRebindingTest.php
@@ -317,10 +317,22 @@ final class SecureHttpClientFactoryRebindingTest extends TestCase
         // hand it to curl to resolve internally.
         $client = $this->buildCapturingClient($capturedOptions);
 
-        $this->expectException(RequestException::class);
-        $this->expectExceptionMessageMatches('/non-canonical numeric IP form/i');
+        try {
+            $client->get('http://2130706433/'); // NOSONAR: rejection test — the request is refused before any socket opens; scheme is irrelevant
+            self::fail('The middleware must refuse a legacy numeric IP form.');
+        } catch (RequestException $e) {
+            // All three parts of the refusal are asserted, not just the first:
+            // the message has to name the host, say what curl would do with it,
+            // and tell the operator the accepted form. A refusal that states
+            // only the verdict leaves whoever hits it with nothing to act on,
+            // and each part is a separate string the compiler is free to drop.
+            self::assertStringContainsString('non-canonical numeric IP form', $e->getMessage());
+            self::assertStringContainsString('2130706433', $e->getMessage());
+            self::assertStringContainsString('bypassing the IP range', $e->getMessage());
+            self::assertStringContainsString('canonical dotted-quad', $e->getMessage());
+        }
 
-        $client->get('http://2130706433/'); // NOSONAR: rejection test — the request is refused before any socket opens; scheme is irrelevant
+        self::assertNull($capturedOptions, 'Nothing may reach the transport.');
     }
 
     #[Test]

--- a/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactorySsrfTest.php
@@ -80,6 +80,15 @@ final class SecureHttpClientFactorySsrfTest extends TestCase
         yield 'ipv6 ula second half fd00::/8' => ['fd00::1'];
         yield 'ipv6 link-local upper edge febf::' => ['febf::1'];
         yield 'ipv6 discard-only 100::/64' => ['100::1'];
+        // Teredo with a dangerous SERVER (127.0.0.1 in bytes 4-7) and a public
+        // client (8.8.4.4, stored XOR 0xffffffff). The row above covers the
+        // mirror case; either leg reaching a dangerous IPv4 must deny, and only
+        // this one exercises the server decode.
+        yield 'teredo internal server 127.0.0.1' => ['2001:0:7f00:1::f7f7:fbfb'];
+        // Bracketed form of an address that must be denied on its merits, so
+        // the bracket strip cannot quietly hand a different address to the
+        // range checks.
+        yield 'ipv6 bracketed ula' => ['[fd00::1]'];
 
         // IPv6 dangerous ranges
         yield 'ipv6 loopback' => ['::1'];
@@ -221,6 +230,9 @@ final class SecureHttpClientFactorySsrfTest extends TestCase
         // client (8.8.4.4, bytes 12-15 stored XOR 0xffffffff).
         yield 'teredo public both legs' => ['2001:0:87f:1::f7f7:fbfb'];
         yield 'ipv4-compatible public ::8.8.8.8' => ['::8.8.8.8'];
+        // The bracket strip must return the address itself, not a truncation
+        // of it: a public IPv6 in brackets stays reachable.
+        yield 'bracketed public ipv6' => ['[2606:4700:4700::1111]'];
     }
 
     #[Test]

--- a/Tests/Unit/Http/SecureHttpClientFactoryTest.php
+++ b/Tests/Unit/Http/SecureHttpClientFactoryTest.php
@@ -64,6 +64,23 @@ final class SecureHttpClientFactoryTest extends TestCase
         self::assertInstanceOf(ClientInterface::class, $client);
     }
 
+    /**
+     * The fallbacks that apply when TYPO3 configures no HTTP timeouts. They
+     * bound how long a request carrying a vault secret may hang, and nothing
+     * asserted them — `createWithNonIntegerTimeoutUsesDefault` below only
+     * checks that a client came back, which is true for any default at all.
+     */
+    #[Test]
+    public function createFallsBackToTheDocumentedTimeoutDefaults(): void
+    {
+        $GLOBALS['TYPO3_CONF_VARS']['HTTP'] = [];
+
+        $config = $this->getGuzzleConfig($this->factory->create());
+
+        self::assertSame(30, $config['timeout'] ?? null);
+        self::assertSame(10, $config['connect_timeout'] ?? null);
+    }
+
     #[Test]
     public function createWithProxyConfig(): void
     {

--- a/Tests/Unit/Http/VaultHttpClientCancellableTest.php
+++ b/Tests/Unit/Http/VaultHttpClientCancellableTest.php
@@ -24,6 +24,7 @@ use GuzzleHttp\Psr7\Response;
 use InvalidArgumentException;
 use Netresearch\NrVault\Audit\AuditContextInterface;
 use Netresearch\NrVault\Audit\AuditLogServiceInterface;
+use Netresearch\NrVault\Audit\HttpCallContext;
 use Netresearch\NrVault\Exception\RequestCancelledException;
 use Netresearch\NrVault\Exception\SecretNotFoundException;
 use Netresearch\NrVault\Exception\VaultException;
@@ -477,6 +478,54 @@ final class VaultHttpClientCancellableTest extends TestCase
             [['http_call_cancelled_before_send', false, self::CANCELLED_BEFORE_SEND_MESSAGE]],
             $auditedRows,
         );
+    }
+
+    /**
+     * The audited status code for a call that never reached the wire.
+     *
+     * Zero is the only honest value here — there was no response — and it is
+     * what an auditor filters on to separate "never sent" from a real HTTP
+     * outcome. Any other number would read as a status the server returned.
+     * The row's action and message are pinned above; nothing pinned the
+     * context the row carries.
+     */
+    #[Test]
+    public function aPreFlightCancellationIsAuditedWithoutAStatusCode(): void
+    {
+        $transfer = new StubbedTransfer();
+        $transport = $this->transportWith($transfer, new ClosureTicker(static function (): void {}));
+
+        $statusCodes = [];
+        $this->auditLogService
+            ->expects(self::once())
+            ->method('log')
+            ->willReturnCallback(
+                static function (
+                    string $identifier,
+                    string $action,
+                    bool $success,
+                    ?string $error = null,
+                    ?string $reason = null,
+                    ?string $hashBefore = null,
+                    ?string $hashAfter = null,
+                    ?AuditContextInterface $context = null,
+                ) use (&$statusCodes): void {
+                    self::assertInstanceOf(HttpCallContext::class, $context);
+                    $statusCodes[] = $context->statusCode;
+                },
+            );
+
+        $client = $this->clientWithTransport($transport)
+            ->withAuthentication('api_key', SecretPlacement::Bearer);
+
+        try {
+            $client->sendCancellable(new Request('GET', self::API_URL), new AlreadyCancelledSignal());
+            self::fail('Expected the pre-flight signal to refuse the send.');
+        } catch (RequestCancelledException) {
+            // The refusal itself is asserted by the test above.
+        }
+
+        self::assertSame([0], $statusCodes);
     }
 
     #[Test]

--- a/Tests/Unit/Http/VaultHttpClientTest.php
+++ b/Tests/Unit/Http/VaultHttpClientTest.php
@@ -867,6 +867,86 @@ final class VaultHttpClientTest extends TestCase
     }
 
     /**
+     * The list guard behind the leading-token check. A body of `[1,2,3]` never
+     * reaches it — it is rejected for not starting with `{` — so the only way
+     * to exercise the guard is the case its own comment describes: an object
+     * whose keys are the consecutive numeric strings PHP decodes back into a
+     * list. Injecting a named field there would re-encode a reshaped
+     * structure, which is why it is refused rather than silently accepted.
+     */
+    #[Test]
+    public function injectBodyFieldRejectsJsonObjectThatDecodesToAList(): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->with('my_api_key')
+            ->willReturn('secret-value');
+
+        $this->innerClient
+            ->expects(self::never())
+            ->method('sendRequest');
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::BodyField);
+
+        $request = new Request('POST', self::API_URL, [
+            'Content-Type' => self::CONTENT_TYPE_JSON,
+        ], '{"0":"a","1":"b"}');
+
+        $this->expectException(VaultException::class);
+        $this->expectExceptionMessageToContain(self::NON_OBJECT_BODY_MESSAGE);
+
+        $authenticatedClient->sendRequest($request);
+    }
+
+    /**
+     * The two body-field refusals carry distinct codes, and a consumer that
+     * wants to tell "not an object" from "not parseable" has nothing else to
+     * match on — the messages are prose. Pin both.
+     *
+     * @return iterable<string, array{0: string, 1: int}>
+     */
+    public static function bodyFieldRefusalCodeProvider(): iterable
+    {
+        yield 'not an object' => ['[1,2,3]', 1735858524];
+        yield 'not valid json' => ['{"broken": ', 1781076764];
+    }
+
+    #[Test]
+    #[DataProvider('bodyFieldRefusalCodeProvider')]
+    public function injectBodyFieldRefusalsCarryTheirDistinctCode(string $body, int $expectedCode): void
+    {
+        $this->vaultService
+            ->method('retrieve')
+            ->with('my_api_key')
+            ->willReturn('secret-value');
+
+        $client = new VaultHttpClient(
+            $this->vaultService,
+            $this->auditLogService,
+            $this->innerClient,
+        );
+
+        $authenticatedClient = $client->withAuthentication('my_api_key', SecretPlacement::BodyField);
+
+        $request = new Request('POST', self::API_URL, [
+            'Content-Type' => self::CONTENT_TYPE_JSON,
+        ], $body);
+
+        try {
+            $authenticatedClient->sendRequest($request);
+            self::fail('Expected the body-field injection to be refused.');
+        } catch (VaultException $exception) {
+            self::assertSame($expectedCode, $exception->getCode());
+        }
+    }
+
+    /**
      * A scalar JSON body (`"value"`, `42`, `true`) is even worse — the old
      * `$data[$field] = ...` on a string/int would fatally error after the
      * secret was already retrieved. Reject it with a clear exception instead.

--- a/infection-security.json5
+++ b/infection-security.json5
@@ -63,16 +63,16 @@
     //   * Deleting or excluding a file/directory from `source` above has the
     //     same effect as lowering the threshold and needs the same sign-off.
     //
-    // MEASUREMENT (2026-08-19, CI run 32262598788 — after the Classes/Http
-    // assertion-hardening pass, #328; ubuntu-latest, PHP 8.5, pcov,
-    // Infection 0.35, Unit+Fuzz):
-    //   3505 mutants — 2987 killed, 491 escaped, 25 timed out, 2 errored,
+    // MEASUREMENT (2026-08-19, CI run 32291041010 — after the second
+    // Classes/Http assertion-hardening pass, #328; ubuntu-latest, PHP 8.5,
+    // pcov, Infection 0.35, Unit+Fuzz):
+    //   3508 mutants — 3006 killed, 475 escaped, 25 timed out, 2 errored,
     //   0 skipped, 0 not covered
-    //   MSI 85.99 %, covered-code MSI 85.99 %, mutation code coverage 100 %
-    //   (same day, before the hardening pass: 3503 mutants, MSI 83.84 % —
-    //   the first four-directory baseline from #307, CI run 32220828311;
-    //   2026-08-02 three-directory baseline: 2338 mutants, MSI 87.77 %;
-    //   2026-07-31: MSI 75.03 %)
+    //   MSI 86.46 %, covered-code MSI 86.46 %, mutation code coverage 100 %
+    //   (same day: 85.99 % after the first hardening pass, CI run
+    //   32262598788; 83.84 % at the first four-directory baseline from #307,
+    //   CI run 32220828311; 2026-08-02 three-directory baseline: 2338
+    //   mutants, MSI 87.77 %; 2026-07-31: MSI 75.03 %)
     //
     //   CI is the authoritative environment for this number. On a slower host
     //   Infection drops a mutant from the MSI denominator when its covering
@@ -90,18 +90,18 @@
     // which is exactly the kind of weakness this gate is meant to hold the
     // line on.
     //
-    // Floor history, both on 2026-08-19: 86 -> 82 for the #307 scope
+    // Floor history, all on 2026-08-19: 86 -> 82 for the #307 scope
     // re-baseline (lowered per the policy above, sign-off recorded in PR #327),
-    // then 82 -> 84 here, raised by the first Classes/Http assertion-hardening
-    // pass (PR #331), which killed 75 of the 566 escapes.
+    // then 82 -> 84 with the first Classes/Http assertion-hardening pass
+    // (PR #331, 75 escapes killed), then 84 -> 85 here with the second
+    // (PR #332, 16 more).
     //
-    // 84 is what the measurement carries, not the 86 #328 set as its target:
-    // at MSI 85.99 a floor of 86 would fail on the spot, and even 85 would
-    // leave the gate tripping on a flake rather than on a regression — two
-    // runs of this same tree differed by one mutant (86.00 vs 85.99). #328
-    // stays open for the remaining 491 escapes, and the next pass raises the
-    // floor again.
+    // 85 is the ~1.5-point margin under 86.46 the paragraph above describes,
+    // and it is still short of the 86 #328 set as its target. Run-to-run
+    // variance is real but small: two runs of the identical tree differed by
+    // one mutant (0.03 points), so the margin is not the constraint — the
+    // remaining 475 escapes are. #328 stays open for them.
     // ------------------------------------------------------------------------
-    "minMsi": 84,
-    "minCoveredMsi": 84
+    "minMsi": 85,
+    "minCoveredMsi": 85
 }


### PR DESCRIPTION
## Summary

Second hardening pass on #328. After the first one (#331), `Classes/Http` still carried **188 of the 491** escaped mutants — the largest share of the gated scope, not the smallest as my own follow-up note on that issue had claimed (corrected there). The three files worked on here hold 181 of those 188: `OAuth/OAuthTokenManager.php` (69), `SecureHttpClientFactory.php` (62), `VaultHttpClient.php` (50).

Every gap has the shape the first pass established: a behaviour is exercised, but nothing asserts what it produced.

- **Timeout defaults.** Nothing pinned the 30 s / 10 s fallbacks that bound how long a request carrying a vault secret may hang. The existing `createWithNonIntegerTimeoutUsesDefault` asserts only that a client came back, which is true for any default at all.
- **Teredo server leg.** The suite covered a Teredo address whose *client* IPv4 is dangerous, so a truncated or unwrapped read of the *server* window kept every assertion green. Adds the mirror case: dangerous server, public client.
- **Bracket strip.** A bracketed address that must stay reachable, so stripping to an empty string is no longer indistinguishable from stripping the brackets.
- **The legacy-numeric-IP refusal** asserted only its first sentence, leaving the other two free to vanish — the part naming the host, and the part telling the operator which form to use instead. A refusal that states only its verdict leaves whoever hits it with nothing to act on.
- **The list-shaped-object guard** was unreachable from the existing tests: a `[1,2,3]` body is rejected by the leading-token check long before it. The case the guard's own comment describes — `{"0":"a","1":"b"}`, an object whose numeric string keys decode back into a PHP list — was untested.
- **The two body-field refusal codes**, which are all a consumer can match on, since the messages are prose.
- **The audited status code for a call that never reached the wire.** Zero is the only honest value there, and it is what separates "never sent" from a real HTTP outcome in the audit trail.

## Related Issues

Relates to #328 (second partial pass). Follows #331.

## Checklist

- [x] Tests pass locally — full Unit+Fuzz suite: 5350 tests, 20470 assertions, no failures
- [x] PHPStan passes — `[OK] No errors`
- [x] Code style is correct — php-cs-fixer 0 of 510, Rector clean
- [x] Documentation updated — not applicable (tests plus two baseline counts)
- [x] CHANGELOG.md — not applicable; no user- or API-facing change

## Test Plan

Each new assertion was verified against the mutant it exists for rather than assumed to kill it — applied by hand, suite watched to fail, then reverted. All 11 were caught:

```
caught  request timeout default            caught  refusal message third fragment
caught  connect timeout default            caught  list-shaped object guard
caught  teredo server window length        caught  not-an-object refusal code
caught  teredo server window unwrapped     caught  invalid-json refusal code
caught  bracket strip length               caught  pre-flight audit status code
caught  refusal message second fragment
```

## Result

CI run [32291041010](https://github.com/netresearch/t3x-nr-vault/actions/runs/32291041010) on this branch: **3508 mutants — 3006 killed, 475 escaped, 25 timed out, 2 errored, 0 skipped; MSI 86.46 %**, against 85.99 % before this pass. **16 more escapes killed**, and the floor moves **84 → 85** — the file's ~1.5-point margin under the measurement.

That is still short of the 86 #328 named. The constraint is the remaining 475 escapes, not the margin: run-to-run variance measured one mutant, 0.03 points, across two runs of an identical tree. `Classes/Http` is down from 188 to 172 escapes and `Classes/Audit` (187) is now the larger carrier, so the next pass belongs there.

Figures are quoted from the CI `infection-security-report` artifact, per the lesson in #307 — a local run reads ~2.5 points high because it drops slow-covered mutants from the MSI denominator.

## Threat-Model Delta

- **Trust boundaries**: none — tests only; no runtime code path was modified.
- **Attacker capability**: none made cheaper. The change removes the ability for a future edit to weaken the Teredo server check, the bracket normalisation, the timeout bounds or the body-shape guard without a red test.
- **Invariants**: adds pinned invariants rather than changing any — the Teredo deny now covers both legs, the outbound timeout defaults are pinned, the JSON body-shape guard and its two refusal codes are pinned, and a call that never egressed is pinned to audit status 0.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_018d4iHdbbBCAPKaP1R3k8eF)_
