### PR TITLE
Make the security-findings list collapsible behind its summary line

### DIFF
--- a/Resources/Private/Language/locallang_mod.xlf
+++ b/Resources/Private/Language/locallang_mod.xlf
@@ -510,6 +510,9 @@
       <trans-unit id="overview.security.status.profile.hardened">
         <source>Hardened profile</source>
       </trans-unit>
+      <trans-unit id="overview.security.status.toggle">
+        <source>Show or hide the individual findings</source>
+      </trans-unit>
       <trans-unit id="overview.security.status.controlsPassed">
         <source>%1$s of %2$s controls passed</source>
       </trans-unit>

--- a/Resources/Private/Partials/SecurityStatus.html
+++ b/Resources/Private/Partials/SecurityStatus.html
@@ -22,7 +22,25 @@
 
     <f:if condition="{securityStatus.available}">
         <f:then>
+            <!--
+                The badge line doubles as the disclosure control for the findings
+                below: on an instance with a handful of warnings the landing page
+                is otherwise a wall of alerts, and the ratio is the summary a
+                reader wants first. `aria-expanded` and `aria-controls` are what
+                make it a control rather than a clickable decoration; the markup
+                stays CSP-safe because Bootstrap drives it from data attributes,
+                with no inline handler.
+            -->
             <p class="mb-3">
+                <button
+                    type="button"
+                    class="btn btn-link p-0 border-0 align-baseline text-decoration-none"
+                    data-bs-toggle="collapse"
+                    data-bs-target="#vault-security-details"
+                    aria-expanded="true"
+                    aria-controls="vault-security-details"
+                    data-testid="vault-security-toggle"
+                >
                 <span class="badge bg-secondary" data-testid="vault-security-profile">
                     <core:icon identifier="actions-shield" size="small" />
                     <!--
@@ -39,7 +57,12 @@
                 <span class="badge bg-{securityStatus.context}" data-testid="vault-security-ratio">
                     {f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.controlsPassed', arguments: {0: securityStatus.passed, 1: securityStatus.total})}
                 </span>
+                    <core:icon identifier="actions-chevron-down" size="small" />
+                    <span class="visually-hidden">{f:translate(key: 'LLL:EXT:nr_vault/Resources/Private/Language/locallang_mod.xlf:overview.security.status.toggle')}</span>
+                </button>
             </p>
+
+            <div class="collapse show" id="vault-security-details" data-testid="vault-security-details">
 
             <f:if condition="{securityStatus.auditReady}">
                 <f:then>
@@ -93,6 +116,7 @@
                     </f:if>
                 </f:else>
             </f:if>
+            </div>
         </f:then>
         <f:else>
             <div class="alert alert-warning" role="alert" data-testid="vault-security-unavailable">

--- a/Tests/Functional/View/SecurityStatusPartialTest.php
+++ b/Tests/Functional/View/SecurityStatusPartialTest.php
@@ -195,6 +195,53 @@ final class SecurityStatusPartialTest extends FunctionalTestCase
         self::assertStringContainsString('&lt;script&gt;', $html);
     }
 
+    public function testTheBadgeLineIsTheDisclosureControlForTheFindings(): void
+    {
+        // The findings are the bulk of this panel on any instance that has some,
+        // and the ratio is the summary a reader wants first. The line therefore
+        // doubles as the control that hides them — which only counts as a
+        // control if it says so to assistive technology.
+        $html = $this->render([
+            'available' => true,
+            'profile' => 'standard',
+            'auditReady' => false,
+            'severity' => 'warning',
+            'context' => 'warning',
+            'passed' => 20,
+            'total' => 24,
+            'criticalCount' => 1,
+            'warningCount' => 3,
+            'detailed' => true,
+            'findings' => [
+                [
+                    'id' => 'audit.hash_chain',
+                    'context' => 'danger',
+                    'summary' => 'Hash chain verification failed.',
+                    'risk' => '',
+                    'remediation' => '',
+                    'docsUrl' => '',
+                ],
+            ],
+        ]);
+
+        self::assertStringContainsString('data-bs-toggle="collapse"', $html);
+        self::assertStringContainsString('data-bs-target="#vault-security-details"', $html);
+        self::assertStringContainsString('aria-controls="vault-security-details"', $html);
+        self::assertStringContainsString('aria-expanded="true"', $html);
+
+        // Expanded by default: a live finding must not be hidden by a default
+        // nobody chose. Collapsing is the reader's decision, not the panel's.
+        self::assertStringContainsString('id="vault-security-details"', $html);
+        self::assertStringContainsString('collapse show', $html);
+
+        // And the findings really do sit inside the collapsible region.
+        $regionStart = strpos($html, 'id="vault-security-details"');
+        $findingPos = strpos($html, 'vault-security-finding"');
+        self::assertIsInt($regionStart);
+        self::assertIsInt($findingPos);
+        self::assertGreaterThan($regionStart, $findingPos);
+    }
+
     /**
      * A complete view shape with per-test overrides, mirroring
      * {@see SecurityStatusProvider::forView()}.


### PR DESCRIPTION
The overview panel prints every doctor finding in full, risk and remediation paragraphs included. On an instance with a handful of warnings that is a wall of alerts under a one-line summary the reader cannot get back to — and the summary (`Standard profile · 20 of 24 controls passed`) is what they want first.

That line is now the disclosure control for the findings below it. Reported from the demo instance, where four findings fill the landing page.

**Details worth naming:**

- `aria-expanded` and `aria-controls` are what make it a control rather than a clickable decoration; a screen reader now announces the state and the region it governs. A visually hidden label says what the button does.
- Bootstrap drives the collapse from data attributes, so no inline handler is introduced and the extension's CSP rule holds (`Resources/AGENTS.md`: no inline `<script>`, no inline handlers).
- **Expanded by default.** Collapsing is the reader's decision; hiding a live error behind a default nobody chose would be worse than the wall of text. The panel keeps showing what it found until someone folds it away.

**Tests:** a new functional test asserts the toggle wiring (`data-bs-toggle`, target, `aria-controls`, `aria-expanded`), that the region starts expanded, and — by comparing string positions — that the findings really sit *inside* the collapsible region rather than merely next to it. Seen to fail before being kept: swapping `data-bs-toggle="collapse"` for `dropdown` turns it red.

While writing it, two existing tests caught a real mistake: the region's first `data-testid` contained the substring `vault-security-finding`, which `testACleanReportRendersTheAuditReadyCallout` asserts is *absent* on a clean report. The id is `vault-security-details` now. That is the assertion doing its job.

Gates run locally: the functional partial suite (8 tests) and cgl. The worktree needed its own `composer install` and a writable `typo3temp/var/tests` before the suite would run at all — a control run on unmodified `main` passed while the worktree failed, which is what identified it as environment rather than code.

_Assisted by claude-code:claude-fable-5 — [Session](https://claude.ai/code/session_0144iD1P22LotW8rxmxrNGro)_
