### PR TITLE
Harden the Classes/Audit assertion gaps

### DIFF
--- a/Tests/Unit/Audit/AuditLogServiceTest.php
+++ b/Tests/Unit/Audit/AuditLogServiceTest.php
@@ -1425,6 +1425,43 @@ final class AuditLogServiceTest extends TestCase
         self::assertArrayHasKey(2, $verification->warnings, 'The increase must still be reported as a (non-fatal) warning');
     }
 
+    /**
+     * The per-epoch row census the verification result carries.
+     *
+     * It is what an auditor reads to answer "how far did the HMAC migration
+     * actually get" — a count that starts one too high, counts in the wrong
+     * steps, or attributes rows to the wrong epoch reports a migration that
+     * did not happen. The result DTO's own test only checks that the array is
+     * passed through; nothing covered the counting itself.
+     */
+    #[Test]
+    public function verifyHashChainCountsRowsPerEpoch(): void
+    {
+        $masterKey = str_repeat("\x01", 32);
+        $hmacKey = hash_hkdf('sha256', $masterKey, 32, 'nr-vault-audit-hmac-v1');
+
+        $row1 = $this->makeV3Row(uid: 1, secretIdentifier: 'secret-a', action: 'create');
+        $hash1 = AuditLogService::calculateHashV2(AuditLogService::extractV2HashRow($row1), '', $hmacKey);
+        $row2 = $this->makeV3Row(uid: 2, secretIdentifier: 'secret-b', action: 'read', crdate: 1704153600);
+        $hash2 = AuditLogService::calculateHashV2(AuditLogService::extractV2HashRow($row2), $hash1, $hmacKey);
+        $row3 = $this->makeV3Row(uid: 3, secretIdentifier: 'secret-c', action: 'read', crdate: 1704240000);
+        $hash3 = AuditLogService::calculateHashV3($row3, $hash2, $hmacKey);
+
+        $rows = [
+            array_merge($row1, ['previous_hash' => '', 'entry_hash' => $hash1, 'hmac_key_epoch' => 2]),
+            array_merge($row2, ['previous_hash' => $hash1, 'entry_hash' => $hash2, 'hmac_key_epoch' => 2]),
+            array_merge($row3, ['previous_hash' => $hash2, 'entry_hash' => $hash3, 'hmac_key_epoch' => 3]),
+        ];
+
+        $verification = $this->runVerifyOverRows($rows);
+
+        self::assertSame(
+            [2 => 2, 3 => 1],
+            $verification->epochCounts,
+            'Two rows at epoch 2 and one at epoch 3, keyed by epoch and sorted.',
+        );
+    }
+
     #[Test]
     public function extractV2HashRowAcceptsBooleanSuccess(): void
     {

--- a/Tests/Unit/Audit/Sink/Rfc5424FormatterTest.php
+++ b/Tests/Unit/Audit/Sink/Rfc5424FormatterTest.php
@@ -149,8 +149,34 @@ final class Rfc5424FormatterTest extends TestCase
 
         $summary = substr($message, (int) strpos($message, '] ') + 2);
 
-        self::assertLessThanOrEqual(300, mb_strlen($summary, 'UTF-8'));
+        // Exact, not "at most": a cap asserted only as an upper bound is met
+        // by a summary that lost its leading characters, kept only its last
+        // one, or was replaced by the ellipsis alone — all of which are still
+        // short enough and still end in "...". The truncation has to keep the
+        // beginning of the text, which is the part that identifies the record.
+        self::assertSame(300, mb_strlen($summary, 'UTF-8'));
         self::assertStringEndsWith('...', $summary);
+        self::assertStringStartsWith('vault audit ', $summary);
+    }
+
+    /**
+     * The cap counts characters, not bytes. A byte-wise truncation of a
+     * multibyte summary both overshoots the character budget and can sever a
+     * UTF-8 sequence, which produces a record a strict collector rejects.
+     */
+    #[Test]
+    public function oversizedMultibyteSummaryIsTruncatedByCharacters(): void
+    {
+        $message = $this->subject->formatEntry(
+            $this->createEntry(secretIdentifier: str_repeat('ä', 5000)),
+            'tip',
+        );
+
+        $summary = substr($message, (int) strpos($message, '] ') + 2);
+
+        self::assertSame(300, mb_strlen($summary, 'UTF-8'));
+        self::assertStringEndsWith('...', $summary);
+        self::assertSame($summary, mb_convert_encoding($summary, 'UTF-8', 'UTF-8'));
     }
 
     /**

--- a/Tests/Unit/Audit/Sink/SinkDeliveryStateTest.php
+++ b/Tests/Unit/Audit/Sink/SinkDeliveryStateTest.php
@@ -1,0 +1,169 @@
+<?php
+
+/*
+ * Copyright (c) 2026 Netresearch DTT GmbH
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */
+
+declare(strict_types=1);
+
+namespace Netresearch\NrVault\Tests\Unit\Audit\Sink;
+
+use Netresearch\NrVault\Audit\Sink\SinkDeliveryState;
+use Netresearch\NrVault\Tests\Unit\TestCase;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Test;
+
+/**
+ * The persisted delivery health of one external audit sink.
+ *
+ * `fromArray()` reads a `sys_registry` payload — data that survived a
+ * serialisation round trip and an extension update, so it is the one place the
+ * class treats its input as untrusted. Every numeric field is coerced through
+ * `is_numeric() ? (int) … : 0`, and the readiness surface reports on the
+ * result: a `lastSuccessAt` that silently became 1 instead of 0 turns "this
+ * sink has never demonstrably accepted a record" into "it succeeded in
+ * January 1970".
+ */
+#[CoversClass(SinkDeliveryState::class)]
+final class SinkDeliveryStateTest extends TestCase
+{
+    #[Test]
+    public function fromArrayReadsAWellFormedRow(): void
+    {
+        $state = SinkDeliveryState::fromArray('syslog', [
+            'lastSuccessAt' => 1_700_000_000,
+            'lastFailureAt' => 1_700_000_500,
+            'consecutiveFailures' => 3,
+            'totalFailures' => 12,
+            'lastError' => 'connection refused',
+        ]);
+
+        self::assertSame('syslog', $state->sinkIdentifier);
+        self::assertSame(1_700_000_000, $state->lastSuccessAt);
+        self::assertSame(1_700_000_500, $state->lastFailureAt);
+        self::assertSame(3, $state->consecutiveFailures);
+        self::assertSame(12, $state->totalFailures);
+        self::assertSame('connection refused', $state->lastError);
+    }
+
+    /**
+     * A registry payload comes back with its numbers as strings often enough
+     * that the cast is load-bearing rather than defensive: the promoted
+     * properties are `int`, so a value that reaches the constructor uncast is
+     * a TypeError under `strict_types`, not a quietly wrong number.
+     */
+    #[Test]
+    public function fromArrayCastsNumericStringsToIntegers(): void
+    {
+        $state = SinkDeliveryState::fromArray('webhook', [
+            'lastSuccessAt' => '1700000000',
+            'lastFailureAt' => '1700000500',
+            'consecutiveFailures' => '3',
+            'totalFailures' => '12',
+        ]);
+
+        self::assertSame(1_700_000_000, $state->lastSuccessAt);
+        self::assertSame(1_700_000_500, $state->lastFailureAt);
+        self::assertSame(3, $state->consecutiveFailures);
+        self::assertSame(12, $state->totalFailures);
+    }
+
+    /**
+     * Rows that predate a field, or carry junk in it, must read as zero — the
+     * value that means "never observed" everywhere this state is consumed.
+     *
+     * @param array<string, mixed> $row
+     */
+    #[Test]
+    #[DataProvider('unusableRowProvider')]
+    public function fromArrayFallsBackToZeroForUnusableValues(array $row): void
+    {
+        $state = SinkDeliveryState::fromArray('file', $row);
+
+        self::assertSame(0, $state->lastSuccessAt);
+        self::assertSame(0, $state->lastFailureAt);
+        self::assertSame(0, $state->consecutiveFailures);
+        self::assertSame(0, $state->totalFailures);
+        self::assertSame('', $state->lastError);
+        self::assertFalse($state->hasEverSucceeded());
+        self::assertFalse($state->isFailing());
+    }
+
+    /**
+     * @return iterable<string, array{0: array<string, mixed>}>
+     */
+    public static function unusableRowProvider(): iterable
+    {
+        yield 'empty row' => [[]];
+        yield 'null values' => [[
+            'lastSuccessAt' => null,
+            'lastFailureAt' => null,
+            'consecutiveFailures' => null,
+            'totalFailures' => null,
+            'lastError' => null,
+        ]];
+        yield 'non-numeric strings' => [[
+            'lastSuccessAt' => 'never',
+            'lastFailureAt' => '',
+            'consecutiveFailures' => 'many',
+            'totalFailures' => [],
+            'lastError' => 42,
+        ]];
+    }
+
+    /**
+     * The two predicates the readiness surface reads. Both are strict `> 0`,
+     * so the zero that means "never observed" must not read as a state.
+     *
+     * @return iterable<string, array{0: int, 1: int, 2: bool, 3: bool}>
+     */
+    public static function healthPredicateProvider(): iterable
+    {
+        yield 'never observed' => [0, 0, false, false];
+        yield 'succeeded once, healthy' => [1_700_000_000, 0, true, false];
+        yield 'succeeded once, now failing' => [1_700_000_000, 2, true, true];
+        yield 'only ever failed' => [0, 1, false, true];
+    }
+
+    #[Test]
+    #[DataProvider('healthPredicateProvider')]
+    public function healthPredicatesReadTheirCounters(
+        int $lastSuccessAt,
+        int $consecutiveFailures,
+        bool $expectedEverSucceeded,
+        bool $expectedFailing,
+    ): void {
+        $state = new SinkDeliveryState(
+            sinkIdentifier: 'syslog',
+            lastSuccessAt: $lastSuccessAt,
+            consecutiveFailures: $consecutiveFailures,
+        );
+
+        self::assertSame($expectedEverSucceeded, $state->hasEverSucceeded());
+        self::assertSame($expectedFailing, $state->isFailing());
+    }
+
+    /**
+     * `toArray()` and `fromArray()` are the two halves of the registry round
+     * trip; a key renamed on one side alone loses the field silently, since
+     * the read side falls back to zero rather than failing.
+     */
+    #[Test]
+    public function toArrayAndFromArrayRoundTrip(): void
+    {
+        $original = new SinkDeliveryState(
+            sinkIdentifier: 'webhook',
+            lastSuccessAt: 1_700_000_000,
+            lastFailureAt: 1_700_000_500,
+            consecutiveFailures: 3,
+            totalFailures: 12,
+            lastError: 'connection refused',
+        );
+
+        $restored = SinkDeliveryState::fromArray($original->sinkIdentifier, $original->toArray());
+
+        self::assertEquals($original, $restored);
+    }
+}

--- a/infection-security.json5
+++ b/infection-security.json5
@@ -63,16 +63,17 @@
     //   * Deleting or excluding a file/directory from `source` above has the
     //     same effect as lowering the threshold and needs the same sign-off.
     //
-    // MEASUREMENT (2026-08-19, CI run 32291041010 — after the second
-    // Classes/Http assertion-hardening pass, #328; ubuntu-latest, PHP 8.5,
-    // pcov, Infection 0.35, Unit+Fuzz):
-    //   3508 mutants — 3006 killed, 475 escaped, 25 timed out, 2 errored,
+    // MEASUREMENT (2026-08-19, CI run 32297200855 — after the Classes/Audit
+    // assertion-hardening pass, #328; ubuntu-latest, PHP 8.5, pcov,
+    // Infection 0.35, Unit+Fuzz):
+    //   3508 mutants — 3030 killed, 451 escaped, 25 timed out, 2 errored,
     //   0 skipped, 0 not covered
-    //   MSI 86.46 %, covered-code MSI 86.46 %, mutation code coverage 100 %
-    //   (same day: 85.99 % after the first hardening pass, CI run
-    //   32262598788; 83.84 % at the first four-directory baseline from #307,
-    //   CI run 32220828311; 2026-08-02 three-directory baseline: 2338
-    //   mutants, MSI 87.77 %; 2026-07-31: MSI 75.03 %)
+    //   MSI 87.14 %, covered-code MSI 87.14 %, mutation code coverage 100 %
+    //   (same day: 86.46 % after the second Http pass, CI run 32291041010;
+    //   85.99 % after the first, CI run 32262598788; 83.84 % at the first
+    //   four-directory baseline from #307, CI run 32220828311; 2026-08-02
+    //   three-directory baseline: 2338 mutants, MSI 87.77 %; 2026-07-31:
+    //   MSI 75.03 %)
     //
     //   CI is the authoritative environment for this number. On a slower host
     //   Infection drops a mutant from the MSI denominator when its covering
@@ -92,16 +93,21 @@
     //
     // Floor history, all on 2026-08-19: 86 -> 82 for the #307 scope
     // re-baseline (lowered per the policy above, sign-off recorded in PR #327),
-    // then 82 -> 84 with the first Classes/Http assertion-hardening pass
-    // (PR #331, 75 escapes killed), then 84 -> 85 here with the second
-    // (PR #332, 16 more).
+    // then raised back by three assertion-hardening passes under #328 —
+    // 82 -> 84 (PR #331, 75 escapes killed), 84 -> 85 (PR #332, 16 more),
+    // 85 -> 86 here (PR #333, 24 more).
     //
-    // 85 is the ~1.5-point margin under 86.46 the paragraph above describes,
-    // and it is still short of the 86 #328 set as its target. Run-to-run
-    // variance is real but small: two runs of the identical tree differed by
-    // one mutant (0.03 points), so the margin is not the constraint — the
-    // remaining 475 escapes are. #328 stays open for them.
+    // 86 restores the floor the gate carried before the widening, now over a
+    // scope 50 % larger: the same number over four directories instead of
+    // three. The margin under the 87.14 measurement is 1.14 points, and
+    // run-to-run variance is one mutant — 0.03 points — measured across two
+    // runs of an identical tree, so that margin is roughly forty mutants of
+    // headroom.
+    //
+    // 451 escapes remain (Http 171, Audit 164, Crypto 67, Security 49). They
+    // are no longer clustered in one mechanism the way the SSRF ranges or the
+    // sink-state coercion were, so further passes buy fewer points per test.
     // ------------------------------------------------------------------------
-    "minMsi": 85,
-    "minCoveredMsi": 85
+    "minMsi": 86,
+    "minCoveredMsi": 86
 }


### PR DESCRIPTION
## Summary

Third hardening pass on #328, and the first outside `Classes/Http`. After the second pass (#332), `Classes/Audit` carried **187 of the 475** escaped mutants and `Classes/Http` 172, so this is where the remaining weight sits.

- **`SinkDeliveryState` had no test file at all**, which is why its whole `fromArray()` coercion escaped. That method reads a `sys_registry` payload — data that survived a serialisation round trip and an extension update, so it is the one place the class treats its input as untrusted — and the readiness surface reports on the result: a `lastSuccessAt` that silently became 1 instead of 0 turns "this sink has never demonstrably accepted a record" into "it succeeded in January 1970". The new test covers the well-formed row, the numeric-string row the registry actually returns (the promoted properties are `int`, so an uncast value is a TypeError under `strict_types`, not a quietly wrong number), the unusable rows that must read as zero, both health predicates, and the `toArray`/`fromArray` round trip.
- **The syslog summary cap** was asserted as "at most 300 characters, ends in `...`". That holds equally for a summary that lost its leading characters, kept only its last one, or was replaced by the ellipsis alone. Now exact: 300 characters, starting with the text it truncates — plus a separate multibyte case, since a byte-wise truncation both overshoots the character budget and can sever a UTF-8 sequence, producing a record a strict collector rejects.
- **The per-epoch row census in `verifyHashChain()`** was uncovered; the result DTO's own test only checks that the array passes through. It is what an auditor reads to answer how far the HMAC migration actually got, so a count that starts one too high or steps by two reports a migration that did not happen.

## Related Issues

Relates to #328 (third partial pass). Follows #332.

## Checklist

- [x] Tests pass locally — full Unit+Fuzz suite: 5362 tests, 20535 assertions, no failures
- [x] PHPStan passes — `[OK] No errors`
- [x] Code style is correct — php-cs-fixer 0 of 511, Rector clean
- [x] Test-base convention check passes — `0 legacy tests allow-listed, no new violations`
- [x] Documentation updated — not applicable (tests only)
- [x] CHANGELOG.md — not applicable; no user- or API-facing change

## Test Plan

Each new assertion was verified against the mutant it exists for rather than assumed to kill it — applied by hand, the covering test run and watched to fail, then reverted. All 12 were caught:

```
caught  lastSuccessAt default          caught  summary truncation offset
caught  lastSuccessAt cast             caught  summary truncation length
caught  consecutiveFailures default    caught  summary replaced by ellipsis
caught  totalFailures cast             caught  summary byte-wise truncation
caught  lastError default              caught  epoch counter start
caught  epoch counter step             caught  epoch counter coalesce order
```

## Result — the floor is back at 86

CI run [32297200855](https://github.com/netresearch/t3x-nr-vault/actions/runs/32297200855) on this branch: **3508 mutants — 3030 killed, 451 escaped, 25 timed out, 2 errored, 0 skipped; MSI 87.14 %**, against 86.46 % before this pass. **24 more escapes killed**, and the floor moves **85 → 86**.

That restores the value the gate carried before #307 widened its scope — the same number, now over four directories instead of three, so the gate is stricter than it was pre-widening rather than merely recovered. Cumulative across the three passes under #328: **115 of the original 566 escapes killed, +3.30 points, floor 82 → 86.**

The margin under the measurement is 1.14 points, roughly forty mutants, against a run-to-run variance of one mutant (0.03 points) measured across two runs of an identical tree.

Remaining: 451 escapes — `Classes/Http` 171, `Classes/Audit` 164, `Classes/Crypto` 67, `Classes/Security` 49. They are no longer clustered in one mechanism the way the SSRF ranges or the sink-state coercion were, so further passes buy fewer points per test.

**On #328:** its title asks for the floor "back above 86". This lands it *at* 86 over a 50 % larger scope. Whether that closes the issue or leaves it open for a strictly higher number is a call worth making deliberately rather than by my reading of the wording, so I have left it open.

## Threat-Model Delta

- **Trust boundaries**: none — tests only; no runtime code path was modified.
- **Attacker capability**: none made cheaper. The change removes the ability for a future edit to weaken the sink-health coercion, the syslog record bound, or the epoch census without a red test. The last two matter to an auditor reading external evidence: a record a collector drops, or an epoch census that overstates the migration, is evidence that misleads.
- **Invariants**: adds pinned invariants rather than changing any — the sink delivery state's zero-means-never-observed coercion, the exact 300-character summary bound with its leading text preserved, and the per-epoch row counts a verification result reports.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_018d4iHdbbBCAPKaP1R3k8eF)_
