### PR TITLE
chore: sync checks.yml with the typo3-extension template

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -3,7 +3,18 @@ name: Checks
 on:
   push:
     branches: [main]
+  # `ready_for_review` is NOT in the default type set (opened, synchronize,
+  # reopened), and without it a pull request opened as a draft never gets its
+  # auto-approval: `pr-quality`'s auto-approve job is gated on
+  # `github.event.pull_request.draft == false`, so it skips while the PR is a
+  # draft and nothing re-runs it when the draft is lifted. The PR then sits at
+  # `reviewDecision: REVIEW_REQUIRED` with nothing red, and the merge tooling
+  # reports the Copilot review quota — true, and not the cause.
+  #
+  # The Go templates already carry this type set in their own pr-quality.yml;
+  # this template folded that job into `checks.yml` and lost it on the way.
   pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
   merge_group:
   schedule:
     - cron: '0 6 * * 1'
@@ -24,29 +35,39 @@ permissions: {}
 # step by hand.
 jobs:
   security:
+    # Ran on this SHA already; lifting a draft changes no code (see `on:`).
+    if: github.event.action != 'ready_for_review'
     uses: netresearch/typo3-ci-workflows/.github/workflows/security.yml@main
     permissions:
       contents: read
       security-events: write
 
   gitleaks:
+    # Ran on this SHA already; lifting a draft changes no code (see `on:`).
+    if: github.event.action != 'ready_for_review'
     uses: netresearch/.github/.github/workflows/gitleaks.yml@main
     permissions:
       contents: read
       security-events: write
 
   zizmor:
+    # Ran on this SHA already; lifting a draft changes no code (see `on:`).
+    if: github.event.action != 'ready_for_review'
     uses: netresearch/.github/.github/workflows/zizmor.yml@main
     permissions:
       contents: read
       security-events: write
 
   fuzz:
+    # Ran on this SHA already; lifting a draft changes no code (see `on:`).
+    if: github.event.action != 'ready_for_review'
     uses: netresearch/typo3-ci-workflows/.github/workflows/fuzz.yml@main
     permissions:
       contents: read
 
   license-check:
+    # Ran on this SHA already; lifting a draft changes no code (see `on:`).
+    if: github.event.action != 'ready_for_review'
     uses: netresearch/typo3-ci-workflows/.github/workflows/license-check.yml@main
     permissions:
       contents: read
@@ -58,6 +79,8 @@ jobs:
   # first SARIF. Merging this file is what triggers that handover, so the
   # narrow default silently removed a control that had been in place.
   codeql:
+    # Ran on this SHA already; lifting a draft changes no code (see `on:`).
+    if: github.event.action != 'ready_for_review'
     uses: netresearch/.github/.github/workflows/codeql.yml@main
     permissions:
       contents: read


### PR DESCRIPTION
[netresearch/.github#387](https://github.com/netresearch/.github/pull/387) added `ready_for_review` to the template's `pull_request` trigger, plus six `if: github.event.action != 'ready_for_review'` guards so lifting a draft does not re-run scan jobs on a SHA that already has results. This repository had not caught up, so the drift check fails on **every** pull request here.

It surfaced on [#335](https://github.com/netresearch/t3x-nr-vault/pull/335), which replaces the runner and touches no workflow at all — a red `drift` check there says nothing about that change, which is why this is separate.

Straight copy of the template file: **23 added lines, zero changed ones**. `drift_compare.py` reports `No drift detected` afterwards, with `ci.yml` and `release.yml` still listed as intentional drift.

_Assisted by claude-code:claude-opus-5 — [Session](https://claude.ai/code/session_01GSptxPLHWsttu9FuqVkvYZ)_